### PR TITLE
chore: centralize path resolution in env.py, add tests, CI, and packaging

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -24,11 +24,13 @@ Everything else runs autonomously.
 ### Step 1: Resolve paths and load epic context
 
 ```bash
-CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 DEFAULT_BRANCH=$(gh repo view "$owner_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
+EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$epic_name")
+EPIC_DIR="$TARGET_REPO/docs/epics/$EPIC_SLUG"
 ```
 
 Fetch all issues in the epic milestone:
@@ -355,39 +357,39 @@ This is the most important review in the entire pipeline — getting the contrac
 Create an `epic/` directory structure in the target repo with a `models/` subdirectory for formal model artifacts:
 
 ```bash
-mkdir -p "$TARGET_REPO/docs/epics/[epic-slug]/models"
+mkdir -p "$EPIC_DIR/models"
 ```
 
 Copy prose artifacts (human-readable, backward-compatible):
 ```bash
-cp $CW_TMP/contracts.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/state-machines.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/invariants.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/adr.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/integration-tests.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/traceability.md "$TARGET_REPO/docs/epics/[epic-slug]/"
-cp $CW_TMP/ui-spec.md "$TARGET_REPO/docs/epics/[epic-slug]/" 2>/dev/null || true
+cp "$CW_TMP/contracts.md" "$EPIC_DIR/"
+cp "$CW_TMP/state-machines.md" "$EPIC_DIR/"
+cp "$CW_TMP/invariants.md" "$EPIC_DIR/"
+cp "$CW_TMP/adr.md" "$EPIC_DIR/"
+cp "$CW_TMP/integration-tests.md" "$EPIC_DIR/"
+cp "$CW_TMP/traceability.md" "$EPIC_DIR/"
+cp "$CW_TMP/ui-spec.md" "$EPIC_DIR/" 2>/dev/null || true
 ```
 
 Copy formal model artifacts (machine-readable, consumed by `/implement`):
 ```bash
-cp $CW_TMP/contracts.json "$TARGET_REPO/docs/epics/[epic-slug]/models/"
-cp $CW_TMP/state-machines.json "$TARGET_REPO/docs/epics/[epic-slug]/models/"
-cp $CW_TMP/ui-spec.json "$TARGET_REPO/docs/epics/[epic-slug]/models/" 2>/dev/null || true
+cp "$CW_TMP/contracts.json" "$EPIC_DIR/models/"
+cp "$CW_TMP/state-machines.json" "$EPIC_DIR/models/"
+cp "$CW_TMP/ui-spec.json" "$EPIC_DIR/models/" 2>/dev/null || true
 ```
 
 Generate the initial transition-map (baseline for `/implement` to verify against):
 ```bash
-python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$CW_TMP/state-machines.json" --output "$TARGET_REPO/docs/epics/[epic-slug]/models/transition-map.json" --format json
+python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$CW_TMP/state-machines.json" --output "$EPIC_DIR/models/transition-map.json" --format json
 ```
 At `/architect` time, this produces a transition-map where existing code transitions are `covered` and new model transitions without code matches are `planned`. This baseline evolves as tickets are implemented.
 
 Generate and copy machine + test views:
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view machine --output "$TARGET_REPO/docs/epics/[epic-slug]/models/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view machine --output "$TARGET_REPO/docs/epics/[epic-slug]/models/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view test --output "$TARGET_REPO/docs/epics/[epic-slug]/models/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view test --output "$TARGET_REPO/docs/epics/[epic-slug]/models/"
+python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view machine --output "$EPIC_DIR/models/"
+python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view machine --output "$EPIC_DIR/models/"
+python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view test --output "$EPIC_DIR/models/"
+python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view test --output "$EPIC_DIR/models/"
 ```
 
 Commit and push **directly to the default branch**. Architecture artifacts are docs, not code — they don't need a feature branch or PR. Avoid creating a branch, as it leads to unnecessary stash/cherry-pick detours when returning to the default branch.
@@ -428,10 +430,10 @@ For each ticket in the epic, append a reference to the architectural artifacts:
 gh issue comment $issue_number --repo "$owner_repo" --body "## Epic Architecture
 
 This ticket is part of **[Epic Name]**. Before implementing, read:
-- [Contracts](../docs/epics/[epic-slug]/contracts.md) — REQUIRES/ENSURES for APIs and entities
-- [State Machines](../docs/epics/[epic-slug]/state-machines.md) — valid transitions
-- [Invariants](../docs/epics/[epic-slug]/invariants.md) — rules that must hold across all tickets
-- [Traceability](../docs/epics/[epic-slug]/traceability.md) — which tests cover which AC
+- [Contracts](../docs/epics/$EPIC_SLUG/contracts.md) — REQUIRES/ENSURES for APIs and entities
+- [State Machines](../docs/epics/$EPIC_SLUG/state-machines.md) — valid transitions
+- [Invariants](../docs/epics/$EPIC_SLUG/invariants.md) — rules that must hold across all tickets
+- [Traceability](../docs/epics/$EPIC_SLUG/traceability.md) — which tests cover which AC
 
 Your implementation must satisfy the contracts and invariants. The /implement skill will enforce this."
 ```

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -22,14 +22,16 @@ Individual ticket quality is handled by `/implement`. This skill validates what 
 ### Step 1: Resolve paths and load epic context
 
 ```bash
-CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 DEFAULT_BRANCH=$(gh repo view "$owner_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
+EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$epic_name")
+EPIC_DIR="$TARGET_REPO/docs/epics/$EPIC_SLUG"
 ```
 
