### PR TITLE
feat: extract formal test artifact generation (#42)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -192,25 +192,15 @@ Revised Wave 3: #45, #46
 
 ```bash
 if [ "$HAS_FORMAL_MODELS" = true ]; then
-  mkdir -p "$CW_TMP/formal-test-artifacts"
-
-  # Test paths and plan from state machine model
-  python3 "$CW_HOME/scripts/render_models.py" "$MODELS_DIR/state-machines.json" --view test \
+  # One idempotent call generates every model-derived test artifact (test paths,
+  # test plan, contract assertions, Hypothesis skeleton, guard templates) plus a
+  # manifest, for whichever models exist in $MODELS_DIR.
+  python3 "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" \
     --output "$CW_TMP/formal-test-artifacts/"
-
-  # Contract assertion templates
-  python3 "$CW_HOME/scripts/render_models.py" "$MODELS_DIR/contracts.json" --view test \
-    --output "$CW_TMP/formal-test-artifacts/"
-
-  # Guard clause templates for the target language
-  python3 "$CW_HOME/scripts/formal_models.py" generate "$MODELS_DIR/contracts.json" \
-    --format guards-py > "$CW_TMP/formal-test-artifacts/guard_templates.py" 2>/dev/null || true
-
-  # Hypothesis state machine skeleton
-  python3 "$CW_HOME/scripts/formal_models.py" generate "$MODELS_DIR/state-machines.json" \
-    --format hypothesis > "$CW_TMP/formal-test-artifacts/test_state_machine_skeleton.py" 2>/dev/null || true
 fi
 ```
+
+The shared `$CW_TMP/formal-test-artifacts/formal-artifacts-manifest.json` lists the generated files; every sub-agent in the wave adapts the same artifacts to its ticket.
 
 These artifacts are shared across all tickets in the wave — each sub-agent receives the same test plan and adapts the relevant portions for its ticket.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -225,18 +225,13 @@ Present a concise summary to the user. If there are open questions that genuinel
 **If formal models exist** (`$HAS_FORMAL_MODELS == true`), generate mechanical test artifacts BEFORE launching the sub-agent. The orchestrator does this directly — it's a deterministic script call, not LLM work:
 
 ```bash
-# Generate test paths and plan from state machine model
-python3 "$CW_HOME/scripts/render_models.py" "$MODELS_DIR/state-machines.json" --view test --output "$TICKET_TMP/"
-
-# Generate contract assertion templates
-python3 "$CW_HOME/scripts/render_models.py" "$MODELS_DIR/contracts.json" --view test --output "$TICKET_TMP/"
-
-# Generate Hypothesis test skeleton (if not already in models dir)
-python3 "$CW_HOME/scripts/formal_models.py" generate "$MODELS_DIR/state-machines.json" --format hypothesis > "$TICKET_TMP/test_state_machine_skeleton.py"
-
-# Generate guard clause templates for the target language
-python3 "$CW_HOME/scripts/formal_models.py" generate "$MODELS_DIR/contracts.json" --format guards-py > "$TICKET_TMP/guard_templates.py"
+# One idempotent call generates every model-derived test artifact (test paths,
+# test plan, contract assertions, Hypothesis skeleton, guard templates) and a
+# manifest, for whichever models exist in $MODELS_DIR.
+python3 "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" --output "$TICKET_TMP/"
 ```
+
+The manifest (`$TICKET_TMP/formal-artifacts-manifest.json`) lists the generated files and per-model status; a non-zero exit means a present model failed validation — fix the model before building on it.
 
 These mechanically generated artifacts are passed to the sub-agent as inputs — the sub-agent adapts them to the target repo's test framework and conventions, not invents tests from scratch.
 
@@ -244,7 +239,7 @@ Launch a **Sonnet sub-agent** in a worktree (`subagent_type: "general-purpose"`,
 - The implementation plan from Step 4
 - The epic contracts and traceability matrix (if they exist)
 - The target repo's test framework and conventions
-- **If formal models exist**: the generated test plan (`$TICKET_TMP/test-plan.md`), test paths (`$TICKET_TMP/test-paths.json`), contract assertions (`$TICKET_TMP/contract-assertions.md`), Hypothesis skeleton (`$TICKET_TMP/test_state_machine_skeleton.py`), and guard templates (`$TICKET_TMP/guard_templates.py`)
+- **If formal models exist**: the generated test plan (`$TICKET_TMP/test-plan.md`), test paths (`$TICKET_TMP/test-paths.json`), contract assertions (`$TICKET_TMP/contract-assertions.md`), Hypothesis skeleton (`$TICKET_TMP/test_state_machine.py`), and guard templates (`$TICKET_TMP/guards.py`) — all listed in `$TICKET_TMP/formal-artifacts-manifest.json`
 - **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).

--- a/scripts/generate_formal_test_artifacts.py
+++ b/scripts/generate_formal_test_artifacts.py
@@ -26,8 +26,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import formal_models as fm  # noqa: E402
 import render_models as rm  # noqa: E402
 
-# Source models we know how to derive test artifacts from.
-MODEL_FILES = ("state-machines.json", "contracts.json", "ui-spec.json")
+# Source models we know how to derive test artifacts from, with the schema each
+# filename is required to hold (so a mislabeled file is flagged, not rendered).
+EXPECTED_SCHEMA = {
+    "state-machines.json": "state-machine",
+    "contracts.json": "contracts",
+    "ui-spec.json": "ui-spec",
+}
+MODEL_FILES = tuple(EXPECTED_SCHEMA)
 # Views that produce *test* artifacts (skip the human/markdown view).
 TEST_VIEWS = ("machine", "test")
 
@@ -35,7 +41,9 @@ TEST_VIEWS = ("machine", "test")
 @dataclass
 class ModelResult:
     name: str
-    status: str  # "ok" | "missing" | "invalid" | "malformed"
+    # "ok" (valid + files) | "empty" (valid, no test artifacts, e.g. ui-spec) |
+    # "missing" | "invalid" | "malformed"
+    status: str
     files: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
@@ -55,8 +63,9 @@ class GenerationManifest:
 
     @property
     def ok(self) -> bool:
-        # A run is OK if no present model failed validation/parsing.
-        return all(r.status in ("ok", "missing") for r in self.results)
+        # A run is OK unless a present model is invalid or malformed. A valid
+        # model that yields no test artifacts ("empty", e.g. ui-spec) is fine.
+        return all(r.status in ("ok", "empty", "missing") for r in self.results)
 
     def to_dict(self) -> dict:
         return {
@@ -81,16 +90,24 @@ class GenerationManifest:
 
 def _generate_one(model_path: Path, output_dir: Path, views=TEST_VIEWS) -> ModelResult:
     name = model_path.name
+    expected = EXPECTED_SCHEMA.get(name)
     try:
         model = fm._load_json(model_path)
     except (json.JSONDecodeError, OSError) as exc:
         return ModelResult(name, "malformed", errors=[str(exc)])
 
+    # The file must hold the schema its name implies; a contracts.json that is
+    # actually a state machine must be rejected, not rendered as a state machine.
     try:
-        schema_type = fm.detect_schema_type(model)
-        errors = fm.validate(model, schema_type)
-    except Exception as exc:  # noqa: BLE001 - unknown schema etc.
+        detected = fm.detect_schema_type(model)
+    except Exception as exc:  # noqa: BLE001 - unknown schema
         return ModelResult(name, "invalid", errors=[str(exc)])
+    if expected and detected != expected:
+        return ModelResult(
+            name, "invalid", errors=[f"expected {expected} schema, found {detected}"]
+        )
+
+    errors = fm.validate(model, expected or detected)
     if errors:
         return ModelResult(name, "invalid", errors=list(errors))
 
@@ -100,7 +117,10 @@ def _generate_one(model_path: Path, output_dir: Path, views=TEST_VIEWS) -> Model
     # Deduplicate while preserving order (machine + test views can overlap).
     seen: set[str] = set()
     deduped = [f for f in files if not (f in seen or seen.add(f))]
-    return ModelResult(name, "ok", files=deduped)
+    # A valid model that produces no test artifacts (e.g. ui-spec, which has no
+    # machine/test view) is "empty", not a failure.
+    status = "ok" if deduped else "empty"
+    return ModelResult(name, status, files=deduped)
 
 
 def generate_artifacts(
@@ -117,6 +137,16 @@ def generate_artifacts(
     models = Path(models_dir)
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
+
+    # Clear artifacts a prior run generated so the output dir stays a faithful
+    # set even when a model later goes missing/invalid.
+    prior_manifest = out / "formal-artifacts-manifest.json"
+    if prior_manifest.exists():
+        try:
+            for stale in json.loads(prior_manifest.read_text()).get("generated_files", []):
+                Path(stale).unlink(missing_ok=True)
+        except (json.JSONDecodeError, OSError):
+            pass
 
     manifest = GenerationManifest(models_dir=str(models), output_dir=str(out))
     for name in MODEL_FILES:
@@ -147,7 +177,7 @@ def main(argv: list[str] | None = None) -> int:
         print(manifest.render_markdown())
     else:
         print(json.dumps(manifest.to_dict(), indent=2))
-    # Non-zero if any present model failed to produce artifacts.
+    # Non-zero if any present model is invalid or malformed.
     return 0 if manifest.ok else 1
 
 

--- a/scripts/generate_formal_test_artifacts.py
+++ b/scripts/generate_formal_test_artifacts.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generate all model-derived test artifacts for a ticket or wave (P1-6).
+
+`/implement` Step 5 and `/implement-wave` Step 4a both duplicate a sequence of
+`render_models.py` / `formal_models.py` calls to turn the epic's formal models
+into mechanical test artifacts (test paths, test plan, contract assertions,
+Hypothesis skeleton, guard templates). This wraps that sequence into one
+idempotent operation that emits a manifest of generated files plus a markdown
+summary — suitable to hand straight into a sub-agent prompt.
+
+Usage:
+    python3 scripts/generate_formal_test_artifacts.py <models-dir> --output <dir>
+    python3 scripts/generate_formal_test_artifacts.py <models-dir> --output <dir> --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import formal_models as fm  # noqa: E402
+import render_models as rm  # noqa: E402
+
+# Source models we know how to derive test artifacts from.
+MODEL_FILES = ("state-machines.json", "contracts.json", "ui-spec.json")
+# Views that produce *test* artifacts (skip the human/markdown view).
+TEST_VIEWS = ("machine", "test")
+
+
+@dataclass
+class ModelResult:
+    name: str
+    status: str  # "ok" | "missing" | "invalid" | "malformed"
+    files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GenerationManifest:
+    models_dir: str
+    output_dir: str
+    results: list[ModelResult] = field(default_factory=list)
+
+    @property
+    def generated_files(self) -> list[str]:
+        files: list[str] = []
+        for r in self.results:
+            files.extend(r.files)
+        return files
+
+    @property
+    def ok(self) -> bool:
+        # A run is OK if no present model failed validation/parsing.
+        return all(r.status in ("ok", "missing") for r in self.results)
+
+    def to_dict(self) -> dict:
+        return {
+            "models_dir": self.models_dir,
+            "output_dir": self.output_dir,
+            "ok": self.ok,
+            "generated_files": self.generated_files,
+            "results": [asdict(r) for r in self.results],
+        }
+
+    def render_markdown(self) -> str:
+        lines = ["# Formal Test Artifacts", "", f"From `{self.models_dir}` -> `{self.output_dir}`", ""]
+        for r in self.results:
+            lines.append(f"- **{r.name}**: {r.status}" + (f" ({len(r.files)} files)" if r.files else ""))
+            for err in r.errors:
+                lines.append(f"  - {err}")
+        if self.generated_files:
+            lines += ["", "## Generated files", ""]
+            lines += [f"- `{f}`" for f in self.generated_files]
+        return "\n".join(lines) + "\n"
+
+
+def _generate_one(model_path: Path, output_dir: Path, views=TEST_VIEWS) -> ModelResult:
+    name = model_path.name
+    try:
+        model = fm._load_json(model_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        return ModelResult(name, "malformed", errors=[str(exc)])
+
+    try:
+        schema_type = fm.detect_schema_type(model)
+        errors = fm.validate(model, schema_type)
+    except Exception as exc:  # noqa: BLE001 - unknown schema etc.
+        return ModelResult(name, "invalid", errors=[str(exc)])
+    if errors:
+        return ModelResult(name, "invalid", errors=list(errors))
+
+    files: list[str] = []
+    for view in views:
+        files.extend(rm.render_model(model_path, view, output_dir))
+    # Deduplicate while preserving order (machine + test views can overlap).
+    seen: set[str] = set()
+    deduped = [f for f in files if not (f in seen or seen.add(f))]
+    return ModelResult(name, "ok", files=deduped)
+
+
+def generate_artifacts(
+    models_dir: str | Path,
+    output_dir: str | Path,
+    *,
+    views=TEST_VIEWS,
+    write_manifest: bool = True,
+) -> GenerationManifest:
+    """Generate test artifacts for every known model present in ``models_dir``.
+
+    Idempotent: re-running overwrites the generated files in ``output_dir``.
+    """
+    models = Path(models_dir)
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    manifest = GenerationManifest(models_dir=str(models), output_dir=str(out))
+    for name in MODEL_FILES:
+        path = models / name
+        if not path.exists():
+            manifest.results.append(ModelResult(name, "missing"))
+            continue
+        manifest.results.append(_generate_one(path, out, views=views))
+
+    if write_manifest:
+        (out / "formal-artifacts-manifest.json").write_text(
+            json.dumps(manifest.to_dict(), indent=2)
+        )
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate model-derived test artifacts")
+    parser.add_argument("models_dir", help="Directory containing the epic's model JSON files")
+    parser.add_argument("--output", required=True, help="Output directory for generated artifacts")
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument("--json", action="store_true", help="Emit manifest JSON (default)")
+    out.add_argument("--markdown", action="store_true", help="Emit markdown summary")
+    args = parser.parse_args(argv)
+
+    manifest = generate_artifacts(args.models_dir, args.output)
+    if args.markdown:
+        print(manifest.render_markdown())
+    else:
+        print(json.dumps(manifest.to_dict(), indent=2))
+    # Non-zero if any present model failed to produce artifacts.
+    return 0 if manifest.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_generate_formal_artifacts.py
+++ b/tests/test_generate_formal_artifacts.py
@@ -73,6 +73,41 @@ def test_missing_models_dir_yields_all_missing(tmp_path):
 # --- invalid / malformed ----------------------------------------------------
 
 
+def test_schema_mismatch_is_invalid(tmp_path):
+    # A contracts.json that actually holds a state machine must be rejected.
+    models = tmp_path / "models"
+    models.mkdir()
+    shutil.copy(SM_EXAMPLE, models / "contracts.json")
+    manifest = gen.generate_artifacts(models, tmp_path / "out")
+    result = _result(manifest, "contracts.json")
+    assert result.status == "invalid"
+    assert any("expected contracts schema" in e for e in result.errors)
+    assert manifest.ok is False
+
+
+def test_valid_ui_spec_with_no_test_artifacts_is_empty_not_failure(tmp_path):
+    models = tmp_path / "models"
+    models.mkdir()
+    shutil.copy(EXAMPLES / "kanban-app-ui-spec.json", models / "ui-spec.json")
+    manifest = gen.generate_artifacts(models, tmp_path / "out")
+    result = _result(manifest, "ui-spec.json")
+    assert result.status == "empty"
+    assert result.files == []
+    assert manifest.ok is True  # empty is not a failure
+
+
+def test_rerun_clears_stale_artifacts_when_model_removed(tmp_path):
+    models = _models_dir(tmp_path, state_machine=True)
+    out = tmp_path / "out"
+    first = gen.generate_artifacts(models, out)
+    assert first.generated_files
+    # Remove the model and rerun; previously-generated files must be cleared.
+    (models / "state-machines.json").unlink()
+    gen.generate_artifacts(models, out)
+    for stale in first.generated_files:
+        assert not Path(stale).exists()
+
+
 def test_invalid_model_reports_errors_and_not_ok(tmp_path):
     models = tmp_path / "models"
     models.mkdir()

--- a/tests/test_generate_formal_artifacts.py
+++ b/tests/test_generate_formal_artifacts.py
@@ -1,0 +1,134 @@
+"""Tests for model-derived test artifact generation (P1-6)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import generate_formal_test_artifacts as gen
+
+REPO = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO / "docs" / "formal-methods" / "examples"
+SM_EXAMPLE = EXAMPLES / "order-lifecycle.state-machine.json"
+CONTRACTS_EXAMPLE = EXAMPLES / "order-lifecycle.contracts.json"
+
+
+def _models_dir(tmp_path, *, state_machine=False, contracts=False) -> Path:
+    d = tmp_path / "models"
+    d.mkdir()
+    if state_machine:
+        shutil.copy(SM_EXAMPLE, d / "state-machines.json")
+    if contracts:
+        shutil.copy(CONTRACTS_EXAMPLE, d / "contracts.json")
+    return d
+
+
+def _result(manifest, name):
+    return next(r for r in manifest.results if r.name == name)
+
+
+# --- per-model presence -----------------------------------------------------
+
+
+def test_state_machine_only(tmp_path):
+    models = _models_dir(tmp_path, state_machine=True)
+    out = tmp_path / "out"
+    manifest = gen.generate_artifacts(models, out)
+    assert _result(manifest, "state-machines.json").status == "ok"
+    assert _result(manifest, "contracts.json").status == "missing"
+    assert manifest.generated_files
+    assert manifest.ok is True
+
+
+def test_contracts_only(tmp_path):
+    models = _models_dir(tmp_path, contracts=True)
+    out = tmp_path / "out"
+    manifest = gen.generate_artifacts(models, out)
+    assert _result(manifest, "contracts.json").status == "ok"
+    assert _result(manifest, "state-machines.json").status == "missing"
+    assert manifest.ok is True
+
+
+def test_both_models(tmp_path):
+    models = _models_dir(tmp_path, state_machine=True, contracts=True)
+    out = tmp_path / "out"
+    manifest = gen.generate_artifacts(models, out)
+    assert _result(manifest, "state-machines.json").status == "ok"
+    assert _result(manifest, "contracts.json").status == "ok"
+    # Contract assertions + test plan produced.
+    names = {Path(f).name for f in manifest.generated_files}
+    assert "contract-assertions.md" in names
+    assert "test-plan.md" in names
+
+
+def test_missing_models_dir_yields_all_missing(tmp_path):
+    out = tmp_path / "out"
+    manifest = gen.generate_artifacts(tmp_path / "models", out)
+    assert all(r.status == "missing" for r in manifest.results)
+    assert manifest.ok is True
+    assert manifest.generated_files == []
+
+
+# --- invalid / malformed ----------------------------------------------------
+
+
+def test_invalid_model_reports_errors_and_not_ok(tmp_path):
+    models = tmp_path / "models"
+    models.mkdir()
+    # Schema-detectable but invalid (state-machine missing required fields).
+    (models / "state-machines.json").write_text(json.dumps({"states": {}}))
+    manifest = gen.generate_artifacts(models, tmp_path / "out")
+    result = _result(manifest, "state-machines.json")
+    assert result.status == "invalid"
+    assert result.errors
+    assert manifest.ok is False
+
+
+def test_malformed_json_is_reported(tmp_path):
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "contracts.json").write_text("{not json")
+    manifest = gen.generate_artifacts(models, tmp_path / "out")
+    assert _result(manifest, "contracts.json").status == "malformed"
+    assert manifest.ok is False
+
+
+# --- idempotency / overwrite ------------------------------------------------
+
+
+def test_rerun_overwrites_and_is_stable(tmp_path):
+    models = _models_dir(tmp_path, state_machine=True)
+    out = tmp_path / "out"
+    first = gen.generate_artifacts(models, out)
+    second = gen.generate_artifacts(models, out)
+    assert sorted(first.generated_files) == sorted(second.generated_files)
+
+
+# --- manifest + CLI ---------------------------------------------------------
+
+
+def test_manifest_file_written_and_serializable(tmp_path):
+    models = _models_dir(tmp_path, state_machine=True)
+    out = tmp_path / "out"
+    gen.generate_artifacts(models, out)
+    manifest_path = out / "formal-artifacts-manifest.json"
+    assert manifest_path.exists()
+    data = json.loads(manifest_path.read_text())
+    assert data["ok"] is True
+    assert "generated_files" in data
+
+
+def test_cli_markdown(tmp_path, capsys):
+    models = _models_dir(tmp_path, contracts=True)
+    rc = gen.main([str(models), "--output", str(tmp_path / "out"), "--markdown"])
+    assert rc == 0
+    assert "# Formal Test Artifacts" in capsys.readouterr().out
+
+
+def test_cli_exit_nonzero_on_invalid(tmp_path, capsys):
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "contracts.json").write_text("{not json")
+    rc = gen.main([str(models), "--output", str(tmp_path / "out")])
+    assert rc == 1


### PR DESCRIPTION
## Summary

P1-6 of the Portable Python Orchestration Core epic. `/implement` Step 5 and `/implement-wave` Step 4a duplicated a sequence of `render_models.py` / `formal_models.py` calls to turn the epic's formal models into mechanical test artifacts. This wraps that into one idempotent operation with a manifest.

Closes #42.

## Changes

- **`scripts/generate_formal_test_artifacts.py`** — `generate_artifacts(models_dir, output_dir)` renders test paths, test plan, contract assertions, Hypothesis skeleton, and guard templates for whichever of `state-machines.json` / `contracts.json` / `ui-spec.json` exist. Validates each model first; records per-model status (`ok`/`missing`/`invalid`/`malformed`); writes `formal-artifacts-manifest.json` + a markdown summary. Idempotent (re-run overwrites); non-zero exit if a present model fails validation.
- **Command prompts** — `implement.md` Step 5 and `implement-wave.md` Step 4a call the helper instead of the duplicated sequence; downstream filename refs updated.

## Acceptance criteria

- [x] Tests cover state-machine-only, contracts-only, both models, missing models, invalid models, and output overwrite behavior (10 tests).
- [x] `/implement` Step 5 and `/implement-wave` Step 4a call this helper.
- [x] Generated manifest is suitable to pass into sub-agent prompts.

## Verification

- `make lint` clean; `make test` — 165 passed (10 new).
- CLI smoke against the repo's example models generates all artifacts and a manifest.