### PR TITLE
feat: add role-based provider configuration

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -110,3 +110,5 @@ python3 $CW_HOME/scripts/check_deps.py --for transcription
 python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
 python3 $CW_HOME/scripts/check_deps.py --for vertex
 ```
+
+Provider roles are configured in `$CW_HOME/config/providers.json`. Validate role dependencies by running the matching provider profiles before a workflow starts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,17 @@ Use `gemini-vertex` as the tool name in `consult_ai.py` to route through Vertex 
 
 See `models.md` for current model IDs, library versions, and default choices. Refresh with `/update`.
 
+## Provider Roles
+
+Provider roles live in `config/providers.json`. Use `scripts/consult_ai.py` directly for one provider, or `--role <role> --output-dir <dir>` for a configured quorum:
+
+```bash
+python3 scripts/consult_ai.py codex prompt.md -o response.md
+python3 scripts/consult_ai.py --role reviewer prompt.md --output-dir "$CW_TMP/reviews"
+```
+
+Roles define required and optional providers. Required providers must succeed; optional providers may be disabled or fail without blocking the role quorum. This keeps Claude, Codex, Gemini, and interactive delegates configurable rather than hard-coded into workflow logic.
+
 ## User Data Directory
 
 Chief-wiggum stores all user-space data under `~/.chief-wiggum/`:

--- a/README.md
+++ b/README.md
@@ -249,3 +249,19 @@ python3 scripts/check_deps.py --for core --provider codex --provider gemini
 python3 scripts/check_deps.py --for transcription
 python3 scripts/check_deps.py --for browser-validation
 ```
+
+## Provider Roles
+
+AI backends are configured by role in `config/providers.json`. Workflows can still call a provider directly:
+
+```bash
+python3 scripts/consult_ai.py codex prompt.md -o response.md
+```
+
+They can also consult a role quorum:
+
+```bash
+python3 scripts/consult_ai.py --role reviewer prompt.md --output-dir ~/.chief-wiggum/tmp/reviews
+```
+
+Role config controls which providers are required or optional. Optional providers can fail or be disabled without blocking the quorum; required providers must be enabled and return successfully.

--- a/config/providers.json
+++ b/config/providers.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "type": "tool",
+      "tool": "codex",
+      "enabled": true
+    },
+    "gemini": {
+      "type": "tool",
+      "tool": "gemini",
+      "enabled": true
+    },
+    "gemini-vertex": {
+      "type": "tool",
+      "tool": "gemini-vertex",
+      "enabled": false
+    },
+    "claude": {
+      "type": "tool",
+      "tool": "claude",
+      "enabled": false
+    },
+    "claude-interactive": {
+      "type": "delegate",
+      "delegate": "claude-interactive",
+      "enabled": true
+    }
+  },
+  "roles": {
+    "explorer": {
+      "required": ["codex"],
+      "optional": ["gemini", "claude-interactive"]
+    },
+    "implementer": {
+      "required": ["codex"],
+      "optional": ["claude-interactive"]
+    },
+    "reviewer": {
+      "required": ["codex", "gemini"],
+      "optional": ["claude-interactive"]
+    },
+    "architecture_critic": {
+      "required": ["codex"],
+      "optional": ["gemini", "claude-interactive"]
+    },
+    "design_critic": {
+      "required": ["gemini"],
+      "optional": ["codex", "claude-interactive"]
+    },
+    "risky_diff_review": {
+      "required": ["codex", "gemini"],
+      "optional": ["claude-interactive"]
+    }
+  }
+}

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -7,18 +7,22 @@ to SDK constructors — never set as env vars, never printed.
 
 Usage:
     python3 consult_ai.py <tool> <prompt_file> [--output <file>] [--context <file>] [--model <model_id>]