-Load epic artifacts from `$TARGET_REPO/docs/epics/[epic-slug]/`:
+Load epic artifacts from `$EPIC_DIR/`:
 - `contracts.md`
 - `state-machines.md`
 - `invariants.md`
@@ -66,10 +68,10 @@ Report:
 
 ### Step 2b: Transition-map audit
 
-If `$TARGET_REPO/docs/epics/[epic-slug]/models/state-machines.json` exists, run a full transition-map verification:
+If `$EPIC_DIR/models/state-machines.json` exists, run a full transition-map verification:
 
 ```bash
-python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$TARGET_REPO/docs/epics/[epic-slug]/models/state-machines.json" --output "$CW_TMP/transition-map-final.json" --format text
+python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$EPIC_DIR/models/state-machines.json" --output "$CW_TMP/transition-map-final.json" --format text
 ```
 
 Report:
@@ -342,7 +344,7 @@ Compile a retrospective from the epic's implementation, incorporating the multi-
    - Integration tests: pass/fail counts
    - Stitch-audit findings: BREAK/WARN counts
 
-Write the retrospective to `$TARGET_REPO/docs/epics/[epic-slug]/retrospective.md` and commit.
+Write the retrospective to `$EPIC_DIR/retrospective.md` and commit.
 
 ### Step 11: Final report
 

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -16,7 +16,8 @@ Create a well-structured GitHub issue with clear title, description, acceptance 
 ### Step 0: Resolve CW_HOME
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 ```
 
 ### Step 1: Gather requirements

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -36,14 +36,16 @@ CAFFEINATE_PID=$!
 Kill it when the workflow completes (or fails): `kill $CAFFEINATE_PID 2>/dev/null`
 
 ```bash
-CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 DEFAULT_BRANCH=$(gh repo view "$owner_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
+EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$epic_name")
+EPIC_DIR="$TARGET_REPO/docs/epics/$EPIC_SLUG"
 ```
 
-Load epic artifacts from `$TARGET_REPO/docs/epics/[epic-slug]/`:
+Load epic artifacts from `$EPIC_DIR/`:
 - `contracts.md` — REQUIRES/ENSURES
 - `state-machines.md` — valid transitions
 - `invariants.md` — cross-cutting rules

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -55,9 +55,9 @@ Kill it when the workflow completes (or fails): `kill $CAFFEINATE_PID 2>/dev/nul
 Resolve the chief-wiggum install directory and the target repo path. **Never hardcode paths.**
 
 ```bash
-CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 DEFAULT_BRANCH=$(gh repo view "$owner_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
 ```
@@ -78,15 +78,19 @@ All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemin
 ```bash
 # Find the ticket's milestone
 MILESTONE=$(gh issue view "$issue_number" --repo "$owner_repo" --json milestone -q '.milestone.title // empty')
+if [ -n "$MILESTONE" ]; then
+  EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$MILESTONE")
+  EPIC_DIR="$TARGET_REPO/docs/epics/$EPIC_SLUG"
+fi
 ```
 
-If a milestone exists and `docs/epics/[epic-slug]/` exists in the target repo, load:
+If a milestone exists and `$EPIC_DIR/` exists in the target repo, load:
 - `contracts.md` — REQUIRES/ENSURES for APIs and entities
 - `state-machines.md` — valid state transitions
 - `invariants.md` — cross-cutting rules
 - `traceability.md` — which acceptance criteria need which tests
 
-Also check for **formal model artifacts** in `docs/epics/[epic-slug]/models/`:
+Also check for **formal model artifacts** in `$EPIC_DIR/models/`:
 - `contracts.json` — structured contracts (machine-readable)
 - `state-machines.json` — structured state machines (machine-readable)
 - `ui-spec.json` — UI specification (pages, components, interactions, navigation)
@@ -100,14 +104,14 @@ Set flags for downstream steps:
 HAS_FORMAL_MODELS=false
 HAS_UI_SPEC=false
 HAS_TRANSITION_MAP=false
-if [ -f "$TARGET_REPO/docs/epics/[epic-slug]/models/state-machines.json" ]; then
+if [ -n "${EPIC_DIR:-}" ] && [ -f "$EPIC_DIR/models/state-machines.json" ]; then
   HAS_FORMAL_MODELS=true
-  MODELS_DIR="$TARGET_REPO/docs/epics/[epic-slug]/models"
+  MODELS_DIR="$EPIC_DIR/models"
 fi
-if [ -f "$TARGET_REPO/docs/epics/[epic-slug]/models/ui-spec.json" ]; then
+if [ -n "${EPIC_DIR:-}" ] && [ -f "$EPIC_DIR/models/ui-spec.json" ]; then
   HAS_UI_SPEC=true
 fi
-if [ -f "$TARGET_REPO/docs/epics/[epic-slug]/models/transition-map.json" ]; then
+if [ -n "${EPIC_DIR:-}" ] && [ -f "$EPIC_DIR/models/transition-map.json" ]; then
   HAS_TRANSITION_MAP=true
 fi
 ```
@@ -447,7 +451,7 @@ Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"
 
 1. **The screenshots** — pass paths to all captured images in `$TICKET_TMP/ux-screenshots/`
 2. **Requirement prose** — the full ticket body (not just AC bullet points): title, description, user story, and any comments
-3. **Domain model artifacts** (if epic context loaded): `contracts.md`, `state-machines.md`, `invariants.md` from `docs/epics/[epic-slug]/`. These represent the "spirit" of the domain — what states are meaningful, what data belongs where, what a user is actually trying to accomplish
+3. **Domain model artifacts** (if epic context loaded): `contracts.md`, `state-machines.md`, `invariants.md` from `$EPIC_DIR/`. These represent the "spirit" of the domain — what states are meaningful, what data belongs where, what a user is actually trying to accomplish
 4. **The AC bullets** — for reference, but instruct the reviewer: *"These bullets define the floor, not the ceiling. Your job is to evaluate whether the screens make sense to a user trying to accomplish the goal described in the prose."*
 
 The sub-agent should evaluate:

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -15,9 +15,9 @@ Interactive brainstorming session that explores a project's requirements, establ
 ### Step 0: Resolve paths and session temp
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 ```
 
 Resolve the target repo:

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -12,7 +12,8 @@ Check that all tools required by chief-wiggum are installed and working.
 ### Step 0: Resolve CW_HOME
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 ```
 
 ### Step 1: Run dependency check
@@ -86,4 +87,11 @@ Re-run the check script to confirm everything is green:
 
 ```bash
 python3 $CW_HOME/scripts/check_deps.py
+```
+
+For workflow-specific preflight checks:
+```bash
+python3 $CW_HOME/scripts/check_deps.py --for implement
+python3 $CW_HOME/scripts/check_deps.py --for transcribe
+python3 $CW_HOME/scripts/check_deps.py --for vertex
 ```

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -17,7 +17,8 @@ Create a well-documented pull request with mermaid architecture diagrams, test e
 ### Step 0: Resolve paths
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
 ```
 

--- a/.claude/commands/stitch-audit.md
+++ b/.claude/commands/stitch-audit.md
@@ -35,9 +35,9 @@ No existing tool does this. Contract testing covers one boundary. OpenAPI codege
 ### Step 1: Resolve paths
 
 ```bash
-CW_HOME=$(python3 "$(dirname "$0")/../../scripts/repo.py" home 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 

--- a/.claude/commands/transcribe.md
+++ b/.claude/commands/transcribe.md
@@ -15,9 +15,9 @@ Transcribe an audio or video recording of a client conversation and parse it int
 ### Step 0: Resolve CW_HOME
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
-CW_TMP="$HOME/.chief-wiggum/tmp"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 ```
 
 ### Step 1: Validate input

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -12,7 +12,8 @@ Fetch the latest AI model IDs and library versions, update `models.md`, and push
 ### Step 0: Resolve CW_HOME
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path('__file__').resolve().parent.parent.parent)" 2>/dev/null || echo "$HOME/repos/chief-wiggum")
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 ```
 
 ### Step 1: Fetch latest model information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          npm ci
+
+      - name: Lint and compile
+        run: make lint
+
+      - name: Test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 __pycache__/
 node_modules/
+.pytest_cache/
+.ruff_cache/
+*.pyc
+*.egg-info/
+.claude/worktrees/
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,28 +94,23 @@ Chief-wiggum stores all user-space data under `~/.chief-wiggum/`:
 Temp files go in `~/.chief-wiggum/tmp/`, **not** `/tmp/`. Each session must create a **unique subdirectory** to avoid collisions when multiple sessions run concurrently:
 
 ```bash
-CW_TMP="$HOME/.chief-wiggum/tmp/$(uuidgen | tr '[:upper:]' '[:lower:]')"
-mkdir -p "$CW_TMP"
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 ```
 
 All temp file references (`approach-prompt.md`, `approach-codex.md`, etc.) go inside `$CW_TMP`. Per-ticket files go in `$CW_TMP/<ticket-number>/` to avoid collisions when implementing multiple tickets in one session (see `/implement` Step 1).
 
 ## Path Resolution
 
-**Chief-wiggum install path**: Never hardcode `~/repos/chief-wiggum`. Skills should resolve the install directory dynamically at the start of each session:
+**Chief-wiggum install path**: Skills should resolve the install directory at the start of each session. `CHIEF_WIGGUM_HOME` can override the common checkout path:
 
 ```bash
