### PR TITLE
feat: add harness delegate protocol and dependency profiles

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -21,7 +21,19 @@ CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 Run the check script to see what's installed and what's missing:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py
+python3 $CW_HOME/scripts/check_deps.py --for core
+```
+
+Dependency checks are profile-based. Use only the profiles the current harness and workflow need:
+
+```bash
+python3 $CW_HOME/scripts/check_deps.py --for core
+python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-code
+python3 $CW_HOME/scripts/check_deps.py --for core --provider codex --provider gemini
+python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
+python3 $CW_HOME/scripts/check_deps.py --for transcription
+python3 $CW_HOME/scripts/check_deps.py --for browser-validation
+python3 $CW_HOME/scripts/check_deps.py --for vertex
 ```
 
 ### Step 2: Report results
@@ -36,6 +48,8 @@ If anything is missing, ask the user if they want to install it. For each missin
 
 - **codex**: OpenAI Codex CLI for multi-AI code consultation
 - **gemini**: Google Gemini CLI for multi-AI code consultation
+- **claude**: Claude Code CLI for Claude Code harness usage or interactive delegation
+- **tmux**: Persistent terminal session manager for the Claude interactive delegate
 - **whisper**: Local speech-to-text for `/transcribe`
 - **browser-use**: AI-driven browser automation for E2E validation
 - **playwright**: Browser automation framework (used by browser-use)
@@ -86,12 +100,13 @@ python3 $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_LOCATION
 Re-run the check script to confirm everything is green:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py
+python3 $CW_HOME/scripts/check_deps.py --for core
 ```
 
 For workflow-specific preflight checks:
 ```bash
 python3 $CW_HOME/scripts/check_deps.py --for implement
-python3 $CW_HOME/scripts/check_deps.py --for transcribe
+python3 $CW_HOME/scripts/check_deps.py --for transcription
+python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
 python3 $CW_HOME/scripts/check_deps.py --for vertex
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,22 @@ A collection of Claude Code skills that orchestrate a full development pipeline 
 
 ## Required Tools
 
-- `claude` - Claude Code CLI
-- `codex` - OpenAI Codex CLI
-- `gemini` - Google Gemini CLI
-- `gh` - GitHub CLI
-- `ffmpeg` - Media processing
-- `whisper` - OpenAI Whisper (local transcription)
-- `playwright` - Browser automation (via target repo)
-- `browser-use` - AI browser agent (via target repo)
+Chief Wiggum dependency checks are profile-based:
+
+- `core` - `gh`, `git`, and Python keyring support
+- `claude-code` - Claude Code CLI for Claude Code harness usage
+- `codex` - OpenAI Codex CLI provider
+- `gemini` - Google Gemini CLI provider
+- `claude-interactive` - Claude Code CLI plus `tmux` for interactive delegation
+- `transcription` - ffmpeg and OpenAI Whisper
+- `browser-validation` - browser-use, Playwright, and Anthropic browser-use integration
+- `vertex` - Vertex AI packages and project configuration
+
+Example:
+
+```bash
+python3 scripts/check_deps.py --for core --provider claude-interactive
+```
 
 ## Secret Management
 
@@ -136,7 +144,7 @@ python3 "$CW_HOME/scripts/repo.py" clean acme/app     # remove cache
 
 ```
 .claude/commands/    # Claude Code skills (the core of this repo)
-skills/              # Codex-native skills and bundled resources
+skills/              # Harness-portable skills and bundled resources
 scripts/             # Python helpers called by skills
 templates/           # Issue, PR, review, and checklist templates
 models.md            # AI model IDs and library versions (refresh with /update)
@@ -193,7 +201,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 /update                         # Refresh model IDs and library versions
 ```
 
-Codex-native skills live under `skills/`. Install them into Codex with a symlink, for example:
+Harness-portable skills live under `skills/`. Install them into Codex with a symlink, for example:
 
 ```bash
 ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ claude /plan-epic owner/repo
 claude /implement owner/repo#42
 ```
 
-Codex-native skills are stored under `skills/`. To install the Claude interactive delegate skill for Codex:
+Harness-portable skills are stored under `skills/`. To install the Claude interactive delegate skill in Codex:
 
 ```bash
 ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