+    python3 consult_ai.py --role <role> <prompt_file> --output-dir <dir>
 
 Tools: codex, gemini, gemini-vertex, claude
 """
 
 import argparse
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # Allow importing keychain from the same directory
 sys.path.insert(0, str(Path(__file__).parent))
 from keychain import get_secret
+from providers import DEFAULT_CONFIG, Provider, load_config, plan_role, validate_config
 
 # Per-tool timeouts (seconds). These are generous — better to wait than to
 # lose a good response to a premature timeout.
@@ -27,6 +31,7 @@ TOOL_TIMEOUTS: dict[str, int] = {
     "gemini": 1200,     # 20 minutes — yolo mode explores the repo via tools
     "gemini-vertex": 600,
     "claude": 600,
+    "claude-interactive": 1800,
 }
 TIMEOUT = 600  # fallback
 
@@ -111,27 +116,98 @@ def consult_claude(prompt: str, model: str | None = None, cwd: str | None = None
     return result.stdout
 
 
+def consult_claude_interactive(prompt: str, model: str | None = None, cwd: str | None = None) -> str:
+    """Delegate to the interactive Claude tmux provider."""
+    if model:
+        print("Warning: --model is ignored for claude-interactive", file=sys.stderr)
+    script = Path(__file__).resolve().parents[1] / "skills" / "claude-interactive-delegate" / "scripts" / "claude_delegate.py"
+    fd, prompt_name = tempfile.mkstemp(suffix=".md")
+    os.close(fd)
+    prompt_file = Path(prompt_name)
+    try:
+        prompt_file.write_text(prompt)
+        cmd = [
+            sys.executable,
+            str(script),
+            "submit",
+            "--prompt-file",
+            str(prompt_file),
+            "--wait",
+        ]
+        if cwd:
+            cmd.extend(["--cwd", cwd])
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=TOOL_TIMEOUTS["claude-interactive"],
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("RESULT="):
+                result_path = Path(line.removeprefix("RESULT="))
+                if result_path.exists():
+                    return result_path.read_text()
+                raise RuntimeError(f"claude-interactive result path does not exist: {result_path}")
+        raise RuntimeError(f"claude-interactive completed without RESULT line: {result.stdout}")
+    finally:
+        prompt_file.unlink(missing_ok=True)
+
+
 TOOLS = {
     "codex": consult_codex,
     "gemini": consult_gemini,
     "gemini-vertex": consult_gemini_vertex,
     "claude": consult_claude,
+    "claude-interactive": consult_claude_interactive,
 }
+
+
+def consult_provider(provider: Provider, prompt: str, model: str | None, cwd: str | None) -> str:
+    if provider.type == "tool":
+        if not provider.tool or provider.tool not in TOOLS:
+            raise ValueError(f"unsupported tool provider: {provider.name}")
+        return TOOLS[provider.tool](prompt, model=model, cwd=cwd)
+    if provider.type == "delegate":
+        if provider.delegate != "claude-interactive":
+            raise ValueError(f"unsupported delegate provider: {provider.name}")
+        return consult_claude_interactive(prompt, model=model, cwd=cwd)
+    raise ValueError(f"unsupported provider type: {provider.type}")
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Consult an AI tool with a prompt.",
     )
-    parser.add_argument("tool", choices=TOOLS.keys(), help="AI tool to consult")
-    parser.add_argument("prompt_file", help="Path to the prompt file")
+    parser.add_argument("target_or_prompt", help="AI tool name, or prompt file when --role is used")
+    parser.add_argument("prompt_file", nargs="?", help="Path to the prompt file")
     parser.add_argument("-o", "--output", help="Write response to file instead of stdout")
+    parser.add_argument("--output-dir", help="Write role provider responses to this directory")
     parser.add_argument("--context", help="Optional context file to append")
     parser.add_argument("--model", help="Override model ID for this call")
     parser.add_argument("--cwd", help="Working directory for the AI tool (e.g., target repo path)")
+    parser.add_argument("--role", help="Provider role to consult from config/providers.json")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Provider config path")
+    parser.add_argument("--enable-provider", action="append", default=[], help="Force-enable provider by name")
+    parser.add_argument("--disable-provider", action="append", default=[], help="Disable provider by name")
     args = parser.parse_args()
 
-    prompt_path = Path(args.prompt_file)
+    if args.role:
+        target = None
+        prompt_file_arg = args.target_or_prompt
+    else:
+        target = args.target_or_prompt
+        prompt_file_arg = args.prompt_file
+        if target not in TOOLS:
+            parser.error(f"unknown tool {target!r}; expected one of: {', '.join(sorted(TOOLS))}")
+        if not prompt_file_arg:
+            parser.error("<prompt_file> is required when consulting a tool")
+    if args.role and not args.output_dir:
+        parser.error("--role requires --output-dir")
+    if args.role and args.output:
+        parser.error("--role writes one file per provider and requires --output-dir, not -o/--output")
+
+    prompt_path = Path(prompt_file_arg)
     if not prompt_path.exists():
         print(f"Prompt file not found: {prompt_path}", file=sys.stderr)
         sys.exit(1)
@@ -143,25 +219,75 @@ def main():
         if ctx_path.exists():
             prompt += f"\n\n---\nContext:\n{ctx_path.read_text()}"
 
-    fn = TOOLS[args.tool]
-    tool_timeout = TOOL_TIMEOUTS.get(args.tool, TIMEOUT)
+    if args.role:
+        config = load_config(Path(args.config))
+        errors = validate_config(
+            config,
+            supported_tools=set(TOOLS),
+            supported_delegates={"claude-interactive"},
+        )
+        if errors:
+            for error in errors:
+                print(f"Config error: {error}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            plan = plan_role(
+                args.role,
+                config,
+                enabled=set(args.enable_provider),
+                disabled=set(args.disable_provider),
+            )
+        except KeyError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not plan.ok:
+            print(
+                f"Missing required providers for role {args.role}: {', '.join(plan.missing_required)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        failures: list[str] = []
+        for provider in plan.runnable:
+            try:
+                output = consult_provider(provider, prompt, args.model, args.cwd)
+                output_path = output_dir / f"{args.role}-{provider.name}.md"
+                output_path.write_text(output)
+                print(f"OK: {provider.name} response written to {output_path}")
+            except Exception as exc:
+                if provider in plan.required:
+                    failures.append(f"{provider.name}: {exc}")
+                else:
+                    skipped = output_dir / f"{args.role}-{provider.name}.error.md"
+                    skipped.write_text(str(exc))
+                    print(f"Warning: optional provider {provider.name} failed: {exc}", file=sys.stderr)
+        if failures:
+            for failure in failures:
+                print(f"Error: {failure}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    assert target is not None
+    fn = TOOLS[target]
+    tool_timeout = TOOL_TIMEOUTS.get(target, TIMEOUT)
     try:
         output = fn(prompt, model=args.model, cwd=args.cwd)
         if args.output:
             out_path = Path(args.output)
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(output)
-            print(f"OK: {args.tool} response written to {args.output}")
+            print(f"OK: {target} response written to {args.output}")
         else:
             print(output)
     except subprocess.TimeoutExpired:
-        msg = f"Timeout: {args.tool} did not respond within {tool_timeout}s"
+        msg = f"Timeout: {target} did not respond within {tool_timeout}s"
         if args.output:
             Path(args.output).write_text(msg)
         print(msg, file=sys.stderr)
         sys.exit(1)
     except subprocess.CalledProcessError as e:
-        msg = f"Error calling {args.tool}: {e.stderr or e}"
+        msg = f"Error calling {target}: {e.stderr or e}"
         if args.output:
             Path(args.output).write_text(msg)
         print(msg, file=sys.stderr)

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Provider and role configuration for Chief Wiggum AI backends."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "config" / "providers.json"
+
+
+@dataclass(frozen=True)
+class Provider:
+    name: str
+    type: str
+    enabled: bool
+    tool: str | None = None
+    delegate: str | None = None
+
+
+@dataclass(frozen=True)
+class Role:
+    name: str
+    required: tuple[str, ...]
+    optional: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RolePlan:
+    role: Role
+    required: tuple[Provider, ...]
+    optional: tuple[Provider, ...]
+    missing_required: tuple[str, ...]
+    skipped_optional: tuple[str, ...]
+
+    @property
+    def runnable(self) -> tuple[Provider, ...]:
+        return self.required + self.optional
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_required
+
+
+def load_config(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    return json.loads(path.expanduser().read_text())
+
+
+def providers_from_config(config: dict[str, Any]) -> dict[str, Provider]:
+    providers: dict[str, Provider] = {}
+    for name, raw in config.get("providers", {}).items():
+        providers[name] = Provider(
+            name=name,
+            type=raw["type"],
+            enabled=bool(raw.get("enabled", True)),
+            tool=raw.get("tool"),
+            delegate=raw.get("delegate"),
+        )
+    return providers
+
+
+def roles_from_config(config: dict[str, Any]) -> dict[str, Role]:
+    roles: dict[str, Role] = {}
+    for name, raw in config.get("roles", {}).items():
+        roles[name] = Role(
+            name=name,
+            required=tuple(raw.get("required", [])),
+            optional=tuple(raw.get("optional", [])),
+        )
+    return roles
+
+
+def provider_is_enabled(provider: Provider, enabled: set[str], disabled: set[str]) -> bool:
+    if provider.name in disabled:
+        return False
+    if provider.name in enabled:
+        return True
+    return provider.enabled
+
+
+def plan_role(
+    role_name: str,
+    config: dict[str, Any],
+    *,
+    enabled: set[str] | None = None,
+    disabled: set[str] | None = None,
+) -> RolePlan:
+    providers = providers_from_config(config)
+    roles = roles_from_config(config)
+    enabled = enabled or set()
+    disabled = disabled or set()
+
+    if role_name not in roles:
+        known = ", ".join(sorted(roles))
+        raise KeyError(f"unknown role: {role_name}. Known roles: {known}")
+
+    role = roles[role_name]
+    required: list[Provider] = []
+    optional: list[Provider] = []
+    missing_required: list[str] = []
+    skipped_optional: list[str] = []
+
+    for name in role.required:
+        provider = providers.get(name)
+        if provider and provider_is_enabled(provider, enabled, disabled):
+            required.append(provider)
+        else:
+            missing_required.append(name)
+
+    for name in role.optional:
+        provider = providers.get(name)
+        if provider and provider_is_enabled(provider, enabled, disabled):
+            optional.append(provider)
+        else:
+            skipped_optional.append(name)
+
+    return RolePlan(
+        role=role,
+        required=tuple(required),
+        optional=tuple(optional),
+        missing_required=tuple(missing_required),
+        skipped_optional=tuple(skipped_optional),
+    )
+
+
+def validate_config(
+    config: dict[str, Any],
+    *,
+    supported_tools: set[str] | None = None,
+    supported_delegates: set[str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    providers = providers_from_config(config)
+    for role_name, role in roles_from_config(config).items():
+        for provider_name in role.required + role.optional:
+            if provider_name not in providers:
+                errors.append(f"role {role_name} references unknown provider {provider_name}")
+    for provider in providers.values():
+        if provider.type == "tool" and not provider.tool:
+            errors.append(f"provider {provider.name} has type=tool but no tool")
+        if supported_tools is not None and provider.type == "tool" and provider.tool not in supported_tools:
+            errors.append(f"provider {provider.name} references unsupported tool {provider.tool}")
+        if provider.type == "delegate" and not provider.delegate:
+            errors.append(f"provider {provider.name} has type=delegate but no delegate")
+        if (
+            supported_delegates is not None
+            and provider.type == "delegate"
+            and provider.delegate not in supported_delegates
+        ):
+            errors.append(
+                f"provider {provider.name} references unsupported delegate {provider.delegate}"
+            )
+        if provider.type not in {"tool", "delegate"}:
+            errors.append(f"provider {provider.name} has unsupported type {provider.type}")
+    return errors

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import consult_ai
+import pytest
+
+
+def write_config(path, *, optional_enabled=True):
+    path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "codex": {"type": "tool", "tool": "codex", "enabled": True},
+                    "gemini": {"type": "tool", "tool": "gemini", "enabled": optional_enabled},
+                },
+                "roles": {"reviewer": {"required": ["codex"], "optional": ["gemini"]}},
+            }
+        )
+    )
+
+
+def test_role_consult_writes_required_and_optional_outputs(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review this.")
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config)
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        return f"{provider.name}: {prompt_text}"
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    consult_ai.main()
+
+    assert (output_dir / "reviewer-codex.md").read_text() == "codex: Review this."
+    assert (output_dir / "reviewer-gemini.md").read_text() == "gemini: Review this."
+
+
+def test_role_consult_does_not_fail_when_optional_provider_is_disabled(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review this.")
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config, optional_enabled=False)
+    called: list[str] = []
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        called.append(provider.name)
+        return provider.name
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    consult_ai.main()
+
+    assert called == ["codex"]
+    assert (output_dir / "reviewer-codex.md").read_text() == "codex"
+    assert not (output_dir / "reviewer-gemini.md").exists()
+
+
+def test_role_consult_fails_when_required_provider_is_disabled(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review this.")
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+            "--disable-provider",
+            "codex",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+
+
+def test_role_consult_fails_cleanly_for_unknown_role(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review this.")
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "missing",
+            str(prompt),
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+
+
+def test_role_consult_rejects_single_output_path(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review this.")
+    config = tmp_path / "providers.json"
+    write_config(config)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "-o",
+            str(tmp_path / "out.md"),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 2
+
+
+def test_claude_interactive_uses_delegate_submit_without_precreating_task(tmp_path, monkeypatch):
+    result_file = tmp_path / "result.md"
+    result_file.write_text("delegate response")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"RESULT={result_file}\n", stderr="")
+
+    monkeypatch.setattr(consult_ai.subprocess, "run", fake_run)
+
+    output = consult_ai.consult_claude_interactive("prompt", cwd=str(tmp_path))
+
+    assert output == "delegate response"
+    cmd = calls[0]
+    assert "submit" in cmd
+    assert "--prompt-file" in cmd
+    assert "--task-id" not in cmd

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+
+import providers
+
+
+def test_default_provider_config_is_valid():
+    config = providers.load_config()
+
+    assert providers.validate_config(config) == []
+    roles = providers.roles_from_config(config)
+    assert {"explorer", "implementer", "reviewer", "architecture_critic", "design_critic", "risky_diff_review"} <= set(roles)
+
+
+def test_role_plan_separates_required_optional_and_disabled():
+    config = {
+        "providers": {
+            "codex": {"type": "tool", "tool": "codex", "enabled": True},
+            "gemini": {"type": "tool", "tool": "gemini", "enabled": True},
+            "claude-interactive": {
+                "type": "delegate",
+                "delegate": "claude-interactive",
+                "enabled": True,
+            },
+        },
+        "roles": {
+            "reviewer": {
+                "required": ["codex", "gemini"],
+                "optional": ["claude-interactive"],
+            }
+        },
+    }
+
+    plan = providers.plan_role("reviewer", config, disabled={"claude-interactive"})
+
+    assert plan.ok
+    assert [provider.name for provider in plan.required] == ["codex", "gemini"]
+    assert plan.optional == ()
+    assert plan.skipped_optional == ("claude-interactive",)
+
+
+def test_required_provider_can_be_disabled_and_makes_plan_not_ok():
+    config = {
+        "providers": {
+            "codex": {"type": "tool", "tool": "codex", "enabled": True},
+            "gemini": {"type": "tool", "tool": "gemini", "enabled": True},
+        },
+        "roles": {"reviewer": {"required": ["codex", "gemini"], "optional": []}},
+    }
+
+    plan = providers.plan_role("reviewer", config, disabled={"gemini"})
+
+    assert not plan.ok
+    assert plan.missing_required == ("gemini",)
+
+
+def test_validate_config_flags_unknown_role_provider():
+    config = {
+        "providers": {"codex": {"type": "tool", "tool": "codex"}},
+        "roles": {"reviewer": {"required": ["codex"], "optional": ["missing"]}},
+    }
+
+    assert providers.validate_config(config) == ["role reviewer references unknown provider missing"]
+
+
+def test_validate_config_can_flag_unknown_backend_names():
+    config = {
+        "providers": {
+            "bad-tool": {"type": "tool", "tool": "bogus"},
+            "bad-delegate": {"type": "delegate", "delegate": "bogus"},
+        },
+        "roles": {},
+    }
+
+    assert providers.validate_config(
+        config,
+        supported_tools={"codex"},
+        supported_delegates={"claude-interactive"},
+    ) == [
+        "provider bad-tool references unsupported tool bogus",
+        "provider bad-delegate references unsupported delegate bogus",
+    ]
+
+
+def test_config_round_trips_from_json_file(tmp_path):
+    path = tmp_path / "providers.json"
+    path.write_text(
+        json.dumps(
+            {
+                "providers": {"codex": {"type": "tool", "tool": "codex"}},
+                "roles": {"reviewer": {"required": ["codex"], "optional": []}},
+            }
+        )
+    )
+
+    assert providers.load_config(path)["roles"]["reviewer"]["required"] == ["codex"]


### PR DESCRIPTION
## Summary
- Add `config/providers.json` with configurable provider roles for explorer, implementer, reviewer, architecture/design critics, and risky diff review
- Add `scripts/providers.py` for role planning, required/optional provider handling, and config validation
- Extend `scripts/consult_ai.py` with `--role <role> --output-dir <dir>` while preserving direct provider calls
- Wire `claude-interactive` as a delegate provider and keep Claude/Codex/Gemini configurable rather than hard-coded
- Document provider role usage in README, CLAUDE.md, and setup guidance

## Test Evidence
- `ruff check scripts/consult_ai.py scripts/providers.py tests/test_consult_ai.py tests/test_providers.py`
- `pytest -q` -> 60 passed
- `python3 -m json.tool config/providers.json`
- `python3 -m py_compile scripts/consult_ai.py scripts/providers.py`

## Delegate Review
Dogfooded the Claude interactive delegate on the staged diff. It found a real `claude-interactive` double task-directory creation bug; fixed by letting the delegate own task creation and reading the `RESULT=` path from stdout. Added regression coverage for that path.

Closes #27