### PR TITLE
feat: extract worktree and branch safety checks (#44)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -230,7 +230,7 @@ For each ticket in the current wave (up to `--max-parallel`):
      - Step 10: Browser-use/E2E validation (unless `--skip-browser-use` was passed)
    - **HARD RULES**:
      - Do NOT create or merge pull requests. Return the branch name and a summary.
-     - You are in a git worktree. Verify with `git rev-parse --show-toplevel`. Never operate on the main checkout.
+     - You are in a git worktree. Assert isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"` (it aborts if you are in the main checkout). Never operate on the main checkout.
      - Write all temp files to `$TICKET_TMP/` (pass the path explicitly).
      - If you encounter a blocking error after 3 retries, report it and stop — do not silently skip steps.
      - Do NOT run `gh pr create`, `gh pr merge`, or `git push`. The orchestrator handles all of this.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -243,7 +243,7 @@ Launch a **Sonnet sub-agent** in a worktree (`subagent_type: "general-purpose"`,
 - **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).
-- You are working in a **git worktree** (created by the `isolation: "worktree"` parameter). At the start, run `git rev-parse --show-toplevel` to discover your working directory. Work ONLY in this directory. Do NOT `cd` to `$TARGET_REPO` — that is the main checkout, not your worktree. If `git rev-parse --show-toplevel` returns the same path as the main checkout, STOP and report the error. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
+- You are working in a **git worktree** (created by the `isolation: "worktree"` parameter). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the worktree root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 
 The sub-agent should:
 
@@ -267,7 +267,7 @@ Launch a **Sonnet sub-agent** in the **same worktree** from Step 5 (`subagent_ty
 
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code, run tests, and commit. The orchestrator owns PR creation (Step 11).
-- You are working in a **git worktree** (the same one from Step 5). Run `git rev-parse --show-toplevel` to confirm your working directory. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
+- You are working in a **git worktree** (the same one from Step 5). Confirm isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 
 The sub-agent should:
 1. Implement the approved approach — the primary objective is **making the failing tests from Step 5 turn green**

--- a/scripts/chief_wiggum/gitops.py
+++ b/scripts/chief_wiggum/gitops.py
@@ -4,9 +4,11 @@ The command prompts repeatedly warn sub-agents not to operate on the main
 checkout, create rogue PRs, or merge from the wrong branch — but enforcement is
 prose. This module makes those checks executable.
 
-Every helper is **read-only**: it inspects git state but never runs destructive
-commands (no ``reset --hard``, ``clean -f``, ``push --force``). A ``runner`` is
-injectable so the logic is unit-testable with mocked subprocess calls.
+Every helper is **non-destructive**: the read helpers only inspect git state,
+and the one mutating helper (``create_staging_branch``) only ever *creates* a
+branch — none run destructive commands (no ``reset --hard``, ``clean -f``,
+``push --force``, ``branch -D``). A ``runner`` is injectable so the logic is
+unit-testable with mocked subprocess calls.
 """
 
 from __future__ import annotations
@@ -76,16 +78,21 @@ def is_valid_branch_name(name: str) -> bool:
         return False
     if name.startswith("/") or name.endswith("/") or "//" in name:
         return False
-    if name.startswith("-") or name.startswith("."):
+    if name.startswith("-"):
         return False
     if name.endswith(".") or name.endswith(".lock"):
         return False
     if ".." in name or "@{" in name or name == "@":
         return False
-    if name.endswith("/") or "/." in name:
-        return False
     if _INVALID_BRANCH_CHARS.search(name):
         return False
+    # Git applies these rules to every "/"-separated path component, not just the
+    # whole ref: no component may be empty, start with ".", or end with ".lock"/".".
+    for component in name.split("/"):
+        if not component or component.startswith("."):
+            return False
+        if component.endswith(".lock") or component.endswith("."):
+            return False
     return True
 
 
@@ -151,7 +158,11 @@ def create_staging_branch(
     an existing branch causes a failure rather than a clobber.
     """
     assert_branch_name(name)
-    result = _git(["branch", name, start_point], repo, runner)
+    # Reject an option-like start point and pass ``--`` so neither operand can be
+    # parsed as an option (e.g. a start_point of ``-D`` turning this destructive).
+    if start_point.startswith("-"):
+        raise GitSafetyError(f"invalid start point: {start_point!r}")
+    result = _git(["branch", "--", name, start_point], repo, runner)
     if result.returncode != 0:
         raise GitSafetyError(
             f"could not create staging branch {name!r}: {(result.stderr or '').strip()}"

--- a/scripts/chief_wiggum/gitops.py
+++ b/scripts/chief_wiggum/gitops.py
@@ -1,0 +1,159 @@
+"""Worktree and branch safety checks (P1-8).
+
+The command prompts repeatedly warn sub-agents not to operate on the main
+checkout, create rogue PRs, or merge from the wrong branch — but enforcement is
+prose. This module makes those checks executable.
+
+Every helper is **read-only**: it inspects git state but never runs destructive
+commands (no ``reset --hard``, ``clean -f``, ``push --force``). A ``runner`` is
+injectable so the logic is unit-testable with mocked subprocess calls.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class GitSafetyError(RuntimeError):
+    """Raised when a worktree/branch safety invariant is violated."""
+
+
+def _git(args: list[str], cwd: str | Path, runner: Runner) -> subprocess.CompletedProcess:
+    return runner(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def is_clean(repo: str | Path, *, runner: Runner = subprocess.run) -> bool:
+    """True if the working tree has no staged/unstaged/untracked changes."""
+    result = _git(["status", "--porcelain"], repo, runner)
+    if result.returncode != 0:
+        raise GitSafetyError(f"git status failed: {(result.stderr or '').strip()}")
+    return result.stdout.strip() == ""
+
+
+def current_branch(repo: str | Path, *, runner: Runner = subprocess.run) -> str:
+    result = _git(["rev-parse", "--abbrev-ref", "HEAD"], repo, runner)
+    if result.returncode != 0:
+        raise GitSafetyError(f"cannot resolve current branch: {(result.stderr or '').strip()}")
+    return result.stdout.strip()
+
+
+def worktree_root(repo: str | Path, *, runner: Runner = subprocess.run) -> Path:
+    result = _git(["rev-parse", "--show-toplevel"], repo, runner)
+    if result.returncode != 0:
+        raise GitSafetyError(f"not a git worktree: {(result.stderr or '').strip()}")
+    return Path(result.stdout.strip())
+
+
+def changed_files(
+    repo: str | Path, base: str, *, runner: Runner = subprocess.run
+) -> list[str]:
+    """Files changed on HEAD relative to ``base`` (``base...HEAD``)."""
+    result = _git(["diff", "--name-only", f"{base}...HEAD"], repo, runner)
+    if result.returncode != 0:
+        raise GitSafetyError(f"git diff failed: {(result.stderr or '').strip()}")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+# --- branch name validation (pure) ------------------------------------------
+
+_INVALID_BRANCH_CHARS = re.compile(r"[ ~^:?*\[\\\x00-\x1f\x7f]")
+
+
+def is_valid_branch_name(name: str) -> bool:
+    """Validate a branch name against git's ref-format rules (pure, no subprocess)."""
+    if not name or name in (".", ".."):
+        return False
+    if name.startswith("/") or name.endswith("/") or "//" in name:
+        return False
+    if name.startswith("-") or name.startswith("."):
+        return False
+    if name.endswith(".") or name.endswith(".lock"):
+        return False
+    if ".." in name or "@{" in name or name == "@":
+        return False
+    if name.endswith("/") or "/." in name:
+        return False
+    if _INVALID_BRANCH_CHARS.search(name):
+        return False
+    return True
+
+
+def assert_branch_name(name: str) -> None:
+    if not is_valid_branch_name(name):
+        raise GitSafetyError(f"invalid branch name: {name!r}")
+
+
+# --- worktree isolation -----------------------------------------------------
+
+
+def assert_worktree(
+    worktree: str | Path,
+    main_checkout: str | Path,
+    *,
+    runner: Runner = subprocess.run,
+) -> Path:
+    """Assert ``worktree`` is a real git worktree distinct from the main checkout.
+
+    Returns the resolved worktree root. Raises if it resolves to the same path
+    as the main checkout (a sub-agent must never operate on the main checkout).
+    """
+    wt_root = worktree_root(worktree, runner=runner).resolve()
+    main_root = worktree_root(main_checkout, runner=runner).resolve()
+    if wt_root == main_root:
+        raise GitSafetyError(
+            f"refusing to operate on the main checkout: worktree {wt_root} == main {main_root}"
+        )
+    return wt_root
+
+
+# --- fast-forward promotion -------------------------------------------------
+
+
+def can_fast_forward(
+    repo: str | Path, base: str, branch: str, *, runner: Runner = subprocess.run
+) -> bool:
+    """True if ``base`` can fast-forward to ``branch`` (base is an ancestor).
+
+    Distinguishes "not fast-forwardable" (returns False) from a git error such
+    as an unknown ref (raises GitSafetyError).
+    """
+    result = _git(["merge-base", "--is-ancestor", base, branch], repo, runner)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise GitSafetyError(
+        f"cannot compare {base}..{branch}: {(result.stderr or '').strip()}"
+    )
+
+
+def create_staging_branch(
+    repo: str | Path,
+    name: str,
+    start_point: str,
+    *,
+    runner: Runner = subprocess.run,
+) -> str:
+    """Create a (non-destructive) staging branch at ``start_point``.
+
+    Validates the name first and uses ``git branch`` (never ``-f``/``-D``), so
+    an existing branch causes a failure rather than a clobber.
+    """
+    assert_branch_name(name)
+    result = _git(["branch", name, start_point], repo, runner)
+    if result.returncode != 0:
+        raise GitSafetyError(
+            f"could not create staging branch {name!r}: {(result.stderr or '').strip()}"
+        )
+    return name

--- a/scripts/git_safety.py
+++ b/scripts/git_safety.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""CLI for worktree and branch safety checks (P1-8).
+
+Gives the command prompts an executable replacement for prose-only worktree
+warnings. Designed to be dropped into a sub-agent prompt so it aborts before
+touching the main checkout.
+
+Exit codes: 0 = check passed, 1 = safety violation / git error, 2 = usage.
+
+Examples:
+    # Abort unless cwd is a worktree distinct from the main checkout
+    python3 scripts/git_safety.py assert-worktree --main "$TARGET_REPO"
+
+    # Validate a branch name
+    python3 scripts/git_safety.py check-branch feat/my-thing
+
+    # Is the working tree clean?
+    python3 scripts/git_safety.py is-clean
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import gitops  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Worktree/branch safety checks")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_wt = sub.add_parser("assert-worktree", help="Assert cwd is a worktree, not the main checkout")
+    p_wt.add_argument("--main", required=True, help="Path to the main checkout")
+    p_wt.add_argument("--worktree", default=".", help="Worktree path (default: cwd)")
+
+    p_branch = sub.add_parser("check-branch", help="Validate a branch name")
+    p_branch.add_argument("name")
+
+    p_clean = sub.add_parser("is-clean", help="Exit 0 if the working tree is clean")
+    p_clean.add_argument("--repo", default=".")
+
+    p_ff = sub.add_parser("can-fast-forward", help="Exit 0 if base can fast-forward to branch")
+    p_ff.add_argument("--repo", default=".")
+    p_ff.add_argument("base")
+    p_ff.add_argument("branch")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "assert-worktree":
+            root = gitops.assert_worktree(args.worktree, args.main)
+            print(f"OK: worktree {root} is isolated from main")
+        elif args.command == "check-branch":
+            gitops.assert_branch_name(args.name)
+            print(f"OK: {args.name} is a valid branch name")
+        elif args.command == "is-clean":
+            if not gitops.is_clean(args.repo):
+                print("Working tree is not clean", file=sys.stderr)
+                return 1
+            print("OK: working tree is clean")
+        elif args.command == "can-fast-forward":
+            if not gitops.can_fast_forward(args.repo, args.base, args.branch):
+                print(f"{args.base} cannot fast-forward to {args.branch}", file=sys.stderr)
+                return 1
+            print(f"OK: {args.base} can fast-forward to {args.branch}")
+    except gitops.GitSafetyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -1,0 +1,132 @@
+"""Tests for worktree and branch safety checks (P1-8)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import git_safety
+import pytest
+from chief_wiggum import gitops
+
+
+def _runner(stdout="", returncode=0, stderr=""):
+    def run(args, **kwargs):
+        return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr=stderr)
+
+    return run
+
+
+# --- cleanliness ------------------------------------------------------------
+
+
+def test_is_clean_true_on_empty_porcelain():
+    assert gitops.is_clean(".", runner=_runner(stdout="")) is True
+
+
+def test_is_clean_false_with_changes():
+    assert gitops.is_clean(".", runner=_runner(stdout=" M file.py\n?? new.py\n")) is False
+
+
+def test_is_clean_raises_on_git_error():
+    with pytest.raises(gitops.GitSafetyError):
+        gitops.is_clean(".", runner=_runner(returncode=128, stderr="not a repo"))
+
+
+# --- branch name validation -------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["feat/x", "fix-123", "release/v1.2.3", "a/b/c"])
+def test_valid_branch_names(name):
+    assert gitops.is_valid_branch_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "has space", "ends.lock", "..", "/leading", "trailing/", "a..b", "x~y", "feat^", "q?", "-dash", "double//slash"],
+)
+def test_invalid_branch_names(name):
+    assert gitops.is_valid_branch_name(name) is False
+
+
+def test_assert_branch_name_raises():
+    with pytest.raises(gitops.GitSafetyError):
+        gitops.assert_branch_name("bad name")
+
+
+# --- worktree isolation -----------------------------------------------------
+
+
+def test_assert_worktree_rejects_main_checkout(tmp_path):
+    # Both resolve to the same toplevel -> violation.
+    same = str(tmp_path)
+    runner = _runner(stdout=same)
+    with pytest.raises(gitops.GitSafetyError, match="main checkout"):
+        gitops.assert_worktree(tmp_path, tmp_path, runner=runner)
+
+
+def test_assert_worktree_accepts_distinct_paths(tmp_path):
+    wt = tmp_path / "wt"
+    main = tmp_path / "main"
+    wt.mkdir()
+    main.mkdir()
+
+    def run(args, **kwargs):
+        # Return the toplevel matching the cwd we were called with.
+        return subprocess.CompletedProcess(args, 0, stdout=kwargs["cwd"], stderr="")
+
+    root = gitops.assert_worktree(wt, main, runner=run)
+    assert root == wt.resolve()
+
+
+# --- fast-forward -----------------------------------------------------------
+
+
+def test_can_fast_forward_true_when_ancestor():
+    assert gitops.can_fast_forward(".", "main", "feat", runner=_runner(returncode=0)) is True
+
+
+def test_can_fast_forward_false_when_not_ancestor():
+    assert gitops.can_fast_forward(".", "main", "feat", runner=_runner(returncode=1)) is False
+
+
+def test_can_fast_forward_raises_on_unknown_ref():
+    with pytest.raises(gitops.GitSafetyError):
+        gitops.can_fast_forward(".", "main", "nope", runner=_runner(returncode=128, stderr="bad ref"))
+
+
+# --- changed files / staging branch -----------------------------------------
+
+
+def test_changed_files_parses_names():
+    out = "a.py\nb/c.py\n\n"
+    assert gitops.changed_files(".", "main", runner=_runner(stdout=out)) == ["a.py", "b/c.py"]
+
+
+def test_create_staging_branch_validates_name_first():
+    with pytest.raises(gitops.GitSafetyError):
+        gitops.create_staging_branch(".", "bad name", "main", runner=_runner())
+
+
+def test_create_staging_branch_maps_git_failure():
+    with pytest.raises(gitops.GitSafetyError, match="staging branch"):
+        gitops.create_staging_branch(
+            ".", "staging/x", "main", runner=_runner(returncode=128, stderr="exists")
+        )
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_check_branch_ok(capsys):
+    assert git_safety.main(["check-branch", "feat/x"]) == 0
+
+
+def test_cli_check_branch_bad(capsys):
+    assert git_safety.main(["check-branch", "bad name"]) == 1
+    assert "Error" in capsys.readouterr().err
+
+
+def test_cli_assert_worktree_same_path_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(gitops, "assert_worktree", lambda *a, **k: (_ for _ in ()).throw(gitops.GitSafetyError("main checkout")))
+    rc = git_safety.main(["assert-worktree", "--main", str(tmp_path)])
+    assert rc == 1

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -42,7 +42,11 @@ def test_valid_branch_names(name):
 
 @pytest.mark.parametrize(
     "name",
-    ["", "has space", "ends.lock", "..", "/leading", "trailing/", "a..b", "x~y", "feat^", "q?", "-dash", "double//slash"],
+    [
+        "", "has space", "ends.lock", "..", "/leading", "trailing/", "a..b",
+        "x~y", "feat^", "q?", "-dash", "double//slash",
+        "foo.lock/bar", "foo/bar.lock/baz", "foo/.hidden", ".lead/x", "a/b./c",
+    ],
 )
 def test_invalid_branch_names(name):
     assert gitops.is_valid_branch_name(name) is False
@@ -112,6 +116,22 @@ def test_create_staging_branch_maps_git_failure():
         gitops.create_staging_branch(
             ".", "staging/x", "main", runner=_runner(returncode=128, stderr="exists")
         )
+
+
+def test_create_staging_branch_rejects_option_like_start_point():
+    with pytest.raises(gitops.GitSafetyError, match="start point"):
+        gitops.create_staging_branch(".", "staging/x", "-D", runner=_runner())
+
+
+def test_create_staging_branch_passes_double_dash():
+    captured = {}
+
+    def run(args, **kwargs):
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    gitops.create_staging_branch(".", "staging/x", "main", runner=run)
+    assert captured["args"] == ["git", "branch", "--", "staging/x", "main"]
 
 
 # --- CLI --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

P1-8 of the Portable Python Orchestration Core epic. The command prompts repeatedly warn sub-agents not to touch the main checkout, but enforcement was prose. This makes the checks executable.

Closes #44.

## Changes

- **`scripts/chief_wiggum/gitops.py`** — read-only helpers (no `reset --hard`/`clean -f`/`push --force`) with an injectable `runner`: `is_clean`, `current_branch`, `worktree_root`, `changed_files`, `is_valid_branch_name` (pure ref-format validation), `assert_worktree` (rejects a worktree resolving to the main checkout), `can_fast_forward` (ancestor check; distinguishes "not fast-forwardable" from a git error), `create_staging_branch` (validates the name, never `-f`/`-D`). `GitSafetyError`.
- **`scripts/git_safety.py`** — CLI (`assert-worktree --main` / `check-branch` / `is-clean` / `can-fast-forward`) for sub-agent prompts; exit 1 on violation.
- **Command prompts** — `implement.md` and `implement-wave.md` replace prose-only worktree assertions with explicit `git_safety.py assert-worktree` calls.

## Acceptance criteria

- [x] Tests cover clean/dirty repo parsing with mocked subprocess, branch name validation, worktree path equality rejection, and fast-forward failure mapping (31 tests).
- [x] `/implement` and `/implement-wave` replace prose-only worktree assertions with explicit helper calls.
- [x] Helper never runs destructive git commands.

## Verification

- `make lint` clean; `make test` — 199 passed (31 new).
- CLI smoke: `assert-worktree --main <this repo>` correctly refuses (cwd == main checkout); branch validation works.