@@ -78,10 +78,10 @@ python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py s
 | `/stitch-audit` | Cross-layer data flow analysis |
 | `/update` | Refresh AI model IDs and library versions |
 
-### Codex Skills
+### Portable Skills
 | Skill | Purpose |
 |-------|---------|
-| `$claude-interactive-delegate` | Delegate bounded Codex tasks to a persistent interactive Claude Code tmux session |
+| `$claude-interactive-delegate` | Delegate bounded agent tasks to a persistent interactive Claude Code tmux session |
 
 ## Pipeline
 
@@ -234,10 +234,18 @@ graph TD
 ## Requirements
 
 - **Python >= 3.11**
-- Claude Code CLI (`claude`)
-- OpenAI Codex CLI (`codex`)
-- Google Gemini CLI (`gemini`)
-- GitHub CLI (`gh`)
-- tmux (for `$claude-interactive-delegate`)
-- ffmpeg, openai-whisper (for transcription)
+- GitHub CLI (`gh`) and `git` for the core workflow
+- Optional provider CLIs: Claude Code (`claude`), OpenAI Codex (`codex`), Google Gemini (`gemini`)
+- Optional delegate support: `tmux` for `$claude-interactive-delegate`
+- Optional transcription support: ffmpeg, openai-whisper
 - Secrets stored in system keyring (managed via `python3 scripts/keychain.py`)