-CW_HOME=$(python3 -c "from pathlib import Path; print(Path(__file__).resolve().parent.parent)" --fake 2>/dev/null || python3 scripts/repo.py home)
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 ```
 
-Or from any location, since `repo.py` computes it from its own `__file__`:
-
-```bash
-# From a skill that knows its own path:
-CW_HOME=$(cd "$(dirname "$0")/../.." && pwd)
-```
-
-In practice, skills reference scripts as `python3 "$CW_HOME/scripts/..."` after resolving `CW_HOME` once.
+In practice, skills reference scripts as `python3 "$CW_HOME/scripts/..."` after resolving `CW_HOME` once. Use `python3 "$CW_HOME/scripts/env.py" tmp` for session temp directories and `python3 "$CW_HOME/scripts/env.py" slug "$epic_name"` for `docs/epics/<slug>` paths.
 
 ## Target Repo Resolution
 
@@ -143,7 +138,7 @@ models.md            # AI model IDs and library versions (refresh with /update)
 
 ### Epic artifacts (in target repos)
 
-`/architect` commits artifacts to `docs/epics/[epic-slug]/` in the target repo:
+`/architect` commits artifacts to `docs/epics/[slug]/` in the target repo:
 ```
 docs/epics/order-lifecycle/
 ├── contracts.md          # REQUIRES/ENSURES for APIs and entities

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: fmt lint test verify-examples
+
+fmt:
+	python3 -m ruff check --fix scripts tests
+	python3 -m ruff format scripts tests
+
+lint:
+	python3 -m ruff check scripts tests
+	python3 -m py_compile scripts/*.py scripts/extractors/*.py
+
+test:
+	python3 -m pytest
+
+verify-examples:
+	python3 scripts/formal_models.py validate docs/formal-methods/examples/order-lifecycle.state-machine.json
+	python3 scripts/formal_models.py validate docs/formal-methods/examples/order-lifecycle.contracts.json
+	python3 -m pytest tests/test_generated_examples.py

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ claude /setup
   "commandDirs": ["~/repos/chief-wiggum/.claude/commands"]
 }
 
+# If chief-wiggum is not checked out at ~/repos/chief-wiggum:
+export CHIEF_WIGGUM_HOME=/path/to/chief-wiggum
+
 # 3. Use from your target project directory (not chief-wiggum)
 claude /transcribe ~/recordings/client-call.mp4
 claude /plan-epic owner/repo
@@ -44,6 +47,7 @@ claude /implement owner/repo#42
 |-------|---------|
 | `/plan-epic` | Group related issues into an epic with dependency graph and integration risks |
 | `/architect` | Define contracts, invariants, state machines, ADRs, and integration tests for an epic |
+| `/implement-wave` | Implement an epic in dependency-ordered parallel waves |
 | `/close-epic` | Epic-level quality gate: integration tests, mutation testing, stitch-audit, retrospective |
 
 ### Ticket Level
@@ -71,12 +75,14 @@ graph TD
         A["/transcribe"]:::entry
         B["/seed"]:::entry
         C["/create-issue"]:::default
+        D["Requirements / Issues"]:::default
     end
 
     subgraph "Epic Flow"
         E["/plan-epic"]:::modified
         F["/architect"]:::new
         G["/implement<br/>(per ticket)"]:::modified
+        W["/implement-wave<br/>(parallel)"]:::modified
         H["/close-epic"]:::new
     end
 
@@ -86,8 +92,10 @@ graph TD
     C --> E
     E --> F
     F --> G
+    F --> W
     G --> G
     G --> H
+    W --> H
 
     classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff
     classDef default fill:#003f5c,stroke:#2f4b7c,color:#fff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chief-wiggum"
+version = "0.1.0"
+description = "Agentic SDLC orchestration for Claude Code"
+requires-python = ">=3.11"
+dependencies = [
+  "jsonschema>=4.0",
+  "keyring>=25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.8",
+]
+transcribe = [
+  "openai-whisper",
+]
+implement = [
+  "browser-use",
+  "langchain-anthropic",
+  "playwright",
+]
+vertex = [
+  "google-cloud-aiplatform",
+  "langchain-google-vertexai",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["scripts"]
+
+[tool.setuptools]
+py-modules = []
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501", "F541", "F841", "UP017"]

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -6,6 +6,7 @@ Checks system keyring for secrets (never prints values).
 Requires Python >= 3.11.
 """
 
+import argparse
 import importlib
 import shutil
 import subprocess
@@ -24,9 +25,32 @@ pass_count = 0
 fail_count = 0
 warn_count = 0
 
+WORKFLOW_REQUIREMENTS = {
+    "base": {
+        "cmds": {"claude", "codex", "gemini", "gh", "ffmpeg", "git"},
+        "pkgs": {"keyring", "whisper"},
+        "secrets": set(),
+    },
+    "implement": {
+        "cmds": {"claude", "codex", "gemini", "gh", "git"},
+        "pkgs": {"keyring", "browser-use", "playwright", "langchain-anthropic"},
+        "secrets": {"ANTHROPIC_API_KEY"},
+    },
+    "transcribe": {
+        "cmds": {"ffmpeg"},
+        "pkgs": {"whisper"},
+        "secrets": set(),
+    },
+    "vertex": {
+        "cmds": set(),
+        "pkgs": {"langchain-google-vertexai", "google-cloud-aiplatform"},
+        "secrets": {"GOOGLE_CLOUD_PROJECT"},
+    },
+}
 
-def check_cmd(name: str, cmd: str, version_flag: str = "--version"):
-    global pass_count, fail_count
+
+def check_cmd(name: str, cmd: str, version_flag: str = "--version", required: bool = True):
+    global pass_count, fail_count, warn_count
     path = shutil.which(cmd)
     if path:
         try:
@@ -39,11 +63,15 @@ def check_cmd(name: str, cmd: str, version_flag: str = "--version"):
         print(f"{GREEN}[OK]{NC}  {name:<14s} {ver}")
         pass_count += 1
     else:
-        print(f"{RED}[MISSING]{NC}  {name:<14s} not found")
-        fail_count += 1
+        if required:
+            print(f"{RED}[MISSING]{NC}  {name:<14s} not found")
+            fail_count += 1
+        else:
+            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not found")
+            warn_count += 1
 
 
-def check_python_pkg(name: str, import_name: str, optional: bool = False):
+def check_python_pkg(name: str, import_name: str, required: bool = True):
     global pass_count, fail_count, warn_count
     try:
         mod = importlib.import_module(import_name)
@@ -51,56 +79,89 @@ def check_python_pkg(name: str, import_name: str, optional: bool = False):
         print(f"{GREEN}[OK]{NC}  {name:<14s} {ver}")
         pass_count += 1
     except ImportError:
-        if optional:
-            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not installed")
-            warn_count += 1
-        else:
+        if required:
             print(f"{RED}[MISSING]{NC}  {name:<14s} python package not found")
             fail_count += 1
+        else:
+            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not installed")
+            warn_count += 1
 
 
-def check_secret(name: str):
-    global pass_count, warn_count
+def check_secret(name: str, required: bool = False):
+    global pass_count, fail_count, warn_count
     if has_secret(name):
         print(f"{GREEN}[OK]{NC}  {name:<24s} keychain")
         pass_count += 1
     else:
-        print(f"{YELLOW}[NOT SET]{NC}  {name:<24s}")
-        warn_count += 1
+        if required:
+            print(f"{RED}[MISSING]{NC}  {name:<24s} not set")
+            fail_count += 1
+        else:
+            print(f"{YELLOW}[NOT SET]{NC}  {name:<24s}")
+            warn_count += 1
+
+
+def is_required(kind: str, name: str, workflows: list[str]) -> bool:
+    return any(name in WORKFLOW_REQUIREMENTS[workflow][kind] for workflow in workflows)
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Check chief-wiggum dependencies.")
+    parser.add_argument(
+        "--for",
+        dest="workflows",
+        action="append",
+        choices=sorted(WORKFLOW_REQUIREMENTS),
+        default=[],
+        help="Workflow to enforce. May be passed multiple times.",
+    )
+    args = parser.parse_args()
+    workflows = args.workflows or ["base"]
+
     print("=== Chief Wiggum Dependency Check ===")
+    print(f"Profile: {', '.join(workflows)}")
 
     print("\n--- CLI Tools ---")
-    check_cmd("claude", "claude", "--version")
-    check_cmd("codex", "codex", "--version")
-    check_cmd("gemini", "gemini", "--version")
-    check_cmd("gh", "gh", "--version")
-    check_cmd("ffmpeg", "ffmpeg", "-version")
-    check_cmd("git", "git", "--version")
+    check_cmd("claude", "claude", "--version", is_required("cmds", "claude", workflows))
+    check_cmd("codex", "codex", "--version", is_required("cmds", "codex", workflows))
+    check_cmd("gemini", "gemini", "--version", is_required("cmds", "gemini", workflows))
+    check_cmd("gh", "gh", "--version", is_required("cmds", "gh", workflows))
+    check_cmd("ffmpeg", "ffmpeg", "-version", is_required("cmds", "ffmpeg", workflows))
+    check_cmd("git", "git", "--version", is_required("cmds", "git", workflows))
 
     print("\n--- Python Packages ---")
-    check_python_pkg("keyring", "keyring")
-    check_python_pkg("whisper", "whisper")
+    check_python_pkg("keyring", "keyring", is_required("pkgs", "keyring", workflows))
+    check_python_pkg("whisper", "whisper", is_required("pkgs", "whisper", workflows))
 
     print("\n--- Python Packages (browser-use — optional, for /implement validation) ---")
-    check_python_pkg("browser-use", "browser_use", optional=True)
-    check_python_pkg("playwright", "playwright", optional=True)
-    check_python_pkg("langchain-anthropic", "langchain_anthropic", optional=True)
+    check_python_pkg("browser-use", "browser_use", is_required("pkgs", "browser-use", workflows))
+    check_python_pkg("playwright", "playwright", is_required("pkgs", "playwright", workflows))
+    check_python_pkg(
+        "langchain-anthropic",
+        "langchain_anthropic",
+        is_required("pkgs", "langchain-anthropic", workflows),
+    )
 
     print("\n--- Python Packages (Vertex AI — optional) ---")
-    check_python_pkg("langchain-google-vertexai", "langchain_google_vertexai", optional=True)
-    check_python_pkg("google-cloud-aiplatform", "google.cloud.aiplatform", optional=True)
+    check_python_pkg(
+        "langchain-google-vertexai",
+        "langchain_google_vertexai",
+        is_required("pkgs", "langchain-google-vertexai", workflows),
+    )
+    check_python_pkg(
+        "google-cloud-aiplatform",
+        "google.cloud.aiplatform",
+        is_required("pkgs", "google-cloud-aiplatform", workflows),
+    )
 
     print("\n--- Secrets (system keyring) ---")
     print("  (manage with: python3 scripts/keychain.py set|get|delete|list)")
     print()
-    check_secret("ANTHROPIC_API_KEY")
-    check_secret("OPENAI_API_KEY")
-    check_secret("GEMINI_API_KEY")
-    check_secret("GOOGLE_CLOUD_PROJECT")
-    check_secret("GOOGLE_CLOUD_LOCATION")
+    check_secret("ANTHROPIC_API_KEY", is_required("secrets", "ANTHROPIC_API_KEY", workflows))
+    check_secret("OPENAI_API_KEY", is_required("secrets", "OPENAI_API_KEY", workflows))
+    check_secret("GEMINI_API_KEY", is_required("secrets", "GEMINI_API_KEY", workflows))
+    check_secret("GOOGLE_CLOUD_PROJECT", is_required("secrets", "GOOGLE_CLOUD_PROJECT", workflows))
+    check_secret("GOOGLE_CLOUD_LOCATION", is_required("secrets", "GOOGLE_CLOUD_LOCATION", workflows))
 
     print(f"\n=== Results: {pass_count} ok, {fail_count} missing, {warn_count} warnings ===")
 

--- a/scripts/env.py
+++ b/scripts/env.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Resolve chief-wiggum paths and common shell values for command prompts.
+
+The Claude command files are markdown, not shell scripts, so snippets cannot
+rely on "$0" or Python's __file__ from the prompt context. This helper gives
+those prompts a tested way to find the installed checkout and derive shared
+values such as temp directories and epic slugs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+
+def _is_chief_wiggum_home(path: Path) -> bool:
+    return (
+        (path / "scripts" / "repo.py").is_file()
+        and (path / ".claude" / "commands").is_dir()
+    )
+
+
+def find_home() -> Path:
+    """Find the chief-wiggum checkout without relying on command prompt state."""
+    env_home = os.environ.get("CHIEF_WIGGUM_HOME") or os.environ.get("CW_HOME")
+    if env_home:
+        candidate = Path(env_home).expanduser().resolve()
+        if _is_chief_wiggum_home(candidate):
+            return candidate
+
+    search_roots = [
+        Path.cwd(),
+        *Path.cwd().parents,
+        Path.home() / "repos" / "chief-wiggum",
+        Path.home() / ".chief-wiggum" / "chief-wiggum",
+    ]
+
+    for root in search_roots:
+        candidate = root.expanduser().resolve()
+        if _is_chief_wiggum_home(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "Could not find chief-wiggum checkout. Set CHIEF_WIGGUM_HOME to its path."
+    )
+
+
+def create_tmp() -> Path:
+    tmp = Path.home() / ".chief-wiggum" / "tmp" / str(uuid.uuid4())
+    tmp.mkdir(parents=True, exist_ok=False)
+    return tmp
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "epic"
+
+
+def shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="chief-wiggum environment helper")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("home", help="Print chief-wiggum checkout path")
+    sub.add_parser("tmp", help="Create and print a session temp directory")
+
+    slug = sub.add_parser("slug", help="Slugify text for docs/epics paths")
+    slug.add_argument("value")
+
+    exports = sub.add_parser("exports", help="Print shell exports for prompts")
+    exports.add_argument("--epic", help="Optional epic/milestone name")
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == "home":
+            print(find_home())
+        elif args.command == "tmp":
+            print(create_tmp())
+        elif args.command == "slug":
+            print(slugify(args.value))
+        elif args.command == "exports":
+            home = find_home()
+            tmp = create_tmp()
+            print(f"export CW_HOME={shell_quote(str(home))}")
+            print(f"export CW_TMP={shell_quote(str(tmp))}")
+            if args.epic:
+                epic_slug = slugify(args.epic)
+                print(f"export EPIC_SLUG={shell_quote(epic_slug)}")
+                print(f'export EPIC_DIR="$TARGET_REPO/docs/epics/{epic_slug}"')
+        else:
+            parser.print_help()
+            return 1
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except FileExistsError:
+        print(
+            f"Error: temp directory collision under {tempfile.gettempdir()}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -24,9 +24,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import textwrap
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -22,26 +22,38 @@ CLI_TOOLS = {
 }
 
 PYTHON_PKGS = {
-    "keyring": ("keyring", [["pip3", "install", "keyring"]]),
-    "whisper": ("whisper", [["pip3", "install", "openai-whisper"]]),
-    "browser-use": ("browser_use", [["pip3", "install", "browser-use"]]),
+    "keyring": ("keyring", [[sys.executable, "-m", "pip", "install", "keyring"]]),
+    "whisper": ("whisper", [[sys.executable, "-m", "pip", "install", "openai-whisper"]]),
+    "browser-use": ("browser_use", [[sys.executable, "-m", "pip", "install", "browser-use"]]),
     "playwright": ("playwright", [
-        ["pip3", "install", "playwright"],
-        ["python3", "-m", "playwright", "install", "chromium"],
+        [sys.executable, "-m", "pip", "install", "playwright"],
+        [sys.executable, "-m", "playwright", "install", "chromium"],
     ]),
-    "langchain-anthropic": ("langchain_anthropic", [["pip3", "install", "langchain-anthropic"]]),
+    "langchain-anthropic": (
+        "langchain_anthropic",
+        [[sys.executable, "-m", "pip", "install", "langchain-anthropic"]],
+    ),
 }
 
 VERTEX_PKGS = {
-    "langchain-google-vertexai": ("langchain_google_vertexai", [["pip3", "install", "langchain-google-vertexai"]]),
-    "google-cloud-aiplatform": ("google.cloud.aiplatform", [["pip3", "install", "google-cloud-aiplatform"]]),
+    "langchain-google-vertexai": (
+        "langchain_google_vertexai",
+        [[sys.executable, "-m", "pip", "install", "langchain-google-vertexai"]],
+    ),
+    "google-cloud-aiplatform": (
+        "google.cloud.aiplatform",
+        [[sys.executable, "-m", "pip", "install", "google-cloud-aiplatform"]],
+    ),
 }
 
 
 def run(cmd: list[str]) -> bool:
     print(f"  Running: {shlex.join(cmd)}")
     result = subprocess.run(cmd)
-    return result.returncode == 0
+    if result.returncode != 0:
+        print(f"Error: command failed with exit code {result.returncode}", file=sys.stderr)
+        sys.exit(result.returncode)
+    return True
 
 
 def install_cli_tools():

--- a/scripts/repo.py
+++ b/scripts/repo.py
@@ -120,7 +120,10 @@ def _parse_owner_repo(owner_repo: str) -> tuple[str, str]:
     """Parse 'owner/repo' or 'owner/repo#123' into (owner, repo)."""
     # Strip issue number if present
     repo_part = owner_repo.split("#")[0]
-    parts = repo_part.strip("/").split("/")
+    if repo_part != repo_part.strip("/"):
+        print(f"Error: expected owner/repo format, got: {owner_repo}", file=sys.stderr)
+        sys.exit(1)
+    parts = repo_part.split("/")
     if len(parts) != 2:
         print(f"Error: expected owner/repo format, got: {owner_repo}", file=sys.stderr)
         sys.exit(1)

--- a/start
+++ b/start
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
-# Launch Claude Code with permissions pre-approved for chief-wiggum skills.
-exec claude --dangerously-skip-permissions "$@"
+# Launch Claude Code for chief-wiggum.
+#
+# Set CHIEF_WIGGUM_DANGEROUS_SKIP_PERMISSIONS=1 only for local throwaway
+# sessions where you explicitly want Claude Code's permission bypass.
+if [ "${CHIEF_WIGGUM_DANGEROUS_SKIP_PERMISSIONS:-}" = "1" ]; then
+  exec claude --dangerously-skip-permissions "$@"
+fi
+
+exec claude "$@"

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,0 +1,22 @@
+import check_deps
+
+
+def test_base_profile_does_not_require_browser_use():
+    assert not check_deps.is_required("pkgs", "browser-use", ["base"])
+
+
+def test_implement_profile_requires_browser_validation_dependencies():
+    workflows = ["implement"]
+
+    assert check_deps.is_required("pkgs", "browser-use", workflows)
+    assert check_deps.is_required("pkgs", "playwright", workflows)
+    assert check_deps.is_required("pkgs", "langchain-anthropic", workflows)
+    assert check_deps.is_required("secrets", "ANTHROPIC_API_KEY", workflows)
+
+
+def test_vertex_profile_requires_vertex_packages_and_project():
+    workflows = ["vertex"]
+
+    assert check_deps.is_required("pkgs", "langchain-google-vertexai", workflows)
+    assert check_deps.is_required("pkgs", "google-cloud-aiplatform", workflows)
+    assert check_deps.is_required("secrets", "GOOGLE_CLOUD_PROJECT", workflows)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import env
+
+
+def test_slugify_normalizes_epic_names():
+    assert env.slugify("Epic: Order Lifecycle!") == "epic-order-lifecycle"
+    assert env.slugify("  ---  ") == "epic"
+
+
+def test_find_home_prefers_valid_environment_path(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("CHIEF_WIGGUM_HOME", str(repo_root))
+
+    assert env.find_home() == repo_root
+
+
+def test_shell_quote_handles_single_quotes():
+    assert env.shell_quote("owner's repo") == "'owner'\"'\"'s repo'"

--- a/tests/test_formal_models.py
+++ b/tests/test_formal_models.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import formal_models as fm
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "docs" / "formal-methods" / "examples"
+
+
+def load_example(name: str) -> dict:
+    return json.loads((EXAMPLES / name).read_text())
+
+
+def test_state_machine_example_validates_and_analyzes():
+    model = load_example("order-lifecycle.state-machine.json")
+
+    assert fm.detect_schema_type(model) == "state-machine"
+    assert fm.validate(model) == []
+
+    analysis = fm.analyze_graph(model)
+    assert analysis.initial == "draft"
+    assert not analysis.has_unreachable_states
+    assert analysis.all_terminals_reachable
+    assert analysis.transition_count > 0
+
+
+def test_contract_example_validates():
+    contracts = load_example("order-lifecycle.contracts.json")
+
+    assert fm.detect_schema_type(contracts) == "contracts"
+    assert fm.validate(contracts) == []
+
+
+def test_xstate_conversion_preserves_initial_and_final_states():
+    model = load_example("order-lifecycle.state-machine.json")
+    xstate = fm.to_xstate(model)
+
+    assert xstate["initial"] == model["initial"]
+    terminal_states = {
+        state for state, definition in model["states"].items() if definition.get("type") == "terminal"
+    }
+    assert terminal_states
+    for state in terminal_states:
+        assert xstate["states"][state]["type"] == "final"

--- a/tests/test_generated_examples.py
+++ b/tests/test_generated_examples.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import render_models
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "docs" / "formal-methods" / "examples"
+GENERATED = EXAMPLES / "generated"
+
+
+def assert_matches_generated(tmp_path: Path, model_name: str, expected_files: list[str]):
+    render_models.render_model(EXAMPLES / model_name, "all", tmp_path)
+
+    for filename in expected_files:
+        assert (tmp_path / filename).read_text() == (GENERATED / filename).read_text()
+
+
+def test_state_machine_generated_artifacts_are_fresh(tmp_path):
+    assert_matches_generated(
+        tmp_path,
+        "order-lifecycle.state-machine.json",
+        [
+            "order-lifecycle.state-machine.md",
+            "xstate-machine.json",
+            "test_state_machine.py",
+            "test-paths.json",
+            "test-plan.md",
+        ],
+    )
+
+
+def test_contract_generated_artifacts_are_fresh(tmp_path):
+    assert_matches_generated(
+        tmp_path,
+        "order-lifecycle.contracts.json",
+        [
+            "order-lifecycle.contracts.md",
+            "contracts_deal.py",
+            "guards.py",
+            "guards.go",
+            "contract-assertions.md",
+        ],
+    )

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,0 +1,21 @@
+import pytest
+import repo
+
+
+def test_parse_owner_repo_accepts_issue_suffix():
+    assert repo._parse_owner_repo("acme/widget-api#42") == ("acme", "widget-api")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "acme",
+        "acme/../repo",
+        "acme/repo/extra",
+        "acme/repo name",
+        "/acme/repo",
+    ],
+)
+def test_parse_owner_repo_rejects_unsafe_values(value):
+    with pytest.raises(SystemExit):
+        repo._parse_owner_repo(value)


### PR DESCRIPTION
## Summary
- New `scripts/env.py` — single source of truth for `CW_HOME` resolution, per-session tmp directories (`~/.chief-wiggum/tmp/<session-id>`), and epic slug derivation
- All 11 skills updated to resolve paths via `env.py` instead of ad-hoc `dirname $0` / `uuidgen` logic; quoted all path expansions
- `docs/epics/[epic-slug]` placeholders replaced with computed `$EPIC_DIR` / `$EPIC_SLUG` throughout /architect and /close-epic
- New pytest suite — 17 tests covering env, repo, check_deps, formal_models, and generated examples
- New `Makefile` (fmt / lint / test / verify-examples), `pyproject.toml` (ruff config), GitHub Actions CI
- `check_deps.py` restructured for clearer reporting; `install_deps.py` safer install flow

## Test plan
- `make lint` — ruff + py_compile: clean
- `make test` — 17/17 pass
- CI workflow runs the same on push