### PR TITLE
feat: visual design contract + design-fidelity gate (#11, #12, #13)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -167,6 +167,14 @@ The UI spec defines:
    - `confirm-dialog`: "browser confirm() for destructive actions"
 4. **Interaction contracts**: For each interactive component, what happens when the user does something: `{ trigger: "click", action: "open-sidebar", target: "settings-panel" }`. This is what prevents "is this a dropdown or a tab or a modal?" confusion.
 5. **Navigation graph**: XState-format state machine where pages are states and links are transitions. Reuses the same format as data state machines.
+6. **Visual design contract** (`design` section): the part that makes "on-brand" checkable. A frontend can satisfy every interaction contract and still ship generic and ugly — 121 passing tests prove nothing about how it looks. Define:
+   - `source`: where the design comes from — the design system / reference product / brand kit discovered by `/seed` Step 3, with references (URLs, repo paths, reference screenshots). Only `net-new` if `/seed` confirmed nothing exists to match.
+   - `tokens`: concrete values — colors (primary required; include brand gradients), typography (fonts + scale), spacing, radii, shadows. Derived from the seed design source when present; deliberate choices (with rationale in the ADR) when net-new. **Never leave a component library's default theme as the implicit answer.**
+   - `component_library`: which library and whether to `adopt`, `extend`, or go `custom` — sub-agents must not hand-roll components when the contract says adopt.
+   - `assets`: logo/wordmark/illustrations/reference screenshots, each with `applies_to` pages. Per-page `design_refs` link pages to the reference screenshots they must visually match.
+   - `voice`: tone and empty-state guidelines, so empty states get personality instead of "No data".
+
+   The design contract is consumed by the design-fidelity gate in `/implement` Step 9 — screenshots of the rendered app are reviewed against these tokens and references, and a frontend that ignores them fails the ticket.
 
 **Critical constraint**: Every component that could be implemented as multiple UI patterns (dropdown vs tab vs modal vs page) MUST have an explicit interaction contract specifying which pattern to use.
 

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -218,7 +218,8 @@ For each ticket in the current wave (up to `--max-parallel`):
      - Step 6: Implement to make tests green
      - Step 7: Multi-AI code review (Codex + Gemini in parallel)
      - Step 8: Apply review fixes, run full test suite, run linting, verify acceptance criteria
-     - Step 9: Browser-use/E2E validation (unless `--skip-browser-use` was passed)
+     - Step 9: UX sanity + design-fidelity gate for frontend tickets — render the app, capture screenshots to `$TICKET_TMP/ux-screenshots/`, review against the ui-spec design contract. Save the screenshots; the orchestrator attaches them to the wave report.
+     - Step 10: Browser-use/E2E validation (unless `--skip-browser-use` was passed)
    - **HARD RULES**:
      - Do NOT create or merge pull requests. Return the branch name and a summary.
      - You are in a git worktree. Verify with `git rev-parse --show-toplevel`. Never operate on the main checkout.
@@ -260,6 +261,7 @@ If any PRs were created by a sub-agent during this wave (matching ticket branch 
 2. Run the full test suite
 3. Run linting
 4. Verify the branch has the expected commits
+5. **For frontend tickets**: verify screenshots exist in `$TICKET_TMP/ux-screenshots/` and LOOK at them. A sub-agent reporting "design review passed" without screenshots is a sub-agent that skipped the gate. If the epic has a design contract and the screenshots show default-theme output, the ticket is not done.
 
 This is the same principle as `/implement` Step 8 — the orchestrator is the quality gate, not the sub-agent.
 
@@ -391,11 +393,13 @@ Ask the user which approach they prefer, or if direct-to-main is fine.
 | 3 | #44 | merged | ~20 min |
 
 ### Per-ticket summary
-| Ticket | Branch | Tests | Review | Merge | Issues |
-|--------|--------|-------|--------|-------|--------|
-| #42 | feat/42-... | 12 pass | 2 fixes applied | clean | — |
-| #43 | feat/43-... | 8 pass | 1 fix applied | clean | — |
-| #44 | feat/44-... | 15 pass | 3 fixes applied | conflict resolved | OrderList merge |
+| Ticket | Branch | Tests | Review | Design fidelity | Merge | Issues |
+|--------|--------|-------|--------|-----------------|-------|--------|
+| #42 | feat/42-... | 12 pass | 2 fixes applied | n/a (backend) | clean | — |
+| #43 | feat/43-... | 8 pass | 1 fix applied | n/a (backend) | clean | — |
+| #44 | feat/44-... | 15 pass | 3 fixes applied | ✓ screenshots reviewed, tokens bound | conflict resolved | OrderList merge |
+
+For frontend tickets, link the screenshot directories so the human can see what shipped.
 
 ### Merge conflicts resolved: N
 - [Details of each conflict and how it was resolved]

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -249,7 +249,7 @@ Launch a **Sonnet sub-agent** in a worktree (`subagent_type: "general-purpose"`,
 - The epic contracts and traceability matrix (if they exist)
 - The target repo's test framework and conventions
 - **If formal models exist**: the generated test plan (`$TICKET_TMP/test-plan.md`), test paths (`$TICKET_TMP/test-paths.json`), contract assertions (`$TICKET_TMP/contract-assertions.md`), Hypothesis skeleton (`$TICKET_TMP/test_state_machine_skeleton.py`), and guard templates (`$TICKET_TMP/guard_templates.py`)
-- **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions.
+- **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).
 - You are working in a **git worktree** (created by the `isolation: "worktree"` parameter). At the start, run `git rev-parse --show-toplevel` to discover your working directory. Work ONLY in this directory. Do NOT `cd` to `$TARGET_REPO` — that is the main checkout, not your worktree. If `git rev-parse --show-toplevel` returns the same path as the main checkout, STOP and report the error. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
@@ -404,7 +404,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 
 If ANY verification fails: fix it directly, or re-launch the coding sub-agent with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
 
-### Step 9: UX sanity pass
+### Step 9: UX sanity + design-fidelity gate
 
 **Skip this step if**:
 - `--skip-browser-use` was explicitly passed, OR
@@ -415,7 +415,9 @@ If ANY verification fails: fix it directly, or re-launch the coding sub-agent wi
 
 If any signal is positive, run the step.
 
-**Goal**: Verify that the implemented UI aligns with the *spirit* of the requirements — information architecture, menu coherence, field exposure, and contextual clarity — not just that the acceptance criteria bullets are mechanically satisfied. Functional tests can pass while screens feel wrong. This step catches that.
+**Goal**: Verify that the implemented UI aligns with the *spirit* of the requirements — information architecture, menu coherence, field exposure, contextual clarity — AND with the **visual design contract** (`ui-spec.json` → `design` section): tokens applied, brand assets present, reference screenshots matched. Functional tests can pass while screens feel wrong or ship off-brand; this is the only step in the loop that actually *looks* at the result. "Build + tests green" is NOT sufficient to call a frontend ticket done.
+
+(Real example: dogeared-coach shipped 131 passing tests and 40 green E2E specs with a client-facing playlist numbered "0., 1., ..." and a completely unthemed stock component library. One screenshot caught both.)
 
 #### Phase 1: Capture screenshots
 
@@ -451,14 +453,31 @@ If services need to be running, start them as in Step 8 before capturing. After 
 
 If screenshot capture fails entirely (services won't start, no browser tooling at all), note it as a gap and move on — do not block.
 
-#### Phase 2: Opus UX review
+#### Phase 1b: Mechanical token check (if a design contract exists)
+
+If `$MODELS_DIR/ui-spec.json` has a `design` section, run a cheap mechanical check before the AI review: for each color token value in `design.tokens.colors`, grep the frontend's theme/CSS files for it. If the primary brand color appears nowhere in the codebase, the frontend ignored the design contract — that's a hard finding, no screenshot review needed to call it.
+
+```bash
+python3 -c "
+import json, sys
+spec = json.load(open('$MODELS_DIR/ui-spec.json'))
+for name, value in spec.get('design', {}).get('tokens', {}).get('colors', {}).items():
+    print(f'{name}\t{value}')
+" | while IFS=$'\t' read -r name value; do
+  grep -ri --include='*.css' --include='*.scss' --include='*.ts' --include='*.tsx' -F "$value" "$WORKTREE/ui/src" >/dev/null 2>&1 \
+    && echo "token $name: BOUND" || echo "token $name: MISSING ($value not found in styles)"
+done
+```
+
+#### Phase 2: Opus UX + design-fidelity review
 
 Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) and give it:
 
 1. **The screenshots** — pass paths to all captured images in `$TICKET_TMP/ux-screenshots/`
 2. **Requirement prose** — the full ticket body (not just AC bullet points): title, description, user story, and any comments
 3. **Domain model artifacts** (if epic context loaded): `contracts.md`, `state-machines.md`, `invariants.md` from `$EPIC_DIR/`. These represent the "spirit" of the domain — what states are meaningful, what data belongs where, what a user is actually trying to accomplish
-4. **The AC bullets** — for reference, but instruct the reviewer: *"These bullets define the floor, not the ceiling. Your job is to evaluate whether the screens make sense to a user trying to accomplish the goal described in the prose."*
+4. **The visual design contract** (if `ui-spec.json` has a `design` section): the design tokens, component-library binding, brand assets, voice guidelines, and — critically — any `reference-screenshot` assets whose `applies_to` covers the pages this ticket touches. Pass the reference image paths so the reviewer can compare side by side. Include the Phase 1b token-check output.
+5. **The AC bullets** — for reference, but instruct the reviewer: *"These bullets define the floor, not the ceiling. Your job is to evaluate whether the screens make sense to a user trying to accomplish the goal described in the prose, and whether they honor the visual design contract."*
 
 The sub-agent should evaluate:
 
@@ -468,10 +487,16 @@ The sub-agent should evaluate:
 - **State legibility**: Can a user tell what state they're in? Is it clear what happened after they submitted a form or completed an action?
 - **Contextual fit**: Does the screen match what the ticket is trying to accomplish? If the domain model says "an order in PENDING state should only show a Confirm button, not a Cancel button", does the screen reflect that?
 - **Missing context**: Is there information the user would need to make a decision that isn't shown?
+- **Design fidelity** (when a design contract exists):
+  - Are the design tokens actually applied — brand colors, typography, spacing — or is this the component library's default theme?
+  - Do the screens match the reference screenshots for these pages (layout density, treatment, hierarchy)?
+  - Are the brand assets present where `applies_to` says they should be (logo in nav, illustration in empty states)?
+  - Does visible copy match the voice guidelines (empty states with personality, not "No data")?
+  - **Surface-level correctness a human would catch in 2 seconds**: 0-indexed lists shown to users, raw enum values in labels, placeholder copy, truncated text, misaligned elements, debug output visible in the UI.
 
 The sub-agent returns findings in the same confidence categories as the code review:
 
-- **High-confidence**: Clear UX problems — missing confirmation message after submit, a Cancel button that should not appear in PENDING state, a form field exposing an internal DB ID. These have an obvious fix.
+- **High-confidence**: Clear UX problems — missing confirmation message after submit, a Cancel button that should not appear in PENDING state, a form field exposing an internal DB ID — and clear design-contract violations: design tokens not applied (Phase 1b MISSING), a page that plainly doesn't match its reference screenshot, a missing brand asset, user-visible 0-indexing or debug output. These have an obvious fix and **fail the ticket until fixed**.
 - **Medium-confidence**: Likely issues that need a quick look — a menu label that's technically correct but potentially confusing, an empty state with no guidance copy. These should be applied but are worth a quick sanity check.
 - **Low-confidence**: Subjective observations or minor polish — layout density, label wording choices, optional affordances the ticket doesn't require. Flag for awareness, do not block.
 
@@ -486,12 +511,14 @@ Apply findings using the same pattern as Step 8:
 
 After applying fixes, re-run the relevant Playwright specs (if they exist) to confirm nothing regressed.
 
-**Fold findings into the PR body**: Add a `## UX sanity` section to the PR body (Step 11) listing:
+**Fold findings into the PR body**: Add a `## UX & design fidelity` section to the PR body (Step 11) listing:
 - What flow was walked
 - High/medium findings found and fixed
 - Low-confidence observations noted
+- Token-check results (Phase 1b) when a design contract exists
+- **Attach the screenshots**: commit them under the PR or upload via `gh` so the human reviewer sees what shipped, not just that tests passed. At minimum, embed the key before/after screenshot paths in the PR body.
 
-If no screenshots could be captured, note "UX sanity: no frontend tooling available — skipped" in the PR body.
+If no screenshots could be captured, that is a **blocker for frontend tickets with a design contract** — fix the tooling (start the services, install Playwright) rather than skipping. Only note "UX sanity: no frontend tooling available — skipped" for repos with no design contract and no browser tooling at all.
 
 ### Step 10: Browser-use validation
 

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -73,14 +73,23 @@ Work through the key architecture decisions with the user. Don't assume — ask.
 
 1. **Backend language/framework** — Consider: what will the AI writing the code produce best? What ecosystem fits the problem domain?
 2. **Frontend stack** — If the user has a preference, use it. If not, recommend modern defaults.
-3. **Database** — Schema flexibility vs relational integrity. Audit trail requirements. Multi-tenancy model.
-4. **AI/LLM integration** — Which model provider? RAG vs context stuffing? Structured output? Streaming?
-5. **Infrastructure & deployment** — Cloud provider, cost optimisation, IaC.
-6. **Authentication & authorisation** — Who are the users? What roles? Any anonymous flows?
-7. **Streaming & real-time** — SSE, WebSockets, or polling? What needs to be real-time?
-8. **Document/file generation** — Any server-side rendering? What formats?
-9. **Mobile vs desktop** — What's the primary device?
-10. **Multi-tenancy** — Needed from day one? What model?
+3. **Design source & brand** — the most important UI question, asked FIRST, not as an afterthought:
+   - "Is there an existing design system, component library, or brand we must match?"
+   - "Is this replicating or extending an existing product? If so, where does its UI live?"
+   - If yes to either, **ingest the design source as a first-class input**:
+     - Extract design tokens (palette including brand gradients, typography scale, spacing, radii) from the existing CSS/theme files or brand kit
+     - Prefer **adopting** the existing component library over hand-rolling
+     - Capture reference screenshots/URLs of the product to match; for replication projects, clone or link the existing UI source as a styling reference
+   - If genuinely net-new, still make deliberate design decisions now: a primary color with a reason, a typography choice, a voice for empty states. "Default component-library theme" is not a decision — it's how brandless admin-tool UIs ship (see dogeared-coach retro).
+   - Record the design source and tokens in the architecture decisions — `/architect` turns them into the `design` section of `ui-spec.json`, and the design-fidelity gate in `/implement` reviews rendered screenshots against them.
+4. **Database** — Schema flexibility vs relational integrity. Audit trail requirements. Multi-tenancy model.
+5. **AI/LLM integration** — Which model provider? RAG vs context stuffing? Structured output? Streaming?
+6. **Infrastructure & deployment** — Cloud provider, cost optimisation, IaC.
+7. **Authentication & authorisation** — Who are the users? What roles? Any anonymous flows?
+8. **Streaming & real-time** — SSE, WebSockets, or polling? What needs to be real-time?
+9. **Document/file generation** — Any server-side rendering? What formats?
+10. **Mobile vs desktop** — What's the primary device?
+11. **Multi-tenancy** — Needed from day one? What model?
 
 Incorporate findings from the sister project exploration (Step 2) as they arrive.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ A collection of Claude Code skills that orchestrate a full development pipeline 
 - **Contracts are executable**: Every REQUIRES/ENSURES from `/architect` becomes a runtime guard in the code. The review checklist verifies this
 - **Unknowns gate work**: Facts that can't be confirmed against a real source are marked `TBD:`/`UNRESOLVED:` in artifacts. `scripts/check_unresolved.py` detects them; `/implement-wave` refuses to build dependent tickets on a guess
 - **Ground truth before contracts**: For products on existing data sources, `/seed` ingests the semantic layer, physical schema, and transformation-repo history into `docs/domain-context.md` before `/architect` writes data contracts
+- **The loop must look at the UI**: "Build + tests green" never closes a frontend ticket. `/architect` writes a visual design contract (ui-spec `design` section: tokens, component-library binding, reference screenshots); `/implement` Step 9 renders the app, screenshots it, and reviews against that contract
 - **Human-in-the-loop**: User confirms at every checkpoint (requirements, approach, final review)
 - **Skills are markdown prompts**: They instruct Claude Code what to do, not executable code
 - **Scripts are Python**: All helpers are Python — no bash scripts

--- a/docs/formal-methods/examples/kanban-app-ui-spec.json
+++ b/docs/formal-methods/examples/kanban-app-ui-spec.json
@@ -6,8 +6,16 @@
       "navbar": {
         "type": "navbar",
         "label": "Global Navigation Bar",
-        "description": "Persistent top bar — brand blue (#0079bf), 44px height. Always visible.",
-        "children": ["nav-logo", "nav-boards-dropdown", "nav-templates-link", "nav-spacer", "nav-search", "nav-notifications", "nav-user-menu"],
+        "description": "Persistent top bar \u2014 brand blue (#0079bf), 44px height. Always visible.",
+        "children": [
+          "nav-logo",
+          "nav-boards-dropdown",
+          "nav-templates-link",
+          "nav-spacer",
+          "nav-search",
+          "nav-notifications",
+          "nav-user-menu"
+        ],
         "responsive": {
           "mobile": "visible",
           "desktop": "visible"
@@ -15,56 +23,203 @@
       }
     }
   },
+  "design": {
+    "source": {
+      "kind": "reference-product",
+      "references": [
+        "https://trello.com",
+        "docs/design/reference-screenshots/"
+      ],
+      "notes": "Replicating the Trello aesthetic: brand blue chrome, card-on-column surfaces, dense but friendly."
+    },
+    "tokens": {
+      "colors": {
+        "primary": "#0079bf",
+        "primary-hover": "#026aa7",
+        "surface": "#ffffff",
+        "board-background": "#0079bf",
+        "column-background": "#ebecf0",
+        "text": "#172b4d",
+        "text-muted": "#5e6c84",
+        "danger": "#eb5a46",
+        "success": "#61bd4f"
+      },
+      "typography": {
+        "fonts": {
+          "body": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          "heading": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+        },
+        "scale": {
+          "sm": "12px",
+          "base": "14px",
+          "lg": "16px",
+          "xl": "20px"
+        }
+      },
+      "spacing": {
+        "xs": "4px",
+        "sm": "8px",
+        "md": "16px",
+        "lg": "24px"
+      },
+      "radii": {
+        "card": "3px",
+        "button": "3px"
+      },
+      "shadows": {
+        "card": "0 1px 0 rgba(9,30,66,.25)"
+      }
+    },
+    "theme": {
+      "modes": [
+        "light"
+      ],
+      "default": "light"
+    },
+    "component_library": {
+      "name": "custom",
+      "usage": "custom",
+      "notes": "Reference product predates modern component libraries; custom components bound to the tokens above."
+    },
+    "assets": [
+      {
+        "id": "logo-mark",
+        "type": "logo",
+        "path": "ui/public/logo.svg",
+        "applies_to": [
+          "nav-logo"
+        ],
+        "description": "White logo mark, 24px, sits in the navbar"
+      },
+      {
+        "id": "ref-board-view",
+        "type": "reference-screenshot",
+        "path": "docs/design/reference-screenshots/board-view.png",
+        "applies_to": [
+          "/b/:boardId"
+        ],
+        "description": "Target look for the board canvas \u2014 column spacing, card density, label pills"
+      }
+    ],
+    "voice": {
+      "tone": "Friendly and efficient \u2014 short imperative labels, no jargon",
+      "empty_states": "One actionable sentence plus a primary button; never a bare 'No data'"
+    }
+  },
   "patterns": {
     "entity-menu": {
       "name": "Entity Menu",
       "type": "menu",
-      "description": "3-dot icon button → dropdown with actions. Used on every entity (list, card, board). Dropdown appears below-right of the trigger. Always includes: edit, archive/delete. Destructive actions are red text with confirm dialog.",
+      "description": "3-dot icon button \u2192 dropdown with actions. Used on every entity (list, card, board). Dropdown appears below-right of the trigger. Always includes: edit, archive/delete. Destructive actions are red text with confirm dialog.",
       "interactions": [
-        { "trigger": "click", "action": "open-popover", "target": "dropdown", "description": "Click 3-dot icon opens dropdown menu" },
-        { "trigger": "keypress:Escape", "action": "close-popover", "target": "dropdown" }
+        {
+          "trigger": "click",
+          "action": "open-popover",
+          "target": "dropdown",
+          "description": "Click 3-dot icon opens dropdown menu"
+        },
+        {
+          "trigger": "keypress:Escape",
+          "action": "close-popover",
+          "target": "dropdown"
+        }
       ],
-      "examples": ["list-header-menu", "card-context-menu", "board-settings-trigger"]
+      "examples": [
+        "list-header-menu",
+        "card-context-menu",
+        "board-settings-trigger"
+      ]
     },
     "confirm-dialog": {
       "name": "Confirm Dialog",
       "type": "dialog",
       "description": "Browser native confirm() for destructive actions. Message describes what will be destroyed. OK = proceed, Cancel = abort. Used for: delete board, delete list, delete card, remove member.",
       "interactions": [
-        { "trigger": "click", "action": "api-call", "target": "DELETE endpoint", "description": "Confirm executes the destructive action" }
+        {
+          "trigger": "click",
+          "action": "api-call",
+          "target": "DELETE endpoint",
+          "description": "Confirm executes the destructive action"
+        }
       ],
-      "examples": ["delete-board", "delete-card", "remove-member"]
+      "examples": [
+        "delete-board",
+        "delete-card",
+        "remove-member"
+      ]
     },
     "inline-edit": {
       "name": "Inline Edit",
       "type": "input",
       "description": "Click text to edit in-place. Text becomes an input/textarea with blue ring. Enter or blur saves, Escape cancels. Used for: list title, card title, board title.",
       "interactions": [
-        { "trigger": "click", "action": "toggle", "target": "edit-mode", "description": "Click text to enter edit mode" },
-        { "trigger": "keypress:Escape", "action": "toggle", "target": "view-mode", "description": "Escape cancels edit" },
-        { "trigger": "submit", "action": "api-call", "target": "PATCH endpoint", "description": "Enter/blur saves" }
+        {
+          "trigger": "click",
+          "action": "toggle",
+          "target": "edit-mode",
+          "description": "Click text to enter edit mode"
+        },
+        {
+          "trigger": "keypress:Escape",
+          "action": "toggle",
+          "target": "view-mode",
+          "description": "Escape cancels edit"
+        },
+        {
+          "trigger": "submit",
+          "action": "api-call",
+          "target": "PATCH endpoint",
+          "description": "Enter/blur saves"
+        }
       ],
-      "examples": ["list-title", "card-title", "board-title"]
+      "examples": [
+        "list-title",
+        "card-title",
+        "board-title"
+      ]
     },
     "sidebar-panel": {
       "name": "Sidebar Panel",
       "type": "sidebar",
-      "description": "Slides in from the right, 320px wide on desktop, full-screen on mobile. Has a header with title + close button. Used for: board settings, activity feed. NOT a separate page — overlays the current content.",
+      "description": "Slides in from the right, 320px wide on desktop, full-screen on mobile. Has a header with title + close button. Used for: board settings, activity feed. NOT a separate page \u2014 overlays the current content.",
       "interactions": [
-        { "trigger": "click", "action": "close-sidebar", "target": "self", "description": "Close button or click outside dismisses" },
-        { "trigger": "keypress:Escape", "action": "close-sidebar", "target": "self" }
+        {
+          "trigger": "click",
+          "action": "close-sidebar",
+          "target": "self",
+          "description": "Close button or click outside dismisses"
+        },
+        {
+          "trigger": "keypress:Escape",
+          "action": "close-sidebar",
+          "target": "self"
+        }
       ],
-      "examples": ["board-settings", "board-activity"]
+      "examples": [
+        "board-settings",
+        "board-activity"
+      ]
     },
     "card-modal": {
       "name": "Card Detail Modal",
       "type": "dialog",
-      "description": "Centered modal overlay (max-width 768px desktop, full-screen mobile). Dark backdrop. Shows card title, description, labels, checklists, comments, attachments, activity. Sidebar on the right with action buttons. NOT a page navigation — URL does not change.",
+      "description": "Centered modal overlay (max-width 768px desktop, full-screen mobile). Dark backdrop. Shows card title, description, labels, checklists, comments, attachments, activity. Sidebar on the right with action buttons. NOT a page navigation \u2014 URL does not change.",
       "interactions": [
-        { "trigger": "click", "action": "close-dialog", "target": "self", "description": "Click backdrop or X button closes" },
-        { "trigger": "keypress:Escape", "action": "close-dialog", "target": "self" }
+        {
+          "trigger": "click",
+          "action": "close-dialog",
+          "target": "self",
+          "description": "Click backdrop or X button closes"
+        },
+        {
+          "trigger": "keypress:Escape",
+          "action": "close-dialog",
+          "target": "self"
+        }
       ],
-      "examples": ["card-detail"]
+      "examples": [
+        "card-detail"
+      ]
     }
   },
   "pages": {
@@ -73,21 +228,45 @@
       "title": "Log In",
       "layout": "centered",
       "auth": "public",
-      "root": ["login-form"],
+      "root": [
+        "login-form"
+      ],
       "components": {
         "login-form": {
           "type": "form",
           "label": "Login Form",
           "description": "Email + password fields, submit button, link to signup",
-          "children": ["login-email", "login-password", "login-submit"],
+          "children": [
+            "login-email",
+            "login-password",
+            "login-submit"
+          ],
           "interactions": [
-            { "trigger": "submit", "action": "api-call", "target": "POST /api/auth/callback/credentials" },
-            { "trigger": "submit", "action": "navigate", "target": "boards", "description": "On success, redirect to /boards" }
+            {
+              "trigger": "submit",
+              "action": "api-call",
+              "target": "POST /api/auth/callback/credentials"
+            },
+            {
+              "trigger": "submit",
+              "action": "navigate",
+              "target": "boards",
+              "description": "On success, redirect to /boards"
+            }
           ]
         },
-        "login-email": { "type": "input", "label": "Email" },
-        "login-password": { "type": "input", "label": "Password" },
-        "login-submit": { "type": "button", "label": "Log In" }
+        "login-email": {
+          "type": "input",
+          "label": "Email"
+        },
+        "login-password": {
+          "type": "input",
+          "label": "Password"
+        },
+        "login-submit": {
+          "type": "button",
+          "label": "Log In"
+        }
       }
     },
     "boards": {
@@ -95,14 +274,24 @@
       "title": "Boards",
       "layout": "sidebar-main",
       "auth": "required",
-      "root": ["boards-sidebar", "boards-main"],
+      "root": [
+        "boards-sidebar",
+        "boards-main"
+      ],
       "components": {
         "boards-sidebar": {
           "type": "sidebar",
           "label": "Boards Sidebar",
           "description": "Left sidebar with: Boards link (active), Templates link, Recently Viewed boards, Workspaces list. Persistent on desktop, slide-out drawer on mobile.",
-          "children": ["sidebar-nav", "sidebar-recent", "sidebar-workspaces"],
-          "responsive": { "mobile": "drawer", "desktop": "sidebar" }
+          "children": [
+            "sidebar-nav",
+            "sidebar-recent",
+            "sidebar-workspaces"
+          ],
+          "responsive": {
+            "mobile": "drawer",
+            "desktop": "sidebar"
+          }
         },
         "sidebar-nav": {
           "type": "list",
@@ -123,13 +312,22 @@
           "type": "section",
           "label": "Boards Content",
           "description": "Main content area showing board grids organized by section",
-          "children": ["starred-section", "workspace-sections", "personal-section", "shared-section", "closed-section"]
+          "children": [
+            "starred-section",
+            "workspace-sections",
+            "personal-section",
+            "shared-section",
+            "closed-section"
+          ]
         },
         "starred-section": {
           "type": "section",
           "label": "Starred Boards",
           "description": "Grid of starred boards. Star icon + heading. Only shown if user has starred boards.",
-          "visibility": { "default": "visible", "condition": "starredBoards.length > 0" }
+          "visibility": {
+            "default": "visible",
+            "condition": "starredBoards.length > 0"
+          }
         },
         "workspace-sections": {
           "type": "section",
@@ -145,15 +343,25 @@
           "type": "section",
           "label": "Shared with you",
           "description": "Boards where user is a member but not the owner. Only shown if any exist.",
-          "visibility": { "default": "visible", "condition": "sharedBoards.length > 0" }
+          "visibility": {
+            "default": "visible",
+            "condition": "sharedBoards.length > 0"
+          }
         },
         "closed-section": {
           "type": "section",
           "label": "Closed Boards",
           "description": "Collapsible section at the bottom. Collapsed by default. Click to expand and lazy-load closed boards. Each has Reopen and Delete buttons.",
-          "visibility": { "default": "collapsed" },
+          "visibility": {
+            "default": "collapsed"
+          },
           "interactions": [
-            { "trigger": "click", "action": "expand", "target": "self", "description": "Click heading to expand/collapse" }
+            {
+              "trigger": "click",
+              "action": "expand",
+              "target": "self",
+              "description": "Click heading to expand/collapse"
+            }
           ]
         }
       }
@@ -163,14 +371,27 @@
       "title": "Board View",
       "layout": "canvas",
       "auth": "required",
-      "description": "The main board view — kanban columns with cards. Board background fills the entire viewport below the navbar.",
-      "root": ["board-header", "board-filter-bar", "board-columns", "board-add-list"],
+      "description": "The main board view \u2014 kanban columns with cards. Board background fills the entire viewport below the navbar.",
+      "root": [
+        "board-header",
+        "board-filter-bar",
+        "board-columns",
+        "board-add-list"
+      ],
       "components": {
         "board-header": {
           "type": "section",
           "label": "Board Header",
           "description": "Semi-transparent bar over the board background. Contains: board title (inline-editable), star toggle, visibility badge, view tabs (Board/Table/Calendar/Timeline), member avatars, invite button, settings trigger (3-dot).",
-          "children": ["board-title", "board-star", "board-visibility", "board-view-tabs", "board-members", "board-invite", "board-settings-trigger"]
+          "children": [
+            "board-title",
+            "board-star",
+            "board-visibility",
+            "board-view-tabs",
+            "board-members",
+            "board-invite",
+            "board-settings-trigger"
+          ]
         },
         "board-title": {
           "type": "input",
@@ -180,7 +401,13 @@
         "board-star": {
           "type": "button",
           "label": "Star Toggle",
-          "interactions": [{ "trigger": "click", "action": "api-call", "target": "PATCH /api/boards/:id { starred }" }]
+          "interactions": [
+            {
+              "trigger": "click",
+              "action": "api-call",
+              "target": "PATCH /api/boards/:id { starred }"
+            }
+          ]
         },
         "board-visibility": {
           "type": "badge",
@@ -192,10 +419,26 @@
           "label": "View Switcher",
           "description": "Tabs: Board (default), Table, Calendar, Timeline. Each navigates to a sub-route.",
           "interactions": [
-            { "trigger": "click", "action": "navigate", "target": "/b/:boardId (Board)" },
-            { "trigger": "click", "action": "navigate", "target": "/b/:boardId/table" },
-            { "trigger": "click", "action": "navigate", "target": "/b/:boardId/calendar" },
-            { "trigger": "click", "action": "navigate", "target": "/b/:boardId/timeline" }
+            {
+              "trigger": "click",
+              "action": "navigate",
+              "target": "/b/:boardId (Board)"
+            },
+            {
+              "trigger": "click",
+              "action": "navigate",
+              "target": "/b/:boardId/table"
+            },
+            {
+              "trigger": "click",
+              "action": "navigate",
+              "target": "/b/:boardId/calendar"
+            },
+            {
+              "trigger": "click",
+              "action": "navigate",
+              "target": "/b/:boardId/timeline"
+            }
           ]
         },
         "board-members": {
@@ -206,48 +449,81 @@
         "board-invite": {
           "type": "button",
           "label": "Invite",
-          "interactions": [{ "trigger": "click", "action": "open-popover", "target": "invite-form" }]
+          "interactions": [
+            {
+              "trigger": "click",
+              "action": "open-popover",
+              "target": "invite-form"
+            }
+          ]
         },
         "board-settings-trigger": {
           "type": "button",
           "label": "Board Menu",
           "pattern": "entity-menu",
-          "interactions": [{ "trigger": "click", "action": "open-sidebar", "target": "board-settings-panel" }]
+          "interactions": [
+            {
+              "trigger": "click",
+              "action": "open-sidebar",
+              "target": "board-settings-panel"
+            }
+          ]
         },
         "board-settings-panel": {
           "type": "sidebar",
           "label": "Board Settings",
           "pattern": "sidebar-panel",
           "description": "Slides in from right. Tabs: Settings, Activity. Settings tab has: visibility dropdown, background picker, members section, danger zone (close board, delete board). Activity tab shows the board activity feed.",
-          "responsive": { "mobile": "full-screen", "desktop": "sidebar" }
+          "responsive": {
+            "mobile": "full-screen",
+            "desktop": "sidebar"
+          }
         },
         "board-filter-bar": {
           "type": "section",
           "label": "Filter Bar",
           "description": "Below the board header. Three filter dropdowns: Labels (multi-select), Members (multi-select), Due Date (overdue/soon/none). Clear button. Cards not matching are dimmed.",
-          "visibility": { "default": "visible" }
+          "visibility": {
+            "default": "visible"
+          }
         },
         "board-columns": {
           "type": "kanban-board",
           "label": "Board Columns",
           "description": "Horizontal scrolling container of list columns. Each column is 272px wide. Columns are drag-droppable to reorder. Cards within columns are drag-droppable between columns.",
-          "children": ["board-list"],
-          "data": { "entity": "List", "source": "GET /api/boards/:boardId/lists" }
+          "children": [
+            "board-list"
+          ],
+          "data": {
+            "entity": "List",
+            "source": "GET /api/boards/:boardId/lists"
+          }
         },
         "board-list": {
           "type": "board-column",
           "label": "List Column",
           "description": "272px wide, rounded corners, gray background (#ebecf0). Header: list title (inline-editable) + 3-dot menu (archive, copy, delete). Body: vertical stack of card items. Footer: Add Card button.",
           "pattern": "entity-menu",
-          "children": ["list-header", "list-cards", "list-add-card"]
+          "children": [
+            "list-header",
+            "list-cards",
+            "list-add-card"
+          ]
         },
         "list-header": {
           "type": "section",
           "label": "List Header",
           "description": "Title (inline-editable) + menu trigger",
-          "children": ["list-title", "list-menu"]
+          "children": [
+            "list-title",
+            "list-menu"
+          ]
         },
-        "list-title": { "type": "input", "label": "List Title", "pattern": "inline-edit" },
+        "list-title": {
+          "type": "input",
+          "label": "List Title",
+          "pattern": "inline-edit"
+        },
         "list-menu": {
           "type": "menu",
           "label": "List Menu",
@@ -262,9 +538,13 @@
         "list-add-card": {
           "type": "button",
           "label": "Add a card",
-          "description": "Click opens inline form: textarea + Add Card button + Cancel. Not a modal — replaces the button in-place.",
+          "description": "Click opens inline form: textarea + Add Card button + Cancel. Not a modal \u2014 replaces the button in-place.",
           "interactions": [
-            { "trigger": "click", "action": "toggle", "target": "add-card-form" }
+            {
+              "trigger": "click",
+              "action": "toggle",
+              "target": "add-card-form"
+            }
           ]
         },
         "board-add-list": {
@@ -272,39 +552,71 @@
           "label": "Add another list",
           "description": "At the end of the columns. Semi-transparent white button. Click opens inline form: input + Add List button + Cancel. Same width as list columns (272px).",
           "interactions": [
-            { "trigger": "click", "action": "toggle", "target": "add-list-form" }
+            {
+              "trigger": "click",
+              "action": "toggle",
+              "target": "add-list-form"
+            }
           ]
         }
-      }
+      },
+      "design_refs": [
+        "ref-board-view"
+      ]
     },
     "card-detail": {
       "route": null,
       "title": "Card Detail",
       "layout": "centered",
-      "description": "NOT a page — this is a modal overlay triggered by clicking a card. URL does not change. Described as a page entry for completeness.",
-      "root": ["card-modal-overlay"],
+      "description": "NOT a page \u2014 this is a modal overlay triggered by clicking a card. URL does not change. Described as a page entry for completeness.",
+      "root": [
+        "card-modal-overlay"
+      ],
       "components": {
         "card-modal-overlay": {
           "type": "dialog",
           "label": "Card Modal",
           "pattern": "card-modal",
           "description": "Two-column layout inside the modal. Left (main): cover, title, labels, description, checklists, comments. Right (sidebar): action buttons (Members, Labels, Due Date, Cover, Move, Copy, Archive, Delete).",
-          "children": ["card-cover", "card-header", "card-labels", "card-members", "card-description", "card-checklists", "card-attachments", "card-comments", "card-actions-sidebar"]
+          "children": [
+            "card-cover",
+            "card-header",
+            "card-labels",
+            "card-members",
+            "card-description",
+            "card-checklists",
+            "card-attachments",
+            "card-comments",
+            "card-actions-sidebar"
+          ]
         },
         "card-cover": {
           "type": "section",
           "label": "Card Cover",
           "description": "Color strip or image at the top of the modal. 80px height.",
-          "visibility": { "default": "visible", "condition": "card.coverColor || card.coverUrl" }
+          "visibility": {
+            "default": "visible",
+            "condition": "card.coverColor || card.coverUrl"
+          }
         },
         "card-header": {
           "type": "section",
           "label": "Card Header",
           "description": "Card icon + title (inline-editable) + breadcrumb showing 'in list: ListName'",
-          "children": ["card-title", "card-breadcrumb"]
+          "children": [
+            "card-title",
+            "card-breadcrumb"
+          ]
         },
-        "card-title": { "type": "input", "label": "Card Title", "pattern": "inline-edit" },
-        "card-breadcrumb": { "type": "breadcrumb", "label": "List Breadcrumb" },
+        "card-title": {
+          "type": "input",
+          "label": "Card Title",
+          "pattern": "inline-edit"
+        },
+        "card-breadcrumb": {
+          "type": "breadcrumb",
+          "label": "List Breadcrumb"
+        },
         "card-labels": {
           "type": "section",
           "label": "Labels",
@@ -340,7 +652,10 @@
           "type": "section",
           "label": "Card Actions",
           "description": "Right sidebar (desktop) or footer (mobile) with action buttons: Members, Labels, Due Date, Cover, Move, Copy, Archive, Delete (red).",
-          "responsive": { "mobile": "visible", "desktop": "sidebar" }
+          "responsive": {
+            "mobile": "visible",
+            "desktop": "sidebar"
+          }
         }
       }
     }
@@ -385,21 +700,30 @@
           "click-table-tab": "board-table",
           "click-calendar-tab": "board-calendar",
           "click-timeline-tab": "board-timeline",
-          "click-card": { "target": "board", "guard": "opens card-detail modal overlay" },
+          "click-card": {
+            "target": "board",
+            "guard": "opens card-detail modal overlay"
+          },
           "delete-board": "boards"
         }
       },
       "board-table": {
         "route": "/b/:boardId/table",
-        "on": { "click-board-tab": "board" }
+        "on": {
+          "click-board-tab": "board"
+        }
       },
       "board-calendar": {
         "route": "/b/:boardId/calendar",
-        "on": { "click-board-tab": "board" }
+        "on": {
+          "click-board-tab": "board"
+        }
       },
       "board-timeline": {
         "route": "/b/:boardId/timeline",
-        "on": { "click-board-tab": "board" }
+        "on": {
+          "click-board-tab": "board"
+        }
       },
       "workspace": {
         "route": "/w/:slug",
@@ -410,11 +734,15 @@
       },
       "workspace-settings": {
         "route": "/w/:slug/settings",
-        "on": { "click-back": "workspace" }
+        "on": {
+          "click-back": "workspace"
+        }
       },
       "templates": {
         "route": "/templates",
-        "on": { "create-from-template": "board" }
+        "on": {
+          "create-from-template": "board"
+        }
       }
     }
   }

