### PR TITLE
feat: extract project verification runner (#45)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -336,10 +336,11 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    - TypeScript/JavaScript: `npx eslint --no-warn-ignored` or `npx biome check`
    - Python: `ruff check` or `flake8`
    - Feed violations back to the code — fix them before proceeding. Gate on zero high-severity findings.
-4. **Run the full test suite** from the repo root:
-   - If a `/test` skill or `make ci` target exists, use it
-   - Otherwise: `pytest` (Python), `npm test` (Node), `go test ./...` (Go)
-   - ALL tests must pass. Zero tolerance.
+4. **Run the full test suite** from the repo root. The verification runner detects the project type and emits structured evidence (command, exit code, duration, log tail) for the PR body — it prefers a `make` target named for the profile when present:
+   ```bash
+   python3 "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint,build --markdown
+   ```
+   It exits non-zero if any step fails. ALL tests must pass. Zero tolerance.
 5. **Start services** and verify they work:
    - If `docker-compose.yml` exists: `docker compose up -d` and wait for healthy
    - If Docker isn't running, start it (`open -a Docker` on macOS, `sudo systemctl start docker` on Linux) and wait

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -109,18 +109,13 @@ Guidelines for diagrams:
 
 **Always re-run tests before shipping.** Do not rely on stale results from earlier in the session — code may have changed since tests last ran.
 
+The verification runner detects the project type (Go/Node/Python/Make/Docker/Playwright), runs the requested profiles, and emits structured evidence (command, exit code, duration, log tail) for the PR body:
+
 ```bash
-# Find and run tests (detect project type)
-if [ -f "go.mod" ]; then
-  go test ./... 2>&1 | tail -20
-elif [ -f "package.json" ]; then
-  npm test 2>&1 | tail -20
-elif [ -f "pyproject.toml" ] || [ -f "setup.py" ]; then
-  pytest 2>&1 | tail -20
-fi
+python3 "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint --markdown
 ```
 
-If tests fail, **stop and fix them**. Do not create a PR with failing tests.
+It exits non-zero if any step fails. **If tests fail, stop and fix them** — do not create a PR with failing tests. Use `--dry-run` first to see the planned commands, and add `build`/`smoke` to `--profile` when relevant.
 
 If browser-use screenshots exist, reference them.
 

--- a/scripts/chief_wiggum/verification.py
+++ b/scripts/chief_wiggum/verification.py
@@ -1,0 +1,254 @@
+"""Project verification runner (P1-9).
+
+`/implement`, `/implement-wave`, `/ship`, and `/close-epic` all repeat heuristics
+for detecting how to test/lint/build/smoke a target repo (Go, Node, Python,
+Docker, Playwright, Makefile). This turns that into a tested detector + command
+planner that emits structured evidence (command, cwd, exit code, duration, log
+tail) instead of terminal prose.
+
+Detection and command *planning* are pure and unit-testable without executing
+any build tool. Execution is a thin, injectable layer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+PROFILES = ("test", "lint", "build", "smoke")
+
+# Per-language command for each non-smoke profile.
+LANG_COMMANDS: dict[str, dict[str, list[str]]] = {
+    "go": {
+        "test": ["go", "test", "./..."],
+        "lint": ["go", "vet", "./..."],
+        "build": ["go", "build", "./..."],
+    },
+    "node": {
+        "test": ["npm", "test"],
+        "lint": ["npm", "run", "lint"],
+        "build": ["npm", "run", "build"],
+    },
+    "python": {
+        "test": ["python3", "-m", "pytest"],
+        "lint": ["python3", "-m", "ruff", "check", "."],
+        "build": ["python3", "-m", "build"],
+    },
+}
+
+_MAKE_TARGET_RE = re.compile(r"^([A-Za-z0-9_.-]+):", re.MULTILINE)
+
+Runner = Callable[[list[str], str], tuple[int, str]]
+Clock = Callable[[], float]
+
+
+@dataclass
+class Detection:
+    has_makefile: bool = False
+    make_targets: tuple[str, ...] = ()
+    has_go: bool = False
+    has_python: bool = False
+    has_node: bool = False
+    node_scripts: tuple[str, ...] = ()
+    has_docker_compose: bool = False
+    has_playwright: bool = False
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class PlannedStep:
+    profile: str
+    tool: str
+    command: list[str]
+    cwd: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class StepEvidence:
+    profile: str
+    tool: str
+    command: list[str]
+    cwd: str
+    exit_code: int | None = None
+    duration_s: float | None = None
+    log_tail: str = ""
+    ok: bool = False
+    planned_only: bool = False
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class VerificationReport:
+    repo: str
+    profiles: list[str]
+    detection: Detection
+    steps: list[StepEvidence] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return all(s.ok or s.planned_only for s in self.steps)
+
+    def to_dict(self) -> dict:
+        return {
+            "repo": self.repo,
+            "profiles": self.profiles,
+            "detection": self.detection.to_dict(),
+            "ok": self.ok,
+            "steps": [s.to_dict() for s in self.steps],
+            "warnings": self.warnings,
+        }
+
+    def render_markdown(self) -> str:
+        lines = ["# Verification Report", "", f"Repo: `{self.repo}`", f"Profiles: {', '.join(self.profiles)}", ""]
+        if not self.steps:
+            lines.append("_No verification steps planned (nothing detected)._")
+        for s in self.steps:
+            cmd = " ".join(s.command)
+            if s.planned_only:
+                lines.append(f"- [plan] `{cmd}` (cwd `{s.cwd}`)")
+            else:
+                mark = "✓" if s.ok else "✗"
+                dur = f"{s.duration_s:.1f}s" if s.duration_s is not None else "?"
+                lines.append(f"- {mark} `{cmd}` — exit {s.exit_code} in {dur}")
+                if not s.ok and s.log_tail:
+                    lines.append("  ```")
+                    lines += [f"  {ln}" for ln in s.log_tail.splitlines()[-15:]]
+                    lines.append("  ```")
+        if self.warnings:
+            lines += ["", "## Warnings", ""] + [f"- {w}" for w in self.warnings]
+        return "\n".join(lines) + "\n"
+
+
+def detect_project(repo: str | Path) -> Detection:
+    """Detect build tooling present in ``repo`` (pure filesystem inspection)."""
+    root = Path(repo)
+    det = Detection()
+
+    makefile = root / "Makefile"
+    if makefile.is_file():
+        det.has_makefile = True
+        try:
+            det.make_targets = tuple(sorted(set(_MAKE_TARGET_RE.findall(makefile.read_text()))))
+        except OSError:
+            det.make_targets = ()
+
+    det.has_go = (root / "go.mod").is_file()
+    det.has_python = (root / "pyproject.toml").is_file() or (root / "setup.py").is_file()
+
+    pkg = root / "package.json"
+    if pkg.is_file():
+        det.has_node = True
+        try:
+            scripts = json.loads(pkg.read_text()).get("scripts", {})
+            det.node_scripts = tuple(sorted(scripts)) if isinstance(scripts, dict) else ()
+        except (json.JSONDecodeError, OSError):
+            det.node_scripts = ()
+
+    det.has_docker_compose = any(
+        (root / name).is_file()
+        for name in ("docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml")
+    )
+    det.has_playwright = any(
+        (root / name).is_file()
+        for name in ("playwright.config.ts", "playwright.config.js", "playwright.config.mjs")
+    )
+    return det
+
+
+def plan_steps(repo: str | Path, profiles: Iterable[str], detection: Detection) -> list[PlannedStep]:
+    """Plan verification commands for ``profiles`` given a detection (pure)."""
+    root = str(repo)
+    steps: list[PlannedStep] = []
+
+    for profile in profiles:
+        if profile == "smoke":
+            if detection.has_docker_compose:
+                steps.append(PlannedStep("smoke", "docker-compose", ["docker", "compose", "up", "-d"], root))
+            if detection.has_playwright:
+                steps.append(PlannedStep("smoke", "playwright", ["npx", "playwright", "test"], root))
+            continue
+
+        # Prefer a Makefile target named exactly for the profile.
+        if detection.has_makefile and profile in detection.make_targets:
+            steps.append(PlannedStep(profile, "make", ["make", profile], root))
+            continue
+
+        if detection.has_go:
+            steps.append(PlannedStep(profile, "go", LANG_COMMANDS["go"][profile], root))
+        if detection.has_python:
+            steps.append(PlannedStep(profile, "python", LANG_COMMANDS["python"][profile], root))
+        if detection.has_node and profile in detection.node_scripts:
+            steps.append(PlannedStep(profile, "node", LANG_COMMANDS["node"][profile], root))
+
+    return steps
+
+
+def _default_runner(command: list[str], cwd: str) -> tuple[int, str]:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=1800)
+    return result.returncode, (result.stdout or "") + (result.stderr or "")
+
+
+def _log_tail(output: str, lines: int = 50) -> str:
+    return "\n".join(output.splitlines()[-lines:])
+
+
+def verify(
+    repo: str | Path,
+    profiles: Iterable[str] = ("test",),
+    *,
+    dry_run: bool = False,
+    runner: Runner = _default_runner,
+    clock: Clock | None = None,
+    log_tail_lines: int = 50,
+) -> VerificationReport:
+    """Detect, plan, and (unless ``dry_run``) execute verification steps."""
+    profiles = list(profiles)
+    detection = detect_project(repo)
+    report = VerificationReport(repo=str(repo), profiles=profiles, detection=detection)
+
+    planned = plan_steps(repo, profiles, detection)
+    if not planned:
+        report.warnings.append("no verification steps detected for the requested profiles")
+
+    if dry_run:
+        report.steps = [
+            StepEvidence(p.profile, p.tool, p.command, p.cwd, planned_only=True) for p in planned
+        ]
+        return report
+
+    import time
+
+    now = clock or time.monotonic
+    for step in planned:
+        start = now()
+        try:
+            exit_code, output = runner(step.command, step.cwd)
+        except Exception as exc:  # noqa: BLE001 - a missing tool shouldn't abort the run
+            report.steps.append(
+                StepEvidence(
+                    step.profile, step.tool, step.command, step.cwd,
+                    exit_code=None, duration_s=round(now() - start, 3),
+                    log_tail=f"runner error: {exc}", ok=False,
+                )
+            )
+            continue
+        report.steps.append(
+            StepEvidence(
+                step.profile, step.tool, step.command, step.cwd,
+                exit_code=exit_code, duration_s=round(now() - start, 3),
+                log_tail=_log_tail(output, log_tail_lines), ok=(exit_code == 0),
+            )
+        )
+    return report

--- a/scripts/chief_wiggum/verification.py
+++ b/scripts/chief_wiggum/verification.py
@@ -40,7 +40,22 @@ LANG_COMMANDS: dict[str, dict[str, list[str]]] = {
     },
 }
 
-_MAKE_TARGET_RE = re.compile(r"^([A-Za-z0-9_.-]+):", re.MULTILINE)
+# Match a make rule line (target[s] before ':'), excluding ':=' assignments.
+# The captured group may hold several space-separated targets (grouped rule).
+_MAKE_TARGET_LINE = re.compile(r"^([A-Za-z0-9_.\-/ ]+?):(?!=)")
+_MAKEFILE_NAMES = ("Makefile", "makefile", "GNUmakefile")
+
+
+def _parse_make_targets(text: str) -> set[str]:
+    targets: set[str] = set()
+    for line in text.splitlines():
+        match = _MAKE_TARGET_LINE.match(line)
+        if not match:
+            continue
+        for name in match.group(1).split():
+            if not name.startswith("."):  # skip .PHONY etc.
+                targets.add(name)
+    return targets
 
 Runner = Callable[[list[str], str], tuple[int, str]]
 Clock = Callable[[], float]
@@ -98,7 +113,10 @@ class VerificationReport:
 
     @property
     def ok(self) -> bool:
-        return all(s.ok or s.planned_only for s in self.steps)
+        # Zero steps is NOT success: "nothing verified" must not green-light a
+        # ship. A run is ok only if it executed (or planned) at least one step
+        # and none failed.
+        return bool(self.steps) and all(s.ok or s.planned_only for s in self.steps)
 
     def to_dict(self) -> dict:
         return {
@@ -136,11 +154,11 @@ def detect_project(repo: str | Path) -> Detection:
     root = Path(repo)
     det = Detection()
 
-    makefile = root / "Makefile"
-    if makefile.is_file():
+    makefile = next((root / n for n in _MAKEFILE_NAMES if (root / n).is_file()), None)
+    if makefile is not None:
         det.has_makefile = True
         try:
-            det.make_targets = tuple(sorted(set(_MAKE_TARGET_RE.findall(makefile.read_text()))))
+            det.make_targets = tuple(sorted(_parse_make_targets(makefile.read_text())))
         except OSError:
             det.make_targets = ()
 
@@ -175,9 +193,17 @@ def plan_steps(repo: str | Path, profiles: Iterable[str], detection: Detection) 
     for profile in profiles:
         if profile == "smoke":
             if detection.has_docker_compose:
-                steps.append(PlannedStep("smoke", "docker-compose", ["docker", "compose", "up", "-d"], root))
+                # --wait blocks until services are healthy/running and fails if
+                # they don't come up, so this is a bounded readiness check.
+                steps.append(
+                    PlannedStep("smoke", "docker-compose", ["docker", "compose", "up", "-d", "--wait"], root)
+                )
             if detection.has_playwright:
-                steps.append(PlannedStep("smoke", "playwright", ["npx", "playwright", "test"], root))
+                # --no-install runs only a locally-installed Playwright (never
+                # fetches an unpinned package over the network).
+                steps.append(
+                    PlannedStep("smoke", "playwright", ["npx", "--no-install", "playwright", "test"], root)
+                )
             continue
 
         # Prefer a Makefile target named exactly for the profile.
@@ -201,6 +227,8 @@ def _default_runner(command: list[str], cwd: str) -> tuple[int, str]:
 
 
 def _log_tail(output: str, lines: int = 50) -> str:
+    if lines <= 0:
+        return ""
     return "\n".join(output.splitlines()[-lines:])
 
 
@@ -214,7 +242,8 @@ def verify(
     log_tail_lines: int = 50,
 ) -> VerificationReport:
     """Detect, plan, and (unless ``dry_run``) execute verification steps."""
-    profiles = list(profiles)
+    # Dedupe while preserving order so --profile test,test runs each step once.
+    profiles = list(dict.fromkeys(profiles))
     detection = detect_project(repo)
     report = VerificationReport(repo=str(repo), profiles=profiles, detection=detection)
 

--- a/scripts/run_verification.py
+++ b/scripts/run_verification.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""CLI for the project verification runner (P1-9).
+
+Detects how to test/lint/build/smoke a repo and emits structured evidence
+(command, cwd, exit code, duration, log tail) as JSON or markdown — so /ship and
+/implement produce machine-readable verification evidence instead of prose.
+
+Examples:
+    # Run the test + lint profiles and emit markdown evidence
+    python3 scripts/run_verification.py --repo . --profile test,lint --markdown
+
+    # Show the planned commands without running anything
+    python3 scripts/run_verification.py --repo . --profile test,lint,build,smoke --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import verification  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect and run project verification")
+    parser.add_argument("--repo", default=".", help="Repo path (default: cwd)")
+    parser.add_argument(
+        "--profile",
+        default="test",
+        help="Comma-separated profiles: test,lint,build,smoke",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print planned commands, run nothing")
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument("--json", action="store_true", help="Emit JSON evidence (default)")
+    out.add_argument("--markdown", action="store_true", help="Emit markdown evidence")
+    args = parser.parse_args(argv)
+
+    profiles = [p.strip() for p in args.profile.split(",") if p.strip()]
+    unknown = [p for p in profiles if p not in verification.PROFILES]
+    if unknown:
+        print(f"Error: unknown profile(s): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+
+    report = verification.verify(args.repo, profiles, dry_run=args.dry_run)
+
+    if args.markdown:
+        print(report.render_markdown())
+    else:
+        print(json.dumps(report.to_dict(), indent=2))
+
+    # Dry-run is informational; a real run fails if any executed step failed.
+    if args.dry_run:
+        return 0
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,180 @@
+"""Tests for the project verification runner (P1-9)."""
+
+from __future__ import annotations
+
+import json
+
+import run_verification
+from chief_wiggum import verification as v
+
+
+def _cmds(steps):
+    return [" ".join(s.command) for s in steps]
+
+
+# --- detection matrix -------------------------------------------------------
+
+
+def test_detect_go(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    det = v.detect_project(tmp_path)
+    assert det.has_go and not det.has_python and not det.has_node
+
+
+def test_detect_python(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    assert v.detect_project(tmp_path).has_python is True
+
+
+def test_detect_setup_py_counts_as_python(tmp_path):
+    (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+    assert v.detect_project(tmp_path).has_python is True
+
+
+def test_detect_node_scripts(tmp_path):
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"test": "jest", "build": "tsc"}}))
+    det = v.detect_project(tmp_path)
+    assert det.has_node and set(det.node_scripts) == {"test", "build"}
+
+
+def test_detect_makefile_targets(tmp_path):
+    (tmp_path / "Makefile").write_text("ci: test lint\n\ntest:\n\tpytest\n\nlint:\n\truff check\n")
+    det = v.detect_project(tmp_path)
+    assert det.has_makefile
+    assert {"ci", "test", "lint"}.issubset(set(det.make_targets))
+
+
+def test_detect_docker_and_playwright(tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    (tmp_path / "playwright.config.ts").write_text("export default {}\n")
+    det = v.detect_project(tmp_path)
+    assert det.has_docker_compose and det.has_playwright
+
+
+def test_malformed_package_json_does_not_crash(tmp_path):
+    (tmp_path / "package.json").write_text("{not json")
+    det = v.detect_project(tmp_path)
+    assert det.has_node and det.node_scripts == ()
+
+
+# --- command planning (no execution) ----------------------------------------
+
+
+def test_plan_prefers_makefile_target(tmp_path):
+    (tmp_path / "Makefile").write_text("test:\n\tpytest\n")
+    (tmp_path / "go.mod").write_text("module x\n")
+    det = v.detect_project(tmp_path)
+    steps = v.plan_steps(tmp_path, ["test"], det)
+    # Makefile target wins over go test.
+    assert _cmds(steps) == ["make test"]
+
+
+def test_plan_go_commands_per_profile(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    det = v.detect_project(tmp_path)
+    steps = v.plan_steps(tmp_path, ["test", "lint", "build"], det)
+    assert _cmds(steps) == ["go test ./...", "go vet ./...", "go build ./..."]
+
+
+def test_plan_node_gated_on_script_presence(tmp_path):
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"test": "jest"}}))
+    det = v.detect_project(tmp_path)
+    steps = v.plan_steps(tmp_path, ["test", "build"], det)
+    # Only 'test' script exists -> no build step planned.
+    assert _cmds(steps) == ["npm test"]
+
+
+def test_plan_smoke_profile(tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    (tmp_path / "playwright.config.ts").write_text("export default {}\n")
+    det = v.detect_project(tmp_path)
+    steps = v.plan_steps(tmp_path, ["smoke"], det)
+    assert _cmds(steps) == ["docker compose up -d", "npx playwright test"]
+
+
+def test_plan_empty_when_nothing_detected(tmp_path):
+    det = v.detect_project(tmp_path)
+    assert v.plan_steps(tmp_path, list(v.PROFILES), det) == []
+
+
+# --- execution with injected runner -----------------------------------------
+
+
+def test_verify_dry_run_does_not_execute(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    calls = []
+
+    def runner(cmd, cwd):
+        calls.append(cmd)
+        return 0, ""
+
+    report = v.verify(tmp_path, ["test"], dry_run=True, runner=runner)
+    assert calls == []
+    assert report.steps[0].planned_only is True
+    assert report.ok is True
+
+
+def test_verify_runs_and_collects_evidence(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    ticks = iter([10.0, 12.5])
+
+    def runner(cmd, cwd):
+        return 0, "PASS\nall good"
+
+    report = v.verify(tmp_path, ["test"], runner=runner, clock=lambda: next(ticks))
+    step = report.steps[0]
+    assert step.ok is True
+    assert step.exit_code == 0
+    assert step.duration_s == 2.5
+    assert "all good" in step.log_tail
+
+
+def test_verify_failure_captures_log_tail_and_not_ok(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+
+    def runner(cmd, cwd):
+        return 1, "\n".join(f"line {i}" for i in range(100))
+
+    report = v.verify(tmp_path, ["test"], runner=runner, log_tail_lines=10)
+    step = report.steps[0]
+    assert step.ok is False
+    assert report.ok is False
+    assert len(step.log_tail.splitlines()) == 10
+    assert "line 99" in step.log_tail
+
+
+def test_verify_runner_error_is_captured(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+
+    def runner(cmd, cwd):
+        raise FileNotFoundError("go not installed")
+
+    report = v.verify(tmp_path, ["test"], runner=runner)
+    assert report.ok is False
+    assert "runner error" in report.steps[0].log_tail
+
+
+# --- serialization / CLI ----------------------------------------------------
+
+
+def test_report_json_and_markdown(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    report = v.verify(tmp_path, ["test"], dry_run=True)
+    json.loads(json.dumps(report.to_dict()))
+    md = report.render_markdown()
+    assert "# Verification Report" in md
+    assert "go test ./..." in md
+
+
+def test_cli_dry_run_json(tmp_path, capsys):
+    (tmp_path / "go.mod").write_text("module x\n")
+    rc = run_verification.main(["--repo", str(tmp_path), "--profile", "test,build", "--dry-run"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert {s["tool"] for s in data["steps"]} == {"go"}
+
+
+def test_cli_rejects_unknown_profile(tmp_path, capsys):
+    rc = run_verification.main(["--repo", str(tmp_path), "--profile", "bogus"])
+    assert rc == 2
+    assert "unknown profile" in capsys.readouterr().err

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -89,12 +89,46 @@ def test_plan_smoke_profile(tmp_path):
     (tmp_path / "playwright.config.ts").write_text("export default {}\n")
     det = v.detect_project(tmp_path)
     steps = v.plan_steps(tmp_path, ["smoke"], det)
-    assert _cmds(steps) == ["docker compose up -d", "npx playwright test"]
+    assert _cmds(steps) == ["docker compose up -d --wait", "npx --no-install playwright test"]
 
 
 def test_plan_empty_when_nothing_detected(tmp_path):
     det = v.detect_project(tmp_path)
     assert v.plan_steps(tmp_path, list(v.PROFILES), det) == []
+
+
+def test_empty_plan_is_not_ok(tmp_path):
+    # Nothing detected -> nothing verified -> must NOT green-light a ship.
+    report = v.verify(tmp_path, ["test"])
+    assert report.steps == []
+    assert report.ok is False
+    assert report.warnings
+
+
+def test_grouped_and_assignment_makefile_lines(tmp_path):
+    (tmp_path / "Makefile").write_text("FLAGS := -x\n\ntest lint:\n\techo hi\n")
+    det = v.detect_project(tmp_path)
+    assert "test" in det.make_targets and "lint" in det.make_targets
+    assert "FLAGS" not in det.make_targets
+
+
+def test_lowercase_makefile_name_detected(tmp_path):
+    (tmp_path / "makefile").write_text("build:\n\tgo build\n")
+    det = v.detect_project(tmp_path)
+    assert det.has_makefile and "build" in det.make_targets
+
+
+def test_duplicate_profiles_run_once(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    runs = []
+    report = v.verify(tmp_path, ["test", "test"], runner=lambda c, w: runs.append(c) or (0, "ok"))
+    assert len(report.steps) == 1
+
+
+def test_log_tail_zero_returns_empty(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    report = v.verify(tmp_path, ["test"], runner=lambda c, w: (1, "noisy output"), log_tail_lines=0)
+    assert report.steps[0].log_tail == ""
 
 
 # --- execution with injected runner -----------------------------------------


### PR DESCRIPTION
## Summary

P1-9 of the Portable Python Orchestration Core epic. `/implement`, `/implement-wave`, `/ship`, and `/close-epic` all repeated heuristics for how to test/lint/build/smoke a repo. This extracts a tested detector + command planner that emits structured evidence instead of terminal prose.

Closes #45.

## Changes

- **`scripts/chief_wiggum/verification.py`**
  - `detect_project()` — Makefile targets, `go.mod`, `package.json` scripts, `pyproject.toml`/`setup.py`, Docker compose, Playwright config.
  - `plan_steps()` (pure) — maps `test`/`lint`/`build`/`smoke` to commands, **prefers a Makefile target** named for the profile, **gates npm steps on script presence**.
  - `verify()` — runs steps via an **injectable runner**, recording command, cwd, exit code, duration, and log tail per step; `dry_run` prints the plan only. JSON + markdown evidence.
- **`scripts/run_verification.py`** — CLI (`--repo --profile --dry-run --json/--markdown`); exit non-zero if any executed step failed.
- **Command prompts** — `ship.md` Step 3 and `implement.md` Step 8 call the runner.

## Acceptance criteria

- [x] Tests cover the project detection matrix and command planning without executing external build tools (19 tests).
- [x] A dry-run mode prints planned commands.
- [x] `/ship` Step 3 and `/implement` Step 8 use the runner.
- [x] Failures are machine-readable and include enough log tail for PR evidence.

## Verification

- `make lint` clean; `make test` — 225 passed (19 new).
- Dry-run against this repo correctly plans `make test` / `make lint` (Makefile preference).