### PR TITLE
feat: GitHub issue/milestone/dependency metadata client (#38)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -81,18 +81,20 @@ Parse the dependency graph from the milestone description. `/plan-epic` writes a
 -->
 ```
 
-Fetch the milestone description and extract this block:
+Parse the block into an adjacency list with the tested helper (no brittle inline parsing):
 
 ```bash
-MILESTONE_DESC=$(gh api "repos/$owner_repo/milestones" --jq ".[] | select(.title == \"$epic_name\") | .description")
+python3 "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name"
 ```
 
-Parse each line inside `<!-- DEPENDENCIES ... -->` to build the adjacency list:
+This emits JSON like:
+```json
+{ "edges": { "42": [], "43": [42], "44": [43] }, "warnings": [], "has_block": true }
 ```
-{ 42: [], 43: [42], 44: [43], 45: [43], 46: [42] }
-```
+where `edges[N]` lists the issues `#N` depends on. Malformed lines and a missing
+milestone surface in `warnings` rather than crashing.
 
-**If the DEPENDENCIES block is missing**, fall back to parsing `depends on #N` annotations from the implementation order in the milestone description or issue bodies. Warn the user that this is less reliable and suggest re-running `/plan-epic` to add structured metadata.
+**If `has_block` is false** (the DEPENDENCIES block is missing), fall back to parsing `depends on #N` annotations from the implementation order in the milestone description or issue bodies. Warn the user that this is less reliable and suggest re-running `/plan-epic` to add structured metadata.
 
 Compute waves using topological sort:
 - **Wave 1**: All tickets with zero unmet dependencies (no `depends on` or all dependencies already closed)

--- a/.claude/commands/plan-epic.md
+++ b/.claude/commands/plan-epic.md
@@ -115,31 +115,21 @@ Ask the user to confirm. Adjust if needed.
 
 ### Step 6: Create the GitHub milestone
 
-Create a milestone to track the epic. The milestone description **must** include a machine-readable dependency block so that `/implement-wave` can parse the DAG without brittle markdown parsing:
+Create a milestone to track the epic. The milestone description **must** include a machine-readable dependency block so that `/implement-wave` can parse the DAG without brittle markdown parsing.
+
+Generate the `<!-- DEPENDENCIES -->` block from a JSON adjacency map with the tested formatter (it de-dupes and sorts deps so the output always matches the parser), then embed it in the milestone description:
 
 ```bash
-gh api repos/$owner_repo/milestones -f title="Epic: [Name]" -f description="$(cat <<'EOF'
+DEPS=$(python3 "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43], "45": [43], "46": [42]}')
+gh api repos/$owner_repo/milestones -f title="Epic: [Name]" -f description="$(cat <<EOF
 [Goal]
 
-<!-- DEPENDENCIES
-#42: []
-#43: [#42]
-#44: [#43]
-#45: [#43]
-#46: [#42]
--->
+$DEPS
 EOF
 )"
 ```
 
-The `<!-- DEPENDENCIES -->` block is an HTML comment (invisible in rendered markdown) containing one line per ticket in the format `#N: [#dep1, #dep2]`. Empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph — `/implement-wave` parses it to compute waves.
-
-Generate the block from a JSON adjacency map with the tested helper so the
-format stays consistent with the parser (deps are de-duped and sorted):
-
-```bash
-python3 "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43]}'
-```
+The block is an HTML comment (invisible in rendered markdown) with one line per ticket in the format `#N: [#dep1, #dep2]`; empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph — `/implement-wave` parses it to compute waves. Do not hand-write it; always generate it with `format-deps` so it round-trips through the parser.
 
 Add all epic tickets to the milestone:
 ```bash

--- a/.claude/commands/plan-epic.md
+++ b/.claude/commands/plan-epic.md
@@ -134,6 +134,13 @@ EOF
 
 The `<!-- DEPENDENCIES -->` block is an HTML comment (invisible in rendered markdown) containing one line per ticket in the format `#N: [#dep1, #dep2]`. Empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph — `/implement-wave` parses it to compute waves.
 
+Generate the block from a JSON adjacency map with the tested helper so the
+format stays consistent with the parser (deps are de-duped and sorted):
+
+```bash
+python3 "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43]}'
+```
+
 Add all epic tickets to the milestone:
 ```bash
 gh issue edit $issue_number --repo "$owner_repo" --milestone "Epic: [Name]"

--- a/scripts/chief_wiggum/github.py
+++ b/scripts/chief_wiggum/github.py
@@ -1,0 +1,289 @@
+"""GitHub issue / milestone / dependency metadata client.
+
+The command prompts embed repeated ``gh issue list``, ``gh issue view``,
+``gh api repos/.../milestones`` and ``gh pr`` calls, plus ad-hoc parsing of the
+machine-readable ``<!-- DEPENDENCIES ... -->`` block that ``/plan-epic`` writes
+into milestone descriptions. That dependency block is a contract the wave
+planner depends on, so it should be parsed by tested code rather than prose.
+
+This module keeps the pure parsing/normalization (dependency block, JSON ->
+dataclass) separate from the ``gh`` transport so the logic is unit-testable
+without network access. A ``runner`` callable is injectable for the gh-backed
+helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+# --- dataclasses ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    state: str = "OPEN"
+    labels: tuple[str, ...] = ()
+    milestone: str | None = None
+    body: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "labels": list(self.labels),
+            "milestone": self.milestone,
+            "body": self.body,
+        }
+
+
+@dataclass(frozen=True)
+class Milestone:
+    title: str
+    description: str = ""
+    number: int | None = None
+    open_issues: int = 0
+    closed_issues: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "description": self.description,
+            "number": self.number,
+            "open_issues": self.open_issues,
+            "closed_issues": self.closed_issues,
+        }
+
+
+@dataclass(frozen=True)
+class PullRequestSummary:
+    number: int
+    title: str
+    state: str = "OPEN"
+    head_ref: str | None = None
+    base_ref: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "head_ref": self.head_ref,
+            "base_ref": self.base_ref,
+        }
+
+
+@dataclass
+class DependencyGraphMetadata:
+    """Adjacency list parsed from a milestone ``<!-- DEPENDENCIES -->`` block.
+
+    ``edges[n]`` is the list of issue numbers that ``#n`` depends on (blockers).
+    Parsing never raises: malformed input is reported via ``warnings`` so the
+    caller can degrade gracefully instead of crashing a workflow.
+    """
+
+    edges: dict[int, list[int]] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def has_block(self) -> bool:
+        return not any(w.startswith("missing DEPENDENCIES block") for w in self.warnings)
+
+    def to_dict(self) -> dict:
+        return {
+            "edges": {str(k): v for k, v in self.edges.items()},
+            "warnings": list(self.warnings),
+            "has_block": self.has_block,
+        }
+
+
+# --- pure parsing -----------------------------------------------------------
+
+_BLOCK_RE = re.compile(r"<!--\s*DEPENDENCIES\b(.*?)-->", re.DOTALL | re.IGNORECASE)
+_LINE_RE = re.compile(r"^#?(\d+)\s*:\s*\[(.*)\]$")
+_DEP_RE = re.compile(r"#?(\d+)")
+
+
+def parse_dependency_block(description: str | None) -> DependencyGraphMetadata:
+    """Parse the ``<!-- DEPENDENCIES ... -->`` block from a milestone body.
+
+    Format (one line per ticket, inside an HTML comment)::
+
+        <!-- DEPENDENCIES
+        #42: []
+        #43: [#42]
+        -->
+
+    Empty brackets mean no dependencies. Malformed lines are skipped with a
+    warning; a missing block yields empty edges plus a warning.
+    """
+    meta = DependencyGraphMetadata()
+    if not description:
+        meta.warnings.append("missing DEPENDENCIES block: empty description")
+        return meta
+
+    match = _BLOCK_RE.search(description)
+    if not match:
+        meta.warnings.append("missing DEPENDENCIES block: not found in description")
+        return meta
+
+    body = match.group(1)
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        line_match = _LINE_RE.match(line)
+        if not line_match:
+            meta.warnings.append(f"malformed dependency line: {raw.strip()!r}")
+            continue
+        node = int(line_match.group(1))
+        deps_text = line_match.group(2).strip()
+        deps = [int(m.group(1)) for m in _DEP_RE.finditer(deps_text)] if deps_text else []
+        if node in meta.edges:
+            meta.warnings.append(f"duplicate dependency entry for #{node}")
+        # Self-dependency is meaningless; drop it but warn.
+        cleaned = []
+        for d in deps:
+            if d == node:
+                meta.warnings.append(f"#{node} lists itself as a dependency")
+                continue
+            cleaned.append(d)
+        meta.edges[node] = cleaned
+
+    return meta
+
+
+def format_dependency_block(edges: dict[int, Iterable[int]]) -> str:
+    """Render an adjacency list back into a ``<!-- DEPENDENCIES -->`` block.
+
+    Inverse of :func:`parse_dependency_block` so ``/plan-epic`` can generate the
+    canonical block via tested code instead of hand-formatting it in prose.
+    Nodes and their dependencies are emitted in ascending order for stable diffs.
+    """
+    lines = ["<!-- DEPENDENCIES"]
+    for node in sorted(edges):
+        deps = sorted(set(edges[node]))
+        rendered = ", ".join(f"#{d}" for d in deps)
+        lines.append(f"#{node}: [{rendered}]")
+    lines.append("-->")
+    return "\n".join(lines)
+
+
+def issue_from_json(data: dict[str, Any]) -> Issue:
+    """Normalize a ``gh issue`` JSON object into an :class:`Issue`."""
+    labels = data.get("labels") or []
+    label_names = tuple(
+        lbl["name"] if isinstance(lbl, dict) else str(lbl) for lbl in labels
+    )
+    milestone = data.get("milestone")
+    if isinstance(milestone, dict):
+        milestone = milestone.get("title")
+    return Issue(
+        number=int(data["number"]),
+        title=data.get("title", ""),
+        state=str(data.get("state", "OPEN")).upper(),
+        labels=label_names,
+        milestone=milestone,
+        body=data.get("body", "") or "",
+    )
+
+
+def milestone_from_json(data: dict[str, Any]) -> Milestone:
+    """Normalize a milestone JSON object (gh api or gh issue view) into one shape."""
+    return Milestone(
+        title=data.get("title", ""),
+        description=data.get("description", "") or "",
+        number=data.get("number"),
+        open_issues=int(data.get("open_issues", 0) or 0),
+        closed_issues=int(data.get("closed_issues", 0) or 0),
+    )
+
+
+def pr_from_json(data: dict[str, Any]) -> PullRequestSummary:
+    return PullRequestSummary(
+        number=int(data["number"]),
+        title=data.get("title", ""),
+        state=str(data.get("state", "OPEN")).upper(),
+        head_ref=data.get("headRefName"),
+        base_ref=data.get("baseRefName"),
+    )
+
+
+# --- gh transport -----------------------------------------------------------
+
+
+def _run_gh(args: list[str], runner: Runner) -> str:
+    result = runner(
+        ["gh", *args], capture_output=True, text=True, check=True, timeout=60
+    )
+    return result.stdout
+
+
+def list_issues(
+    repo: str, *, state: str = "open", limit: int = 200, runner: Runner = subprocess.run
+) -> list[Issue]:
+    out = _run_gh(
+        [
+            "issue", "list", "--repo", repo, "--state", state,
+            "--limit", str(limit),
+            "--json", "number,title,state,labels,milestone,body",
+        ],
+        runner,
+    )
+    return [issue_from_json(d) for d in json.loads(out or "[]")]
+
+
+def view_issue(repo: str, number: int, *, runner: Runner = subprocess.run) -> Issue:
+    out = _run_gh(
+        [
+            "issue", "view", str(number), "--repo", repo,
+            "--json", "number,title,state,labels,milestone,body",
+        ],
+        runner,
+    )
+    return issue_from_json(json.loads(out))
+
+
+def list_milestones(repo: str, *, runner: Runner = subprocess.run) -> list[Milestone]:
+    out = _run_gh(
+        ["api", f"repos/{repo}/milestones", "--paginate"],
+        runner,
+    )
+    return [milestone_from_json(d) for d in json.loads(out or "[]")]
+
+
+def find_milestone(
+    repo: str, title: str, *, runner: Runner = subprocess.run
+) -> Milestone | None:
+    for milestone in list_milestones(repo, runner=runner):
+        if milestone.title == title:
+            return milestone
+    return None
+
+
+def dependency_graph(
+    repo: str, milestone_title: str, *, runner: Runner = subprocess.run
+) -> DependencyGraphMetadata:
+    """Fetch a milestone and parse its dependency block."""
+    milestone = find_milestone(repo, milestone_title, runner=runner)
+    if milestone is None:
+        meta = DependencyGraphMetadata()
+        meta.warnings.append(
+            f"missing DEPENDENCIES block: milestone {milestone_title!r} not found"
+        )
+        return meta
+    return parse_dependency_block(milestone.description)
+
+
+def issues_as_dicts(issues: Iterable[Issue]) -> list[dict]:
+    return [i.to_dict() for i in issues]

--- a/scripts/chief_wiggum/github.py
+++ b/scripts/chief_wiggum/github.py
@@ -111,7 +111,26 @@ class DependencyGraphMetadata:
 
 _BLOCK_RE = re.compile(r"<!--\s*DEPENDENCIES\b(.*?)-->", re.DOTALL | re.IGNORECASE)
 _LINE_RE = re.compile(r"^#?(\d+)\s*:\s*\[(.*)\]$")
-_DEP_RE = re.compile(r"#?(\d+)")
+_DEP_TOKEN_RE = re.compile(r"^#?(\d+)$")
+
+
+def _parse_dep_tokens(deps_text: str) -> list[int] | None:
+    """Parse the comma-separated contents of ``[...]``.
+
+    Returns the list of issue numbers, or ``None`` if any token is malformed
+    (so the caller can warn and skip the whole line rather than silently
+    dropping or inventing edges).
+    """
+    deps_text = deps_text.strip()
+    if not deps_text:
+        return []
+    deps: list[int] = []
+    for token in deps_text.split(","):
+        match = _DEP_TOKEN_RE.match(token.strip())
+        if not match:
+            return None
+        deps.append(int(match.group(1)))
+    return deps
 
 
 def parse_dependency_block(description: str | None) -> DependencyGraphMetadata:
@@ -147,8 +166,10 @@ def parse_dependency_block(description: str | None) -> DependencyGraphMetadata:
             meta.warnings.append(f"malformed dependency line: {raw.strip()!r}")
             continue
         node = int(line_match.group(1))
-        deps_text = line_match.group(2).strip()
-        deps = [int(m.group(1)) for m in _DEP_RE.finditer(deps_text)] if deps_text else []
+        deps = _parse_dep_tokens(line_match.group(2))
+        if deps is None:
+            meta.warnings.append(f"malformed dependency line: {raw.strip()!r}")
+            continue
         if node in meta.edges:
             meta.warnings.append(f"duplicate dependency entry for #{node}")
         # Self-dependency is meaningless; drop it but warn.
@@ -254,12 +275,32 @@ def view_issue(repo: str, number: int, *, runner: Runner = subprocess.run) -> Is
     return issue_from_json(json.loads(out))
 
 
+def _flatten_pages(parsed: Any) -> list[dict]:
+    """Flatten ``gh api --paginate --slurp`` output into a single list.
+
+    With ``--slurp`` gh returns an array of per-page responses; for array
+    endpoints that is a list-of-lists. Accept either a flat list of objects or
+    a list of page-arrays and flatten one level so a single ``json.loads`` can
+    never hit "extra data" on multi-page results.
+    """
+    if not isinstance(parsed, list):
+        return []
+    flat: list[dict] = []
+    for item in parsed:
+        if isinstance(item, list):
+            flat.extend(item)
+        else:
+            flat.append(item)
+    return flat
+
+
 def list_milestones(repo: str, *, runner: Runner = subprocess.run) -> list[Milestone]:
     out = _run_gh(
-        ["api", f"repos/{repo}/milestones", "--paginate"],
+        ["api", f"repos/{repo}/milestones?per_page=100", "--paginate", "--slurp"],
         runner,
     )
-    return [milestone_from_json(d) for d in json.loads(out or "[]")]
+    pages = _flatten_pages(json.loads(out or "[]"))
+    return [milestone_from_json(d) for d in pages]
 
 
 def find_milestone(

--- a/scripts/epic_metadata.py
+++ b/scripts/epic_metadata.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -74,9 +75,21 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(meta.to_dict(), indent=2))
         elif args.command == "format-deps":
             raw = json.loads(args.edges)
-            edges = {int(k): [int(d) for d in v] for k, v in raw.items()}
+            if not isinstance(raw, dict):
+                raise ValueError("format-deps expects a JSON object mapping number -> [deps]")
+            edges: dict[int, list[int]] = {}
+            for k, v in raw.items():
+                if not isinstance(v, list):
+                    raise ValueError(
+                        f"dependencies for #{k} must be a JSON array of issue numbers, got {v!r}"
+                    )
+                edges[int(k)] = [int(d) for d in v]
             print(github.format_dependency_block(edges))
-    except Exception as exc:  # noqa: BLE001 - surface gh/transport errors cleanly
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip() or str(exc)
+        print(f"Error: gh command failed: {detail}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 - surface transport/parse errors cleanly
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/scripts/epic_metadata.py
+++ b/scripts/epic_metadata.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""CLI for GitHub issue / milestone / dependency metadata.
+
+Replaces ad-hoc ``gh`` calls and brittle dependency-block parsing in the
+command prompts with one tested helper that emits normalized JSON.
+
+Examples:
+    # All open issues in a repo, normalized
+    python3 scripts/epic_metadata.py issues acme/app
+
+    # Parse the dependency graph from a milestone description
+    python3 scripts/epic_metadata.py deps acme/app --milestone "Epic: Name"
+
+    # Parse a dependency block from a file/stdin (offline, no gh)
+    python3 scripts/epic_metadata.py parse-deps --file milestone-body.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import github  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="GitHub epic metadata helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_issues = sub.add_parser("issues", help="List normalized issues for a repo")
+    p_issues.add_argument("repo")
+    p_issues.add_argument("--state", default="open")
+    p_issues.add_argument("--limit", type=int, default=200)
+
+    p_ms = sub.add_parser("milestones", help="List milestones for a repo")
+    p_ms.add_argument("repo")
+
+    p_deps = sub.add_parser("deps", help="Parse a milestone's dependency graph")
+    p_deps.add_argument("repo")
+    p_deps.add_argument("--milestone", required=True)
+
+    p_parse = sub.add_parser("parse-deps", help="Parse a dependency block offline")
+    src = p_parse.add_mutually_exclusive_group(required=True)
+    src.add_argument("--file", help="Read milestone description from this file")
+    src.add_argument("--stdin", action="store_true", help="Read description from stdin")
+
+    p_fmt = sub.add_parser(
+        "format-deps", help="Render a dependency block from a JSON adjacency map"
+    )
+    p_fmt.add_argument(
+        "edges",
+        help='JSON object mapping issue number -> list of blockers, e.g. \'{"43": [42]}\'',
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "issues":
+            issues = github.list_issues(args.repo, state=args.state, limit=args.limit)
+            print(json.dumps(github.issues_as_dicts(issues), indent=2))
+        elif args.command == "milestones":
+            milestones = github.list_milestones(args.repo)
+            print(json.dumps([m.to_dict() for m in milestones], indent=2))
+        elif args.command == "deps":
+            meta = github.dependency_graph(args.repo, args.milestone)
+            print(json.dumps(meta.to_dict(), indent=2))
+        elif args.command == "parse-deps":
+            text = sys.stdin.read() if args.stdin else Path(args.file).read_text()
+            meta = github.parse_dependency_block(text)
+            print(json.dumps(meta.to_dict(), indent=2))
+        elif args.command == "format-deps":
+            raw = json.loads(args.edges)
+            edges = {int(k): [int(d) for d in v] for k, v in raw.items()}
+            print(github.format_dependency_block(edges))
+    except Exception as exc:  # noqa: BLE001 - surface gh/transport errors cleanly
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -1,0 +1,198 @@
+"""Tests for the GitHub issue/milestone/dependency metadata client (P0-2)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+from chief_wiggum import github
+
+# --- dependency block parsing -----------------------------------------------
+
+VALID_BLOCK = """\
+Goal: ship the thing.
+
+<!-- DEPENDENCIES
+#42: []
+#43: [#42]
+#44: [#43, #42]
+-->
+"""
+
+
+def test_parse_valid_dependency_block():
+    meta = github.parse_dependency_block(VALID_BLOCK)
+    assert meta.edges == {42: [], 43: [42], 44: [43, 42]}
+    assert meta.has_block is True
+    assert meta.warnings == []
+
+
+def test_parse_missing_block_warns_not_raises():
+    meta = github.parse_dependency_block("Just a goal, no block.")
+    assert meta.edges == {}
+    assert meta.has_block is False
+    assert any("missing DEPENDENCIES block" in w for w in meta.warnings)
+
+
+def test_parse_empty_description():
+    meta = github.parse_dependency_block("")
+    assert meta.edges == {}
+    assert meta.has_block is False
+
+
+def test_parse_malformed_lines_are_skipped_with_warning():
+    block = """\
+<!-- DEPENDENCIES
+#42: []
+this is not valid
+#43: [#42]
+#44: not-a-list
+-->
+"""
+    meta = github.parse_dependency_block(block)
+    assert meta.edges == {42: [], 43: [42]}
+    assert sum("malformed dependency line" in w for w in meta.warnings) == 2
+
+
+def test_parse_tolerates_missing_hash_and_whitespace():
+    block = "<!-- DEPENDENCIES\n  42 : [ 41 , 40 ]\n-->"
+    meta = github.parse_dependency_block(block)
+    assert meta.edges == {42: [41, 40]}
+
+
+def test_parse_warns_on_duplicate_and_self_dependency():
+    block = "<!-- DEPENDENCIES\n#42: [#42]\n#42: [#41]\n-->"
+    meta = github.parse_dependency_block(block)
+    assert any("itself" in w for w in meta.warnings)
+    assert any("duplicate" in w for w in meta.warnings)
+    # self-edge stripped
+    assert 42 not in meta.edges[42]
+
+
+def test_parse_is_case_insensitive_on_marker():
+    block = "<!-- dependencies\n#1: []\n-->"
+    meta = github.parse_dependency_block(block)
+    assert meta.edges == {1: []}
+
+
+def test_format_dependency_block_roundtrips_through_parser():
+    edges = {44: [43, 42], 42: [], 43: [42]}
+    block = github.format_dependency_block(edges)
+    # Stable, sorted output.
+    assert block.splitlines()[1] == "#42: []"
+    meta = github.parse_dependency_block(block)
+    assert meta.edges == {42: [], 43: [42], 44: [42, 43]}
+    assert meta.warnings == []
+
+
+def test_format_dependency_block_dedupes_and_sorts_deps():
+    block = github.format_dependency_block({1: [3, 2, 2]})
+    assert "#1: [#2, #3]" in block
+
+
+# --- JSON normalization -----------------------------------------------------
+
+
+def test_issue_from_json_normalizes_labels_and_milestone():
+    data = {
+        "number": "42",
+        "title": "Do it",
+        "state": "open",
+        "labels": [{"name": "bug"}, {"name": "p1"}],
+        "milestone": {"title": "Epic: Name"},
+        "body": "details",
+    }
+    issue = github.issue_from_json(data)
+    assert issue.number == 42
+    assert issue.state == "OPEN"
+    assert issue.labels == ("bug", "p1")
+    assert issue.milestone == "Epic: Name"
+
+
+def test_issue_from_json_handles_null_milestone_and_body():
+    issue = github.issue_from_json({"number": 7, "title": "x", "milestone": None, "body": None})
+    assert issue.milestone is None
+    assert issue.body == ""
+    assert issue.labels == ()
+
+
+def test_milestone_from_json_normalizes_counts():
+    ms = github.milestone_from_json(
+        {"title": "Epic", "description": None, "open_issues": 3, "closed_issues": 2}
+    )
+    assert ms.description == ""
+    assert (ms.open_issues, ms.closed_issues) == (3, 2)
+
+
+def test_pr_from_json():
+    pr = github.pr_from_json(
+        {"number": 5, "title": "feat", "state": "merged", "headRefName": "f", "baseRefName": "main"}
+    )
+    assert pr.state == "MERGED"
+    assert pr.head_ref == "f"
+    assert pr.base_ref == "main"
+
+
+def test_dependency_metadata_to_dict_roundtrips_json():
+    meta = github.parse_dependency_block(VALID_BLOCK)
+    blob = json.dumps(meta.to_dict())
+    restored = json.loads(blob)
+    assert restored["edges"] == {"42": [], "43": [42], "44": [43, 42]}
+    assert restored["has_block"] is True
+
+
+# --- gh transport (mocked subprocess) ---------------------------------------
+
+
+def _runner(stdout):
+    def run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    return run
+
+
+def test_list_issues_uses_runner_and_normalizes():
+    payload = json.dumps(
+        [{"number": 1, "title": "a", "state": "open", "labels": [{"name": "x"}]}]
+    )
+    issues = github.list_issues("acme/app", runner=_runner(payload))
+    assert issues[0].number == 1
+    assert issues[0].labels == ("x",)
+
+
+def test_list_issues_handles_empty_output():
+    assert github.list_issues("acme/app", runner=_runner("")) == []
+
+
+def test_find_milestone_matches_title():
+    payload = json.dumps(
+        [
+            {"title": "Other", "description": "x"},
+            {"title": "Epic: Name", "description": "<!-- DEPENDENCIES\n#1: []\n-->"},
+        ]
+    )
+    ms = github.find_milestone("acme/app", "Epic: Name", runner=_runner(payload))
+    assert ms is not None and ms.title == "Epic: Name"
+
+
+def test_dependency_graph_for_missing_milestone_warns():
+    meta = github.dependency_graph("acme/app", "Nope", runner=_runner("[]"))
+    assert meta.edges == {}
+    assert any("not found" in w for w in meta.warnings)
+
+
+def test_dependency_graph_parses_found_milestone():
+    payload = json.dumps(
+        [{"title": "Epic: Name", "description": VALID_BLOCK}]
+    )
+    meta = github.dependency_graph("acme/app", "Epic: Name", runner=_runner(payload))
+    assert meta.edges == {42: [], 43: [42], 44: [43, 42]}
+
+
+def test_run_gh_propagates_called_process_error():
+    def failing(args, **kwargs):
+        raise subprocess.CalledProcessError(1, args, stderr="boom")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        github.list_issues("acme/app", runner=failing)

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -61,6 +61,15 @@ def test_parse_tolerates_missing_hash_and_whitespace():
     assert meta.edges == {42: [41, 40]}
 
 
+@pytest.mark.parametrize("bad", ["[abc]", "[2x]", "[#42 typo]", "[42, ]", "[, 42]"])
+def test_parse_rejects_malformed_dep_tokens_without_inventing_edges(bad):
+    block = f"<!-- DEPENDENCIES\n#43: {bad}\n-->"
+    meta = github.parse_dependency_block(block)
+    # The whole line is skipped, not partially parsed.
+    assert 43 not in meta.edges
+    assert any("malformed dependency line" in w for w in meta.warnings)
+
+
 def test_parse_warns_on_duplicate_and_self_dependency():
     block = "<!-- DEPENDENCIES\n#42: [#42]\n#42: [#41]\n-->"
     meta = github.parse_dependency_block(block)
@@ -188,6 +197,19 @@ def test_dependency_graph_parses_found_milestone():
     )
     meta = github.dependency_graph("acme/app", "Epic: Name", runner=_runner(payload))
     assert meta.edges == {42: [], 43: [42], 44: [43, 42]}
+
+
+def test_list_milestones_flattens_slurped_pages():
+    # gh api --paginate --slurp returns a list of per-page arrays.
+    payload = json.dumps([[{"title": "A"}], [{"title": "B"}]])
+    milestones = github.list_milestones("acme/app", runner=_runner(payload))
+    assert [m.title for m in milestones] == ["A", "B"]
+
+
+def test_list_milestones_accepts_flat_array():
+    payload = json.dumps([{"title": "A"}, {"title": "B"}])
+    milestones = github.list_milestones("acme/app", runner=_runner(payload))
+    assert [m.title for m in milestones] == ["A", "B"]
 
 
 def test_run_gh_propagates_called_process_error():


### PR DESCRIPTION
## Summary

P0-2 of the **Portable Python Orchestration Core** epic. Wraps the repeated `gh issue list`/`gh issue view`/`gh api .../milestones` calls and the brittle `<!-- DEPENDENCIES -->` block parsing in a tested client, so the dependency graph contract is parsed by code rather than prose.

Closes #38.

## Changes

- **`scripts/chief_wiggum/github.py`**
  - Dataclasses: `Issue`, `Milestone`, `PullRequestSummary`, `DependencyGraphMetadata` (all with `to_dict()`).
  - `parse_dependency_block` / `format_dependency_block` — round-trippable parse/render of the canonical milestone block; tolerant of whitespace and missing `#`, case-insensitive marker, de-dupes & drops self-edges.
  - JSON normalizers (`issue_from_json`, `milestone_from_json`, `pr_from_json`) that handle null fields, dict-or-string labels, and string/int numbers.
  - gh transport (`list_issues`, `view_issue`, `list_milestones`, `find_milestone`, `dependency_graph`) with an **injectable `runner`** so parsing is testable offline.
- **`scripts/epic_metadata.py`** — CLI: `issues` / `milestones` / `deps` / `parse-deps` / `format-deps`, all emitting normalized JSON.
- **Command prompts** — `implement-wave.md` delegates parsing to `epic_metadata.py deps`; `plan-epic.md` delegates block formatting to `epic_metadata.py format-deps`.

## Acceptance criteria

- [x] Tests cover dependency block parsing, missing block behavior, malformed lines, issue suffix/number parsing, and JSON output normalization (20 tests).
- [x] `/plan-epic` delegates dependency-block formatting to Python.
- [x] `/implement-wave` delegates dependency-block parsing to Python.
- [x] Missing or malformed dependency metadata returns structured warnings, not unhandled tracebacks.

## Verification

- `make lint` clean; `make test` — 100 passed (20 new).
- CLI smoke: `format-deps` round-trips; live `deps` against this repo's epic correctly reports `has_block: false` with a warning (that milestone was created without a block).