--- a/scripts/render_models.py
+++ b/scripts/render_models.py
@@ -120,6 +120,138 @@ def render_state_machine_human(sm: dict) -> str:
     return "\n".join(lines)
 
 
+def render_ui_spec_human(spec: dict) -> str:
+    """Render a UI spec model to prose markdown: design contract, pages, patterns, navigation."""
+    lines = []
+
+    app = spec.get("app", {})
+    title = app.get("name", "UI Specification")
+    lines.append(f"# UI Specification: {title}")
+    lines.append("")
+    if app.get("description"):
+        lines.append(app["description"])
+        lines.append("")
+
+    # Design contract
+    design = spec.get("design")
+    if design:
+        lines.append("## Visual Design Contract")
+        lines.append("")
+        source = design.get("source", {})
+        lines.append(f"**Source**: {source.get('kind', 'unspecified')}")
+        for ref in source.get("references", []):
+            lines.append(f"- {ref}")
+        if source.get("notes"):
+            lines.append(f"\n{source['notes']}")
+        lines.append("")
+
+        tokens = design.get("tokens", {})
+        colors = tokens.get("colors", {})
+        if colors:
+            lines.append("### Color tokens")
+            lines.append("| Token | Value |")
+            lines.append("|-------|-------|")
+            for name, value in colors.items():
+                lines.append(f"| `{name}` | `{value}` |")
+            lines.append("")
+
+        typography = tokens.get("typography", {})
+        if typography:
+            lines.append("### Typography")
+            for role, stack in typography.get("fonts", {}).items():
+                lines.append(f"- **{role}**: `{stack}`")
+            scale = typography.get("scale", {})
+            if scale:
+                scale_str = ", ".join(f"{k}={v}" for k, v in scale.items())
+                lines.append(f"- **Scale**: {scale_str}")
+            lines.append("")
+
+        for group in ("spacing", "radii", "shadows"):
+            values = tokens.get(group, {})
+            if values:
+                group_str = ", ".join(f"{k}={v}" for k, v in values.items())
+                lines.append(f"- **{group.capitalize()}**: {group_str}")
+        if any(tokens.get(g) for g in ("spacing", "radii", "shadows")):
+            lines.append("")
+
+        lib = design.get("component_library")
+        if lib:
+            version = f" {lib['version']}" if lib.get("version") else ""
+            lines.append(f"**Component library**: {lib['name']}{version} ({lib['usage']})")
+            if lib.get("notes"):
+                lines.append(f"  — {lib['notes']}")
+            lines.append("")
+
+        assets = design.get("assets", [])
+        if assets:
+            lines.append("### Brand assets & references")
+            for asset in assets:
+                applies = f" → {', '.join(asset['applies_to'])}" if asset.get("applies_to") else ""
+                path = f" (`{asset['path']}`)" if asset.get("path") else ""
+                lines.append(f"- **{asset['id']}** [{asset['type']}]{path}{applies}: {asset.get('description', '')}")
+            lines.append("")
+
+        voice = design.get("voice")
+        if voice:
+            lines.append("### Voice")
+            if voice.get("tone"):
+                lines.append(f"- **Tone**: {voice['tone']}")
+            if voice.get("empty_states"):
+                lines.append(f"- **Empty states**: {voice['empty_states']}")
+            lines.append("")
+
+    # Shared patterns
+    patterns = spec.get("patterns", {})
+    if patterns:
+        lines.append("## Shared Patterns")
+        lines.append("")
+        for pattern_id, pattern in patterns.items():
+            lines.append(f"- **{pattern_id}** ({pattern.get('type', '')}): {pattern.get('description', '')}")
+        lines.append("")
+
+    # Pages
+    lines.append("## Pages")
+    lines.append("")
+    for route, page in spec.get("pages", {}).items():
+        lines.append(f"### {page.get('title', route)} (`{page.get('route', route)}`)")
+        if page.get("description"):
+            lines.append(page["description"])
+        lines.append(f"- **Layout**: {page.get('layout', '—')} | **Auth**: {page.get('auth', 'required')}")
+        if page.get("design_refs"):
+            lines.append(f"- **Design references**: {', '.join(page['design_refs'])}")
+        components = page.get("components", {})
+        interactions = [
+            (cid, ix)
+            for cid, comp in components.items()
+            for ix in comp.get("interactions", [])
+        ]
+        if interactions:
+            lines.append("- **Interaction contracts**:")
+            for cid, ix in interactions:
+                target = f" → {ix['target']}" if ix.get("target") else ""
+                desc = f" ({ix['description']})" if ix.get("description") else ""
+                lines.append(f"  - `{cid}`: {ix['trigger']} → {ix['action']}{target}{desc}")
+        lines.append("")
+
+    # Navigation graph as Mermaid
+    nav = spec.get("navigation", {})
+    states = nav.get("states", {})
+    if states:
+        lines.append("## Navigation")
+        lines.append("")
+        lines.append("```mermaid")
+        lines.append("stateDiagram-v2")
+        lines.append(f"    [*] --> {nav['initial']}")
+        for state_id, state in states.items():
+            for event, target in state.get("on", {}).items():
+                target_id = target if isinstance(target, str) else target["target"]
+                lines.append(f"    {state_id} --> {target_id}: {event}")
+        lines.append("```")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
 def render_contracts_human(contracts: dict) -> str:
     """Render contract definitions to prose markdown matching /architect format."""
     lines = []
