### PR TITLE
feat: domain ground-truth ingestion + unresolved-unknowns gates (#14, #15, #16)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -44,8 +44,11 @@ Also load any existing architecture docs from the target repo:
 ```bash
 cat "$TARGET_REPO/ARCHITECTURE.md" 2>/dev/null
 cat "$TARGET_REPO/CLAUDE.md" 2>/dev/null
+cat "$TARGET_REPO/docs/domain-context.md" 2>/dev/null
 ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 ```
+
+`docs/domain-context.md` (written by `/seed` Step 2.5) is the **ground truth for data contracts**: canonical metric definitions, real schema names, source caveats, and mined use cases — each with citations. If the epic touches an existing data source and this file doesn't exist, run the `/seed` Step 2.5 ingestion now (semantic layer, schema introspection, transformation-repo history) before writing any data contract. Contracts authored from guessed table/column names are how query layers get built against names that don't exist.
 
 ### Step 2: Explore the codebase
 
@@ -102,6 +105,8 @@ For every entity and API endpoint the epic touches, define:
 - Operations with REQUIRES (preconditions), ENSURES (postconditions), ERROR CASES, state transitions touched, invariants touched
 - Each condition carries a `description` (human-readable) and an `expression` (machine-checkable pseudo-code)
 - Provenance: every element carries `derived_from` linking back to tickets, acceptance criteria, or epic invariants
+
+**Ground every data fact in a real source.** Field names, metric definitions, and external identifiers must come from `docs/domain-context.md` (or direct introspection) — cite the source in `notes`. Where a fact genuinely cannot be confirmed yet (external system unavailable, awaiting client answer), write an explicit `TBD:` marker in the field — e.g. `"notes": "TBD: confirm column name against dbt model orders_daily"`. Markers are machine-detected and **gate dependent tickets** in `/implement-wave`; a silent guess does not.
 
 **Verifier-in-the-loop**: After the sub-agent produces `contracts.json`, validate it:
 ```bash
@@ -289,6 +294,9 @@ python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/state-machines.jso
 
 # Graph analysis — check for structural defects
 python3 "$CW_HOME/scripts/formal_models.py" graph "$CW_TMP/state-machines.json"
+
+# Unresolved-unknowns scan — TBD/UNRESOLVED/PLACEHOLDER markers across all artifacts
+python3 "$CW_HOME/scripts/check_unresolved.py" "$CW_TMP" --format text
 ```
 
 Check the graph analysis output for:
@@ -298,6 +306,8 @@ Check the graph analysis output for:
 - **Invariant count**: Ensure invariants exist — zero invariants means the model is likely too shallow
 
 If any of these checks fail, fix the JSON models and regenerate prose before proceeding.
+
+For the unresolved scan: each finding is either **resolvable now** (go confirm it — introspect the schema, read the transformation repo, ask the user) or **genuinely external** (keep the marker). Resolve everything resolvable before proceeding. Surviving markers are not errors, but they MUST be surfaced in Step 6 and Step 9, and they will gate dependent tickets in `/implement-wave` — never silently delete a marker without actually resolving the fact behind it.
 
 #### 5b. Multi-AI validation
 
@@ -337,6 +347,7 @@ Flag genuine disagreements for the user in Step 6.
 - **Contracts**: key entities and their REQUIRES/ENSURES
 - **Invariants**: the cross-cutting rules with IDs
 - **Model health**: graph analysis — any unreachable states, dead states, missing paths
+- **Open unknowns**: every surviving `TBD:`/`UNRESOLVED:` marker, which tickets each one blocks, and the plan to resolve it (who/what/when)
 - **Test coverage preview**: number of test paths that will be mechanically generated (from the test view)
 - ADR: key decisions with trade-offs
 - Integration tests: what will be validated at epic close
@@ -468,6 +479,10 @@ Your implementation must satisfy the contracts and invariants. The /implement sk
 
 ### Coverage gaps
 - [Any AC without a planned test — these need attention during implementation]
+
+### Open unknowns (blockers)
+- [Each surviving TBD/UNRESOLVED marker: what it is, which tickets it blocks, how to resolve it]
+- [Omit this section only if `check_unresolved.py` reports zero findings]
 
 ### Next steps
 1. `/implement owner/repo#[first-ticket]` — start implementing (will inherit epic context + formal models)

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -94,6 +94,16 @@ Gate criteria:
 
 Findings feed into Step 9 (multi-AI analysis) and the final report.
 
+### Step 2c: Unresolved-unknowns audit
+
+No epic closes with open unknowns in its artifacts:
+
+```bash
+python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format text
+```
+
+Any surviving `TBD:`/`UNRESOLVED:`/`PLACEHOLDER` marker is a finding: either the fact was resolved during implementation (update the artifact with the real value and a citation) or it wasn't (which means some ticket was built on a guess — trace it and verify what actually shipped). Target: zero markers.
+
 ### Step 3: Integration test execution
 
 Run the integration tests defined in `integration-tests.md`. These test cross-ticket behaviour that no individual ticket validates.

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -53,6 +53,14 @@ Load epic artifacts from `$EPIC_DIR/`:
 
 **If epic artifacts don't exist, STOP.** Run `/architect` first. Wave implementation without contracts is unsafe — parallel tickets will diverge on design decisions.
 
+**Scan for unresolved external unknowns** in the epic artifacts:
+
+```bash
+python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json > "$CW_TMP/unresolved.json"
+```
+
+Each finding carries the tickets it blocks (from `derived_from` provenance). Tickets listed in `blocked_tickets` must NOT be implemented on a guess — see Step 2 and Step 4.
+
 ### Step 2: Build the wave plan
 
 Fetch all open tickets in the epic milestone:
@@ -93,6 +101,11 @@ Compute waves using topological sort:
 
 Also identify **integration risks** from the epic plan — tickets within the same wave that touch the same files/components. Flag these for the merge step.
 
+**Apply the unresolved-unknowns gate.** For each ticket in `blocked_tickets` (from Step 1's scan):
+1. First try to **resolve the unknown now** — introspect the real schema, read the source repo, check the external service. Many "unknowns" are 10 minutes of research. If resolved: update the artifact (remove the marker, cite the source), commit, and un-gate the ticket.
+2. If the unknown needs the user (credentials, a client answer, a business decision): mark the ticket **GATED** in the wave plan with a one-line "resolve X first" reason, and move it (plus its transitive dependents) to a later wave or out of the plan.
+3. Never launch a GATED ticket on a guessed value. A placeholder that ships is a production incident with a delay timer.
+
 Present the wave plan to the user:
 
 ```markdown
@@ -109,6 +122,9 @@ Present the wave plan to the user:
 ### Wave 3 (parallel, after Wave 2 merges)
 - #44 - Order admin UI (M) — depends on #43
   ⚠️ Integration risk: shares OrderList component with #46 (Wave 2)
+
+### Gated (unresolved unknowns — not scheduled)
+- #47 - Revenue rollup query — ⛔ GATED: contracts.json carries "TBD: confirm orders_daily column names against dbt model" — resolve before implementing
 
 ### Estimated timeline
 - Waves: 3
@@ -142,7 +158,9 @@ git status --porcelain  # must be empty
 
 For each wave, in order:
 
-**Before launching a wave**, check for failed dependencies. If any ticket in a previous wave failed, remove all downstream dependents from the current and future waves. Recompute the wave plan with the remaining tickets. Report to the user which tickets were dropped and why:
+**Before launching a wave**, re-run the unresolved scan (`check_unresolved.py "$EPIC_DIR" --format json`) — artifacts may have changed since the plan was made. Any ticket in the wave that is still blocked by an unresolved marker is held back (resolve it or defer it; never implement on a guess).
+
+Also check for failed dependencies. If any ticket in a previous wave failed, remove all downstream dependents from the current and future waves. Recompute the wave plan with the remaining tickets. Report to the user which tickets were dropped and why:
 
 ```markdown
 ⚠️ Skipping #44 (depends on #43 which failed in Wave 2)
@@ -409,3 +427,4 @@ After all waves complete:
 - **Max-parallel limits API pressure.** Two concurrent tickets means up to 8 simultaneous AI API calls (3-4 consultations per ticket). Respect rate limits. Increase only with high-tier API access.
 - **Failed tickets don't block the wave.** If one ticket in a wave fails, the other tickets in that wave can still merge. The failed ticket is retried or deferred to a later wave.
 - **Pre-flight catches auth failures early.** Discovering expired Codex auth 20 minutes into a 3-ticket wave wastes all 3 tickets' work. Check before launching.
+- **Unknowns gate work; they don't ride along.** A `TBD:` in an artifact means "we don't actually know this yet". Implementing a dependent ticket anyway converts the unknown into silent wrong code. Resolve it or defer the ticket — those are the only two options.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -118,6 +118,12 @@ fi
 
 These artifacts are **hard constraints** on the implementation. The coding sub-agent MUST satisfy them. The review checklist MUST verify them. When formal models exist, test generation in Step 5 uses them for mechanical path coverage.
 
+**Unresolved-unknowns gate**: scan the epic artifacts for markers this ticket would inherit:
+```bash
+python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json
+```
+If any finding's `tickets` list includes this ticket (or the finding sits on an entity/operation this ticket implements), do NOT implement on the guessed value. Resolve the unknown first — introspect the real source, read the upstream repo, or ask the user — update the artifact with a citation, then proceed. Building a query layer against `TBD:` schema names produces code that compiles, passes mocked tests, and fails on first contact with reality.
+
 If no epic context exists, proceed without it — the skill works standalone too.
 
 All subsequent steps should work within `$TARGET_REPO`. Use `$CW_HOME` for chief-wiggum scripts/templates. Use `$CW_TMP` for temporary files (not `/tmp/`). Use `$DEFAULT_BRANCH` instead of hardcoding `main`.

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -49,6 +49,24 @@ If yes, send an **Explore sub-agent** (`subagent_type: "Explore"`, thoroughness:
 
 Continue the conversation while the agent works.
 
+### Step 2.5: Ingest domain ground truth
+
+Most seed failures are not bad architecture — they're architecture built on **guessed facts**. Before brainstorming, find out what real sources of truth exist and ingest them. Ask the user:
+
+1. **Existing data model** — "Does this product read from or write to an existing data source? Where does its truth live?" If yes, ingest it **before any data contracts are written**:
+   - The semantic/modeling layer (dbt, Dataform, LookML, a metrics store) — canonical metric definitions, dimensions, measures
+   - The physical schema — introspect it (run `\d`/`SHOW CREATE TABLE`/`db.collection.findOne()` against a real instance, or read migration files). Never trust table/column names from memory or docs alone.
+   - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **Explore sub-agent** over the repo history; caveats live in PR descriptions, not schemas.
+2. **Real use cases** — "Where do real user requests live?" (issue tracker, support queue, team chat channels, existing dashboards). If accessible, mine them with a sub-agent to derive:
+   - The question patterns the product must answer (these become golden eval cases for `/architect` traceability)
+   - The dimensions/measures/entities users actually slice by
+   - Domain caveats stated by the team ("ignore test accounts", "EU revenue is net of VAT")
+   - Demo scenarios and UI suggestion prompts/empty-state copy grounded in real requests
+
+Write the findings to `$CW_TMP/domain-context.md` with **citations** (file paths, PR links, ticket links) for every claim. Facts that cannot be confirmed against a real source are written with an explicit `TBD:` marker — these gate dependent work later (`/architect` and `/implement-wave` run `check_unresolved.py` against artifacts).
+
+If the product has no existing data source and no usage history (true greenfield), note that in `domain-context.md` and move on — don't invent ceremony.
+
 ### Step 3: Interactive architecture brainstorm
 
 Work through the key architecture decisions with the user. Don't assume — ask. Cover:
@@ -75,7 +93,7 @@ Once the key decisions are made, write them to `$CW_TMP/architecture-decisions.m
 - Each decision with rationale
 - Patterns carried forward from sister projects
 - Lessons learned to apply
-- Open questions (deferred)
+- Open questions (deferred) — anything that must be confirmed against an external source gets a `TBD:` marker so downstream gates catch it
 
 Show the user a summary and confirm the decisions look right before proceeding.
 
@@ -109,19 +127,21 @@ When both reviews are back:
 
 ### Step 7: Commit architecture decisions
 
-Copy the finalised architecture decisions to the target repo as `ARCHITECTURE.md`. Update `CLAUDE.md` if the tech stack has changed from what was previously documented.
+Copy the finalised architecture decisions to the target repo as `ARCHITECTURE.md`. If Step 2.5 produced domain context, copy it to `docs/domain-context.md` — `/architect` loads it before writing data contracts. Update `CLAUDE.md` if the tech stack has changed from what was previously documented.
 
 Commit and push:
 ```bash
 cd "$TARGET_DIR"
-git add ARCHITECTURE.md CLAUDE.md
+mkdir -p docs
+cp "$CW_TMP/domain-context.md" docs/domain-context.md 2>/dev/null || true
+git add ARCHITECTURE.md CLAUDE.md docs/domain-context.md
 git commit -m "Add architecture decisions from seed session"
 git push
 ```
 
 ### Step 8: Seed the backlog
 
-Based on the architecture decisions and requirements docs, plan out the initial issues. Organise by:
+Based on the architecture decisions, domain context, and requirements docs, plan out the initial issues. Where Step 2.5 mined real use cases, fold them in: derived question patterns become acceptance criteria and golden eval cases, and team-stated caveats become explicit constraints on the relevant issues. Organise by:
 - **Foundation** — Repo scaffold, infrastructure, database, auth, audit trail
 - **Core engine** — AI pipeline, knowledge base, streaming
 - **Milestone 1** — First user-facing value (often a free tier or demo)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ A collection of Claude Code skills that orchestrate a full development pipeline 
 - **Two-tier quality**: Epic-level contracts and invariants prevent cross-ticket bugs; ticket-level TDD and structured review prevent per-ticket bugs
 - **Test-first**: Write failing tests before implementation code. The objective is "make these tests pass", not "implement this feature"
 - **Contracts are executable**: Every REQUIRES/ENSURES from `/architect` becomes a runtime guard in the code. The review checklist verifies this
+- **Unknowns gate work**: Facts that can't be confirmed against a real source are marked `TBD:`/`UNRESOLVED:` in artifacts. `scripts/check_unresolved.py` detects them; `/implement-wave` refuses to build dependent tickets on a guess
+- **Ground truth before contracts**: For products on existing data sources, `/seed` ingests the semantic layer, physical schema, and transformation-repo history into `docs/domain-context.md` before `/architect` writes data contracts
 - **Human-in-the-loop**: User confirms at every checkpoint (requirements, approach, final review)
 - **Skills are markdown prompts**: They instruct Claude Code what to do, not executable code
 - **Scripts are Python**: All helpers are Python — no bash scripts

--- a/scripts/check_unresolved.py
+++ b/scripts/check_unresolved.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Scan epic architecture artifacts for unresolved external unknowns.
+
+The marker convention: any artifact string (JSON model field or markdown prose)
+containing an UPPERCASE `TBD`, `UNRESOLVED`, or `PLACEHOLDER` token marks a fact
+that could not be confirmed against a real source (schema names, config values,
+external endpoints, metric definitions, ...). Authors write e.g.
+
+    "expression": "orders.total_cents > 0  -- TBD: confirm column against dbt model"
+    "UNRESOLVED: which Cloudflare account hosts the prod stream?"
+
+Unknowns must gate dependent work, not silently propagate into implementation.
+/architect runs this after synthesis and reports open unknowns as blockers;
+/implement-wave runs it before each wave and gates tickets whose artifacts
+carry markers.
+
+CLI:
+    python3 scripts/check_unresolved.py <epic-dir-or-file> [...] [--format text|json]
+
+Exit codes: 0 = no unresolved markers, 1 = markers found, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# Uppercase-only, whole-word: lowercase "tbd"/"placeholder" in normal prose
+# (e.g. an input field's placeholder text) must not trip the gate.
+MARKER_RE = re.compile(r"\b(TBD|UNRESOLVED|PLACEHOLDER)\b")
+
+SCANNED_SUFFIXES = {".json", ".md"}
+
+
+@dataclass
+class Finding:
+    file: str
+    location: str  # JSON path or "line N"
+    marker: str
+    text: str
+    tickets: list[str]  # tickets this finding blocks (from derived_from provenance)
+
+
+def _provenance_tickets(ancestors: list) -> list[str]:
+    """Collect ticket refs from derived_from blocks on the value or its ancestors."""
+    tickets: list[str] = []
+    for node in ancestors:
+        if not isinstance(node, dict):
+            continue
+        for prov in node.get("derived_from", []) or []:
+            if isinstance(prov, dict) and prov.get("type") in ("ticket", "acceptance_criterion"):
+                ref = str(prov.get("ref", ""))
+                if ref and ref not in tickets:
+                    tickets.append(ref)
+    return tickets
+
+
+def scan_json(path: Path) -> list[Finding]:
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"WARNING: cannot parse {path}: {exc}", file=sys.stderr)
+        return []
+
+    findings: list[Finding] = []
+
+    def walk(node, json_path: str, ancestors: list) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, f"{json_path}.{key}", ancestors + [node])
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                walk(item, f"{json_path}[{i}]", ancestors)
+        elif isinstance(node, str):
+            match = MARKER_RE.search(node)
+            if match:
+                findings.append(Finding(
+                    file=str(path),
+                    location=json_path.lstrip("."),
+                    marker=match.group(1),
+                    text=node.strip()[:200],
+                    tickets=_provenance_tickets(ancestors),
+                ))
+
+    walk(data, "", [])
+    return findings
+
+
+def scan_markdown(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as exc:
+        print(f"WARNING: cannot read {path}: {exc}", file=sys.stderr)
+        return []
+    for lineno, line in enumerate(lines, start=1):
+        match = MARKER_RE.search(line)
+        if match:
+            ticket_refs = re.findall(r"#\d+", line)
+            findings.append(Finding(
+                file=str(path),
+                location=f"line {lineno}",
+                marker=match.group(1),
+                text=line.strip()[:200],
+                tickets=ticket_refs,
+            ))
+    return findings
+
+
+def collect_files(targets: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for target in targets:
+        if target.is_dir():
+            files.extend(sorted(p for p in target.rglob("*") if p.suffix in SCANNED_SUFFIXES))
+        elif target.suffix in SCANNED_SUFFIXES:
+            files.append(target)
+    return files
+
+
+def scan(targets: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in collect_files(targets):
+        if path.suffix == ".json":
+            findings.extend(scan_json(path))
+        else:
+            findings.extend(scan_markdown(path))
+    return findings
+
+
+def blocked_tickets(findings: list[Finding]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for f in findings:
+        for ticket in f.tickets:
+            counts[ticket] = counts.get(ticket, 0) + 1
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan epic artifacts for unresolved external unknowns (TBD/UNRESOLVED/PLACEHOLDER markers)"
+    )
+    parser.add_argument("targets", nargs="+", help="Epic directory or artifact file(s) to scan")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    targets = [Path(t) for t in args.targets]
+    missing = [t for t in targets if not t.exists()]
+    if missing:
+        for t in missing:
+            print(f"ERROR: {t} does not exist", file=sys.stderr)
+        return 2
+
+    findings = scan(targets)
+    blocked = blocked_tickets(findings)
+
+    if args.format == "json":
+        print(json.dumps({
+            "findings": [asdict(f) for f in findings],
+            "blocked_tickets": blocked,
+            "count": len(findings),
+        }, indent=2))
+    else:
+        if not findings:
+            print("OK: no unresolved markers found")
+        else:
+            print(f"UNRESOLVED: {len(findings)} marker(s) found\n")
+            for f in findings:
+                tickets = f" [blocks {', '.join(f.tickets)}]" if f.tickets else ""
+                print(f"  {f.file} ({f.location}){tickets}")
+                print(f"    {f.marker}: {f.text}")
+            if blocked:
+                print("\nTickets blocked by unresolved unknowns:")
+                for ticket, count in sorted(blocked.items()):
+                    print(f"  {ticket}: {count} unresolved marker(s)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_unresolved.py
+++ b/tests/test_check_unresolved.py
@@ -1,0 +1,95 @@
+"""Tests for scripts/check_unresolved.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import check_unresolved  # noqa: E402
+
+
+def test_clean_artifacts_produce_no_findings(tmp_path):
+    (tmp_path / "contracts.json").write_text(json.dumps({
+        "entities": [{"name": "Order", "description": "An order placed by a customer"}],
+    }))
+    (tmp_path / "invariants.md").write_text("INV-001: every order has a customer_id\n")
+    assert check_unresolved.scan([tmp_path]) == []
+
+
+def test_json_marker_found_with_location_and_provenance(tmp_path):
+    model = {
+        "entities": [{
+            "name": "Metric",
+            "derived_from": [{"type": "ticket", "ref": "#42"}],
+            "fields": [{
+                "name": "total",
+                "notes": "TBD: confirm column name against the dbt model",
+            }],
+        }],
+    }
+    (tmp_path / "contracts.json").write_text(json.dumps(model))
+    findings = check_unresolved.scan([tmp_path])
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.marker == "TBD"
+    assert "entities[0].fields[0].notes" in f.location
+    assert f.tickets == ["#42"]
+
+
+def test_markdown_marker_found_with_line_number(tmp_path):
+    (tmp_path / "adr.md").write_text("# ADR\n\nUNRESOLVED: which region hosts prod? (#7)\n")
+    findings = check_unresolved.scan([tmp_path])
+    assert len(findings) == 1
+    assert findings[0].location == "line 3"
+    assert findings[0].tickets == ["#7"]
+
+
+def test_lowercase_placeholder_prose_does_not_trip(tmp_path):
+    model = {"pages": {"/": {"components": {
+        "search": {"type": "input", "description": "search box with placeholder text 'find a video'"},
+    }}}}
+    (tmp_path / "ui-spec.json").write_text(json.dumps(model))
+    (tmp_path / "notes.md").write_text("the input shows placeholder copy until focus\n")
+    assert check_unresolved.scan([tmp_path]) == []
+
+
+def test_blocked_tickets_aggregation(tmp_path):
+    model = {
+        "entities": [{
+            "name": "A",
+            "derived_from": [{"type": "ticket", "ref": "#10"}],
+            "description": "TBD: confirm source",
+            "fields": [{"name": "x", "notes": "PLACEHOLDER until schema introspection"}],
+        }],
+    }
+    (tmp_path / "contracts.json").write_text(json.dumps(model))
+    findings = check_unresolved.scan([tmp_path])
+    assert check_unresolved.blocked_tickets(findings) == {"#10": 2}
+
+
+def test_cli_exit_codes(tmp_path):
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    (clean / "contracts.json").write_text(json.dumps({"entities": []}))
+
+    dirty = tmp_path / "dirty"
+    dirty.mkdir()
+    (dirty / "adr.md").write_text("TBD: confirm\n")
+
+    script = SCRIPTS / "check_unresolved.py"
+    ok = subprocess.run([sys.executable, str(script), str(clean)], capture_output=True, text=True)
+    assert ok.returncode == 0
+    assert "OK" in ok.stdout
+
+    bad = subprocess.run([sys.executable, str(script), str(dirty), "--format", "json"],
+                         capture_output=True, text=True)
+    assert bad.returncode == 1
+    payload = json.loads(bad.stdout)
+    assert payload["count"] == 1
+
+    missing = subprocess.run([sys.executable, str(script), str(tmp_path / "nope")],
+                             capture_output=True, text=True)
+    assert missing.returncode == 2


### PR DESCRIPTION
## Summary

Implements the domain-context third of retro #10's fixes. Verified motivation: the dogeared-coach review showed the pipeline's artifacts can be excellent, but the analytics-app retro showed what happens when contracts are authored from guesses — this PR makes guessing structurally impossible to ship.

### #15 — unresolved unknowns gate dependent work
- New `scripts/check_unresolved.py`: scans epic artifacts (JSON models + markdown) for uppercase `TBD`/`UNRESOLVED`/`PLACEHOLDER` markers. JSON findings carry the tickets they block via `derived_from` provenance. Lowercase prose ("placeholder text in the input") does not trip it. Exit 1 on findings, `--format json` for orchestration.
- `/architect` Step 5a runs the scan; open unknowns appear at the Step 6 checkpoint and as an **Open unknowns (blockers)** section in the report.
- `/implement-wave` scans before planning and re-scans before each wave: blocked tickets are resolved now or marked GATED and deferred — never implemented on a guess.
- `/implement` applies the same gate for single tickets; `/close-epic` Step 2c requires zero markers to close.

### #14 — ingest the real data model before writing data contracts
- `/seed` Step 2.5: when the product sits on an existing data source, ingest the semantic/modeling layer, introspect the physical schema, and sweep the transformation repo's history/PRs for caveats (deprecations, normalization rules, test-record exclusions) — into `docs/domain-context.md` with citations.
- `/architect` loads it and requires every data fact in `contracts.json` to cite a real source or carry an explicit `TBD:` marker.

### #16 — mine real use cases
- `/seed` Step 2.5 also mines issue trackers / team chat / dashboards for real question patterns, dimensions/measures, and team-stated caveats → golden eval cases, UI suggestion prompts, demo scenarios; folded into issue creation in Step 8.

## Test plan
- `make lint` clean, `make test` 23/23 (6 new tests for the scanner: provenance mapping, lowercase non-trip, CLI exit codes)

Closes #14, closes #15, closes #16