### PR TITLE
docs: add harness-neutral project instructions and install docs (#29)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Chief Wiggum Agent Instructions
+
+Chief Wiggum is a harness-portable SDLC orchestration layer. Treat the workflow contract as separate from the harness used to execute it.
+
+## Portable Core
+
+- Workflow intent lives in issue/milestone artifacts, formal models, `templates/`, `scripts/`, and portable skills under `skills/`.
+- Claude Code slash commands under `.claude/commands/` are an adapter for Claude Code, not the only source of truth.
+- Provider roles live in `config/providers.json`; use role names such as `reviewer`, `architecture_critic`, `design_critic`, and `risky_diff_review` instead of hard-coding vendor/model names in new workflow code.
+- Delegated workers should use the shared file protocol in `scripts/delegates/README.md` when a durable handoff is needed.
+
+## Harness Adapters
+
+- Claude Code: use `.claude/commands/` and `CLAUDE.md`.
+- Codex or other skill-aware harnesses: install portable skills from `skills/` and use any harness-specific metadata as optional UI/config data.
+- Claude interactive delegation: use `$claude-interactive-delegate` only as an optional provider configured through `config/providers.json`.
+
+## Working Rules
+
+- Resolve paths through `scripts/env.py` and `scripts/repo.py`; do not hardcode local checkout paths.
+- Run dependency checks with the narrowest profile that matches the workflow, for example `python3 scripts/check_deps.py --for core --provider codex`.
+- Treat provider output as advisory unless the workflow explicitly defines it as a generated artifact. Verify code, tests, screenshots, and repository facts locally.
+- Keep new instructions harness-neutral unless they are explicitly inside a harness adapter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,11 @@
 
 Project-agnostic orchestration layer for AI-powered software development lifecycle.
 
+This file is the Claude Code adapter guide. Harness-neutral instructions live in `AGENTS.md`, and cross-harness install guidance lives in `docs/harnesses.md`.
+
 ## What This Repo Is
 
-A collection of Claude Code skills that orchestrate a full development pipeline at two levels:
+A collection of portable workflow contracts, scripts, and Claude Code slash-command adapters that orchestrate a full development pipeline at two levels:
 
 - **Product level**: `/design` — runs once per product between `/seed` and epic planning. Divergent rendered HTML mockups → human picks a direction → tokens mechanically extracted into `docs/design/` (design.json, approved mockups, reference screenshots), which `/architect` folds into epic ui-specs and the design-fidelity gate compares built screens against.
 - **Epic level**: `/plan-epic` → `/architect` → (implement tickets) → `/close-epic` — defines contracts, invariants, and integration tests before implementation, validates cross-cutting quality after.
@@ -27,7 +29,7 @@ A collection of Claude Code skills that orchestrate a full development pipeline 
 - **The loop must look at the UI**: "Build + tests green" never closes a frontend ticket. `/architect` writes a visual design contract (ui-spec `design` section: tokens, component-library binding, reference screenshots); `/implement` Step 9 renders the app, screenshots it, and reviews against that contract
 - **Designs are chosen, not converged**: `/design` generates 3–4 deliberately distinct rendered directions and a human picks — one generated design converges to the model's default taste. Tokens are extracted mechanically from the approved mock's CSS (`scripts/extract_design.py`), so the contract can't drift from what was approved
 - **Human-in-the-loop**: User confirms at every checkpoint (requirements, approach, final review)
-- **Skills are markdown prompts**: They instruct Claude Code what to do, not executable code
+- **Workflow instructions are markdown prompts**: In Claude Code they are slash commands; in other harnesses they should be packaged as portable skills or native adapter metadata
 - **Scripts are Python**: All helpers are Python — no bash scripts
 - **Secrets never touch env vars**: API keys are fetched from macOS Keychain at call time by Python wrappers and passed directly to SDK constructors. They are never set as environment variables, never printed, never logged. This prevents secrets from leaking into conversation history.
 - **Same prompt for all AIs**: codex, gemini, and opus get identical context. Value is in natural divergence, not roleplay
@@ -154,7 +156,7 @@ python3 "$CW_HOME/scripts/repo.py" clean acme/app     # remove cache
 ## Repo Layout
 
 ```
-.claude/commands/    # Claude Code skills (the core of this repo)
+.claude/commands/    # Claude Code slash-command adapter
 skills/              # Harness-portable skills and bundled resources
 scripts/             # Python helpers called by skills
 templates/           # Issue, PR, review, and checklist templates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chief Wiggum
 
-Agentic SDLC orchestration for Claude Code. It turns vague tickets into a disciplined delivery loop: requirements capture, epic planning, architecture, test-first implementation, structured review, and PR-ready output.
+Harness-portable agentic SDLC orchestration. It turns vague tickets into a disciplined delivery loop: requirements capture, epic planning, architecture, test-first implementation, structured review, and PR-ready output.
 
 ## Why This Exists
 
@@ -17,6 +17,8 @@ Agentic SDLC orchestration for Claude Code. It turns vague tickets into a discip
 - **Shipping**: generate PRs with architecture context and supporting artifacts
 
 ## Quick Start
+
+### Claude Code
 
 ```bash
 # 1. Clone and verify
@@ -38,12 +40,16 @@ claude /plan-epic owner/repo
 claude /implement owner/repo#42
 ```
 
+### Portable Skills
+
 Harness-portable skills are stored under `skills/`. To install the Claude interactive delegate skill in Codex:
 
 ```bash
 ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
 python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py start
 ```
+
+For other harnesses, install or symlink `skills/<name>` into the harness's skill discovery path. See `AGENTS.md` and `docs/harnesses.md` for the portable core and adapter model.
 
 **Important**: Run skills from your target project directory, not from chief-wiggum itself.
 
@@ -190,7 +196,8 @@ sequenceDiagram
 %%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
 graph TD
     subgraph "Chief Wiggum"
-        Skills[".claude/commands/"]:::entry
+        Core["Portable workflow core<br/>skills/ + templates/ + config/"]:::entry
+        ClaudeAdapter["Claude Code adapter<br/>.claude/commands/"]:::entry
         Scripts["scripts/"]:::modified
         Templates["templates/"]:::modified
     end
@@ -213,8 +220,9 @@ graph TD
         Whisper["Whisper"]:::existing
     end
 
-    Skills --> Scripts
-    Skills --> Templates
+    ClaudeAdapter --> Core
+    Core --> Scripts
+    Core --> Templates
     Scripts -->|consult_ai.py| Codex
     Scripts -->|consult_ai.py| Gemini
     Scripts -->|sub-agent| Opus

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1,0 +1,90 @@
+# Harness Installation and Adapter Guide
+
+Chief Wiggum has a portable workflow core and harness-specific adapters.
+
+For agents reading the repository directly, start with `AGENTS.md`. For Claude Code sessions, `CLAUDE.md` adds adapter-specific operating instructions.
+
+## Concepts
+
+- **Portable workflow contract**: skills, references, scripts, templates, formal models, provider roles, and delegated-worker task protocol.
+- **Harness adapter**: the mechanism a specific agent runtime uses to invoke those workflows, such as Claude Code slash commands or Codex skill metadata.
+- **Provider**: an AI backend or delegate used by a workflow role, configured in `config/providers.json`.
+
+## Claude Code
+
+Claude Code uses the existing slash-command adapter:
+
+```json
+{
+  "commandDirs": ["~/repos/chief-wiggum/.claude/commands"]
+}
+```
+
+Run from the target repo:
+
+```bash
+claude /setup
+claude /plan-epic owner/repo
+claude /implement owner/repo#42
+```
+
+`CLAUDE.md` remains the Claude Code adapter instructions file. Keep Claude-specific session behavior there or under `.claude/commands/`.
+
+## Portable Skills
+
+Portable skills live under `skills/`. They use the `SKILL.md` plus `scripts/`, `references/`, and `assets/` layout where possible. Harness-specific metadata can live beside the portable skill, but should not be required to understand the core workflow.
+
+Every portable skill should keep durable behavior in files a generic agent can read: `SKILL.md` for instructions, `references/` for protocol details, `scripts/` for executable helpers, and `assets/` for reusable artifacts. Harness metadata may improve discovery or UI, but it should not be the only place a required instruction appears.
+
+Example Codex install:
+
+```bash
+ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
+```
+
+Other skill-aware harnesses should install or symlink the same `skills/<name>` directory using their native discovery path.
+
+If a harness does not have a skill system, use a thin adapter that loads `SKILL.md` and any referenced files, then invokes the same scripts and delegated-worker protocol. Avoid forking workflow logic into harness-specific prompt copies unless the harness syntax requires a small wrapper.
+
+## Provider Roles
+
+AI backends are selected by role:
+
+```bash
+python3 scripts/consult_ai.py --role reviewer prompt.md --output-dir "$CW_TMP/reviews"
+```
+
+Configure roles in `config/providers.json`. Required providers must succeed. Optional providers may be disabled or fail without blocking the role quorum.
+
+## Dependency Profiles
+
+Check the narrowest profile required by the active harness and workflow:
+
+```bash
+python3 scripts/check_deps.py --for core
+python3 scripts/check_deps.py --for core --provider claude-code
+python3 scripts/check_deps.py --for core --provider codex --provider gemini
+python3 scripts/check_deps.py --for core --provider claude-interactive
+python3 scripts/check_deps.py --for transcription
+python3 scripts/check_deps.py --for browser-validation
+```
+
+## Claude Interactive Delegate
+
+`$claude-interactive-delegate` drives a persistent interactive Claude Code tmux session through a file-based task handoff. It is an optional provider, not a required harness dependency.
+
+Use it when a workflow role benefits from a Claude Code review or critique:
+
+```yaml
+providers:
+  claude-interactive:
+    type: delegate
+    delegate: claude-interactive
+    enabled: true
+roles:
+  risky_diff_review:
+    required: [codex, gemini]
+    optional: [claude-interactive]
+```
+
+Do not use terminal output as the result contract. Use the delegated-worker files documented in `scripts/delegates/README.md`.


### PR DESCRIPTION
## Summary

Adds harness-neutral documentation so Chief Wiggum can be installed and used from Claude Code, Codex, and other compatible agent harnesses without reverse-engineering Claude-specific docs.

Closes #29.

## Changes

- **`AGENTS.md`** (new) — harness-neutral agent instructions: portable core vs. harness adapters, provider-role indirection, working rules.
- **`docs/harnesses.md`** (new) — install & adapter guide covering Claude Code slash commands, portable `skills/`, provider roles, dependency profiles, and the optional Claude interactive delegate.
- **`CLAUDE.md`** — reframed as the Claude Code *adapter* guide; points to `AGENTS.md`/`docs/harnesses.md` and no longer reads as the sole source of truth.
- **`README.md`** — splits Quick Start into Claude Code vs. portable skills, points other harnesses at `skills/`, and updates the architecture diagram to show a portable core behind the Claude adapter.

## Acceptance criteria

- [x] Documentation distinguishes portable workflow contracts from harness-specific adapters.
- [x] Install instructions cover Claude Code commands, portable `skills/`, and harness-specific skill metadata.
- [x] `CLAUDE.md` remains available for Claude Code but no longer reads as the only source of truth.
- [x] A harness-neutral agent instructions file exists (`AGENTS.md`) and README points non-Claude harnesses at `skills/`.
- [x] Docs explain that Claude interactive delegation is optional and provider-configured.

## Scope

Docs only — no command implementation text migrated (per the issue's out-of-scope note).