@@ -426,6 +558,11 @@ def render_model(model_path: Path, view: str, output_dir: Path) -> list[str]:
             files_created.append(str(out))
         elif schema_type == "contracts":
             md = render_contracts_human(model)
+            out = output_dir / f"{model_path.stem}.md"
+            out.write_text(md)
+            files_created.append(str(out))
+        elif schema_type == "ui-spec":
+            md = render_ui_spec_human(model)
             out = output_dir / f"{model_path.stem}.md"
             out.write_text(md)
             files_created.append(str(out))

--- a/templates/formal-models/ui-spec-schema.json
+++ b/templates/formal-models/ui-spec-schema.json
@@ -20,6 +20,10 @@
         }
       }
     },
+    "design": {
+      "$ref": "#/$defs/design",
+      "description": "Visual design contract — tokens, theme, typography, component-library binding, and brand assets. A frontend can satisfy every interaction contract and still ship off-brand; this section makes visual identity checkable."
+    },
     "patterns": {
       "type": "object",
       "description": "Shared UI patterns referenced by components. Define once, reuse everywhere.",
@@ -44,6 +48,140 @@
     }
   },
   "$defs": {
+    "design": {
+      "type": "object",
+      "description": "The visual design contract. Implementations MUST bind these tokens (e.g. as CSS variables) and the design-fidelity gate reviews rendered screenshots against them.",
+      "required": ["source", "tokens"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "object",
+          "description": "Where this design comes from — discovered by /seed (existing system, reference product) or authored net-new",
+          "required": ["kind"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["existing-design-system", "reference-product", "brand-kit", "net-new"]
+            },
+            "references": {
+              "type": "array",
+              "description": "URLs, repo paths, or screenshot paths for the design source (e.g. the product being replicated, the Figma export, the tokens file)",
+              "items": { "type": "string" }
+            },
+            "notes": { "type": "string" }
+          }
+        },
+        "tokens": {
+          "type": "object",
+          "description": "Design tokens. Keys are semantic names, values are concrete CSS values. These are binding — a frontend that ignores them fails the conformance check.",
+          "additionalProperties": false,
+          "properties": {
+            "colors": {
+              "type": "object",
+              "description": "Semantic color name → CSS value (hex/hsl/gradient). MUST include at least 'primary'. Include brand gradients here.",
+              "required": ["primary"],
+              "additionalProperties": { "type": "string" }
+            },
+            "typography": {
+              "type": "object",
+              "description": "Font families and scale",
+              "additionalProperties": false,
+              "properties": {
+                "fonts": {
+                  "type": "object",
+                  "description": "Role (heading/body/mono) → font stack",
+                  "additionalProperties": { "type": "string" }
+                },
+                "scale": {
+                  "type": "object",
+                  "description": "Size name (xs/sm/base/lg/xl/...) → CSS size",
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            },
+            "spacing": {
+              "type": "object",
+              "description": "Spacing scale name → CSS value",
+              "additionalProperties": { "type": "string" }
+            },
+            "radii": {
+              "type": "object",
+              "description": "Border-radius name → CSS value",
+              "additionalProperties": { "type": "string" }
+            },
+            "shadows": {
+              "type": "object",
+              "description": "Shadow name → CSS value",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "theme": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "modes": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["light", "dark", "high-contrast"] }
+            },
+            "default": { "type": "string" }
+          }
+        },
+        "component_library": {
+          "type": "object",
+          "description": "The component library binding — prefer adopting an existing library over hand-rolling",
+          "required": ["name", "usage"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" },
+            "usage": {
+              "type": "string",
+              "enum": ["adopt", "extend", "custom"],
+              "description": "adopt = use as-is with tokens; extend = themed wrapper components; custom = hand-rolled (justify in notes)"
+            },
+            "notes": { "type": "string" }
+          }
+        },
+        "assets": {
+          "type": "array",
+          "description": "Brand assets and reference screenshots, with the pages/regions they apply to",
+          "items": {
+            "type": "object",
+            "required": ["id", "type"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "type": {
+                "type": "string",
+                "enum": ["logo", "wordmark", "illustration", "icon-set", "reference-screenshot"]
+              },
+              "path": { "type": "string", "description": "Repo path or URL" },
+              "applies_to": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Page routes or component IDs this asset applies to"
+              },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "voice": {
+          "type": "object",
+          "description": "Copy/personality guidelines — empty states, greetings, error tone",
+          "additionalProperties": false,
+          "properties": {
+            "tone": { "type": "string" },
+            "empty_states": { "type": "string", "description": "How empty states should feel (e.g. 'warm, dog-themed illustration + one actionable sentence')" }
+          }
+        },
+        "derived_from": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/provenance" }
+        }
+      }
+    },
     "shell": {
       "type": "object",
       "description": "Persistent app shell — always visible regardless of current page",
@@ -103,6 +241,11 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Ordered list of top-level component IDs (the page's direct children)"
+        },
+        "design_refs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "IDs of design assets (from design.assets) that apply to this page — brand treatments, reference screenshots to match"
         },
         "derived_from": {
           "type": "array",

--- a/tests/test_ui_spec_design.py
+++ b/tests/test_ui_spec_design.py
@@ -1,0 +1,79 @@
+"""Tests for the ui-spec design contract: schema validation and human rendering."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import formal_models as fm  # noqa: E402
+import render_models as rm  # noqa: E402
+
+EXAMPLE = REPO_ROOT / "docs" / "formal-methods" / "examples" / "kanban-app-ui-spec.json"
+
+
+def _minimal_spec(**design) -> dict:
+    spec = {
+        "pages": {"home": {"route": "/", "layout": "centered"}},
+        "navigation": {"initial": "home", "states": {"home": {"route": "/"}}},
+    }
+    if design:
+        spec["design"] = design["design"]
+    return spec
+
+
+def test_example_with_design_section_validates():
+    data = json.loads(EXAMPLE.read_text())
+    assert "design" in data, "example should demonstrate the design contract"
+    assert fm.validate(data, "ui-spec") == []
+
+
+def test_design_requires_source_and_tokens():
+    spec = _minimal_spec(design={"theme": {"modes": ["light"]}})
+    errors = fm.validate(spec, "ui-spec")
+    assert any("source" in e for e in errors)
+    assert any("tokens" in e for e in errors)
+
+
+def test_design_colors_require_primary():
+    spec = _minimal_spec(design={
+        "source": {"kind": "net-new"},
+        "tokens": {"colors": {"accent": "#ff7c43"}},
+    })
+    errors = fm.validate(spec, "ui-spec")
+    assert any("primary" in e for e in errors)
+
+
+def test_valid_design_section_passes():
+    spec = _minimal_spec(design={
+        "source": {"kind": "brand-kit", "references": ["docs/brand.md"]},
+        "tokens": {"colors": {"primary": "#0079bf"}},
+        "component_library": {"name": "shadcn/ui", "usage": "adopt"},
+    })
+    assert fm.validate(spec, "ui-spec") == []
+
+
+def test_invalid_source_kind_rejected():
+    spec = _minimal_spec(design={
+        "source": {"kind": "vibes"},
+        "tokens": {"colors": {"primary": "#000"}},
+    })
+    assert fm.validate(spec, "ui-spec") != []
+
+
+def test_human_render_includes_design_contract():
+    data = json.loads(EXAMPLE.read_text())
+    md = rm.render_ui_spec_human(data)
+    assert "## Visual Design Contract" in md
+    assert "`primary` | `#0079bf`" in md
+    assert "reference-screenshot" in md
+    assert "## Pages" in md
+    assert "stateDiagram-v2" in md  # navigation graph
+
+
+def test_human_render_without_design_section_still_works():
+    spec = _minimal_spec()
+    md = rm.render_ui_spec_human(spec)
+    assert "Visual Design Contract" not in md
+    assert "## Pages" in md


### PR DESCRIPTION
## Summary

Implements the design third of retro #10's fixes. Follows #18 (merged) — rebased onto main.

Grounded in fresh evidence: I rendered dogeared-coach and reviewed screenshots of every major view. The code-level review said "professional, domain-aware, has design tokens" — the rendered app is stock shadcn monochrome with no logo, no brand color, a bare landing page leaking "Backend status: ok", and a client-facing playlist numbered **0., 1., ...** that 131 unit tests + 40 E2E specs never caught (filed as dogeared-coach#55–58). The loop is structurally blind to the UI; this PR gives it eyes and a contract to check against.

### #12 — ui-spec visual design contract
- Schema: new validated `design` section — `source` (existing-design-system / reference-product / brand-kit / net-new), binding `tokens` (colors require `primary`; typography, spacing, radii, shadows), `theme`, `component_library` (adopt/extend/custom), `assets` (logo/illustrations/reference-screenshots with `applies_to`), and `voice` (tone + empty-state guidelines). Pages gain `design_refs`.
- `render_models.py`: new **ui-spec human renderer** — also fixes an existing gap where `--view human` on a ui-spec silently produced nothing (architect.md Step 4d was calling it).
- Worked example: kanban ui-spec now demonstrates a full design section (Trello-as-reference-product).

### #11 — /seed discovers the design source
- Design source & brand is now the **first UI question** in the brainstorm: existing design system? replicating an existing product? If yes — ingest tokens, adopt the component library, capture reference screenshots. If net-new — make deliberate token choices with rationale; "library default theme" is explicitly not a decision.

### #13 — design-fidelity gate
- `/implement` Step 9 → **UX sanity + design-fidelity gate**: a mechanical token check (grep contract colors in built styles — if the primary brand color appears nowhere, the contract was ignored) plus an Opus screenshot review against tokens, reference screenshots, brand assets, voice, and 2-second-human-catch defects (0-indexed lists, debug output, raw enums). High-confidence violations **fail the ticket**; screenshots are attached to the PR body.
- `/implement-wave`: sub-agents save screenshots; the orchestrator independently **looks** at them before merging (a "design review passed" report without screenshots = skipped gate); wave report gains a design-fidelity column with screenshot links.

## Test plan
- `make lint` clean; `make test` 30/30 (7 new: schema requires source/tokens/primary, rejects bad source kinds, example validates, renderer emits design contract, renderer works without one)

Closes #11, closes #12, closes #13
