### PR TITLE
feat: add /stitch-audit skill for cross-layer data flow analysis

### DIFF
--- a/.claude/commands/stitch-audit.md
+++ b/.claude/commands/stitch-audit.md
@@ -1,0 +1,175 @@
+# Stitch Audit — Cross-Layer Data Flow Analysis
+
+Traces a feature's data flow across the full stack — frontend forms, API handlers, database operations, admin views — and flags where fields get lost, names drift, validation diverges, or intent dies at layer boundaries.
+
+No existing tool does this. Contract testing covers one boundary. OpenAPI codegen covers spec-to-types. This skill fills the gap: **cross-layer, cross-language, full-trace analysis**.
+
+## When to use
+
+- After an AI agent implements a full-stack feature (the primary use case)
+- Before shipping a PR that touches multiple layers
+- When debugging "the form sends X but the API doesn't accept it" issues
+- Periodic audit of convention consistency across the codebase
+
+## Usage
+
+```
+/stitch-audit <owner/repo> --trace <keyword>
+/stitch-audit <owner/repo> --patterns [path]
+```
+
+## Parameters
+
+- `owner/repo`: Target GitHub repository (e.g., `plwp/dgrd`)
+- `--trace <keyword>`: Trace a feature's data flow across all layers (e.g., `waitlist`, `booking`, `psychosocial`)
+- `--patterns [path]`: Scan for convention inconsistencies, optionally scoped to a sub-path (e.g., `backend/`)
+
+## Autonomy
+
+**Run to completion without pausing.** This is an audit/analysis skill — no human-in-the-loop checkpoints. Present the final report and let the user decide what to act on.
+
+---
+
+## Workflow — Trace Mode (`--trace <keyword>`)
+
+### Step 1: Resolve paths
+
+```bash
+CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
+CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
+mkdir -p "$CW_TMP"
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+```
+
+### Step 2: Discovery + Extraction
+
+Run the extraction orchestrator to find and parse all schemas related to the keyword:
+
+```bash
+python3 "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --trace "$keyword" -o "$CW_TMP/extraction.json"
+```
+
+This uses the pluggable extractor architecture — whichever extractors match the repo's tech stack run automatically (Go+MongoDB, TypeScript, etc.).
+
+After extraction completes, report what was found:
+- Number of schemas extracted per layer
+- Which extractors were active
+- Any layers with zero results (potential gap)
+
+If extraction finds nothing, stop and report: "No schemas found for keyword '$keyword'. Try a different keyword or check that the feature exists in this repo."
+
+### Step 3: Cross-boundary diffing
+
+Run the stack-agnostic differ on the extraction output:
+
+```bash
+python3 "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format json -o "$CW_TMP/findings.json"
+python3 "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format text -o "$CW_TMP/findings.txt"
+```
+
+Read `$CW_TMP/findings.txt` for a quick overview. Read `$CW_TMP/findings.json` for structured data.
+
+If there are zero findings, report "Clean — no mismatches detected" and skip Steps 4-5.
+
+### Step 4: Git provenance
+
+For BREAK/WARN findings, trace how each break was introduced:
+
+```bash
+python3 "$CW_HOME/scripts/stitch_provenance.py" "$CW_TMP/findings.json" --repo "$TARGET_REPO" --gh-repo "$owner_repo" -o "$CW_TMP/provenance.json"
+```
+
+This enriches each finding with:
+- The commit SHA that introduced each side of the break
+- The PR that contained the commit
+- Issues linked to the PR (via `Closes #N`)
+- Analysis: same_commit / same_pr / same_issue / different_work_streams
+
+### Step 5: Gemini semantic analysis
+
+Build the analysis prompt from the template:
+
+```bash
+PROMPT=$(cat "$CW_HOME/templates/stitch-audit-prompt.md")
+```
+
+Replace placeholders:
+- `{{KEYWORD}}` → the trace keyword
+- `{{REPO}}` → owner/repo
+- `{{EXTRACTION_JSON}}` → contents of `$CW_TMP/extraction.json`
+- `{{DIFF_REPORT}}` → contents of `$CW_TMP/findings.txt`
+- `{{PROVENANCE}}` → contents of `$CW_TMP/provenance.json`
+
+Write the filled prompt to `$CW_TMP/stitch-prompt.md`, then consult Gemini:
+
+```bash
+python3 "$CW_HOME/scripts/consult_ai.py" gemini "$CW_TMP/stitch-prompt.md" -o "$CW_TMP/stitch-gemini.md"
+```
+
+If Gemini times out, retry once. If it fails again, proceed without it — the automated findings are still valuable.
+
+### Step 6: Report
+
+Present the final report to the user, structured as:
+
+---
+
+#### Stitch Audit Report: `<keyword>` in `<owner/repo>`
+
+**Extractors active**: (list)
+**Schemas found**: (count by layer)
+**Boundaries checked**: (list of layer pairs that had data on both sides)
+
+##### BREAK (data loss / type mismatch)
+For each:
+- What: the mismatch
+- Where: source file:line → target file:line
+- Provenance: how it was introduced (commit/PR/issue)
+- Fix: concrete action
+
+##### WARN (naming / validation drift)
+Same format.
+
+##### INFO (dead fields / conventions)
+Same format, more concise.
+
+##### Gemini Analysis
+Include the Gemini response (Summary, Critical Findings, Observations, Verdict).
+
+---
+
+## Workflow — Patterns Mode (`--patterns [path]`)
+
+### Step 1: Resolve paths
+
+Same as trace mode.
+
+### Step 2: Convention scan
+
+```bash
+python3 "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --patterns "$scan_path" -o "$CW_TMP/patterns.json"
+```
+
+### Step 3: Report
+
+Present the pattern analysis:
+- **Naming styles**: Distribution of snake_case / camelCase / PascalCase across layers
+- **Tag coverage**: Percentage of Go struct fields with json/bson tags
+- **Schema definition styles**: Interface vs Zod ratio, consistency
+- **Inconsistencies**: Any layer or file that breaks the dominant convention
+
+Flag specific files that diverge from the codebase norm. No provenance or Gemini analysis needed — this is a quick convention check.
+
+---
+
+## Known Limitations
+
+This is a Tier 1 regex-based analysis. It catches 80-85% of issues — good enough for an audit tool. Known gaps:
+
+- Embedded Go structs (anonymous fields) — tags inherited but not inlined
+- TypeScript `Pick<T, K>`, `Omit<T, K>`, mapped types — not resolved
+- Multi-file type composition (`type A extends B` across files) — not traced
+- Complex nested `bson.M` inside `$set` / `$push` — partially captured
+- Zod `.transform()` / `.pipe()` chains — partially captured
+
+False negatives are acceptable. False positives should be rare.

--- a/scripts/extractors/__init__.py
+++ b/scripts/extractors/__init__.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Extractor auto-discovery registry.
+
+Imports all modules in this package, instantiates each Extractor subclass,
+and returns those whose detect() method matches the given repo.
+
+Adding a new stack = drop a new .py file here with a class that inherits
+from Extractor. No registration boilerplate needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+from .base import Extractor
+
+
+def _find_extractor_classes() -> list[type[Extractor]]:
+    """Import all sibling modules and collect Extractor subclasses."""
+    classes: list[type[Extractor]] = []
+    package_dir = Path(__file__).parent
+
+    for info in pkgutil.iter_modules([str(package_dir)]):
+        if info.name == "base":
+            continue
+        module = importlib.import_module(f".{info.name}", package=__package__)
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, Extractor)
+                and attr is not Extractor
+            ):
+                classes.append(attr)
+
+    return classes
+
+
+def get_extractors(repo_path: Path) -> list[Extractor]:
+    """Return instantiated extractors that detect their stack in the repo."""
+    result: list[Extractor] = []
+    for cls in _find_extractor_classes():
+        instance = cls()
+        try:
+            if instance.detect(repo_path):
+                result.append(instance)
+        except Exception:
+            # If detection fails, skip this extractor silently.
+            pass
+    return result
+
+
+__all__ = ["get_extractors", "Extractor"]

