### PR TITLE
feat: add Claude interactive delegate skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ python3 "$CW_HOME/scripts/repo.py" clean acme/app     # remove cache
 
 ```
 .claude/commands/    # Claude Code skills (the core of this repo)
+skills/              # Codex-native skills and bundled resources
 scripts/             # Python helpers called by skills
 templates/           # Issue, PR, review, and checklist templates
 models.md            # AI model IDs and library versions (refresh with /update)
@@ -190,4 +191,10 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 /ship                           # Create PR with mermaid diagrams (standalone)
 /stitch-audit owner/repo --trace keyword   # Cross-layer data flow audit
 /update                         # Refresh model IDs and library versions
+```
+
+Codex-native skills live under `skills/`. Install them into Codex with a symlink, for example:
+
+```bash
+ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ claude /plan-epic owner/repo
 claude /implement owner/repo#42
 ```
 
+Codex-native skills are stored under `skills/`. To install the Claude interactive delegate skill for Codex:
+
+```bash
+ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
+python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py start
+```
+
 **Important**: Run skills from your target project directory, not from chief-wiggum itself.
 
 ## Skills
@@ -70,6 +77,11 @@ claude /implement owner/repo#42
 | `/ship` | PR creation with mermaid architecture diagrams |
 | `/stitch-audit` | Cross-layer data flow analysis |
 | `/update` | Refresh AI model IDs and library versions |
+
+### Codex Skills
+| Skill | Purpose |
+|-------|---------|
+| `$claude-interactive-delegate` | Delegate bounded Codex tasks to a persistent interactive Claude Code tmux session |
 
 ## Pipeline
 
@@ -226,5 +238,6 @@ graph TD
 - OpenAI Codex CLI (`codex`)
 - Google Gemini CLI (`gemini`)
 - GitHub CLI (`gh`)
+- tmux (for `$claude-interactive-delegate`)
 - ffmpeg, openai-whisper (for transcription)
 - Secrets stored in system keyring (managed via `python3 scripts/keychain.py`)

