### PR TITLE
feat: parallel provider quorum runner with retries + manifest (#40)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -76,15 +76,14 @@ Prepare a consultation prompt at `$CW_TMP/architect-prompt.md` including:
   5. Where are the integration risks and how should we test them?
   6. What could go wrong between tickets? (dual sources of truth, race conditions, inconsistent reads)
 
-Fire all three consultations in parallel:
+Fire the `architecture_critic` quorum (codex + gemini in parallel, with retries + output validation):
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" codex $CW_TMP/architect-prompt.md -o $CW_TMP/architect-codex.md --cwd "$TARGET_REPO" &
-python3 "$CW_HOME/scripts/consult_ai.py" gemini $CW_TMP/architect-prompt.md -o $CW_TMP/architect-gemini.md --cwd "$TARGET_REPO" &
-wait
+python3 "$CW_HOME/scripts/consult_ai.py" --role architecture_critic $CW_TMP/architect-prompt.md \
+  --output-dir "$CW_TMP/architect-consult" --cwd "$TARGET_REPO"
 ```
 
-Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) in parallel to explore the codebase and produce its own architectural analysis at `$CW_TMP/architect-opus.md`.
+Responses land at `$CW_TMP/architect-consult/architecture_critic-<provider>.md` with status in `architecture_critic-manifest.json`. Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) in parallel to explore the codebase and produce its own architectural analysis at `$CW_TMP/architect-opus.md`.
 
 **HARD RULE**: Wait for ALL THREE before proceeding.
 
@@ -336,13 +335,14 @@ Prepare a validation prompt at `$CW_TMP/validate-artifacts-prompt.md` containing
   6. Does every precondition have a corresponding error case? (REQUIRES without an ERROR CASE means a silent failure)
   7. Are the `expression` fields in preconditions/postconditions/invariants reasonable and implementable?
 
-Run Codex and Gemini in parallel:
+Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation):
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" codex $CW_TMP/validate-artifacts-prompt.md -o $CW_TMP/validate-codex.md --cwd "$TARGET_REPO" &
-python3 "$CW_HOME/scripts/consult_ai.py" gemini $CW_TMP/validate-artifacts-prompt.md -o $CW_TMP/validate-gemini.md --cwd "$TARGET_REPO" &
-wait
+python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/validate-artifacts-prompt.md \
+  --output-dir "$CW_TMP/validate-artifacts" --cwd "$TARGET_REPO"
 ```
+
+Responses land at `$CW_TMP/validate-artifacts/reviewer-<provider>.md` (status in `reviewer-manifest.json`).
 
 Review both responses. Apply clear improvements to the JSON models. Regenerate prose if models changed:
 ```bash

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -327,15 +327,14 @@ Prepare a findings prompt at `$CW_TMP/close-epic-review-prompt.md` containing:
   5. What is the highest-risk area of this epic that needs the most attention before shipping?
   6. Are there any gaps the automated checks could not cover?
 
-Run Codex and Gemini in parallel:
+Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation):
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" codex $CW_TMP/close-epic-review-prompt.md -o $CW_TMP/close-review-codex.md --cwd "$TARGET_REPO" &
-python3 "$CW_HOME/scripts/consult_ai.py" gemini $CW_TMP/close-epic-review-prompt.md -o $CW_TMP/close-review-gemini.md --cwd "$TARGET_REPO" &
-wait
+python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/close-epic-review-prompt.md \
+  --output-dir "$CW_TMP/close-review" --cwd "$TARGET_REPO"
 ```
 
-Synthesise both reviews. Categorise findings:
+Read `$CW_TMP/close-review/reviewer-codex.md` and `reviewer-gemini.md` (status in `reviewer-manifest.json`). Synthesise both reviews. Categorise findings:
 - **Consensus risks**: Both AIs flagged the same area — high confidence, address before shipping
 - **Unique insights**: Only one AI flagged — investigate, may be a genuine blind spot or a false positive
 - **Recommendations**: Suggestions for the retrospective and future epics

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -102,13 +102,14 @@ This is the **only** step that blocks on the user. Do not add approval gates els
 
 ### Step 4: Multi-AI design critique
 
-Unless `--skip-critique`: send the approved direction's screenshots to all three AIs with the **same prompt** (value is in natural divergence):
+Unless `--skip-critique`: send the approved direction's screenshots to the `design_critic` quorum with the **same prompt** (value is in natural divergence). The role runs its providers in parallel with retries + output validation:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" gemini "$DESIGN_TMP/critique-prompt.md" --cwd "$DESIGN_TMP" -o "$DESIGN_TMP/critique-gemini.md"
-python3 "$CW_HOME/scripts/consult_ai.py" codex  "$DESIGN_TMP/critique-prompt.md" --cwd "$DESIGN_TMP" -o "$DESIGN_TMP/critique-codex.md"
-python3 "$CW_HOME/scripts/consult_ai.py" claude "$DESIGN_TMP/critique-prompt.md" --cwd "$DESIGN_TMP" -o "$DESIGN_TMP/critique-claude.md"
+python3 "$CW_HOME/scripts/consult_ai.py" --role design_critic "$DESIGN_TMP/critique-prompt.md" \
+  --cwd "$DESIGN_TMP" --output-dir "$DESIGN_TMP/critique"
 ```
+
+Responses land at `$DESIGN_TMP/critique/design_critic-<provider>.md` with status in `design_critic-manifest.json`.
 
 The prompt names the screenshot files (cwd is `$DESIGN_TMP` so the CLIs can open them) and asks for critique against:
 - **Audience fit**: does this read right for the audience in `docs/domain-context.md`?

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -74,7 +74,7 @@ TICKET_TMP="$CW_TMP/$issue_number"
 mkdir -p "$TICKET_TMP"
 ```
 
-All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemini.md`, `approach-opus.md`, `implementation-plan.md`, `review-prompt.md`, `review-codex.md`, `review-gemini.md`, `impl-diff.txt`) go in `$TICKET_TMP`, not `$CW_TMP`. Shared session files (e.g., epic context) remain in `$CW_TMP`.
+All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemini.md`, `approach-opus.md`, `implementation-plan.md`, `review-prompt.md`, `reviews/reviewer-*.md`, `impl-diff.txt`) go in `$TICKET_TMP`, not `$CW_TMP`. Shared session files (e.g., epic context) remain in `$CW_TMP`.
 
 **Load epic context** (if this ticket belongs to an epic):
 