--- a/scripts/extractors/base.py
+++ b/scripts/extractors/base.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Abstract base class and shared types for stitch-audit extractors.
+
+Each language/framework extractor inherits from Extractor and implements
+the four required methods: detect, discover, extract, scan_patterns.
+
+Shared data types (Field, Schema) provide a stack-agnostic representation
+that stitch_diff.py consumes without knowing the source language.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Field:
+    """A single field extracted from a schema definition."""
+
+    name: str  # Field name as it appears in this layer
+    type: str | None = None  # Type (language-specific string)
+    line: int = 0  # Line number in source file
+    required: bool | None = None  # True/False/None if unknown
+    tags: dict[str, str] = field(default_factory=dict)  # json_tag, bson_tag, validator, etc.
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Schema:
+    """A schema extracted from a single file — struct, interface, Zod schema, etc."""
+
+    file: str  # Relative path within repo
+    layer: str  # frontend_forms | api_handlers | database_ops | admin_views
+    schema_type: str  # go_struct | bson_m_op | ts_interface | zod_schema | form_fields
+    name: str  # Struct/interface/schema name
+    fields: list[Field] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        return d
+
+
+# Standard layer names — extractors map their files to these.
+LAYERS = frozenset({
+    "frontend_forms",
+    "api_handlers",
+    "database_ops",
+    "admin_views",
+})
+
+
+class Extractor(ABC):
+    """Base class for language/framework-specific schema extractors."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier, e.g. 'go_mongo', 'typescript'."""
+
+    @abstractmethod
+    def detect(self, repo_path: Path) -> bool:
+        """Return True if this repo contains files this extractor handles."""
+
+    @abstractmethod
+    def discover(self, repo_path: Path, keyword: str) -> dict[str, list[Path]]:
+        """Find files related to keyword.
+
+        Returns dict of layer_name -> file list.
+        Layer names must be from LAYERS.
+        """
+
+    @abstractmethod
+    def extract(self, file_path: Path, keyword: str | None = None) -> list[Schema]:
+        """Extract schemas from a single file. Returns list of Schema objects."""
+
+    @abstractmethod
+    def scan_patterns(self, repo_path: Path, scan_path: str | None = None) -> dict:
+        """Scan for convention inconsistencies. Returns convention counts."""
+
+
+def schemas_to_json(schemas: list[Schema]) -> str:
+    """Serialize a list of Schema objects to JSON."""
+    return json.dumps([s.to_dict() for s in schemas], indent=2)
+
+
+def schemas_from_json(data: str) -> list[Schema]:
+    """Deserialize JSON back into Schema objects."""
+    raw = json.loads(data)
+    result = []
+    for item in raw:
+        fields = [Field(**f) for f in item.pop("fields", [])]
+        result.append(Schema(**item, fields=fields))
+    return result