--- a/skills/claude-interactive-delegate/SKILL.md
+++ b/skills/claude-interactive-delegate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: claude-interactive-delegate
+description: Delegate bounded tasks from Codex to a persistent interactive Claude Code terminal session using tmux/PTY instead of claude -p. Use when Codex should ask Claude Code to act as an optional reviewer, architecture critic, design critic, implementation advisor, or Chief Wiggum provider through an interactive session with file-based task handoff and completion sentinels.
+---
+
+# Claude Interactive Delegate
+
+## Overview
+
+Use this skill to drive an existing or newly started interactive Claude Code session as a delegated worker. Codex sends the task through a real terminal session, Claude writes the durable result to files, and Codex reads those files back into the main workflow.
+
+This skill is for bounded delegation, not for replacing Codex's local verification. Codex remains responsible for deciding whether the delegated output is useful and for independently checking any code, tests, or claims before shipping.
+
+## Requirements
+
+- `claude` must be installed and logged in for interactive Claude Code use.
+- `tmux` must be installed so the Claude session persists independently of the current shell.
+- The delegated task must be expressible as a prompt file and have a clear output file.
+
+Do not use `claude -p` for this workflow. The driver starts or reuses an interactive `claude` session in tmux.
+
+## Quick Start
+
+Start or verify the delegate session. By default, the session command is `claude --dangerously-skip-permissions`; set `CLAUDE_DELEGATE_CMD` or pass `--claude-cmd` to use a different mode such as `claude --permission-mode auto`.
+
+```bash
+python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py start
+python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py status
+```
+
+Delegate a prompt file:
+
+```bash
+python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py submit \
+  --prompt-file /path/to/prompt.md \
+  --cwd /path/to/target/repo \
+  --wait
+```
+
+Read the returned `result.md` path from the command output, then evaluate it before acting on it.
+
+## Workflow
+
+1. Create a bounded task prompt.
+   - State the role: reviewer, architecture critic, design critic, implementation advisor, etc.
+   - Include exact files, diffs, screenshots, or artifact paths Claude should inspect.
+   - Ask for a concrete artifact, usually findings or a recommendation, not open-ended exploration.
+
+2. Submit the task with `scripts/claude_delegate.py submit`.
+   - Use `--cwd` when Claude should work from a target repo.
+   - Use `--task-id` only when a stable ID is useful for later lookup.
+   - Use `--wait` for short review tasks; omit it for long-running work and poll with `wait`.
+
+3. Monitor status.
+   - Use `status` to check whether the tmux session exists.
+   - Use `capture` to inspect the latest terminal pane if the task appears stuck.
+   - Use `wait --task-id <id>` to wait for `DONE` or `ERROR`.
+
+4. Consume the result.
+   - Read `result.md` only after `DONE` exists.
+   - If `ERROR` exists, inspect it and decide whether to retry with a narrower prompt.
+   - Treat Claude's answer as advisory input. Run local verification for code, tests, screenshots, and repository facts.
+
+## Task Directory Contract
+
+The driver creates task directories under `~/.chief-wiggum/delegates/claude/` by default:
+
+```text
+task-id/
+├── prompt.md       # task prompt written by Codex
+├── result.md       # final answer written by Claude
+├── DONE            # completion sentinel written by Claude
+└── ERROR           # blocked/error sentinel written by Claude
+```
+
+Codex should never parse terminal output as the result contract. Terminal capture is for debugging only.
+
+For full protocol details, read `references/protocol.md`.
+
+## Boundaries
+
+- Do not automate account login, billing changes, subscription changes, API-credit consent, or payment prompts. If the interactive session reaches one of these states, stop and surface it to the user.
+- Do not let the delegate create or merge PRs unless the current workflow explicitly requires it and Codex will verify the outcome.
+- Do not trust self-reported test results. Codex must run or inspect verification independently.
+- Do not leave completed delegate sessions open indefinitely if they are no longer needed.
+- Use `scripts/claude_delegate.py stop` before changing the delegate permission mode, then start a fresh session.
+
+## Chief Wiggum Provider Use
+
+When wiring this into Chief Wiggum, treat it as an optional provider:
+
+```yaml
+providers:
+  claude-interactive:
+    enabled: true
+    session: cw-claude
+    task_root: ~/.chief-wiggum/delegates/claude
+    roles:
+      - architecture_critic
+      - design_critic
+      - risky_diff_review
+```
+
+Use it for high-value critique and synthesis, not as a required path for every ticket. The workflow should proceed when optional Claude delegation is unavailable unless the user explicitly requested Claude review.

--- a/skills/claude-interactive-delegate/agents/openai.yaml
+++ b/skills/claude-interactive-delegate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Claude Interactive Delegate"
+  short_description: "Delegate tasks to interactive Claude"
+  default_prompt: "Use $claude-interactive-delegate to delegate a bounded review task to a persistent Claude Code session."