@@ -314,20 +314,19 @@ The sub-agent should:
 
 2. Prepare a review prompt using `$CW_HOME/templates/review-prompt.md` as a base. Read the template, replace the `{{TICKET_TITLE}}`, `{{TICKET_DESCRIPTION}}`, `{{ACCEPTANCE_CRITERIA}}`, and `{{DIFF}}` placeholders with actual values. **Also include the structured checklist** from `$CW_HOME/templates/review-checklist.md` and the epic contracts/invariants if they exist. Write to `$TICKET_TMP/review-prompt.md`.
 
-3. Run external AI reviews in parallel:
+3. Run external AI reviews as a quorum (parallel, with retries + output validation):
    ```bash
-   python3 "$CW_HOME/scripts/consult_ai.py" codex $TICKET_TMP/review-prompt.md -o $TICKET_TMP/review-codex.md --cwd "$(git rev-parse --show-toplevel)" &
-   python3 "$CW_HOME/scripts/consult_ai.py" gemini $TICKET_TMP/review-prompt.md -o $TICKET_TMP/review-gemini.md --cwd "$(git rev-parse --show-toplevel)" &
-   wait
+   python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $TICKET_TMP/review-prompt.md \
+     --output-dir "$TICKET_TMP/reviews" --cwd "$(git rev-parse --show-toplevel)"
    ```
 