--- a/scripts/extractors/go_mongo.py
+++ b/scripts/extractors/go_mongo.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""
+Go + MongoDB extractor for stitch-audit.
+
+Handles:
+- Go struct definitions with json:"tag" and bson:"tag" extraction
+- bson.M{...} operation key extraction (InsertOne, UpdateOne, FindOne patterns)
+- Handler file classification (gin.Context, http.Handler, echo.Context markers)
+- Pattern scanning: json/bson tag style distribution, tag coverage
+
+Limitations (Tier 1 regex):
+- Embedded (anonymous) structs noted as "inherited" but fields not inlined
+- Nested bson.M inside $set / $push only partially captured
+- Complex multi-line struct tags may miss edge cases
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+from .base import Extractor, Field, Schema
+
+# Markers that indicate a Go file is an HTTP handler
+_HANDLER_MARKERS = re.compile(
+    r"gin\.Context|echo\.Context|http\.Handler|http\.Request|chi\.Router|mux\.Router"
+)
+
+# Markers that indicate a Go file does MongoDB operations
+_MONGO_MARKERS = re.compile(
+    r"bson\.M\b|bson\.D\b|mongo\.Collection|InsertOne|UpdateOne|FindOne|Find\("
+)
+
+# Match a Go struct definition
+_STRUCT_RE = re.compile(r"^type\s+(\w+)\s+struct\s*\{", re.MULTILINE)
+
+# Match a struct field line:  Name Type `json:"x" bson:"y"`
+_FIELD_RE = re.compile(
+    r"^\s+(\w+)\s+(\S+)"  # name, type
+    r"(?:\s+`([^`]+)`)?"  # optional backtick tags
+    r"\s*$",
+    re.MULTILINE,
+)
+
+# Extract a specific tag value: json:"name,omitempty" -> name
+_TAG_RE = re.compile(r'(\w+):"([^"]*)"')
+
+# bson.M{ "key": value } — capture keys inside bson.M literals
+_BSON_M_KEY_RE = re.compile(r'"(\w+)"(?:\s*:)')
+
+# MongoDB operation patterns: collection.Method(ctx, bson.M{...})
+_MONGO_OP_RE = re.compile(
+    r"\.\s*(InsertOne|UpdateOne|UpdateMany|FindOne|Find|DeleteOne|DeleteMany|Aggregate)"
+    r"\s*\([^)]*bson\.M\s*\{([^}]*)\}",
+    re.DOTALL,
+)
+
+# Extended pattern: match bson.M blocks that may span lines
+_BSON_M_BLOCK_RE = re.compile(r"bson\.M\s*\{([^}]*)\}", re.DOTALL)
+
+
+class GoMongoExtractor(Extractor):
+    """Extract schemas from Go structs, bson tags, and MongoDB operations."""
+
+    def name(self) -> str:
+        return "go_mongo"
+
+    def detect(self, repo_path: Path) -> bool:
+        """Check for Go files with bson imports or MongoDB usage."""
+        for go_file in repo_path.rglob("*.go"):
+            if go_file.is_relative_to(repo_path / "vendor"):
+                continue
+            try:
+                content = go_file.read_text(errors="replace")
+                if "bson" in content or _MONGO_MARKERS.search(content):
+                    return True
+            except OSError:
+                continue
+        return False
+
+    def discover(self, repo_path: Path, keyword: str) -> dict[str, list[Path]]:
+        """Find Go files related to keyword, classified by layer."""
+        kw_lower = keyword.lower()
+        result: dict[str, list[Path]] = {
+            "api_handlers": [],
+            "database_ops": [],
+        }
+
+        for go_file in repo_path.rglob("*.go"):
+            if go_file.is_relative_to(repo_path / "vendor"):
+                continue
+            try:
+                content = go_file.read_text(errors="replace")
+            except OSError:
+                continue
+
+            # Check if file mentions the keyword
+            if kw_lower not in content.lower():
+                continue
+
+            # Classify by layer
+            if _HANDLER_MARKERS.search(content):
+                result["api_handlers"].append(go_file)
+            if _MONGO_MARKERS.search(content):
+                result["database_ops"].append(go_file)
+            # A file can appear in both — that's fine for a handler that
+            # also does direct DB ops.
+
+        return {k: v for k, v in result.items() if v}
+
+    def extract(self, file_path: Path, keyword: str | None = None) -> list[Schema]:
+        """Extract struct definitions and bson.M operations from a Go file."""
+        try:
+            content = file_path.read_text(errors="replace")
+        except OSError:
+            return []
+
+        lines = content.split("\n")
+        schemas: list[Schema] = []
+
+        # Determine layer
+        is_handler = bool(_HANDLER_MARKERS.search(content))
+        is_mongo = bool(_MONGO_MARKERS.search(content))
+
+        # 1. Extract struct definitions
+        for match in _STRUCT_RE.finditer(content):
+            struct_name = match.group(1)
+
+            # If keyword given, skip structs that don't relate to it
+            if keyword and keyword.lower() not in struct_name.lower():
+                # Also check if the struct is in a keyword-related file
+                if keyword.lower() not in file_path.stem.lower():
+                    continue
+
+            struct_start = match.start()
+            start_line = content[:struct_start].count("\n") + 1
+
+            # Find the closing brace
+            brace_depth = 0
+            struct_end = struct_start
+            for i, ch in enumerate(content[struct_start:], struct_start):
+                if ch == "{":
+                    brace_depth += 1
+                elif ch == "}":
+                    brace_depth -= 1
+                    if brace_depth == 0:
+                        struct_end = i
+                        break
+
+            struct_body = content[struct_start:struct_end + 1]
+            fields = self._extract_struct_fields(struct_body, start_line)
+
+            if not fields:
+                continue
+
+            layer = "api_handlers" if is_handler else "database_ops"
+            schemas.append(Schema(
+                file=str(file_path),
+                layer=layer,
+                schema_type="go_struct",
+                name=struct_name,
+                fields=fields,
+            ))
+
+        # 2. Extract bson.M operation keys
+        if is_mongo:
+            bson_schemas = self._extract_bson_ops(content, file_path, keyword)
+            schemas.extend(bson_schemas)
+
+        return schemas
+
+    def _extract_struct_fields(self, struct_body: str, base_line: int) -> list[Field]:
+        """Parse fields from a Go struct body."""
+        fields: list[Field] = []
+        struct_lines = struct_body.split("\n")
+
+        for i, line in enumerate(struct_lines[1:], 1):  # Skip the type...struct{ line
+            line_stripped = line.strip()
+            if not line_stripped or line_stripped.startswith("//") or line_stripped == "}":
+                continue
+
+            # Embedded struct (no type, just a name)
+            if re.match(r"^\s*\*?\w+\s*$", line_stripped.split("`")[0].strip()):
+                continue
+
+            field_match = _FIELD_RE.match(line)
+            if not field_match:
+                continue
+
+            fname = field_match.group(1)
+            ftype = field_match.group(2)
+            tags_str = field_match.group(3) or ""
+
+            # Parse struct tags
+            tags: dict[str, str] = {}
+            for tag_match in _TAG_RE.finditer(tags_str):
+                tag_key = tag_match.group(1)
+                tag_val = tag_match.group(2).split(",")[0]  # Strip ",omitempty" etc.
+                if tag_val == "-":
+                    tags[f"{tag_key}_tag"] = "-"  # Explicitly ignored
+                else:
+                    tags[f"{tag_key}_tag"] = tag_val
+
+            # Determine required from validate tag
+            required = None
+            if "validate" in tags_str:
+                validate_match = re.search(r'validate:"([^"]*)"', tags_str)
+                if validate_match:
+                    validate_val = validate_match.group(1)
+                    tags["validator"] = validate_val
+                    if "required" in validate_val:
+                        required = True
+
+            # Determine required from pointer type
+            if ftype.startswith("*"):
+                if required is None:
+                    required = False
+
+            fields.append(Field(
+                name=fname,
+                type=ftype,
+                line=base_line + i,
+                required=required,
+                tags=tags,
+            ))
+
+        return fields
+
+    def _extract_bson_ops(
+        self, content: str, file_path: Path, keyword: str | None
+    ) -> list[Schema]:
+        """Extract field names from bson.M{} operations."""
+        schemas: list[Schema] = []
+
+        for op_match in _MONGO_OP_RE.finditer(content):
+            op_name = op_match.group(1)
+            bson_body = op_match.group(2)
+
+            # Check keyword relevance
+            if keyword:
+                # Look at surrounding context (100 chars before the op)
+                ctx_start = max(0, op_match.start() - 200)
+                context = content[ctx_start:op_match.end()]
+                if keyword.lower() not in context.lower():
+                    continue
+
+            op_line = content[:op_match.start()].count("\n") + 1
+            keys = _BSON_M_KEY_RE.findall(bson_body)
+
+            # Filter out MongoDB operators ($set, $push, etc.)
+            fields = []
+            for key in keys:
+                if key.startswith("$"):
+                    # Look inside the operator's value for actual field names
+                    # e.g., "$set": bson.M{"field1": val, "field2": val}
+                    op_block_re = re.compile(
+                        rf'"\${re.escape(key[1:])}":\s*bson\.M\s*\{{([^}}]*)\}}',
+                        re.DOTALL,
+                    )
+                    for inner_match in op_block_re.finditer(bson_body):
+                        inner_keys = _BSON_M_KEY_RE.findall(inner_match.group(1))
+                        for inner_key in inner_keys:
+                            if not inner_key.startswith("$"):
+                                fields.append(Field(
+                                    name=inner_key,
+                                    type=None,
+                                    line=op_line,
+                                    tags={"bson_tag": inner_key, "mongo_op": op_name},
+                                ))
+                else:
+                    fields.append(Field(
+                        name=key,
+                        type=None,
+                        line=op_line,
+                        tags={"bson_tag": key, "mongo_op": op_name},
+                    ))
+
+            if fields:
+                schemas.append(Schema(
+                    file=str(file_path),
+                    layer="database_ops",
+                    schema_type="bson_m_op",
+                    name=f"{op_name}@L{op_line}",
+                    fields=fields,
+                ))
+
+        return schemas
+
+    def scan_patterns(self, repo_path: Path, scan_path: str | None = None) -> dict:
+        """Scan Go files for convention inconsistencies."""
+        root = repo_path / scan_path if scan_path else repo_path
+
+        json_styles: Counter[str] = Counter()  # snake_case, camelCase, etc.
+        bson_styles: Counter[str] = Counter()
+        missing_json = 0
+        missing_bson = 0
+        total_fields = 0
+
+        for go_file in root.rglob("*.go"):
+            if go_file.is_relative_to(repo_path / "vendor"):
+                continue
+            try:
+                content = go_file.read_text(errors="replace")
+            except OSError:
+                continue
+
+            for match in _FIELD_RE.finditer(content):
+                tags_str = match.group(3) or ""
+                total_fields += 1
+
+                # Check json tag
+                json_match = re.search(r'json:"([^"]*)"', tags_str)
+                if json_match:
+                    tag_val = json_match.group(1).split(",")[0]
+                    if tag_val != "-":
+                        json_styles[_classify_naming(tag_val)] += 1
+                else:
+                    missing_json += 1
+
+                # Check bson tag
+                bson_match = re.search(r'bson:"([^"]*)"', tags_str)
+                if bson_match:
+                    tag_val = bson_match.group(1).split(",")[0]
+                    if tag_val != "-":
+                        bson_styles[_classify_naming(tag_val)] += 1
+                else:
+                    missing_bson += 1
+
+        return {
+            "extractor": self.name(),
+            "total_fields": total_fields,
+            "json_tag_styles": dict(json_styles),
+            "bson_tag_styles": dict(bson_styles),
+            "missing_json_tags": missing_json,
+            "missing_bson_tags": missing_bson,
+        }
+
+
+def _classify_naming(name: str) -> str:
+    """Classify a name as snake_case, camelCase, PascalCase, or other."""
+    if "_" in name:
+        return "snake_case"
+    if name[0].isupper():
+        return "PascalCase"
+    if name[0].islower() and any(c.isupper() for c in name[1:]):
+        return "camelCase"
+    if name.islower():
+        return "lowercase"
+    return "other"