--- a/skills/claude-interactive-delegate/references/protocol.md
+++ b/skills/claude-interactive-delegate/references/protocol.md
@@ -1,0 +1,65 @@
+# Claude Interactive Delegate Protocol
+
+## Session Model
+
+The delegate is a named tmux session running the normal interactive Claude Code CLI:
+
+```bash
+tmux new-session -d -s cw-claude 'claude --dangerously-skip-permissions'
+```
+
+The driver uses `tmux load-buffer`, `tmux paste-buffer`, and `tmux send-keys Enter` to send prompts into the session. This keeps the session interactive while avoiding `claude -p`.
+
+Set `CLAUDE_DELEGATE_CMD` or pass `--claude-cmd` to use another interactive mode, for example `claude --permission-mode auto`.
+
+## Task Handoff
+
+Each delegated task has a unique directory:
+
+```text
+~/.chief-wiggum/delegates/claude/<task-id>/
+├── prompt.md
+├── result.md
+├── DONE
+└── ERROR
+```
+
+Codex writes `prompt.md`. Claude must write either:
+
+- `result.md` and `DONE`, or
+- `ERROR` with a short reason.
+
+Terminal output is not the task API. Use `capture` only to diagnose a stuck session.
+
+## Prompt Shape
+
+A good delegated prompt includes:
+
+- Role: reviewer, critic, implementation advisor, or synthesizer.
+- Inputs: exact repo path, files, diffs, screenshots, logs, or artifact paths.
+- Required output format.
+- Clear stop condition.
+- Instruction to write `result.md` and touch `DONE`.
+
+Keep prompts bounded. If the task needs broad exploration, ask for findings and recommended next steps rather than asking Claude to own the whole delivery.
+
+## Blocking Conditions
+
+The delegate should be treated as blocked if the session requires:
+
+- Login or account selection.
+- Billing, subscription, payment, or API-credit consent.
+- Tool permission decisions that were not preconfigured for the session.
+- Interactive clarification that cannot be answered from the task prompt.
+
+In these cases, Codex should inspect `capture` output, report the issue to the user, and avoid faking an answer.
+
+## Verification
+
+Claude delegate output is advisory. Codex must independently verify:
+
+- Tests and lint results.
+- File paths and line references.
+- Screenshots or rendered UI claims.
+- Security, billing, and account-state claims.
+- Any recommended code change before applying it.