-   **Validate review output**: After `wait`, check that both `review-codex.md` and `review-gemini.md` exist and contain substantive output (>100 bytes, not starting with "Timeout:" or "Error:"). Retry any failed consultation up to 2 times. If a consultation still fails after retries, proceed with available reviews but note the gap in the synthesis.
+   The `reviewer` role runs codex + gemini in parallel, **retries failed required providers**, **validates** each response (non-empty, not starting with `Timeout:`/`Error:`), and writes `$TICKET_TMP/reviews/reviewer-manifest.json` plus `reviewer-<provider>.md`. If the quorum fails (a required provider never produced valid output) the command exits non-zero — note the gap and proceed with the available reviews.
 
 4. Perform its own review of the diff.
 
 5. Synthesize using:
    ```bash
-   python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/review-codex.md $TICKET_TMP/review-gemini.md
+   python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/reviews/reviewer-codex.md $TICKET_TMP/reviews/reviewer-gemini.md
    ```
 
 6. Return a concise summary categorising each piece of feedback:

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -115,16 +115,13 @@ Write a consultation prompt to `$CW_TMP/consultation-prompt.md` asking for a cri
 4. Specific technical feedback on the key decisions
 5. Cost optimisation traps
 
-Fire off **Gemini and Codex in parallel** using `consult_ai.py`:
+Fire the `explorer` quorum (providers run in parallel, with retries + output validation) using `consult_ai.py`:
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" gemini "$CW_TMP/consultation-prompt.md" \
-  --context "$CW_TMP/architecture-decisions.md" -o "$CW_TMP/review-gemini.md"
-
-python3 "$CW_HOME/scripts/consult_ai.py" codex "$CW_TMP/consultation-prompt.md" \
-  --context "$CW_TMP/architecture-decisions.md" -o "$CW_TMP/review-codex.md"
+python3 "$CW_HOME/scripts/consult_ai.py" --role explorer "$CW_TMP/consultation-prompt.md" \
+  --context "$CW_TMP/architecture-decisions.md" --output-dir "$CW_TMP/consult"
 ```
 
-Run both in the background. Continue the conversation or work on other steps while waiting.
+Responses land at `$CW_TMP/consult/explorer-<provider>.md` with status in `explorer-manifest.json`. Continue the conversation or work on other steps while waiting.
 
 ### Step 6: Synthesise AI feedback
 

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -22,7 +22,14 @@ from pathlib import Path
 # Allow importing keychain from the same directory
 sys.path.insert(0, str(Path(__file__).parent))
 from keychain import get_secret
-from providers import DEFAULT_CONFIG, Provider, load_config, plan_role, validate_config
+from providers import (
+    DEFAULT_CONFIG,
+    Provider,
+    load_config,
+    plan_role,
+    run_role_quorum,
+    validate_config,
+)
 
 # Per-tool timeouts (seconds). These are generous — better to wait than to
 # lose a good response to a premature timeout.
@@ -190,6 +197,8 @@ def main():
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Provider config path")
     parser.add_argument("--enable-provider", action="append", default=[], help="Force-enable provider by name")
     parser.add_argument("--disable-provider", action="append", default=[], help="Disable provider by name")
+    parser.add_argument("--max-attempts", type=int, default=2, help="Retries for required providers in --role mode")
+    parser.add_argument("--min-bytes", type=int, default=20, help="Minimum substantive output size in --role mode")
     args = parser.parse_args()
 
     if args.role:
@@ -246,25 +255,27 @@ def main():
                 file=sys.stderr,
             )
             sys.exit(1)
-        output_dir = Path(args.output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        failures: list[str] = []
-        for provider in plan.runnable:
-            try:
-                output = consult_provider(provider, prompt, args.model, args.cwd)
-                output_path = output_dir / f"{args.role}-{provider.name}.md"
-                output_path.write_text(output)
-                print(f"OK: {provider.name} response written to {output_path}")
-            except Exception as exc:
-                if provider in plan.required:
-                    failures.append(f"{provider.name}: {exc}")
-                else:
-                    skipped = output_dir / f"{args.role}-{provider.name}.error.md"
-                    skipped.write_text(str(exc))
-                    print(f"Warning: optional provider {provider.name} failed: {exc}", file=sys.stderr)
-        if failures:
-            for failure in failures:
-                print(f"Error: {failure}", file=sys.stderr)
+        # Run the quorum in parallel with retries + output validation, and write
+        # a manifest. Required providers must produce substantive output.
+        manifest = run_role_quorum(
+            plan,
+            lambda provider: consult_provider(provider, prompt, args.model, args.cwd),
+            args.output_dir,
+            max_attempts=args.max_attempts,
+            min_bytes=args.min_bytes,
+        )
+        for result in manifest.results:
+            if result.status == "ok":
+                print(f"OK: {result.name} response written to {result.path}")
+            elif result.required:
+                print(f"Error: required provider {result.name} failed: {result.error}", file=sys.stderr)
+            else:
+                print(f"Warning: optional provider {result.name} failed: {result.error}", file=sys.stderr)
+        if not manifest.ok:
+            print(
+                f"Role {args.role} quorum failed: {', '.join(manifest.failed_required)}",
+                file=sys.stderr,
+            )
             sys.exit(1)
         return
 

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -197,7 +197,7 @@ def main():
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Provider config path")
     parser.add_argument("--enable-provider", action="append", default=[], help="Force-enable provider by name")
     parser.add_argument("--disable-provider", action="append", default=[], help="Disable provider by name")
-    parser.add_argument("--max-attempts", type=int, default=2, help="Retries for required providers in --role mode")
+    parser.add_argument("--max-attempts", type=int, default=2, help="Total attempts for required providers in --role mode (incl. first try)")
     parser.add_argument("--min-bytes", type=int, default=20, help="Minimum substantive output size in --role mode")
     args = parser.parse_args()
 

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -139,6 +139,14 @@ def validate_config(
         for provider_name in role.required + role.optional:
             if provider_name not in providers:
                 errors.append(f"role {role_name} references unknown provider {provider_name}")
+        # A provider referenced twice (within a list or across required+optional)
+        # would run twice and clobber its own output file.
+        all_refs = list(role.required) + list(role.optional)
+        seen: set[str] = set()
+        for name in all_refs:
+            if name in seen:
+                errors.append(f"role {role_name} references provider {name} more than once")
+            seen.add(name)
     for provider in providers.values():
         if provider.type == "tool" and not provider.tool:
             errors.append(f"provider {provider.name} has type=tool but no tool")
@@ -178,6 +186,7 @@ class ProviderResult:
     path: str | None = None
     attempts: int = 0
     error: str | None = None
+    error_path: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -187,6 +196,7 @@ class ProviderResult:
             "path": self.path,
             "attempts": self.attempts,
             "error": self.error,
+            "error_path": self.error_path,
         }
 
 
@@ -235,6 +245,13 @@ def _run_one_provider(
     max_attempts: int,
     min_bytes: int,
 ) -> ProviderResult:
+    # Clear any stale artifacts from a previous run so a failure can't leave an
+    # old success file (or vice versa) for a later reader to pick up.
+    ok_path = output_dir / f"{role_name}-{provider.name}.md"
+    err_path = output_dir / f"{role_name}-{provider.name}.error.md"
+    ok_path.unlink(missing_ok=True)
+    err_path.unlink(missing_ok=True)
+
     # Only required providers are retried; an optional provider gets one shot.
     attempts_allowed = max(1, max_attempts) if required else 1
     last_error: str | None = None
@@ -249,13 +266,13 @@ def _run_one_provider(
         if problem:
             last_error = problem
             continue
-        path = output_dir / f"{role_name}-{provider.name}.md"
-        path.write_text(text)
-        return ProviderResult(provider.name, required, "ok", str(path), attempt, None)
+        ok_path.write_text(text)
+        return ProviderResult(provider.name, required, "ok", str(ok_path), attempt, None)
 
-    err_path = output_dir / f"{role_name}-{provider.name}.error.md"
     err_path.write_text(last_error or "unknown error")
-    return ProviderResult(provider.name, required, "failed", None, attempt, last_error)
+    return ProviderResult(
+        provider.name, required, "failed", None, attempt, last_error, str(err_path)
+    )
 
 
 def run_role_quorum(
@@ -277,8 +294,15 @@ def run_role_quorum(
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    tasks: list[tuple[Provider, bool]] = [(p, True) for p in plan.required]
-    tasks += [(p, False) for p in plan.optional]
+    # Required first; dedupe by name (a provider listed twice, or in both
+    # required and optional, must not run twice and clobber its own file).
+    tasks: list[tuple[Provider, bool]] = []
+    seen: set[str] = set()
+    for provider, required in [(p, True) for p in plan.required] + [(p, False) for p in plan.optional]:
+        if provider.name in seen:
+            continue
+        seen.add(provider.name)
+        tasks.append((provider, required))
     order = {p.name: i for i, (p, _) in enumerate(tasks)}
 
     results: list[ProviderResult] = []

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -155,3 +157,150 @@ def validate_config(
         if provider.type not in {"tool", "delegate"}:
             errors.append(f"provider {provider.name} has unsupported type {provider.type}")
     return errors
+
+
+# --- parallel quorum execution ----------------------------------------------
+
+# Output beginning with one of these markers is a failure sentinel written by a
+# failed provider call, not a substantive response.
+INVALID_MARKERS = ("Timeout:", "Error:")
+
+# An ``execute`` callable runs a single provider and returns its response text.
+# It is injected so the quorum runner is testable without real provider calls.
+ExecuteFn = Callable[[Provider], str]
+
+
+@dataclass
+class ProviderResult:
+    name: str
+    required: bool
+    status: str  # "ok" | "failed"
+    path: str | None = None
+    attempts: int = 0
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "required": self.required,
+            "status": self.status,
+            "path": self.path,
+            "attempts": self.attempts,
+            "error": self.error,
+        }
+
+
+@dataclass
+class QuorumManifest:
+    role: str
+    results: list[ProviderResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True iff every required provider produced valid output."""
+        return all(r.status == "ok" for r in self.results if r.required)
+
+    @property
+    def failed_required(self) -> list[str]:
+        return [r.name for r in self.results if r.required and r.status != "ok"]
+
+    def to_dict(self) -> dict:
+        return {
+            "role": self.role,
+            "ok": self.ok,
+            "failed_required": self.failed_required,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+def validate_output(text: str | None, *, min_bytes: int = 20) -> str | None:
+    """Return a failure reason if ``text`` is not a substantive response, else None."""
+    if text is None:
+        return "no output"
+    stripped = text.strip()
+    if len(stripped.encode("utf-8")) < min_bytes:
+        return f"output too short (<{min_bytes} bytes)"
+    for marker in INVALID_MARKERS:
+        if stripped.startswith(marker):
+            return f"output starts with failure marker {marker!r}"
+    return None
+
+
+def _run_one_provider(
+    provider: Provider,
+    required: bool,
+    execute: ExecuteFn,
+    output_dir: Path,
+    role_name: str,
+    max_attempts: int,
+    min_bytes: int,
+) -> ProviderResult:
+    # Only required providers are retried; an optional provider gets one shot.
+    attempts_allowed = max(1, max_attempts) if required else 1
+    last_error: str | None = None
+    attempt = 0
+    for attempt in range(1, attempts_allowed + 1):
+        try:
+            text = execute(provider)
+        except Exception as exc:  # noqa: BLE001 - any provider failure is retryable
+            last_error = f"execution failed: {exc}"
+            continue
+        problem = validate_output(text, min_bytes=min_bytes)
+        if problem:
+            last_error = problem
+            continue
+        path = output_dir / f"{role_name}-{provider.name}.md"
+        path.write_text(text)
+        return ProviderResult(provider.name, required, "ok", str(path), attempt, None)
+
+    err_path = output_dir / f"{role_name}-{provider.name}.error.md"
+    err_path.write_text(last_error or "unknown error")
+    return ProviderResult(provider.name, required, "failed", None, attempt, last_error)
+
+
+def run_role_quorum(
+    plan: RolePlan,
+    execute: ExecuteFn,
+    output_dir: str | Path,
+    *,
+    max_attempts: int = 2,
+    min_bytes: int = 20,
+    max_workers: int | None = None,
+    write_manifest: bool = True,
+) -> QuorumManifest:
+    """Run a role's providers concurrently with retries and output validation.
+
+    Required and optional providers run in parallel. Required providers are
+    retried up to ``max_attempts`` times; optional providers fail without
+    blocking the quorum. A ``{role}-manifest.json`` records per-provider status.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    tasks: list[tuple[Provider, bool]] = [(p, True) for p in plan.required]
+    tasks += [(p, False) for p in plan.optional]
+    order = {p.name: i for i, (p, _) in enumerate(tasks)}
+
+    results: list[ProviderResult] = []
+    if tasks:
+        workers = max_workers or len(tasks)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(
+                    _run_one_provider,
+                    provider, required, execute, out, plan.role.name, max_attempts, min_bytes,
+                )
+                for provider, required in tasks
+            ]
+            for fut in concurrent.futures.as_completed(futures):
+                results.append(fut.result())
+
+    # Deterministic order: required (config order) then optional.
+    results.sort(key=lambda r: order.get(r.name, 1_000))
+    manifest = QuorumManifest(plan.role.name, results)
+
+    if write_manifest:
+        (out / f"{plan.role.name}-manifest.json").write_text(
+            json.dumps(manifest.to_dict(), indent=2)
+        )
+    return manifest

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -45,6 +45,8 @@ def test_role_consult_writes_required_and_optional_outputs(tmp_path, monkeypatch
             str(config),
             "--output-dir",
             str(output_dir),
+            "--min-bytes",
+            "1",
         ],
     )
 
@@ -79,6 +81,8 @@ def test_role_consult_does_not_fail_when_optional_provider_is_disabled(tmp_path,
             str(config),
             "--output-dir",
             str(output_dir),
+            "--min-bytes",
+            "1",
         ],
     )
 

--- a/tests/test_provider_quorum.py
+++ b/tests/test_provider_quorum.py
@@ -1,0 +1,149 @@
+"""Tests for the parallel provider quorum runner (P0-4)."""
+
+from __future__ import annotations
+
+import json
+
+import providers
+from providers import Provider, Role, RolePlan, run_role_quorum, validate_output
+
+
+def _provider(name: str) -> Provider:
+    return Provider(name=name, type="tool", enabled=True, tool=name)
+
+
+def _plan(required: list[str], optional: list[str]) -> RolePlan:
+    role = Role(name="reviewer", required=tuple(required), optional=tuple(optional))
+    return RolePlan(
+        role=role,
+        required=tuple(_provider(n) for n in required),
+        optional=tuple(_provider(n) for n in optional),
+        missing_required=(),
+        skipped_optional=(),
+    )
+
+
+SUBSTANTIVE = "This is a substantive review with several findings to report."
+
+
+# --- output validation ------------------------------------------------------
+
+
+def test_validate_output_rejects_short_and_failure_markers():
+    assert validate_output(None) == "no output"
+    assert validate_output("tiny", min_bytes=20).startswith("output too short")
+    assert "Timeout:" in validate_output("Timeout: provider did not respond in 600s")
+    assert "Error:" in validate_output("Error: calling codex failed")
+    assert validate_output(SUBSTANTIVE) is None
+
+
+# --- required / optional semantics ------------------------------------------
+
+
+def test_required_provider_failure_fails_quorum(tmp_path):
+    def execute(provider):
+        raise RuntimeError("boom")
+
+    manifest = run_role_quorum(_plan(["codex"], []), execute, tmp_path)
+    assert manifest.ok is False
+    assert manifest.failed_required == ["codex"]
+    assert manifest.results[0].status == "failed"
+    assert "boom" in manifest.results[0].error
+
+
+def test_optional_provider_failure_does_not_fail_quorum(tmp_path):
+    def execute(provider):
+        if provider.name == "gemini":
+            raise RuntimeError("optional down")
+        return SUBSTANTIVE
+
+    manifest = run_role_quorum(_plan(["codex"], ["gemini"]), execute, tmp_path)
+    assert manifest.ok is True
+    statuses = {r.name: r.status for r in manifest.results}
+    assert statuses == {"codex": "ok", "gemini": "failed"}
+
+
+def test_retry_succeeds_on_second_attempt(tmp_path):
+    calls = {"codex": 0}
+
+    def execute(provider):
+        calls[provider.name] += 1
+        if calls[provider.name] < 2:
+            raise RuntimeError("transient")
+        return SUBSTANTIVE
+
+    manifest = run_role_quorum(_plan(["codex"], []), execute, tmp_path, max_attempts=2)
+    result = manifest.results[0]
+    assert result.status == "ok"
+    assert result.attempts == 2
+
+
+def test_optional_provider_is_not_retried(tmp_path):
+    calls = {"gemini": 0}
+
+    def execute(provider):
+        calls[provider.name] += 1
+        raise RuntimeError("down")
+
+    run_role_quorum(_plan(["codex"], ["gemini"]), lambda p: SUBSTANTIVE if p.name == "codex" else execute(p), tmp_path, max_attempts=3)
+    assert calls["gemini"] == 1
+
+
+def test_timeout_output_marker_is_treated_as_failure(tmp_path):
+    def execute(provider):
+        return "Timeout: codex did not respond within 600s"
+
+    manifest = run_role_quorum(_plan(["codex"], []), execute, tmp_path, max_attempts=1)
+    assert manifest.ok is False
+    assert "failure marker" in manifest.results[0].error
+
+
+def test_too_short_output_is_failure(tmp_path):
+    manifest = run_role_quorum(_plan(["codex"], []), lambda p: "ok", tmp_path, min_bytes=50, max_attempts=1)
+    assert manifest.ok is False
+    assert "too short" in manifest.results[0].error
+
+
+# --- manifest content + files -----------------------------------------------
+
+
+def test_manifest_written_and_serializable(tmp_path):
+    manifest = run_role_quorum(_plan(["codex"], ["gemini"]), lambda p: SUBSTANTIVE, tmp_path)
+    manifest_path = tmp_path / "reviewer-manifest.json"
+    assert manifest_path.exists()
+    data = json.loads(manifest_path.read_text())
+    assert data["role"] == "reviewer"
+    assert data["ok"] is True
+    assert {r["name"] for r in data["results"]} == {"codex", "gemini"}
+    # Response files written per provider.
+    assert (tmp_path / "reviewer-codex.md").read_text() == SUBSTANTIVE
+    assert (tmp_path / "reviewer-gemini.md").read_text() == SUBSTANTIVE
+
+
+def test_results_are_deterministically_ordered(tmp_path):
+    plan = _plan(["codex", "gemini"], ["claude-interactive"])
+    manifest = run_role_quorum(plan, lambda p: SUBSTANTIVE, tmp_path)
+    assert [r.name for r in manifest.results] == ["codex", "gemini", "claude-interactive"]
+
+
+def test_disabled_provider_absent_from_plan_is_not_run(tmp_path):
+    # A disabled optional never enters the plan, so it is never executed.
+    config = {
+        "providers": {
+            "codex": {"type": "tool", "tool": "codex", "enabled": True},
+            "gemini": {"type": "tool", "tool": "gemini", "enabled": False},
+        },
+        "roles": {"reviewer": {"required": ["codex"], "optional": ["gemini"]}},
+    }
+    plan = providers.plan_role("reviewer", config)
+    assert "gemini" in plan.skipped_optional
+
+    ran: list[str] = []
+
+    def execute(provider):
+        ran.append(provider.name)
+        return SUBSTANTIVE
+
+    manifest = run_role_quorum(plan, execute, tmp_path)
+    assert ran == ["codex"]
+    assert manifest.ok is True

--- a/tests/test_provider_quorum.py
+++ b/tests/test_provider_quorum.py
@@ -126,6 +126,42 @@ def test_results_are_deterministically_ordered(tmp_path):
     assert [r.name for r in manifest.results] == ["codex", "gemini", "claude-interactive"]
 
 
+def test_failure_clears_stale_success_file(tmp_path):
+    # An earlier run left reviewer-codex.md; this run fails -> stale must be gone.
+    (tmp_path / "reviewer-codex.md").write_text("stale success from a previous run")
+
+    def execute(provider):
+        raise RuntimeError("down")
+
+    manifest = run_role_quorum(_plan(["codex"], []), execute, tmp_path, max_attempts=1)
+    assert not (tmp_path / "reviewer-codex.md").exists()
+    assert (tmp_path / "reviewer-codex.error.md").exists()
+    assert manifest.results[0].error_path == str(tmp_path / "reviewer-codex.error.md")
+
+
+def test_success_clears_stale_error_file(tmp_path):
+    (tmp_path / "reviewer-codex.error.md").write_text("stale error")
+    manifest = run_role_quorum(_plan(["codex"], []), lambda p: SUBSTANTIVE, tmp_path)
+    assert not (tmp_path / "reviewer-codex.error.md").exists()
+    assert manifest.results[0].error_path is None
+
+
+def test_duplicate_provider_across_required_and_optional_runs_once(tmp_path):
+    plan = _plan(["codex"], ["codex"])  # overlap
+    runs: list[str] = []
+    run_role_quorum(plan, lambda p: runs.append(p.name) or SUBSTANTIVE, tmp_path)
+    assert runs.count("codex") == 1
+
+
+def test_validate_config_rejects_duplicate_role_references():
+    config = {
+        "providers": {"codex": {"type": "tool", "tool": "codex"}},
+        "roles": {"reviewer": {"required": ["codex"], "optional": ["codex"]}},
+    }
+    errors = providers.validate_config(config)
+    assert any("more than once" in e for e in errors)
+
+
 def test_disabled_provider_absent_from_plan_is_not_run(tmp_path):
     # A disabled optional never enters the plan, so it is never executed.
     config = {


### PR DESCRIPTION
## Summary

P0-4 of the **Portable Python Orchestration Core** epic. Centralizes multi-provider execution: command prompts launched providers with shell `& wait` background jobs and hand-written output checks. This replaces that with a tested quorum runner — parallel execution, required/optional semantics, retries, output validation, and a status manifest.

Closes #40.

## Changes

- **`scripts/providers.py`** — `run_role_quorum(plan, execute, output_dir, ...)`:
  - Runs required + optional providers **concurrently** (`ThreadPoolExecutor`).
  - **Retries** failed *required* providers up to `max_attempts`; optional providers get one shot and fail without blocking.
  - **Validates** each response (`validate_output`: non-empty ≥ `min_bytes`, not starting with `Timeout:`/`Error:`).
  - Writes per-provider `{role}-{provider}.md` and a `{role}-manifest.json`.
  - `ProviderResult` / `QuorumManifest` dataclasses; `execute` fn injectable for testing.
- **`scripts/consult_ai.py`** — the `--role` path delegates to the quorum runner (parallel + retries + validation + manifest); adds `--max-attempts` / `--min-bytes`. Single-provider calls unchanged.
- **Command prompts** — replaced `& wait` provider blocks with role-runner calls: `implement` (reviewer), `architect` (architecture_critic + reviewer), `close-epic` (reviewer), `seed` (explorer), `design` (design_critic). `design` no longer invokes the disabled `claude` provider directly.

## Acceptance criteria

- [x] Tests cover required-provider failure, optional-provider failure, retry success, timeout output, disabled provider, and manifest content (11 new tests).
- [x] `/implement`, `/architect`, `/close-epic`, `/seed`, `/design` call the role runner instead of shell `& wait` blocks where roles fit. (`/stitch-audit` is single-provider — no quorum role fits.)
- [x] Existing one-provider calls still work for direct use.
- [x] `config/providers.json` remains the source of roles.

## Verification

- `make lint` clean; `make test` — 138 passed (11 new).
- End-to-end quorum smoke against the `reviewer` role produces a valid manifest with per-provider status.