### PR TITLE
feat: extract wave planning and gating (#39)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -96,12 +96,21 @@ milestone surface in `warnings` rather than crashing.
 
 **If `has_block` is false** (the DEPENDENCIES block is missing), fall back to parsing `depends on #N` annotations from the implementation order in the milestone description or issue bodies. Warn the user that this is less reliable and suggest re-running `/plan-epic` to add structured metadata.
 
-Compute waves using topological sort:
-- **Wave 1**: All tickets with zero unmet dependencies (no `depends on` or all dependencies already closed)
-- **Wave 2**: Tickets whose dependencies are all in Wave 1
-- **Wave N**: Tickets whose dependencies are all in Waves 1..N-1
+Compute the wave plan with the tested planner instead of sorting by hand. Feed it the dependency edges, the full epic issue list, the already-closed issues, and the tickets gated by the Step 1 unresolved scan (`blocked_tickets`):
 
-Also identify **integration risks** from the epic plan — tickets within the same wave that touch the same files/components. Flag these for the merge step.
+```bash
+python3 "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name" > "$CW_TMP/deps.json"
+python3 "$CW_HOME/scripts/plan_waves.py" \
+  --deps-json "$CW_TMP/deps.json" \
+  --issues "$EPIC_ISSUES" \
+  --closed "$CLOSED_ISSUES" \
+  --gated "$BLOCKED_TICKETS" \
+  --markdown
+```
+
+The planner emits dependency-ordered `waves` (each a batch of tickets with no unmet dependencies, safe to run in parallel), plus `gated` (held back), `skipped` (already closed), `integration_risks`, and per-ticket `gate_reasons`. It **exits non-zero on a dependency cycle** — stop and fix the graph before building anything. Transitive gating is built in: gating a ticket holds back everything that (transitively) depends on it.
+
+The planner also surfaces **integration risks** — shared dependencies (diamonds / fan-out). Flag these for the merge step.
 
 **Apply the unresolved-unknowns gate.** For each ticket in `blocked_tickets` (from Step 1's scan):
 1. First try to **resolve the unknown now** — introspect the real schema, read the source repo, check the external service. Many "unknowns" are 10 minutes of research. If resolved: update the artifact (remove the marker, cite the source), commit, and un-gate the ticket.

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -63,10 +63,14 @@ Each finding carries the tickets it blocks (from `derived_from` provenance). Tic
 
 ### Step 2: Build the wave plan
 
-Fetch all open tickets in the epic milestone:
+Fetch **all** tickets in the epic milestone (both open and closed — closed tickets satisfy dependents and must be passed to the planner so it can mark them done rather than schedule them):
 
 ```bash
-gh issue list --repo "$owner_repo" --milestone "$epic_name" --state open --limit 100 --json number,title,body,labels
+# Full epic issue list, and the closed subset.
+EPIC_ISSUES=$(gh issue list --repo "$owner_repo" --milestone "$epic_name" --state all --limit 200 --json number -q 'map(.number) | join(",")')
+CLOSED_ISSUES=$(gh issue list --repo "$owner_repo" --milestone "$epic_name" --state closed --limit 200 --json number -q 'map(.number) | join(",")')
+# Tickets gated by Step 1's unresolved-marker scan (comma-separated issue numbers).
+BLOCKED_TICKETS="${BLOCKED_TICKETS:-}"
 ```
 
 Parse the dependency graph from the milestone description. `/plan-epic` writes a machine-readable `<!-- DEPENDENCIES -->` block:

--- a/scripts/chief_wiggum/planning.py
+++ b/scripts/chief_wiggum/planning.py
@@ -1,0 +1,214 @@
+"""Wave planning and gating for ``/implement-wave``.
+
+Wave planning is algorithmic and risky: a mistake can launch tickets before
+their dependencies have landed, or build a ticket that is blocked by a ``TBD:``
+marker. This module turns the dependency graph + ticket state into a
+deterministic, tested wave plan.
+
+Inputs:
+    issues   - all ticket numbers in the epic
+    edges    - adjacency map ``{n: [deps...]}`` (n depends on each dep);
+               typically ``DependencyGraphMetadata.edges`` from github.py
+    closed   - tickets already closed (their dependents are unblocked)
+    gated    - tickets that cannot be built (e.g. unresolved TBD markers or a
+               failed prior implementation); they and their transitive
+               dependents are held back
+
+Output: a :class:`WavePlan` with ``waves`` (dependency-ordered, parallelizable
+batches of buildable tickets), ``gated``, ``skipped`` (already closed),
+``warnings``, and ``integration_risks``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+
+class DependencyCycleError(ValueError):
+    """Raised when the dependency graph contains a cycle (no valid ordering)."""
+
+    def __init__(self, cycle: list[int]):
+        self.cycle = cycle
+        chain = " -> ".join(f"#{n}" for n in cycle)
+        super().__init__(f"dependency cycle detected: {chain}")
+
+
+@dataclass
+class WavePlan:
+    waves: list[list[int]] = field(default_factory=list)
+    gated: list[int] = field(default_factory=list)
+    skipped: list[int] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    integration_risks: list[str] = field(default_factory=list)
+    gate_reasons: dict[int, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "waves": self.waves,
+            "gated": self.gated,
+            "skipped": self.skipped,
+            "warnings": self.warnings,
+            "integration_risks": self.integration_risks,
+            "gate_reasons": {str(k): v for k, v in self.gate_reasons.items()},
+        }
+
+
+def _detect_cycle(nodes: set[int], deps_of: Mapping[int, list[int]]) -> list[int] | None:
+    """Return a cycle as a node list if one exists among ``nodes``, else None."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in nodes}
+    stack: list[int] = []
+
+    def visit(n: int) -> list[int] | None:
+        color[n] = GRAY
+        stack.append(n)
+        for dep in deps_of.get(n, []):
+            if dep not in nodes:
+                continue
+            if color[dep] == GRAY:
+                idx = stack.index(dep)
+                return stack[idx:] + [dep]
+            if color[dep] == WHITE:
+                found = visit(dep)
+                if found:
+                    return found
+        color[n] = BLACK
+        stack.pop()
+        return None
+
+    for node in sorted(nodes):
+        if color[node] == WHITE:
+            found = visit(node)
+            if found:
+                return found
+    return None
+
+
+def plan_waves(
+    issues: Iterable[int],
+    edges: Mapping[int, Iterable[int]],
+    *,
+    closed: Iterable[int] = (),
+    gated: Iterable[int] = (),
+) -> WavePlan:
+    """Compute a dependency-ordered wave plan.
+
+    Raises :class:`DependencyCycleError` if the open subgraph has a cycle.
+    """
+    issues = set(issues)
+    closed_set = set(closed)
+    gated_set = set(gated)
+    deps_of: dict[int, list[int]] = {n: list(dict.fromkeys(edges.get(n, []))) for n in issues}
+    # Nodes include any issue referenced as a dependency too.
+    nodes = set(issues) | {d for deps in deps_of.values() for d in deps}
+
+    plan = WavePlan()
+
+    # Cycle detection over all nodes (open or closed) — a cycle is unbuildable.
+    cycle = _detect_cycle(nodes, deps_of)
+    if cycle is not None:
+        raise DependencyCycleError(cycle)
+
+    # Closed tickets are done; nothing to schedule.
+    open_issues = {n for n in issues if n not in closed_set}
+    plan.skipped = sorted(n for n in issues if n in closed_set)
+
+    def reason_for(n: int) -> tuple[bool, str]:
+        """Is node n a *direct* block source, and why."""
+        if n in gated_set:
+            return True, "gated (unresolved marker or failed implementation)"
+        for dep in deps_of.get(n, []):
+            # A dep is satisfiable only if it is an epic ticket (will be built)
+            # or already closed. Anything else is an unknown reference.
+            if dep not in issues and dep not in closed_set:
+                return True, f"depends on missing/unknown #{dep}"
+        return False, ""
+
+    # Seed directly-blocked nodes (gated + missing dependency refs).
+    blocked: dict[int, str] = {}
+    for n in sorted(open_issues):
+        is_blocked, why = reason_for(n)
+        if is_blocked:
+            blocked[n] = why
+            if "missing/unknown" in why:
+                plan.warnings.append(f"#{n} {why}; holding it and its dependents")
+
+    # Propagate blocking transitively to dependents.
+    changed = True
+    while changed:
+        changed = False
+        for n in sorted(open_issues):
+            if n in blocked:
+                continue
+            for dep in deps_of.get(n, []):
+                if dep in blocked:
+                    blocked[n] = f"depends on blocked #{dep}"
+                    changed = True
+                    break
+
+    buildable = {n for n in open_issues if n not in blocked}
+
+    # Kahn-style wave assignment. A dep is satisfied if it is closed or already
+    # placed in an earlier wave. Closed nodes seed the "placed" set.
+    placed: set[int] = set(closed_set)
+    remaining = set(buildable)
+    while remaining:
+        wave = sorted(
+            n
+            for n in remaining
+            if all(dep in placed for dep in deps_of.get(n, []))
+        )
+        if not wave:
+            # Should not happen for a cycle-free, correctly-blocked graph, but
+            # guard against silent deadlock.
+            for n in sorted(remaining):
+                blocked[n] = "unresolved dependency (deadlock guard)"
+                plan.warnings.append(f"#{n} could not be scheduled; marking blocked")
+            break
+        plan.waves.append(wave)
+        placed.update(wave)
+        remaining.difference_update(wave)
+
+    plan.gated = sorted(blocked)
+    plan.gate_reasons = dict(sorted(blocked.items()))
+
+    # Integration risks: a ticket many others depend on (fan-in > 1) is a
+    # shared dependency whose change ripples; flag it for extra integration care.
+    dependents: dict[int, list[int]] = {}
+    for n in issues:
+        for dep in deps_of.get(n, []):
+            dependents.setdefault(dep, []).append(n)
+    for dep in sorted(dependents):
+        if len(dependents[dep]) > 1:
+            who = ", ".join(f"#{d}" for d in sorted(dependents[dep]))
+            plan.integration_risks.append(
+                f"#{dep} is a shared dependency of {who} (diamond / fan-out)"
+            )
+
+    return plan
+
+
+def render_markdown(plan: WavePlan) -> str:
+    """Render a concise human-readable wave plan report."""
+    lines = ["# Wave Plan", ""]
+    if plan.waves:
+        for i, wave in enumerate(plan.waves):
+            tickets = ", ".join(f"#{n}" for n in wave)
+            lines.append(f"- **Wave {i + 1}** ({len(wave)}): {tickets}")
+    else:
+        lines.append("- _No buildable tickets._")
+    if plan.skipped:
+        lines += ["", "## Skipped (already closed)", ""]
+        lines.append(", ".join(f"#{n}" for n in plan.skipped))
+    if plan.gated:
+        lines += ["", "## Gated / blocked", ""]
+        for n in plan.gated:
+            lines.append(f"- #{n}: {plan.gate_reasons.get(n, 'blocked')}")
+    if plan.integration_risks:
+        lines += ["", "## Integration risks", ""]
+        lines += [f"- {risk}" for risk in plan.integration_risks]
+    if plan.warnings:
+        lines += ["", "## Warnings", ""]
+        lines += [f"- {w}" for w in plan.warnings]
+    return "\n".join(lines) + "\n"

--- a/scripts/plan_waves.py
+++ b/scripts/plan_waves.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""CLI for dependency-ordered wave planning (P0-3).
+
+Turns a dependency graph + ticket state into a wave plan. Designed to consume
+the JSON emitted by ``epic_metadata.py deps`` plus the epic's issue/closed/gated
+state, so ``/implement-wave`` Step 2 becomes one tested call.
+
+Exit codes:
+    0  plan produced
+    1  bad input
+    2  dependency cycle (no valid ordering)
+
+Examples:
+    python3 scripts/plan_waves.py \
+      --issues 42,43,44 \
+      --edges '{"42": [], "43": [42], "44": [43]}' \
+      --closed 42 --gated 44 --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import planning  # noqa: E402
+
+
+def _parse_int_list(value: str | None) -> list[int]:
+    if not value:
+        return []
+    return [int(x) for x in value.replace(",", " ").split()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan implementation waves")
+    parser.add_argument("--issues", help="Comma/space-separated epic issue numbers")
+    parser.add_argument(
+        "--edges",
+        help='JSON adjacency map {"n": [deps]}; or use --deps-json for full deps output',
+    )
+    parser.add_argument(
+        "--deps-json",
+        help="Path to `epic_metadata.py deps` JSON (reads .edges); '-' for stdin",
+    )
+    parser.add_argument("--closed", help="Comma/space-separated closed issue numbers")
+    parser.add_argument("--gated", help="Comma/space-separated gated issue numbers")
+    parser.add_argument("--markdown", action="store_true", help="Emit markdown report")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.deps_json:
+            raw = sys.stdin.read() if args.deps_json == "-" else Path(args.deps_json).read_text()
+            edges = {int(k): v for k, v in json.loads(raw).get("edges", {}).items()}
+        elif args.edges:
+            edges = {int(k): v for k, v in json.loads(args.edges).items()}
+        else:
+            parser.error("one of --edges or --deps-json is required")
+
+        issues = _parse_int_list(args.issues) or list(edges)
+        plan = planning.plan_waves(
+            issues,
+            edges,
+            closed=_parse_int_list(args.closed),
+            gated=_parse_int_list(args.gated),
+        )
+    except planning.DependencyCycleError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except (ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.markdown:
+        print(planning.render_markdown(plan))
+    else:
+        print(json.dumps(plan.to_dict(), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plan_waves.py
+++ b/scripts/plan_waves.py
@@ -51,14 +51,37 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--markdown", action="store_true", help="Emit markdown report")
     args = parser.parse_args(argv)
 
+    if not args.deps_json and not args.edges:
+        print("Error: one of --edges or --deps-json is required", file=sys.stderr)
+        return 1
+
+    deps_warnings: list[str] = []
     try:
         if args.deps_json:
             raw = sys.stdin.read() if args.deps_json == "-" else Path(args.deps_json).read_text()
-            edges = {int(k): v for k, v in json.loads(raw).get("edges", {}).items()}
-        elif args.edges:
-            edges = {int(k): v for k, v in json.loads(args.edges).items()}
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                raise ValueError("--deps-json must be a JSON object with an 'edges' map")
+            deps_warnings = list(parsed.get("warnings", []))
+            edges = {int(k): v for k, v in parsed.get("edges", {}).items()}
         else:
-            parser.error("one of --edges or --deps-json is required")
+            parsed = json.loads(args.edges)
+            if not isinstance(parsed, dict):
+                raise ValueError("--edges must be a JSON object mapping number -> [deps]")
+            edges = {int(k): v for k, v in parsed.items()}
+
+        # A malformed dependency line is dropped upstream by epic_metadata.py,
+        # which would leave the affected ticket looking dependency-free. Refuse
+        # to plan on a graph we know is corrupt rather than risk scheduling a
+        # ticket before its real dependency lands.
+        malformed = [w for w in deps_warnings if "malformed dependency line" in w]
+        if malformed:
+            print(
+                "Error: refusing to plan on a corrupt dependency graph:\n  "
+                + "\n  ".join(malformed),
+                file=sys.stderr,
+            )
+            return 1
 
         issues = _parse_int_list(args.issues) or list(edges)
         plan = planning.plan_waves(
@@ -67,10 +90,12 @@ def main(argv: list[str] | None = None) -> int:
             closed=_parse_int_list(args.closed),
             gated=_parse_int_list(args.gated),
         )
+        # Surface remaining (non-fatal) deps metadata warnings in the plan.
+        plan.warnings = deps_warnings + plan.warnings
     except planning.DependencyCycleError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
-    except (ValueError, KeyError, json.JSONDecodeError) as exc:
+    except (ValueError, KeyError, OSError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 

--- a/tests/test_plan_waves.py
+++ b/tests/test_plan_waves.py
@@ -1,0 +1,149 @@
+"""Tests for wave planning and gating (P0-3)."""
+
+from __future__ import annotations
+
+import json
+
+import plan_waves
+import pytest
+from chief_wiggum import planning
+
+# --- topology: independent / chains / diamonds ------------------------------
+
+
+def test_independent_tickets_form_one_wave():
+    plan = planning.plan_waves([1, 2, 3], {1: [], 2: [], 3: []})
+    assert plan.waves == [[1, 2, 3]]
+    assert plan.gated == []
+
+
+def test_chain_forms_sequential_waves():
+    plan = planning.plan_waves([1, 2, 3], {1: [], 2: [1], 3: [2]})
+    assert plan.waves == [[1], [2], [3]]
+
+
+def test_diamond_orders_correctly_and_flags_risk():
+    # 1 -> {2,3} -> 4
+    edges = {1: [], 2: [1], 3: [1], 4: [2, 3]}
+    plan = planning.plan_waves([1, 2, 3, 4], edges)
+    assert plan.waves == [[1], [2, 3], [4]]
+    # Only #1 is a shared dependency (of #2 and #3); #4's deps each have one dependent.
+    assert any("#1 is a shared dependency" in r for r in plan.integration_risks)
+    assert all(not r.startswith("#4") for r in plan.integration_risks)
+
+
+# --- cycles -----------------------------------------------------------------
+
+
+def test_cycle_raises():
+    with pytest.raises(planning.DependencyCycleError):
+        planning.plan_waves([1, 2], {1: [2], 2: [1]})
+
+
+def test_self_cycle_raises():
+    with pytest.raises(planning.DependencyCycleError):
+        planning.plan_waves([1], {1: [1]})
+
+
+# --- closed dependencies ----------------------------------------------------
+
+
+def test_closed_dependency_unblocks_dependent():
+    # 2 depends on 1; 1 is already closed -> 2 builds in wave 1.
+    plan = planning.plan_waves([1, 2], {1: [], 2: [1]}, closed=[1])
+    assert plan.skipped == [1]
+    assert plan.waves == [[2]]
+
+
+def test_dependency_on_external_closed_issue_is_satisfied():
+    # 5 depends on 99 (not in epic) but 99 is closed -> 5 is buildable.
+    plan = planning.plan_waves([5], {5: [99]}, closed=[99])
+    assert plan.waves == [[5]]
+    assert plan.gated == []
+
+
+# --- missing dependency references ------------------------------------------
+
+
+def test_missing_dependency_reference_blocks_and_warns():
+    # 5 depends on 99 which is neither in the epic nor closed.
+    plan = planning.plan_waves([5], {5: [99]})
+    assert plan.waves == []
+    assert plan.gated == [5]
+    assert any("missing/unknown #99" in w for w in plan.warnings)
+
+
+# --- gating + transitive gates ----------------------------------------------
+
+
+def test_gated_ticket_is_held_back():
+    plan = planning.plan_waves([1, 2], {1: [], 2: []}, gated=[2])
+    assert plan.waves == [[1]]
+    assert plan.gated == [2]
+    assert "gated" in plan.gate_reasons[2]
+
+
+def test_transitive_gate_holds_back_dependents():
+    # 1 gated; 2 depends on 1; 3 depends on 2 -> all held back.
+    edges = {1: [], 2: [1], 3: [2], 4: []}
+    plan = planning.plan_waves([1, 2, 3, 4], edges, gated=[1])
+    assert plan.waves == [[4]]
+    assert plan.gated == [1, 2, 3]
+    assert "depends on blocked #1" in plan.gate_reasons[2]
+    assert "depends on blocked #2" in plan.gate_reasons[3]
+
+
+def test_partial_gate_still_builds_independent_branch():
+    # Two independent chains; gate one root, the other still builds.
+    edges = {1: [], 2: [1], 10: [], 20: [10]}
+    plan = planning.plan_waves([1, 2, 10, 20], edges, gated=[1])
+    assert plan.waves == [[10], [20]]
+    assert plan.gated == [1, 2]
+
+
+# --- serialization / rendering ----------------------------------------------
+
+
+def test_to_dict_is_json_serializable():
+    plan = planning.plan_waves([1, 2], {1: [], 2: [1]}, gated=[])
+    blob = json.dumps(plan.to_dict())
+    data = json.loads(blob)
+    assert data["waves"] == [[1], [2]]
+    assert set(data) == {
+        "waves", "gated", "skipped", "warnings", "integration_risks", "gate_reasons"
+    }
+
+
+def test_render_markdown_includes_sections():
+    edges = {1: [], 2: [1], 3: [1]}
+    plan = planning.plan_waves([1, 2, 3], edges, gated=[3])
+    md = planning.render_markdown(plan)
+    assert "# Wave Plan" in md
+    assert "Wave 1" in md
+    assert "Gated / blocked" in md
+    assert "Integration risks" in md
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_emits_json(capsys):
+    rc = plan_waves.main(["--issues", "1,2,3", "--edges", '{"1": [], "2": [1], "3": [2]}'])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["waves"] == [[1], [2], [3]]
+
+
+def test_cli_cycle_exits_2(capsys):
+    rc = plan_waves.main(["--issues", "1,2", "--edges", '{"1": [2], "2": [1]}'])
+    assert rc == 2
+    assert "cycle" in capsys.readouterr().err
+
+
+def test_cli_reads_deps_json_shape(tmp_path, capsys):
+    deps = {"edges": {"1": [], "2": [1]}, "warnings": [], "has_block": True}
+    path = tmp_path / "deps.json"
+    path.write_text(json.dumps(deps))
+    rc = plan_waves.main(["--deps-json", str(path), "--issues", "1,2"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["waves"] == [[1], [2]]

--- a/tests/test_plan_waves.py
+++ b/tests/test_plan_waves.py
@@ -147,3 +147,46 @@ def test_cli_reads_deps_json_shape(tmp_path, capsys):
     rc = plan_waves.main(["--deps-json", str(path), "--issues", "1,2"])
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["waves"] == [[1], [2]]
+
+
+def test_cli_refuses_corrupt_graph_from_malformed_deps(tmp_path, capsys):
+    # epic_metadata.py dropped a malformed line; planning on the partial graph
+    # could schedule a ticket before its real dependency. Refuse instead.
+    deps = {
+        "edges": {"2": []},
+        "warnings": ["malformed dependency line: '#2: [#1 typo]'"],
+        "has_block": True,
+    }
+    path = tmp_path / "deps.json"
+    path.write_text(json.dumps(deps))
+    rc = plan_waves.main(["--deps-json", str(path), "--issues", "1,2"])
+    assert rc == 1
+    assert "corrupt dependency graph" in capsys.readouterr().err
+
+
+def test_cli_surfaces_nonfatal_deps_warnings(tmp_path, capsys):
+    deps = {
+        "edges": {"1": []},
+        "warnings": ["missing DEPENDENCIES block: not found in description"],
+        "has_block": False,
+    }
+    path = tmp_path / "deps.json"
+    path.write_text(json.dumps(deps))
+    rc = plan_waves.main(["--deps-json", str(path), "--issues", "1"])
+    assert rc == 0
+    assert any("missing DEPENDENCIES block" in w for w in json.loads(capsys.readouterr().out)["warnings"])
+
+
+def test_cli_missing_inputs_exits_1_not_cycle_code(capsys):
+    rc = plan_waves.main(["--issues", "1"])
+    assert rc == 1  # distinct from cycle's exit 2
+
+
+def test_cli_missing_deps_file_exits_1(capsys):
+    rc = plan_waves.main(["--deps-json", "/nonexistent/deps.json", "--issues", "1"])
+    assert rc == 1
+
+
+def test_cli_non_object_edges_exits_1(capsys):
+    rc = plan_waves.main(["--edges", "[1, 2, 3]"])
+    assert rc == 1


### PR DESCRIPTION
## Summary

P0-3 of the **Portable Python Orchestration Core** epic. Moves `/implement-wave`'s dependency planning, topological ordering, gated-ticket propagation, and cycle detection out of prose into a tested planner — so the wave plan can't accidentally launch a ticket before its dependencies land or build one blocked by a `TBD:` marker.

Closes #39.

## Changes

- **`scripts/chief_wiggum/planning.py`** — `plan_waves(issues, edges, closed, gated)`:
  - Kahn-style wave assignment; a dep is satisfied when closed or placed in an earlier wave.
  - Cycle detection → `DependencyCycleError` (CLI exits non-zero).
  - Blocking seeded from `gated` tickets and **missing/unknown dependency references**, then propagated **transitively** to all dependents.
  - Closed tickets satisfy dependents and are reported under `skipped`.
  - Output: `waves`, `gated`, `skipped`, `warnings`, `integration_risks` (shared-dependency diamonds), `gate_reasons`; plus a markdown renderer.
- **`scripts/plan_waves.py`** — CLI consuming `epic_metadata.py deps` JSON (`--deps-json`) or inline `--edges`, with `--issues/--closed/--gated`. Exit `2` on cycle, `1` on bad input.
- **`implement-wave.md` Step 2** — now calls `plan_waves.py` instead of hand-sorting.

## Acceptance criteria

- [x] Tests cover independent tickets, chains, diamonds, cycles, missing dependency references, already-closed dependencies, gated tickets, and transitive gates (16 tests).
- [x] CLI exits non-zero for dependency cycles.
- [x] `/implement-wave` Step 2 becomes a call to the planner.
- [x] Planner output includes `waves`, `gated`, `skipped`, `warnings`, and `integration_risks`.

## Verification

- `make lint` clean; `make test` — 123 passed (16 new).
- CLI smoke (closed+gated+markdown) produces correct waves, skip, gate, and diamond risk.