+
+Check only the profiles you intend to use:
+
+```bash
+python3 scripts/check_deps.py --for core
+python3 scripts/check_deps.py --for core --provider claude-interactive
+python3 scripts/check_deps.py --for core --provider codex --provider gemini
+python3 scripts/check_deps.py --for transcription
+python3 scripts/check_deps.py --for browser-validation
+```

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -26,20 +26,64 @@ fail_count = 0
 warn_count = 0
 
 WORKFLOW_REQUIREMENTS = {
+    "core": {
+        "cmds": {"gh", "git"},
+        "pkgs": {"keyring"},
+        "secrets": set(),
+    },
     "base": {
-        "cmds": {"claude", "codex", "gemini", "gh", "ffmpeg", "git"},
-        "pkgs": {"keyring", "whisper"},
+        "extends": {"core"},
+        "cmds": set(),
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "claude-code": {
+        "cmds": {"claude"},
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "codex": {
+        "cmds": {"codex"},
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "gemini": {
+        "cmds": {"gemini"},
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "claude-interactive": {
+        "cmds": {"claude", "tmux"},
+        "pkgs": set(),
         "secrets": set(),
     },
     "implement": {
-        "cmds": {"claude", "codex", "gemini", "gh", "git"},
-        "pkgs": {"keyring", "browser-use", "playwright", "langchain-anthropic"},
-        "secrets": {"ANTHROPIC_API_KEY"},
+        "extends": {"core", "browser-validation"},
+        "cmds": set(),
+        "pkgs": set(),
+        "secrets": set(),
     },
     "transcribe": {
+        "extends": {"transcription"},
+        "cmds": set(),
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "transcription": {
         "cmds": {"ffmpeg"},
         "pkgs": {"whisper"},
         "secrets": set(),
+    },
+    "browser": {
+        "extends": {"browser-validation"},
+        "cmds": set(),
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "browser-validation": {
+        "cmds": set(),
+        "pkgs": {"browser-use", "playwright", "langchain-anthropic"},
+        "secrets": {"ANTHROPIC_API_KEY"},
     },
     "vertex": {
         "cmds": set(),
@@ -101,31 +145,71 @@ def check_secret(name: str, required: bool = False):
             warn_count += 1
 
 
+def expand_profiles(profiles: list[str]) -> set[str]:
+    expanded: set[str] = set()
+
+    def visit(profile: str) -> None:
+        if profile in expanded:
+            return
+        requirements = WORKFLOW_REQUIREMENTS[profile]
+        expanded.add(profile)
+        for parent in requirements.get("extends", set()):
+            visit(parent)
+
+    for profile in profiles:
+        visit(profile)
+    return expanded
+
+
+def required_items(kind: str, profiles: list[str]) -> set[str]:
+    required: set[str] = set()
+    for profile in expand_profiles(profiles):
+        required.update(WORKFLOW_REQUIREMENTS[profile][kind])
+    return required
+
+
 def is_required(kind: str, name: str, workflows: list[str]) -> bool:
-    return any(name in WORKFLOW_REQUIREMENTS[workflow][kind] for workflow in workflows)
+    return name in required_items(kind, workflows)
+
+
+def selected_profiles(workflows: list[str], providers: list[str]) -> list[str]:
+    return (workflows or ["core"]) + providers
 
 
 def main():
     parser = argparse.ArgumentParser(description="Check chief-wiggum dependencies.")
+    profile_choices = sorted(WORKFLOW_REQUIREMENTS)
     parser.add_argument(
         "--for",
         dest="workflows",
         action="append",
-        choices=sorted(WORKFLOW_REQUIREMENTS),
+        choices=profile_choices,
         default=[],
-        help="Workflow to enforce. May be passed multiple times.",
+        help="Profile to enforce. May be passed multiple times.",
+    )
+    parser.add_argument(
+        "--provider",
+        dest="providers",
+        action="append",
+        choices=["claude-code", "codex", "gemini", "claude-interactive", "vertex"],
+        default=[],
+        help="Provider profile to enforce. May be passed multiple times.",
     )
     args = parser.parse_args()
-    workflows = args.workflows or ["base"]
+    workflows = selected_profiles(args.workflows, args.providers)
 
     print("=== Chief Wiggum Dependency Check ===")
     print(f"Profile: {', '.join(workflows)}")
+    print(f"Expanded: {', '.join(sorted(expand_profiles(workflows)))}")
+    if "base" in workflows:
+        print("Note: 'base' is a compatibility alias for 'core'. Use provider profiles for AI CLIs.")
 
     print("\n--- CLI Tools ---")
     check_cmd("claude", "claude", "--version", is_required("cmds", "claude", workflows))
     check_cmd("codex", "codex", "--version", is_required("cmds", "codex", workflows))
     check_cmd("gemini", "gemini", "--version", is_required("cmds", "gemini", workflows))
     check_cmd("gh", "gh", "--version", is_required("cmds", "gh", workflows))
+    check_cmd("tmux", "tmux", "-V", is_required("cmds", "tmux", workflows))
     check_cmd("ffmpeg", "ffmpeg", "-version", is_required("cmds", "ffmpeg", workflows))
     check_cmd("git", "git", "--version", is_required("cmds", "git", workflows))
 
@@ -166,7 +250,7 @@ def main():
     print(f"\n=== Results: {pass_count} ok, {fail_count} missing, {warn_count} warnings ===")
 
     if fail_count > 0:
-        print("\nRun /setup to install missing dependencies.")
+        print("\nRun /setup or choose narrower --for/--provider profiles to install missing dependencies.")
         sys.exit(1)
 
 

--- a/scripts/delegates/README.md
+++ b/scripts/delegates/README.md
@@ -1,0 +1,36 @@
+# Delegated Worker Task Protocol
+
+Chief Wiggum delegates bounded work to providers through a shared file-based task contract. Use this protocol for harness subagents, subprocess reviewers, interactive terminal delegates, or future provider adapters.
+
+## Task Directory
+
+Each task lives under a provider-specific root:
+
+```text
+~/.chief-wiggum/delegates/<provider>/<task-id>/
+├── prompt.md       # input prompt written by the orchestrator
+├── result.md       # final answer written by the worker
+├── DONE            # success sentinel
+├── ERROR           # blocked/error sentinel with a concise reason
+├── worker.log      # optional provider log
+└── metadata.json   # optional structured metadata
+```
+
+The orchestrator reads `result.md` only after `DONE` exists. If `ERROR` exists, the orchestrator treats the task as blocked and decides whether to retry with a narrower prompt.
+
+Terminal output is diagnostic only. Do not parse terminal UI or stdout as the primary result contract when a provider can write files.
+
+## Worker Prompt Requirements
+
+Worker prompts should include:
+
+- role and stop condition
+- exact input paths or artifacts
+- required output format
+- `result.md` path
+- `DONE` and `ERROR` sentinel paths
+- boundaries such as no PR creation or no billing/account consent
+
+## Verification
+
+Worker results are advisory unless the workflow explicitly defines them as generated artifacts. The orchestrator must independently verify tests, lint, screenshots, file references, and repository state.

--- a/scripts/delegates/__init__.py
+++ b/scripts/delegates/__init__.py
@@ -1,0 +1,1 @@
+"""Delegated worker helpers."""

--- a/scripts/delegates/task_protocol.py
+++ b/scripts/delegates/task_protocol.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Shared file-based task protocol for delegated workers."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_TASK_ROOT = Path.home() / ".chief-wiggum" / "delegates"
+
+
+@dataclass(frozen=True)
+class TaskPaths:
+    """Paths for a delegated worker task directory."""
+
+    task_id: str
+    task_dir: Path
+    prompt: Path
+    result: Path
+    done: Path
+    error: Path
+    log: Path
+    metadata: Path
+
+
+def new_task_id() -> str:
+    return time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8]
+
+
+def task_paths(task_root: Path, task_id: str) -> TaskPaths:
+    task_dir = task_root.expanduser().resolve() / task_id
+    return TaskPaths(
+        task_id=task_id,
+        task_dir=task_dir,
+        prompt=task_dir / "prompt.md",
+        result=task_dir / "result.md",
+        done=task_dir / "DONE",
+        error=task_dir / "ERROR",
+        log=task_dir / "worker.log",
+        metadata=task_dir / "metadata.json",
+    )
+
+
+def create_task(task_root: Path, task_id: str | None = None, prompt: str | None = None) -> TaskPaths:
+    paths = task_paths(task_root, task_id or new_task_id())
+    paths.task_dir.mkdir(parents=True, exist_ok=False)
+    if prompt is not None:
+        paths.prompt.write_text(prompt)
+    return paths
+
+
+def wait_for_completion(paths: TaskPaths, timeout_seconds: int, poll_seconds: float = 2.0) -> str:
+    """Wait for DONE or ERROR and return 'done' or 'error'.
+
+    Raises TimeoutError if neither sentinel appears before the timeout.
+    """
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if paths.done.exists():
+            return "done"
+        if paths.error.exists():
+            return "error"
+        time.sleep(poll_seconds)
+    raise TimeoutError(f"no DONE or ERROR after {timeout_seconds}s: {paths.task_dir}")

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -18,6 +18,7 @@ CLI_TOOLS = {
     "codex": ["npm", "install", "-g", "@openai/codex"],
     "gemini": ["npm", "install", "-g", "@google/gemini-cli"],
     "gh": ["brew", "install", "gh"],
+    "tmux": ["brew", "install", "tmux"],
     "ffmpeg": ["brew", "install", "ffmpeg"],
 }
 

--- a/skills/claude-interactive-delegate/SKILL.md
+++ b/skills/claude-interactive-delegate/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: claude-interactive-delegate
-description: Delegate bounded tasks from Codex to a persistent interactive Claude Code terminal session using tmux/PTY instead of claude -p. Use when Codex should ask Claude Code to act as an optional reviewer, architecture critic, design critic, implementation advisor, or Chief Wiggum provider through an interactive session with file-based task handoff and completion sentinels.
+description: Delegate bounded tasks from an agent orchestrator to a persistent interactive Claude Code terminal session using tmux/PTY instead of claude -p. Use when an orchestrator should ask Claude Code to act as an optional reviewer, architecture critic, design critic, implementation advisor, or Chief Wiggum provider through an interactive session with file-based task handoff and completion sentinels.
 ---
 
 # Claude Interactive Delegate
 
 ## Overview
 
-Use this skill to drive an existing or newly started interactive Claude Code session as a delegated worker. Codex sends the task through a real terminal session, Claude writes the durable result to files, and Codex reads those files back into the main workflow.
+Use this skill to drive an existing or newly started interactive Claude Code session as a delegated worker. The orchestrator sends the task through a real terminal session, Claude writes the durable result to files, and the orchestrator reads those files back into the main workflow.
 
-This skill is for bounded delegation, not for replacing Codex's local verification. Codex remains responsible for deciding whether the delegated output is useful and for independently checking any code, tests, or claims before shipping.
+This skill is for bounded delegation, not for replacing local verification. The orchestrator remains responsible for deciding whether the delegated output is useful and for independently checking any code, tests, or claims before shipping.
 
 ## Requirements
 
@@ -67,21 +67,21 @@ The driver creates task directories under `~/.chief-wiggum/delegates/claude/` by
 
 ```text
 task-id/
-├── prompt.md       # task prompt written by Codex
+├── prompt.md       # task prompt written by the orchestrator
 ├── result.md       # final answer written by Claude
 ├── DONE            # completion sentinel written by Claude
 └── ERROR           # blocked/error sentinel written by Claude
 ```
 
-Codex should never parse terminal output as the result contract. Terminal capture is for debugging only.
+The orchestrator should never parse terminal output as the result contract. Terminal capture is for debugging only.
 
 For full protocol details, read `references/protocol.md`.
 
 ## Boundaries
 
 - Do not automate account login, billing changes, subscription changes, API-credit consent, or payment prompts. If the interactive session reaches one of these states, stop and surface it to the user.
-- Do not let the delegate create or merge PRs unless the current workflow explicitly requires it and Codex will verify the outcome.
-- Do not trust self-reported test results. Codex must run or inspect verification independently.
+- Do not let the delegate create or merge PRs unless the current workflow explicitly requires it and the orchestrator will verify the outcome.
+- Do not trust self-reported test results. The orchestrator must run or inspect verification independently.
 - Do not leave completed delegate sessions open indefinitely if they are no longer needed.
 - Use `scripts/claude_delegate.py stop` before changing the delegate permission mode, then start a fresh session.
 

--- a/skills/claude-interactive-delegate/references/protocol.md
+++ b/skills/claude-interactive-delegate/references/protocol.md
@@ -14,17 +14,19 @@ Set `CLAUDE_DELEGATE_CMD` or pass `--claude-cmd` to use another interactive mode
 
 ## Task Handoff
 
-Each delegated task has a unique directory:
+Each delegated task follows the shared Chief Wiggum delegated-worker protocol in `scripts/delegates/README.md`. Each task has a unique directory:
 
 ```text
 ~/.chief-wiggum/delegates/claude/<task-id>/
 ├── prompt.md
 ├── result.md
 ├── DONE
-└── ERROR
+├── ERROR
+├── worker.log
+└── metadata.json
 ```
 
-Codex writes `prompt.md`. Claude must write either:
+The orchestrator writes `prompt.md`. Claude must write either:
 
 - `result.md` and `DONE`, or
 - `ERROR` with a short reason.
@@ -52,11 +54,11 @@ The delegate should be treated as blocked if the session requires:
 - Tool permission decisions that were not preconfigured for the session.
 - Interactive clarification that cannot be answered from the task prompt.
 
-In these cases, Codex should inspect `capture` output, report the issue to the user, and avoid faking an answer.
+In these cases, the orchestrator should inspect `capture` output, report the issue to the user, and avoid faking an answer.
 
 ## Verification
 
-Claude delegate output is advisory. Codex must independently verify:
+Claude delegate output is advisory. The orchestrator must independently verify:
 
 - Tests and lint results.
 - File paths and line references.

--- a/skills/claude-interactive-delegate/scripts/claude_delegate.py
+++ b/skills/claude-interactive-delegate/scripts/claude_delegate.py
@@ -8,9 +8,25 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 import uuid
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if (REPO_ROOT / "scripts" / "delegates" / "task_protocol.py").is_file():
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+try:
+    from delegates.task_protocol import (  # noqa: E402
+        TaskPaths,
+        create_task,
+        task_paths,
+        wait_for_completion,
+    )
+except ModuleNotFoundError as exc:
+    raise SystemExit(
+        "Could not import Chief Wiggum's shared delegate protocol. "
+        "Install this skill as a symlink to the chief-wiggum checkout, or run it from the repository copy."
+    ) from exc
 
 DEFAULT_SESSION = "cw-claude"
 DEFAULT_TASK_ROOT = Path.home() / ".chief-wiggum" / "delegates" / "claude"
@@ -63,34 +79,23 @@ def send_text(session: str, text: str) -> None:
     run(["tmux", "send-keys", "-t", session, "Enter"])
 
 
-def make_task_dir(task_root: Path, task_id: str | None) -> tuple[str, Path]:
-    task_id = task_id or time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8]
-    task_dir = (task_root / task_id).expanduser().resolve()
-    task_dir.mkdir(parents=True, exist_ok=False)
-    return task_id, task_dir
-
-
-def build_delegate_message(task_dir: Path, cwd: str | None) -> str:
-    prompt_path = task_dir / "prompt.md"
-    result_path = task_dir / "result.md"
-    done_path = task_dir / "DONE"
-    error_path = task_dir / "ERROR"
+def build_delegate_message(paths: TaskPaths, cwd: str | None) -> str:
     cwd_line = f"\nWork from this repository/directory when relevant:\n{Path(cwd).expanduser().resolve()}\n" if cwd else ""
     return f"""Delegated Chief Wiggum task.
 
-The operator has authorized this interactive Claude Code session to handle bounded delegated engineering tasks from Codex.
+The operator has authorized this interactive Claude Code session to handle bounded delegated engineering tasks from an agent orchestrator.
 
 Read the task prompt:
-{prompt_path}
+{paths.prompt}
 {cwd_line}
 Write your final answer as Markdown to:
-{result_path}
+{paths.result}
 
 When complete, run:
-touch {done_path}
+touch {paths.done}
 
 If you are blocked, write a concise reason to:
-{error_path}
+{paths.error}
 
 Then stop working on this delegated task.
 
@@ -104,7 +109,6 @@ Important boundaries:
 def submit(args: argparse.Namespace) -> int:
     start_session(args.session, args.claude_cmd)
     task_root = Path(args.task_root).expanduser()
-    task_id, task_dir = make_task_dir(task_root, args.task_id)
 
     if args.prompt_file:
         prompt = Path(args.prompt_file).expanduser().read_text()
@@ -113,39 +117,35 @@ def submit(args: argparse.Namespace) -> int:
     else:
         raise SystemExit("submit requires --prompt-file or --prompt")
 
-    (task_dir / "prompt.md").write_text(prompt)
-    send_text(args.session, build_delegate_message(task_dir, args.cwd))
+    paths = create_task(task_root, args.task_id, prompt)
+    send_text(args.session, build_delegate_message(paths, args.cwd))
 
-    print(f"TASK_ID={task_id}")
-    print(f"TASK_DIR={task_dir}")
-    print(f"PROMPT={task_dir / 'prompt.md'}")
-    print(f"RESULT={task_dir / 'result.md'}")
-    print(f"DONE={task_dir / 'DONE'}")
-    print(f"ERROR={task_dir / 'ERROR'}")
+    print(f"TASK_ID={paths.task_id}")
+    print(f"TASK_DIR={paths.task_dir}")
+    print(f"PROMPT={paths.prompt}")
+    print(f"RESULT={paths.result}")
+    print(f"DONE={paths.done}")
+    print(f"ERROR={paths.error}")
 
     if args.wait:
-        return wait_for_task(task_dir, args.timeout_seconds)
+        return wait_for_task(paths, args.timeout_seconds)
     return 0
 
 
-def wait_for_task(task_dir: Path, timeout_seconds: int) -> int:
-    deadline = time.time() + timeout_seconds
-    done = task_dir / "DONE"
-    error = task_dir / "ERROR"
-    while time.time() < deadline:
-        if done.exists():
-            print(f"OK: task complete: {task_dir}")
-            result = task_dir / "result.md"
-            if result.exists():
-                print(f"RESULT={result}")
-            return 0
-        if error.exists():
-            print(f"ERROR: task blocked: {task_dir}", file=sys.stderr)
-            print(error.read_text(), file=sys.stderr)
-            return 2
-        time.sleep(2)
-    print(f"TIMEOUT: no DONE or ERROR after {timeout_seconds}s: {task_dir}", file=sys.stderr)
-    return 3
+def wait_for_task(paths: TaskPaths, timeout_seconds: int) -> int:
+    try:
+        status = wait_for_completion(paths, timeout_seconds)
+    except TimeoutError as exc:
+        print(f"TIMEOUT: {exc}", file=sys.stderr)
+        return 3
+    if status == "done":
+        print(f"OK: task complete: {paths.task_dir}")
+        if paths.result.exists():
+            print(f"RESULT={paths.result}")
+        return 0
+    print(f"ERROR: task blocked: {paths.task_dir}", file=sys.stderr)
+    print(paths.error.read_text(), file=sys.stderr)
+    return 2
 
 
 def status(args: argparse.Namespace) -> int:
@@ -224,7 +224,7 @@ def main() -> int:
     if args.command == "submit":
         return submit(args)
     if args.command == "wait":
-        return wait_for_task(Path(args.task_root).expanduser() / args.task_id, args.timeout_seconds)
+        return wait_for_task(task_paths(Path(args.task_root).expanduser(), args.task_id), args.timeout_seconds)
     if args.command == "capture":
         return capture(args)
     if args.command == "attach":

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,8 +1,20 @@
 import check_deps
 
 
-def test_base_profile_does_not_require_browser_use():
-    assert not check_deps.is_required("pkgs", "browser-use", ["base"])
+def test_core_profile_does_not_require_ai_or_browser_tools():
+    profiles = ["core"]
+
+    assert check_deps.is_required("cmds", "gh", profiles)
+    assert check_deps.is_required("cmds", "git", profiles)
+    assert not check_deps.is_required("cmds", "claude", profiles)
+    assert not check_deps.is_required("cmds", "codex", profiles)
+    assert not check_deps.is_required("cmds", "gemini", profiles)
+    assert not check_deps.is_required("pkgs", "browser-use", profiles)
+
+
+def test_base_profile_is_backward_compatible_alias_for_core():
+    assert check_deps.is_required("cmds", "gh", ["base"])
+    assert not check_deps.is_required("cmds", "codex", ["base"])
 
 
 def test_implement_profile_requires_browser_validation_dependencies():
@@ -12,6 +24,21 @@ def test_implement_profile_requires_browser_validation_dependencies():
     assert check_deps.is_required("pkgs", "playwright", workflows)
     assert check_deps.is_required("pkgs", "langchain-anthropic", workflows)
     assert check_deps.is_required("secrets", "ANTHROPIC_API_KEY", workflows)
+    assert check_deps.is_required("cmds", "gh", workflows)
+    assert not check_deps.is_required("cmds", "claude", workflows)
+
+
+def test_provider_profiles_require_specific_cli_tools():
+    assert check_deps.is_required("cmds", "codex", ["codex"])
+    assert check_deps.is_required("cmds", "gemini", ["gemini"])
+    assert check_deps.is_required("cmds", "claude", ["claude-code"])
+    assert check_deps.is_required("cmds", "claude", ["claude-interactive"])
+    assert check_deps.is_required("cmds", "tmux", ["claude-interactive"])
+
+
+def test_selected_profiles_default_to_core_and_append_providers():
+    assert check_deps.selected_profiles([], []) == ["core"]
+    assert check_deps.selected_profiles(["transcription"], ["gemini"]) == ["transcription", "gemini"]
 
 
 def test_vertex_profile_requires_vertex_packages_and_project():

--- a/tests/test_claude_delegate.py
+++ b/tests/test_claude_delegate.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -20,27 +23,47 @@ def load_module():
 def test_make_task_dir_creates_unique_task_directory(tmp_path):
     delegate = load_module()
 
-    task_id, task_dir = delegate.make_task_dir(tmp_path, "task-123")
+    paths = delegate.create_task(tmp_path, "task-123")
 
-    assert task_id == "task-123"
-    assert task_dir == tmp_path / "task-123"
-    assert task_dir.is_dir()
+    assert paths.task_id == "task-123"
+    assert paths.task_dir == tmp_path / "task-123"
+    assert paths.prompt == tmp_path / "task-123" / "prompt.md"
+    assert paths.result == tmp_path / "task-123" / "result.md"
+    assert paths.done == tmp_path / "task-123" / "DONE"
+    assert paths.error == tmp_path / "task-123" / "ERROR"
+    assert paths.task_dir.is_dir()
     with pytest.raises(FileExistsError):
-        delegate.make_task_dir(tmp_path, "task-123")
+        delegate.create_task(tmp_path, "task-123")
 
 
 def test_build_delegate_message_uses_file_handoff_contract(tmp_path):
     delegate = load_module()
-    task_dir = tmp_path / "task-123"
-    task_dir.mkdir()
+    paths = delegate.create_task(tmp_path, "task-123")
     cwd = tmp_path / "repo"
     cwd.mkdir()
 
-    message = delegate.build_delegate_message(task_dir, str(cwd))
+    message = delegate.build_delegate_message(paths, str(cwd))
 
-    assert str(task_dir / "prompt.md") in message
-    assert str(task_dir / "result.md") in message
-    assert f"touch {task_dir / 'DONE'}" in message
-    assert str(task_dir / "ERROR") in message
+    assert str(paths.prompt) in message
+    assert str(paths.result) in message
+    assert f"touch {paths.done}" in message
+    assert str(paths.error) in message
     assert str(cwd.resolve()) in message
     assert "Do not answer login, billing, subscription, payment, or API-credit consent prompts" in message
+
+
+def test_script_bootstraps_shared_protocol_without_pytest_pythonpath(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = ""
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Drive an interactive Claude Code session" in result.stdout

--- a/tests/test_task_protocol.py
+++ b/tests/test_task_protocol.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from delegates import task_protocol
+
+
+def test_create_task_writes_prompt_and_paths(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1", "Review this diff.")
+
+    assert paths.task_id == "worker-1"
+    assert paths.task_dir == tmp_path / "worker-1"
+    assert paths.prompt.read_text() == "Review this diff."
+    assert paths.result == paths.task_dir / "result.md"
+    assert paths.done == paths.task_dir / "DONE"
+    assert paths.error == paths.task_dir / "ERROR"
+    assert paths.log == paths.task_dir / "worker.log"
+    assert paths.metadata == paths.task_dir / "metadata.json"
+
+
+def test_wait_for_completion_detects_done(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    paths.done.touch()
+
+    assert task_protocol.wait_for_completion(paths, timeout_seconds=1, poll_seconds=0.01) == "done"
+
+
+def test_wait_for_completion_detects_error(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    paths.error.write_text("blocked")
+
+    assert task_protocol.wait_for_completion(paths, timeout_seconds=1, poll_seconds=0.01) == "error"
+
+
+def test_wait_for_completion_times_out(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+
+    with pytest.raises(TimeoutError):
+        task_protocol.wait_for_completion(paths, timeout_seconds=0, poll_seconds=0.01)


### PR DESCRIPTION
## Summary
- Add a shared file-based delegated-worker protocol under `scripts/delegates/`
- Refactor the Claude interactive delegate to consume the shared protocol
- Make dependency checks profile-based so core, harness, provider, transcription, browser, and Vertex requirements are independently selectable
- Update setup/docs for harness-portable skills and provider profiles

## Test Evidence
- `ruff check scripts/check_deps.py scripts/install_deps.py scripts/delegates/task_protocol.py skills/claude-interactive-delegate/scripts/claude_delegate.py tests/test_check_deps.py tests/test_claude_delegate.py tests/test_task_protocol.py`
- `pytest -q` -> 48 passed
- `python3 /Users/patwork/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/claude-interactive-delegate`
- `PYTHONPATH= python3 skills/claude-interactive-delegate/scripts/claude_delegate.py --help`
- `python3 scripts/check_deps.py --for core --provider claude-interactive`

## Delegate Review
Ran a bounded Claude interactive delegate review through `cw-claude`; it identified import-bootstrap and CLI-profile test gaps, both addressed before this PR.

Closes #31
Closes #32