--- a/skills/claude-interactive-delegate/scripts/claude_delegate.py
+++ b/skills/claude-interactive-delegate/scripts/claude_delegate.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Drive an interactive Claude Code session through tmux with file handoff."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+DEFAULT_SESSION = "cw-claude"
+DEFAULT_TASK_ROOT = Path.home() / ".chief-wiggum" / "delegates" / "claude"
+DEFAULT_TIMEOUT_SECONDS = 30 * 60
+DEFAULT_CLAUDE_CMD = os.environ.get(
+    "CLAUDE_DELEGATE_CMD",
+    "claude --dangerously-skip-permissions",
+)
+
+
+def require_tool(name: str) -> None:
+    if not shutil.which(name):
+        raise SystemExit(
+            f"Missing required tool: {name}. Install it and retry. "
+            f"On macOS: brew install {name}"
+        )
+
+
+def run(cmd: list[str], *, check: bool = True, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def has_session(session: str) -> bool:
+    result = run(["tmux", "has-session", "-t", session], check=False)
+    return result.returncode == 0
+
+
+def start_session(session: str, claude_cmd: str) -> None:
+    require_tool("tmux")
+    require_tool("claude")
+    if has_session(session):
+        print(f"OK: tmux session already exists: {session}")
+        return
+    run(["tmux", "new-session", "-d", "-s", session, claude_cmd])
+    print(f"OK: started tmux session: {session}")
+
+
+def send_text(session: str, text: str) -> None:
+    if not has_session(session):
+        raise SystemExit(f"tmux session not found: {session}. Run start first.")
+    buffer_name = f"cw-{uuid.uuid4().hex}"
+    run(["tmux", "load-buffer", "-b", buffer_name, "-"], input_text=text)
+    run(["tmux", "paste-buffer", "-d", "-b", buffer_name, "-t", session])
+    run(["tmux", "send-keys", "-t", session, "Enter"])
+
+
+def make_task_dir(task_root: Path, task_id: str | None) -> tuple[str, Path]:
+    task_id = task_id or time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8]
+    task_dir = (task_root / task_id).expanduser().resolve()
+    task_dir.mkdir(parents=True, exist_ok=False)
+    return task_id, task_dir
+
+
+def build_delegate_message(task_dir: Path, cwd: str | None) -> str:
+    prompt_path = task_dir / "prompt.md"
+    result_path = task_dir / "result.md"
+    done_path = task_dir / "DONE"
+    error_path = task_dir / "ERROR"
+    cwd_line = f"\nWork from this repository/directory when relevant:\n{Path(cwd).expanduser().resolve()}\n" if cwd else ""
+    return f"""Delegated Chief Wiggum task.
+
+The operator has authorized this interactive Claude Code session to handle bounded delegated engineering tasks from Codex.
+
+Read the task prompt:
+{prompt_path}
+{cwd_line}
+Write your final answer as Markdown to:
+{result_path}
+
+When complete, run:
+touch {done_path}
+
+If you are blocked, write a concise reason to:
+{error_path}
+
+Then stop working on this delegated task.
+
+Important boundaries:
+- Do not answer login, billing, subscription, payment, or API-credit consent prompts. If one appears, write ERROR if possible and stop.
+- Do not create, push, merge, or close PRs unless the prompt explicitly asks for it.
+- Be concrete and cite files/commands you inspected.
+"""
+
+
+def submit(args: argparse.Namespace) -> int:
+    start_session(args.session, args.claude_cmd)
+    task_root = Path(args.task_root).expanduser()
+    task_id, task_dir = make_task_dir(task_root, args.task_id)
+
+    if args.prompt_file:
+        prompt = Path(args.prompt_file).expanduser().read_text()
+    elif args.prompt:
+        prompt = args.prompt
+    else:
+        raise SystemExit("submit requires --prompt-file or --prompt")
+
+    (task_dir / "prompt.md").write_text(prompt)
+    send_text(args.session, build_delegate_message(task_dir, args.cwd))
+
+    print(f"TASK_ID={task_id}")
+    print(f"TASK_DIR={task_dir}")
+    print(f"PROMPT={task_dir / 'prompt.md'}")
+    print(f"RESULT={task_dir / 'result.md'}")
+    print(f"DONE={task_dir / 'DONE'}")
+    print(f"ERROR={task_dir / 'ERROR'}")
+
+    if args.wait:
+        return wait_for_task(task_dir, args.timeout_seconds)
+    return 0
+
+
+def wait_for_task(task_dir: Path, timeout_seconds: int) -> int:
+    deadline = time.time() + timeout_seconds
+    done = task_dir / "DONE"
+    error = task_dir / "ERROR"
+    while time.time() < deadline:
+        if done.exists():
+            print(f"OK: task complete: {task_dir}")
+            result = task_dir / "result.md"
+            if result.exists():
+                print(f"RESULT={result}")
+            return 0
+        if error.exists():
+            print(f"ERROR: task blocked: {task_dir}", file=sys.stderr)
+            print(error.read_text(), file=sys.stderr)
+            return 2
+        time.sleep(2)
+    print(f"TIMEOUT: no DONE or ERROR after {timeout_seconds}s: {task_dir}", file=sys.stderr)
+    return 3
+
+
+def status(args: argparse.Namespace) -> int:
+    require_tool("tmux")
+    if has_session(args.session):
+        print(f"OK: tmux session exists: {args.session}")
+        return 0
+    print(f"MISSING: tmux session not found: {args.session}")
+    return 1
+
+
+def stop(args: argparse.Namespace) -> int:
+    require_tool("tmux")
+    if not has_session(args.session):
+        print(f"OK: tmux session already absent: {args.session}")
+        return 0
+    run(["tmux", "kill-session", "-t", args.session])
+    print(f"OK: stopped tmux session: {args.session}")
+    return 0
+
+
+def capture(args: argparse.Namespace) -> int:
+    require_tool("tmux")
+    if not has_session(args.session):
+        print(f"MISSING: tmux session not found: {args.session}", file=sys.stderr)
+        return 1
+    result = run(["tmux", "capture-pane", "-pt", args.session, "-S", str(args.lines * -1)])
+    print(result.stdout)
+    return 0
+
+
+def attach(args: argparse.Namespace) -> int:
+    require_tool("tmux")
+    os.execvp("tmux", ["tmux", "attach", "-t", args.session])
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session", default=DEFAULT_SESSION, help="tmux session name")
+    parser.add_argument("--task-root", default=str(DEFAULT_TASK_ROOT), help="delegate task root")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start", help="start the interactive Claude session")
+    start.add_argument("--claude-cmd", default=DEFAULT_CLAUDE_CMD, help="command to run in tmux")
+
+    sub.add_parser("status", help="check whether the tmux session exists")
+    sub.add_parser("stop", help="stop the tmux session")
+
+    submit_parser = sub.add_parser("submit", help="submit a delegated task")
+    submit_parser.add_argument("--prompt-file", help="path to task prompt")
+    submit_parser.add_argument("--prompt", help="inline task prompt")
+    submit_parser.add_argument("--cwd", help="target repo/directory for Claude to use")
+    submit_parser.add_argument("--task-id", help="stable task ID")
+    submit_parser.add_argument("--claude-cmd", default=DEFAULT_CLAUDE_CMD, help="command to run if session starts")
+    submit_parser.add_argument("--wait", action="store_true", help="wait for DONE or ERROR")
+    submit_parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+
+    wait_parser = sub.add_parser("wait", help="wait for a submitted task")
+    wait_parser.add_argument("--task-id", required=True)
+    wait_parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+
+    capture_parser = sub.add_parser("capture", help="print recent tmux pane output")
+    capture_parser.add_argument("--lines", type=int, default=120)
+
+    sub.add_parser("attach", help="attach to the tmux session")
+
+    args = parser.parse_args()
+    if args.command == "start":
+        start_session(args.session, args.claude_cmd)
+        return 0
+    if args.command == "status":
+        return status(args)
+    if args.command == "stop":
+        return stop(args)
+    if args.command == "submit":
+        return submit(args)
+    if args.command == "wait":
+        return wait_for_task(Path(args.task_root).expanduser() / args.task_id, args.timeout_seconds)
+    if args.command == "capture":
+        return capture(args)
+    if args.command == "attach":
+        return attach(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_claude_delegate.py
+++ b/tests/test_claude_delegate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "skills" / "claude-interactive-delegate" / "scripts" / "claude_delegate.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("claude_delegate", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_make_task_dir_creates_unique_task_directory(tmp_path):
+    delegate = load_module()
+
+    task_id, task_dir = delegate.make_task_dir(tmp_path, "task-123")
+
+    assert task_id == "task-123"
+    assert task_dir == tmp_path / "task-123"
+    assert task_dir.is_dir()
+    with pytest.raises(FileExistsError):
+        delegate.make_task_dir(tmp_path, "task-123")
+
+
+def test_build_delegate_message_uses_file_handoff_contract(tmp_path):
+    delegate = load_module()
+    task_dir = tmp_path / "task-123"
+    task_dir.mkdir()
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+
+    message = delegate.build_delegate_message(task_dir, str(cwd))
+
+    assert str(task_dir / "prompt.md") in message
+    assert str(task_dir / "result.md") in message
+    assert f"touch {task_dir / 'DONE'}" in message
+    assert str(task_dir / "ERROR") in message
+    assert str(cwd.resolve()) in message
+    assert "Do not answer login, billing, subscription, payment, or API-credit consent prompts" in message


### PR DESCRIPTION
## Summary
- Add a Codex-native `$claude-interactive-delegate` skill under `skills/`
- Add a tmux-backed interactive Claude driver that uses file-based task handoff instead of `claude -p`
- Document installation and provider usage, plus unit tests for the delegate protocol

## Test Evidence
- `python3 /Users/patwork/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/claude-interactive-delegate`
- `python3 -m py_compile skills/claude-interactive-delegate/scripts/claude_delegate.py`
- `ruff check skills/claude-interactive-delegate/scripts/claude_delegate.py tests/test_claude_delegate.py`
- `pytest -q` -> 40 passed

## Local Smoke Test
- Started `cw-claude` via tmux with `claude --dangerously-skip-permissions`
- Submitted `smoke-test-danger` through the delegate protocol
- Claude wrote `result.md` and `DONE` without manual approval prompts