--- a/scripts/extractors/typescript.py
+++ b/scripts/extractors/typescript.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+TypeScript extractor for stitch-audit.
+
+Handles:
+- TypeScript interface and type definitions
+- Zod schema (z.object({...})) field extraction with validator types
+- Form field extraction (register("field"), name="field")
+- Admin view classification (path-based: admin/manage/dashboard)
+- Pattern scanning: naming convention distribution
+
+Limitations (Tier 1 regex):
+- Pick<T, K>, Omit<T, K>, mapped types not resolved
+- Multi-file type composition (extends across files) not traced
+- Complex Zod chains (.transform, .pipe) partially captured
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+from .base import Extractor, Field, Schema
+
+# TypeScript interface/type definition
+_INTERFACE_RE = re.compile(
+    r"^(?:export\s+)?(?:interface|type)\s+(\w+)(?:\s+extends\s+[\w,\s<>]+)?\s*(?:=\s*)?\{",
+    re.MULTILINE,
+)
+
+# Interface/type field line:  name: Type;  or  name?: Type;
+_TS_FIELD_RE = re.compile(
+    r"^\s+(\w+)(\??):\s*(.+?)\s*;?\s*$",
+    re.MULTILINE,
+)
+
+# Zod schema: z.object({ ... })
+_ZOD_SCHEMA_RE = re.compile(
+    r"(?:const|let|var|export\s+const)\s+(\w+)\s*=\s*z\.object\s*\(\s*\{",
+    re.MULTILINE,
+)
+
+# Zod field:  fieldName: z.string().optional(),
+_ZOD_FIELD_RE = re.compile(
+    r"^\s+(\w+):\s*(z\.\w+\([^)]*\)(?:\.\w+\([^)]*\))*)",
+    re.MULTILINE,
+)
+
+# React Hook Form register("fieldName") or register('fieldName')
+_REGISTER_RE = re.compile(r'register\s*\(\s*["\'](\w+(?:\.\w+)*)["\']')
+
+# HTML/JSX name="fieldName" or name={'fieldName'}
+_NAME_ATTR_RE = re.compile(r'name\s*=\s*["\'{](\w+(?:\.\w+)*)["\'}]')
+
+# Admin/manage/dashboard path markers
+_ADMIN_PATH_RE = re.compile(r"admin|manage|dashboard", re.IGNORECASE)
+
+# Form markers — files that are likely form components
+_FORM_MARKERS = re.compile(
+    r"<form|useForm|FormProvider|handleSubmit|onSubmit|register\(|<Form"
+)
+
+
+class TypeScriptExtractor(Extractor):
+    """Extract schemas from TypeScript interfaces, Zod schemas, and form fields."""
+
+    def name(self) -> str:
+        return "typescript"
+
+    def detect(self, repo_path: Path) -> bool:
+        """Check for TypeScript files in the repo."""
+        for pattern in ("*.ts", "*.tsx"):
+            for ts_file in repo_path.rglob(pattern):
+                if "node_modules" in ts_file.parts:
+                    continue
+                return True
+        return False
+
+    def discover(self, repo_path: Path, keyword: str) -> dict[str, list[Path]]:
+        """Find TypeScript files related to keyword, classified by layer."""
+        kw_lower = keyword.lower()
+        result: dict[str, list[Path]] = {
+            "frontend_forms": [],
+            "api_handlers": [],
+            "admin_views": [],
+        }
+
+        for pattern in ("*.ts", "*.tsx"):
+            for ts_file in repo_path.rglob(pattern):
+                if "node_modules" in ts_file.parts or ".next" in ts_file.parts:
+                    continue
+
+                try:
+                    content = ts_file.read_text(errors="replace")
+                except OSError:
+                    continue
+
+                if kw_lower not in content.lower() and kw_lower not in str(ts_file).lower():
+                    continue
+
+                rel = str(ts_file.relative_to(repo_path))
+
+                # Classify by layer
+                if _ADMIN_PATH_RE.search(rel):
+                    result["admin_views"].append(ts_file)
+                elif _FORM_MARKERS.search(content):
+                    result["frontend_forms"].append(ts_file)
+                elif self._is_api_handler(content, rel):
+                    result["api_handlers"].append(ts_file)
+                else:
+                    # Default: check if it defines types/interfaces (shared types)
+                    if _INTERFACE_RE.search(content) or _ZOD_SCHEMA_RE.search(content):
+                        result["api_handlers"].append(ts_file)
+                    elif _FORM_MARKERS.search(content):
+                        result["frontend_forms"].append(ts_file)
+
+        return {k: v for k, v in result.items() if v}
+
+    def _is_api_handler(self, content: str, rel_path: str) -> bool:
+        """Check if file is an API route handler."""
+        api_markers = (
+            "NextApiRequest",
+            "NextApiResponse",
+            "NextRequest",
+            "NextResponse",
+            "express.Router",
+            "app.get(",
+            "app.post(",
+            "router.get(",
+            "router.post(",
+        )
+        # Path-based detection
+        if "/api/" in rel_path or "/routes/" in rel_path:
+            return True
+        return any(m in content for m in api_markers)
+
+    def extract(self, file_path: Path, keyword: str | None = None) -> list[Schema]:
+        """Extract interfaces, Zod schemas, and form fields from a TypeScript file."""
+        try:
+            content = file_path.read_text(errors="replace")
+        except OSError:
+            return []
+
+        schemas: list[Schema] = []
+        rel_path = str(file_path)
+
+        # Determine layer
+        is_admin = bool(_ADMIN_PATH_RE.search(rel_path))
+        is_form = bool(_FORM_MARKERS.search(content))
+        is_api = self._is_api_handler(content, rel_path)
+
+        # 1. Extract TypeScript interfaces/types
+        for match in _INTERFACE_RE.finditer(content):
+            iface_name = match.group(1)
+
+            if keyword and keyword.lower() not in iface_name.lower():
+                if keyword.lower() not in Path(file_path).stem.lower():
+                    continue
+
+            iface_start = match.start()
+            start_line = content[:iface_start].count("\n") + 1
+
+            # Find closing brace
+            body = self._find_block(content, match.end() - 1)
+            if body is None:
+                continue
+
+            fields = self._extract_ts_fields(body, start_line)
+            if not fields:
+                continue
+
+            layer = "admin_views" if is_admin else "api_handlers"
+            schemas.append(Schema(
+                file=str(file_path),
+                layer=layer,
+                schema_type="ts_interface",
+                name=iface_name,
+                fields=fields,
+            ))
+
+        # 2. Extract Zod schemas
+        for match in _ZOD_SCHEMA_RE.finditer(content):
+            schema_name = match.group(1)
+
+            if keyword and keyword.lower() not in schema_name.lower():
+                if keyword.lower() not in Path(file_path).stem.lower():
+                    continue
+
+            schema_start = match.start()
+            start_line = content[:schema_start].count("\n") + 1
+
+            body = self._find_block(content, match.end() - 1)
+            if body is None:
+                continue
+
+            fields = self._extract_zod_fields(body, start_line)
+            if not fields:
+                continue
+
+            layer = "frontend_forms" if is_form else "api_handlers"
+            schemas.append(Schema(
+                file=str(file_path),
+                layer=layer,
+                schema_type="zod_schema",
+                name=schema_name,
+                fields=fields,
+            ))
+
+        # 3. Extract form fields (register/name attributes)
+        if is_form:
+            form_fields = self._extract_form_fields(content, file_path)
+            if form_fields:
+                layer = "admin_views" if is_admin else "frontend_forms"
+                schemas.append(Schema(
+                    file=str(file_path),
+                    layer=layer,
+                    schema_type="form_fields",
+                    name=f"form@{Path(file_path).stem}",
+                    fields=form_fields,
+                ))
+
+        return schemas
+
+    def _find_block(self, content: str, open_brace_pos: int) -> str | None:
+        """Find the content between matching braces starting at open_brace_pos."""
+        if open_brace_pos >= len(content) or content[open_brace_pos] != "{":
+            return None
+        depth = 0
+        for i in range(open_brace_pos, len(content)):
+            if content[i] == "{":
+                depth += 1
+            elif content[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return content[open_brace_pos:i + 1]
+        return None
+
+    def _extract_ts_fields(self, body: str, base_line: int) -> list[Field]:
+        """Parse fields from a TypeScript interface/type body."""
+        fields: list[Field] = []
+        for match in _TS_FIELD_RE.finditer(body):
+            fname = match.group(1)
+            optional = match.group(2) == "?"
+            ftype = match.group(3).rstrip(";").strip()
+            line = base_line + body[:match.start()].count("\n")
+
+            fields.append(Field(
+                name=fname,
+                type=ftype,
+                line=line,
+                required=not optional,
+                tags={},
+            ))
+        return fields
+
+    def _extract_zod_fields(self, body: str, base_line: int) -> list[Field]:
+        """Parse fields from a Zod schema body."""
+        fields: list[Field] = []
+        for match in _ZOD_FIELD_RE.finditer(body):
+            fname = match.group(1)
+            zod_chain = match.group(2)
+            line = base_line + body[:match.start()].count("\n")
+
+            # Determine type from Zod chain
+            type_match = re.search(r"z\.(\w+)", zod_chain)
+            ftype = type_match.group(1) if type_match else None
+
+            # Determine required/optional
+            required = ".optional()" not in zod_chain and ".nullable()" not in zod_chain
+
+            # Collect validators
+            tags: dict[str, str] = {}
+            validators = re.findall(r"\.(\w+)\(([^)]*)\)", zod_chain)
+            for vname, vargs in validators:
+                if vname in ("min", "max", "email", "url", "regex", "length"):
+                    tags[f"validator_{vname}"] = vargs or "true"
+
+            fields.append(Field(
+                name=fname,
+                type=ftype,
+                line=line,
+                required=required,
+                tags=tags,
+            ))
+        return fields
+
+    def _extract_form_fields(self, content: str, file_path: Path) -> list[Field]:
+        """Extract field names from form registrations and name attributes."""
+        seen: dict[str, int] = {}  # name -> first line number
+        fields: list[Field] = []
+
+        for match in _REGISTER_RE.finditer(content):
+            fname = match.group(1)
+            line = content[:match.start()].count("\n") + 1
+            if fname not in seen:
+                seen[fname] = line
+
+        for match in _NAME_ATTR_RE.finditer(content):
+            fname = match.group(1)
+            line = content[:match.start()].count("\n") + 1
+            if fname not in seen:
+                seen[fname] = line
+
+        for fname, line in seen.items():
+            fields.append(Field(
+                name=fname,
+                type=None,
+                line=line,
+                required=None,
+                tags={"source": "form_field"},
+            ))
+
+        return fields
+
+    def scan_patterns(self, repo_path: Path, scan_path: str | None = None) -> dict:
+        """Scan TypeScript files for naming convention inconsistencies."""
+        root = repo_path / scan_path if scan_path else repo_path
+
+        naming_styles: Counter[str] = Counter()
+        total_fields = 0
+        zod_count = 0
+        interface_count = 0
+
+        for pattern in ("*.ts", "*.tsx"):
+            for ts_file in root.rglob(pattern):
+                if "node_modules" in ts_file.parts or ".next" in ts_file.parts:
+                    continue
+                try:
+                    content = ts_file.read_text(errors="replace")
+                except OSError:
+                    continue
+
+                # Count interfaces and Zod schemas
+                interface_count += len(_INTERFACE_RE.findall(content))
+                zod_count += len(_ZOD_SCHEMA_RE.findall(content))
+
+                # Classify field naming
+                for match in _TS_FIELD_RE.finditer(content):
+                    fname = match.group(1)
+                    naming_styles[_classify_naming(fname)] += 1
+                    total_fields += 1
+
+        return {
+            "extractor": self.name(),
+            "total_fields": total_fields,
+            "naming_styles": dict(naming_styles),
+            "interface_count": interface_count,
+            "zod_schema_count": zod_count,
+        }
+
+
+def _classify_naming(name: str) -> str:
+    """Classify a name as snake_case, camelCase, PascalCase, or other."""
+    if "_" in name:
+        return "snake_case"
+    if name[0:1].isupper():
+        return "PascalCase"
+    if name[0:1].islower() and any(c.isupper() for c in name[1:]):
+        return "camelCase"
+    if name.islower():
+        return "lowercase"
+    return "other"

--- a/scripts/stitch_diff.py
+++ b/scripts/stitch_diff.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Cross-boundary schema diffing for stitch-audit.
+
+Entirely stack-agnostic — works on standardized Schema/Field JSON from
+any extractor. The diff logic doesn't know or care whether the fields
+came from Go structs or Python dataclasses.
+
+Boundaries diffed (by layer, not by language):
+    frontend_forms  ->  api_handlers
+    api_handlers    ->  database_ops
+    database_ops    ->  admin_views
+    frontend_forms  ->  admin_views   (completeness check)
+
+Field name resolution per layer:
+    frontend_forms: field.name (form field name / Zod key)
+    api_handlers:   field.tags["json_tag"] -> fallback field.name
+    database_ops:   field.tags["bson_tag"] -> fallback field.name
+    admin_views:    field.name (TS interface field)
+
+Severity levels:
+    BREAK  — Data lost, data hidden, type mismatch
+    WARN   — Naming inconsistency, validation mismatch, required/optional divergence
+    INFO   — Dead fields, API-only fields, convention drift
+
+Usage:
+    python3 stitch_diff.py <extraction.json> [-o findings.json] [--format json|text]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from extractors.base import Field, Schema, schemas_from_json
+
+
+@dataclass
+class Finding:
+    """A single diff finding between two layers."""
+
+    severity: str  # BREAK | WARN | INFO
+    category: str  # data_lost | data_hidden | type_mismatch | naming | validation | dead_field
+    message: str
+    source_layer: str
+    target_layer: str
+    source_file: str | None = None
+    target_file: str | None = None
+    source_field: str | None = None
+    target_field: str | None = None
+    source_line: int | None = None
+    target_line: int | None = None
+    details: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# Ordered boundaries to diff
+BOUNDARIES = [
+    ("frontend_forms", "api_handlers"),
+    ("api_handlers", "database_ops"),
+    ("database_ops", "admin_views"),
+    ("frontend_forms", "admin_views"),
+]
+
+
+def _canonical(name: str) -> str:
+    """Canonicalize a field name for comparison: lowercase, strip _/-."""
+    return re.sub(r"[_\-]", "", name.lower())
+
+
+def _resolve_name(f: Field, layer: str) -> str:
+    """Resolve the effective field name for a given layer."""
+    if layer == "api_handlers":
+        return f.tags.get("json_tag") or f.name
+    if layer == "database_ops":
+        return f.tags.get("bson_tag") or f.name
+    # frontend_forms, admin_views: use field.name directly
+    return f.name
+
+
+def _collect_fields_by_layer(schemas: list[Schema]) -> dict[str, list[tuple[Field, Schema]]]:
+    """Group fields by layer, pairing each field with its parent schema."""
+    by_layer: dict[str, list[tuple[Field, Schema]]] = {}
+    for schema in schemas:
+        layer = schema.layer
+        if layer not in by_layer:
+            by_layer[layer] = []
+        for f in schema.fields:
+            by_layer[layer].append((f, schema))
+    return by_layer
+
+
+def diff_boundary(
+    source_layer: str,
+    target_layer: str,
+    source_fields: list[tuple[Field, Schema]],
+    target_fields: list[tuple[Field, Schema]],
+) -> list[Finding]:
+    """Diff fields across a single boundary between two layers."""
+    findings: list[Finding] = []
+
+    # Build canonical name maps
+    source_map: dict[str, tuple[Field, Schema]] = {}
+    for f, s in source_fields:
+        name = _resolve_name(f, source_layer)
+        canon = _canonical(name)
+        source_map[canon] = (f, s)
+
+    target_map: dict[str, tuple[Field, Schema]] = {}
+    for f, s in target_fields:
+        name = _resolve_name(f, target_layer)
+        canon = _canonical(name)
+        target_map[canon] = (f, s)
+
+    # Fields in source but not in target -> data lost or data hidden
+    for canon, (sf, ss) in source_map.items():
+        src_name = _resolve_name(sf, source_layer)
+        if canon not in target_map:
+            # Determine severity based on direction
+            if source_layer == "frontend_forms" and target_layer in ("api_handlers", "database_ops"):
+                severity = "BREAK"
+                category = "data_lost"
+                msg = f"Field '{src_name}' sent from {source_layer} but not received in {target_layer}"
+            elif source_layer == "database_ops" and target_layer == "admin_views":
+                severity = "BREAK"
+                category = "data_hidden"
+                msg = f"Field '{src_name}' stored in DB but not displayed in {target_layer}"
+            else:
+                severity = "INFO"
+                category = "dead_field"
+                msg = f"Field '{src_name}' in {source_layer} has no counterpart in {target_layer}"
+
+            findings.append(Finding(
+                severity=severity,
+                category=category,
+                message=msg,
+                source_layer=source_layer,
+                target_layer=target_layer,
+                source_file=ss.file,
+                source_field=src_name,
+                source_line=sf.line,
+            ))
+            continue
+
+        # Field exists in both — check for mismatches
+        tf, ts = target_map[canon]
+        tgt_name = _resolve_name(tf, target_layer)
+
+        # Naming inconsistency (canonical matches but actual names differ)
+        if src_name != tgt_name:
+            findings.append(Finding(
+                severity="WARN",
+                category="naming",
+                message=f"Naming mismatch: '{src_name}' ({source_layer}) vs '{tgt_name}' ({target_layer})",
+                source_layer=source_layer,
+                target_layer=target_layer,
+                source_file=ss.file,
+                target_file=ts.file,
+                source_field=src_name,
+                target_field=tgt_name,
+                source_line=sf.line,
+                target_line=tf.line,
+            ))
+
+        # Type mismatch
+        if sf.type and tf.type and not _types_compatible(sf.type, tf.type):
+            findings.append(Finding(
+                severity="BREAK",
+                category="type_mismatch",
+                message=f"Type mismatch for '{src_name}': {sf.type} ({source_layer}) vs {tf.type} ({target_layer})",
+                source_layer=source_layer,
+                target_layer=target_layer,
+                source_file=ss.file,
+                target_file=ts.file,
+                source_field=src_name,
+                target_field=tgt_name,
+                source_line=sf.line,
+                target_line=tf.line,
+                details={"source_type": sf.type, "target_type": tf.type},
+            ))
+
+        # Required/optional divergence
+        if sf.required is not None and tf.required is not None:
+            if sf.required != tf.required:
+                findings.append(Finding(
+                    severity="WARN",
+                    category="validation",
+                    message=(
+                        f"Required/optional mismatch for '{src_name}': "
+                        f"{'required' if sf.required else 'optional'} ({source_layer}) vs "
+                        f"{'required' if tf.required else 'optional'} ({target_layer})"
+                    ),
+                    source_layer=source_layer,
+                    target_layer=target_layer,
+                    source_file=ss.file,
+                    target_file=ts.file,
+                    source_field=src_name,
+                    target_field=tgt_name,
+                    source_line=sf.line,
+                    target_line=tf.line,
+                ))
+
+    # Fields in target but not in source -> server-set or dead
+    for canon, (tf, ts) in target_map.items():
+        tgt_name = _resolve_name(tf, target_layer)
+        if canon not in source_map:
+            findings.append(Finding(
+                severity="INFO",
+                category="dead_field",
+                message=f"Field '{tgt_name}' in {target_layer} has no source in {source_layer} (possibly server-set)",
+                source_layer=source_layer,
+                target_layer=target_layer,
+                target_file=ts.file,
+                target_field=tgt_name,
+                target_line=tf.line,
+            ))
+
+    return findings
+
+
+# Cross-language type compatibility mappings
+_TYPE_ALIASES: dict[str, set[str]] = {
+    "string": {"string", "str", "text", "varchar"},
+    "number": {"number", "int", "int32", "int64", "float", "float32", "float64", "double", "decimal"},
+    "boolean": {"boolean", "bool"},
+    "array": {"array", "[]", "list", "slice"},
+    "object": {"object", "map", "dict", "bson.m", "interface{}"},
+    "date": {"date", "time.time", "datetime", "timestamp"},
+}
+
+
+def _types_compatible(t1: str, t2: str) -> bool:
+    """Check if two type strings are semantically compatible across languages."""
+    c1 = t1.lower().strip("*&")
+    c2 = t2.lower().strip("*&")
+
+    if c1 == c2:
+        return True
+
+    # Check array types: []string vs string[]
+    if c1.startswith("[]") or c1.endswith("[]") or c2.startswith("[]") or c2.endswith("[]"):
+        base1 = c1.strip("[]")
+        base2 = c2.strip("[]")
+        is_arr1 = "[]" in c1
+        is_arr2 = "[]" in c2
+        if is_arr1 != is_arr2:
+            return False
+        return _types_compatible(base1, base2) if base1 and base2 else True
+
+    # Check aliases
+    for _group, aliases in _TYPE_ALIASES.items():
+        if c1 in aliases and c2 in aliases:
+            return True
+
+    return False
+
+
+def diff_all(schemas: list[Schema]) -> list[Finding]:
+    """Run diff across all standard boundaries."""
+    by_layer = _collect_fields_by_layer(schemas)
+    findings: list[Finding] = []
+
+    for src_layer, tgt_layer in BOUNDARIES:
+        src_fields = by_layer.get(src_layer, [])
+        tgt_fields = by_layer.get(tgt_layer, [])
+        if not src_fields or not tgt_fields:
+            continue
+        findings.extend(diff_boundary(src_layer, tgt_layer, src_fields, tgt_fields))
+
+    return findings
+
+
+def format_text(findings: list[Finding]) -> str:
+    """Format findings as human-readable text."""
+    if not findings:
+        return "No findings."
+
+    lines: list[str] = []
+    by_severity: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_severity.setdefault(f.severity, []).append(f)
+
+    for severity in ("BREAK", "WARN", "INFO"):
+        group = by_severity.get(severity, [])
+        if not group:
+            continue
+        lines.append(f"\n{'='*60}")
+        lines.append(f" {severity} ({len(group)} findings)")
+        lines.append(f"{'='*60}")
+        for f in group:
+            lines.append(f"\n  [{f.category}] {f.message}")
+            if f.source_file:
+                loc = f"    source: {f.source_file}"
+                if f.source_line:
+                    loc += f":{f.source_line}"
+                lines.append(loc)
+            if f.target_file:
+                loc = f"    target: {f.target_file}"
+                if f.target_line:
+                    loc += f":{f.target_line}"
+                lines.append(loc)
+
+    summary = {s: len(fs) for s, fs in by_severity.items()}
+    lines.append(f"\nSummary: {summary}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Cross-boundary schema diffing for stitch-audit"
+    )
+    parser.add_argument("extraction_json", help="Path to extraction JSON file")
+    parser.add_argument("-o", "--output", help="Write output to file")
+    parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args()
+
+    extraction_path = Path(args.extraction_json)
+    if not extraction_path.exists():
+        print(f"Error: {extraction_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    data = extraction_path.read_text()
+    schemas = schemas_from_json(data)
+    print(f"Loaded {len(schemas)} schemas", file=sys.stderr)
+
+    findings = diff_all(schemas)
+    print(
+        f"Found {len(findings)} findings "
+        f"({sum(1 for f in findings if f.severity == 'BREAK')} BREAK, "
+        f"{sum(1 for f in findings if f.severity == 'WARN')} WARN, "
+        f"{sum(1 for f in findings if f.severity == 'INFO')} INFO)",
+        file=sys.stderr,
+    )
+
+    if args.format == "json":
+        output = json.dumps([f.to_dict() for f in findings], indent=2)
+    else:
+        output = format_text(findings)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output)
+        print(f"OK: findings written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stitch_extract.py
+++ b/scripts/stitch_extract.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Stitch-audit extraction orchestrator.
+
+Discovers files in a target repo, delegates extraction to pluggable
+extractor modules, and outputs standardized Schema/Field JSON.
+
+The orchestrator never mentions Go or TypeScript directly — it calls
+get_extractors(repo), gets back whichever extractors match, and runs
+them all. Adding a new stack = add a new file to extractors/, done.
+
+Usage:
+    python3 stitch_extract.py <repo_path> --trace <keyword> [-o output.json]
+    python3 stitch_extract.py <repo_path> --patterns [path] [-o output.json]
+
+Modes:
+    --trace <keyword>   Trace a feature's data flow across all layers
+    --patterns [path]   Scan for convention inconsistencies
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow importing extractors from the same directory
+sys.path.insert(0, str(Path(__file__).parent))
+from extractors import get_extractors
+from extractors.base import Schema, schemas_to_json
+
+
+def trace(repo_path: Path, keyword: str) -> list[Schema]:
+    """Trace a keyword across all layers using all matching extractors."""
+    extractors = get_extractors(repo_path)
+    if not extractors:
+        print(
+            f"Warning: no extractors matched repo at {repo_path}",
+            file=sys.stderr,
+        )
+        return []
+
+    print(
+        f"Extractors active: {', '.join(e.name() for e in extractors)}",
+        file=sys.stderr,
+    )
+
+    all_schemas: list[Schema] = []
+
+    for extractor in extractors:
+        # Discover files by layer
+        discovered = extractor.discover(repo_path, keyword)
+        file_count = sum(len(v) for v in discovered.values())
+        print(
+            f"  [{extractor.name()}] discovered {file_count} files "
+            f"across {len(discovered)} layers",
+            file=sys.stderr,
+        )
+
+        for layer, files in discovered.items():
+            for file_path in files:
+                schemas = extractor.extract(file_path, keyword=keyword)
+                # Ensure relative paths in output
+                for s in schemas:
+                    try:
+                        s.file = str(Path(s.file).relative_to(repo_path))
+                    except ValueError:
+                        pass  # Already relative
+                    # Override layer from discover if extractor set it generically
+                    if s.layer != layer and layer in (
+                        "frontend_forms",
+                        "api_handlers",
+                        "database_ops",
+                        "admin_views",
+                    ):
+                        s.layer = layer
+                all_schemas.extend(schemas)
+
+    return all_schemas
+
+
+def scan_patterns(repo_path: Path, scan_path: str | None = None) -> dict:
+    """Scan for convention inconsistencies using all matching extractors."""
+    extractors = get_extractors(repo_path)
+    if not extractors:
+        print(
+            f"Warning: no extractors matched repo at {repo_path}",
+            file=sys.stderr,
+        )
+        return {"extractors": [], "patterns": []}
+
+    results = []
+    for extractor in extractors:
+        result = extractor.scan_patterns(repo_path, scan_path)
+        results.append(result)
+        print(
+            f"  [{extractor.name()}] scanned {result.get('total_fields', 0)} fields",
+            file=sys.stderr,
+        )
+
+    return {
+        "extractors": [e.name() for e in extractors],
+        "patterns": results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Stitch-audit extraction orchestrator"
+    )
+    parser.add_argument("repo_path", help="Path to target repository")
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--trace",
+        metavar="KEYWORD",
+        help="Trace a feature keyword across all layers",
+    )
+    mode.add_argument(
+        "--patterns",
+        nargs="?",
+        const=None,
+        default=False,
+        metavar="PATH",
+        help="Scan for convention inconsistencies (optional: sub-path)",
+    )
+
+    parser.add_argument("-o", "--output", help="Write output to file instead of stdout")
+    args = parser.parse_args()
+
+    repo = Path(args.repo_path).resolve()
+    if not repo.is_dir():
+        print(f"Error: {repo} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    if args.trace:
+        schemas = trace(repo, args.trace)
+        output = schemas_to_json(schemas)
+        print(f"Extracted {len(schemas)} schemas", file=sys.stderr)
+    elif args.patterns is not False:
+        result = scan_patterns(repo, args.patterns)
+        output = json.dumps(result, indent=2)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output)
+        print(f"OK: output written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stitch_provenance.py
+++ b/scripts/stitch_provenance.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Git provenance enrichment for stitch-audit findings.
+
+For BREAK/WARN findings, traces how each break was introduced using
+git blame and GitHub API (via gh CLI). Answers the question: "Were both
+sides introduced in the same PR? Same issue? Or different work streams?"
+
+Usage:
+    python3 stitch_provenance.py <findings.json> --repo <path> --gh-repo <owner/repo> [-o output.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class BlameInfo:
+    """Result of git blame for a single line."""
+
+    sha: str
+    author: str
+    summary: str
+
+
+@dataclass
+class PRInfo:
+    """GitHub PR linked to a commit."""
+
+    number: int
+    title: str
+    url: str
+    linked_issues: list[str]  # Issue numbers extracted from PR body
+
+
+# Cache to avoid redundant API calls
+_blame_cache: dict[str, BlameInfo] = {}
+_pr_cache: dict[str, PRInfo | None] = {}
+
+
+def git_blame_line(repo_path: Path, file_path: str, line: int) -> BlameInfo | None:
+    """Run git blame on a single line and return commit info."""
+    cache_key = f"{file_path}:{line}"
+    if cache_key in _blame_cache:
+        return _blame_cache[cache_key]
+
+    try:
+        result = subprocess.run(
+            ["git", "blame", "-L", f"{line},{line}", "--porcelain", "--", file_path],
+            capture_output=True,
+            text=True,
+            cwd=repo_path,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+
+        lines = result.stdout.strip().split("\n")
+        if not lines:
+            return None
+
+        sha = lines[0].split()[0]
+        author = ""
+        summary = ""
+        for bl in lines:
+            if bl.startswith("author "):
+                author = bl[7:]
+            elif bl.startswith("summary "):
+                summary = bl[8:]
+
+        info = BlameInfo(sha=sha, author=author, summary=summary)
+        _blame_cache[cache_key] = info
+        return info
+
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def get_pr_for_commit(gh_repo: str, sha: str) -> PRInfo | None:
+    """Look up the PR that introduced a commit via GitHub API."""
+    if sha in _pr_cache:
+        return _pr_cache[sha]
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{gh_repo}/commits/{sha}/pulls",
+             "--jq", '.[0] | {number, title, html_url, body}'],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            _pr_cache[sha] = None
+            return None
+
+        data = json.loads(result.stdout)
+        if not data or not data.get("number"):
+            _pr_cache[sha] = None
+            return None
+
+        # Extract linked issues from PR body
+        linked_issues: list[str] = []
+        body = data.get("body", "") or ""
+        import re
+        for match in re.finditer(r"(?:closes|fixes|resolves)\s+#(\d+)", body, re.IGNORECASE):
+            linked_issues.append(match.group(1))
+
+        pr_info = PRInfo(
+            number=data["number"],
+            title=data.get("title", ""),
+            url=data.get("html_url", ""),
+            linked_issues=linked_issues,
+        )
+        _pr_cache[sha] = pr_info
+        return pr_info
+
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        _pr_cache[sha] = None
+        return None
+
+
+def enrich_finding(
+    finding: dict,
+    repo_path: Path,
+    gh_repo: str,
+) -> dict:
+    """Add git provenance to a single finding."""
+    provenance: dict[str, dict] = {}
+
+    # Enrich source side
+    if finding.get("source_file") and finding.get("source_line"):
+        blame = git_blame_line(repo_path, finding["source_file"], finding["source_line"])
+        if blame:
+            source_prov: dict = {
+                "sha": blame.sha,
+                "author": blame.author,
+                "commit_summary": blame.summary,
+            }
+            pr = get_pr_for_commit(gh_repo, blame.sha)
+            if pr:
+                source_prov["pr_number"] = pr.number
+                source_prov["pr_title"] = pr.title
+                source_prov["pr_url"] = pr.url
+                if pr.linked_issues:
+                    source_prov["linked_issues"] = pr.linked_issues
+            provenance["source"] = source_prov
+
+    # Enrich target side
+    if finding.get("target_file") and finding.get("target_line"):
+        blame = git_blame_line(repo_path, finding["target_file"], finding["target_line"])
+        if blame:
+            target_prov: dict = {
+                "sha": blame.sha,
+                "author": blame.author,
+                "commit_summary": blame.summary,
+            }
+            pr = get_pr_for_commit(gh_repo, blame.sha)
+            if pr:
+                target_prov["pr_number"] = pr.number
+                target_prov["pr_title"] = pr.title
+                target_prov["pr_url"] = pr.url
+                if pr.linked_issues:
+                    target_prov["linked_issues"] = pr.linked_issues
+            provenance["target"] = target_prov
+
+    # Add analysis: same PR? Same issue? Different work streams?
+    if "source" in provenance and "target" in provenance:
+        src = provenance["source"]
+        tgt = provenance["target"]
+
+        if src.get("sha") == tgt.get("sha"):
+            provenance["analysis"] = "same_commit"
+        elif src.get("pr_number") and src["pr_number"] == tgt.get("pr_number"):
+            provenance["analysis"] = "same_pr"
+        elif src.get("linked_issues") and tgt.get("linked_issues"):
+            overlap = set(src["linked_issues"]) & set(tgt["linked_issues"])
+            if overlap:
+                provenance["analysis"] = f"same_issue({'#' + ', #'.join(overlap)})"
+            else:
+                provenance["analysis"] = "different_work_streams"
+        elif src.get("author") == tgt.get("author"):
+            provenance["analysis"] = "same_author_different_prs"
+        else:
+            provenance["analysis"] = "different_work_streams"
+
+    if provenance:
+        finding["provenance"] = provenance
+
+    return finding
+
+
+def enrich_findings(
+    findings: list[dict],
+    repo_path: Path,
+    gh_repo: str,
+) -> list[dict]:
+    """Enrich BREAK/WARN findings with git provenance."""
+    enriched = []
+    for finding in findings:
+        if finding.get("severity") in ("BREAK", "WARN"):
+            finding = enrich_finding(finding, repo_path, gh_repo)
+        enriched.append(finding)
+    return enriched
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Git provenance enrichment for stitch-audit"
+    )
+    parser.add_argument("findings_json", help="Path to findings JSON file")
+    parser.add_argument("--repo", required=True, help="Path to target repo")
+    parser.add_argument("--gh-repo", required=True, help="GitHub owner/repo (e.g. plwp/dgrd)")
+    parser.add_argument("-o", "--output", help="Write output to file")
+    args = parser.parse_args()
+
+    findings_path = Path(args.findings_json)
+    if not findings_path.exists():
+        print(f"Error: {findings_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    repo_path = Path(args.repo).resolve()
+    if not repo_path.is_dir():
+        print(f"Error: {repo_path} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    findings = json.loads(findings_path.read_text())
+    break_warn = [f for f in findings if f.get("severity") in ("BREAK", "WARN")]
+    print(f"Enriching {len(break_warn)} BREAK/WARN findings with provenance", file=sys.stderr)
+
+    enriched = enrich_findings(findings, repo_path, args.gh_repo)
+
+    output = json.dumps(enriched, indent=2)
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output)
+        print(f"OK: enriched findings written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/stitch-audit-prompt.md
+++ b/templates/stitch-audit-prompt.md
@@ -1,0 +1,64 @@
+# Stitch Audit — Semantic Analysis
+
+You are reviewing a cross-layer data flow audit for the **{{KEYWORD}}** feature in **{{REPO}}**.
+
+## Extraction
+
+The following schemas were extracted across the full stack (frontend forms, API handlers, database operations, admin views):
+
+```json
+{{EXTRACTION_JSON}}
+```
+
+## Diff Report
+
+Automated boundary diffing found these mismatches:
+
+```
+{{DIFF_REPORT}}
+```
+
+## Git Provenance
+
+For BREAK/WARN findings, here is the git history showing how each side was introduced:
+
+```json
+{{PROVENANCE}}
+```
+
+## Your Analysis
+
+Go beyond what regex diffing can detect. Look for:
+
+1. **Lost intent** — Is the semantic meaning of a field shifting across boundaries? e.g. a field called `interests` on the form becomes `tags` in the DB, losing the user-facing meaning.
+
+2. **Dead data paths** — Data collected from users but never displayed, queried, or used downstream. This wastes user effort and may create GDPR liability.
+
+3. **Validation gaps** — Frontend allows values that the backend will reject (or vice versa). Look at Zod validators vs Go struct validators vs MongoDB schema constraints.
+
+4. **Convention drift** — Does this feature follow the same naming/typing patterns as the rest of the codebase? Flag divergences that will confuse future developers.
+
+5. **Completeness** — Fields that *should* exist based on the feature's purpose but don't appear anywhere. Think about what a user would expect from this feature.
+
+6. **Provenance interpretation** — Based on the git trail, explain *how* these breaks likely happened. Was it AI context drift (same PR, different passes)? Separate work streams? A refactor that missed one layer?
+
+## Output Format
+
+Structure your response as:
+
+### Summary
+One paragraph: overall health of this feature's data flow.
+
+### Critical Findings
+For each issue, state:
+- **What**: The specific mismatch or gap
+- **Why it matters**: User impact, data loss risk, or maintenance burden
+- **How it likely happened**: Based on provenance data
+- **Suggested fix**: Concrete action (not "review this")
+
+### Observations
+Lower-severity patterns or suggestions that don't need immediate action.
+
+### Verdict
+One of: CLEAN | NEEDS_FIXES | BROKEN
+With a one-line justification.


### PR DESCRIPTION
## Summary

- Adds `/stitch-audit` skill that traces a feature's data flow across the full stack (frontend forms → API handlers → database ops → admin views) and flags where fields get lost, names drift, validation diverges, or intent dies at layer boundaries
- Pluggable extractor architecture — ships Go+MongoDB and TypeScript extractors; adding new stacks is just dropping a file into `scripts/extractors/`
- Two modes: `--trace <keyword>` for full data flow analysis with git provenance and Gemini semantic review, `--patterns [path]` for convention consistency scanning

## New files (9)

| File | Purpose |
|------|---------|
| `.claude/commands/stitch-audit.md` | Skill prompt (trace + patterns modes) |
| `scripts/extractors/base.py` | `Field`, `Schema` types + `Extractor` ABC |
| `scripts/extractors/__init__.py` | Auto-discovery registry |
| `scripts/extractors/go_mongo.py` | Go structs, bson tags, bson.M ops |
| `scripts/extractors/typescript.py` | TS interfaces, Zod schemas, form fields |
| `scripts/stitch_extract.py` | Extraction orchestrator |
| `scripts/stitch_diff.py` | Stack-agnostic cross-boundary diffing |
| `scripts/stitch_provenance.py` | Git blame → PR → issue enrichment |
| `templates/stitch-audit-prompt.md` | Gemini analysis prompt template |

## Test plan

- [x] `base.py` — Field/Schema serialization roundtrip verified
- [x] `__init__.py` — Registry discovers both extractors
- [x] `go_mongo.py` — Extracts structs with json/bson tags from synthetic Go files
- [x] `typescript.py` — Extracts interfaces, Zod schemas, form fields from synthetic TS files
- [x] `stitch_diff.py` — Correctly flags known waitlist breaks (contact_name, interests, painpoint as BREAK/data_lost; phone, facility_count as BREAK/data_hidden)
- [ ] End-to-end: `/stitch-audit plwp/dgrd --trace waitlist`
- [ ] Patterns mode: `/stitch-audit plwp/dgrd --patterns backend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)