### PR TITLE
feat: extract review prompt assembly and review run (#43)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -300,24 +300,25 @@ The sub-agent should:
    git diff "$DEFAULT_BRANCH"...HEAD > $TICKET_TMP/impl-diff.txt
    ```
 
-2. Prepare a review prompt using `$CW_HOME/templates/review-prompt.md` as a base. Read the template, replace the `{{TICKET_TITLE}}`, `{{TICKET_DESCRIPTION}}`, `{{ACCEPTANCE_CRITERIA}}`, and `{{DIFF}}` placeholders with actual values. **Also include the structured checklist** from `$CW_HOME/templates/review-checklist.md` and the epic contracts/invariants if they exist. Write to `$TICKET_TMP/review-prompt.md`.
-
-3. Run external AI reviews as a quorum (parallel, with retries + output validation):
+2. Run the review pipeline in one call. It captures the `base...HEAD` diff, assembles the review prompt from `templates/review-prompt.md` + `review-checklist.md` (plus any epic artifacts you pass), runs the `reviewer` quorum (parallel, retries, output validation), and writes the synthesis prompt + a manifest. Pass a `ticket.json` with the title/body/acceptance criteria, and optionally epic artifacts:
    ```bash
-   python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $TICKET_TMP/review-prompt.md \
-     --output-dir "$TICKET_TMP/reviews" --cwd "$(git rev-parse --show-toplevel)"
+   python3 "$CW_HOME/scripts/run_review.py" \
+     --ticket-context "$TICKET_TMP/ticket.json" \
+     --worktree "$(git rev-parse --show-toplevel)" --base "$DEFAULT_BRANCH" \
+     --output-dir "$TICKET_TMP/reviews" \
+     --epic-artifact "Contracts=$EPIC_DIR/contracts.md" \
+     --epic-artifact "Invariants=$EPIC_DIR/invariants.md"
    ```
+   Outputs land in `$TICKET_TMP/reviews/`: `impl-diff.txt`, `review-prompt.md`, `reviewer-<provider>.md`, `synthesis-prompt.md`, and `review-manifest.json`. It refuses to run outside a git repo or when `--base` can't be resolved; a non-zero exit means a required provider never produced valid output (note the gap, proceed with available reviews).
 
-   The `reviewer` role runs codex + gemini in parallel, **retries failed required providers**, **validates** each response (non-empty, not starting with `Timeout:`/`Error:`), and writes `$TICKET_TMP/reviews/reviewer-manifest.json` plus `reviewer-<provider>.md`. If the quorum fails (a required provider never produced valid output) the command exits non-zero — note the gap and proceed with the available reviews.
+3. Perform its own review of the diff.
 
-4. Perform its own review of the diff.
-
-5. Synthesize using:
+4. Synthesize using:
    ```bash
    python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/reviews/reviewer-codex.md $TICKET_TMP/reviews/reviewer-gemini.md
    ```
 
-6. Return a concise summary categorising each piece of feedback:
+5. Return a concise summary categorising each piece of feedback:
    - **High-confidence fixes**: Concrete bugs/regressions with clear failure scenarios. Apply automatically.
    - **Medium-confidence findings**: Plausible issues that need a quick local verification before applying.
    - **Low-confidence or architectural feedback**: Speculative concerns or design trade-offs. Flag for user decision.

--- a/scripts/chief_wiggum/review.py
+++ b/scripts/chief_wiggum/review.py
@@ -1,0 +1,227 @@
+"""Review prompt assembly and review run (P1-7).
+
+`/implement` Step 7 is mandatory and repeated in wave sub-agent prompts: capture
+the diff, assemble a review prompt from templates + epic artifacts, run the
+reviewer provider quorum, validate outputs, and produce synthesis inputs. This
+module makes that deterministic pipeline one tested helper.
+
+The pure parts (template substitution, diff truncation, synthesis prompt) are
+unit-testable; git and provider execution are injected.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import providers
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+# Truncate very large diffs so a provider call isn't blown past its context.
+DEFAULT_MAX_DIFF_BYTES = 200_000
+
+
+class ReviewError(RuntimeError):
+    """Raised when a review cannot be set up (not a git repo, no base, etc.)."""
+
+
+@dataclass
+class TicketContext:
+    number: int | None
+    title: str
+    body: str = ""
+    acceptance_criteria: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TicketContext:
+        ac = data.get("acceptance_criteria") or data.get("ac") or []
+        if isinstance(ac, str):
+            ac = [line.strip("-* ").strip() for line in ac.splitlines() if line.strip()]
+        return cls(
+            number=data.get("number"),
+            title=data.get("title", ""),
+            body=data.get("body", ""),
+            acceptance_criteria=list(ac),
+        )
+
+
+# --- pure assembly ----------------------------------------------------------
+
+
+def _format_acceptance(criteria: list[str]) -> str:
+    if not criteria:
+        return "(none specified)"
+    return "\n".join(f"- {c}" for c in criteria)
+
+
+def assemble_review_prompt(
+    template: str,
+    ticket: TicketContext,
+    diff: str,
+    *,
+    checklist: str | None = None,
+    epic_sections: Iterable[tuple[str, str]] = (),
+) -> str:
+    """Substitute the review template and append the checklist + epic context.
+
+    Uses plain ``str.replace`` (not ``str.format``) so braces in the diff are
+    never interpreted as format fields.
+    """
+    prompt = template
+    replacements = {
+        "{{TICKET_TITLE}}": ticket.title or "(untitled)",
+        "{{TICKET_DESCRIPTION}}": ticket.body or "(no description)",
+        "{{ACCEPTANCE_CRITERIA}}": _format_acceptance(ticket.acceptance_criteria),
+        "{{DIFF}}": diff,
+    }
+    for token, value in replacements.items():
+        prompt = prompt.replace(token, value)
+
+    extra: list[str] = []
+    for title, content in epic_sections:
+        if content and content.strip():
+            extra.append(f"\n\n## {title}\n\n{content.strip()}")
+    if checklist and checklist.strip():
+        extra.append(f"\n\n---\n\n{checklist.strip()}")
+    return prompt + "".join(extra)
+
+
+def truncate_diff(diff: str, max_bytes: int = DEFAULT_MAX_DIFF_BYTES) -> str:
+    encoded = diff.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return diff
+    head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return head + f"\n\n... [diff truncated at {max_bytes} bytes of {len(encoded)}] ..."
+
+
+def build_synthesis_prompt(response_paths: list[str]) -> str:
+    listing = "\n".join(f"- {p}" for p in response_paths) or "- (no reviewer responses)"
+    return (
+        "Synthesize the independent code reviews below into one actionable report.\n"
+        "Categorize each finding as high-confidence (apply), medium (verify first), "
+        "or low/architectural (flag for user). Note consensus vs single-reviewer findings.\n\n"
+        f"Reviewer responses:\n{listing}\n"
+    )
+
+
+# --- git --------------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: str | Path, runner: Runner) -> subprocess.CompletedProcess:
+    return runner(["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=60)
+
+
+def assert_git_repo(worktree: str | Path, *, runner: Runner = subprocess.run) -> Path:
+    result = _git(["rev-parse", "--show-toplevel"], worktree, runner)
+    if result.returncode != 0:
+        raise ReviewError(f"not a git repository: {worktree}")
+    return Path(result.stdout.strip())
+
+
+def capture_diff(
+    worktree: str | Path,
+    base: str,
+    *,
+    runner: Runner = subprocess.run,
+    max_bytes: int = DEFAULT_MAX_DIFF_BYTES,
+) -> str:
+    """Capture ``base...HEAD`` diff, refusing if the base ref can't be resolved."""
+    check = _git(["rev-parse", "--verify", base], worktree, runner)
+    if check.returncode != 0:
+        raise ReviewError(f"base ref cannot be resolved: {base}")
+    result = _git(["diff", f"{base}...HEAD"], worktree, runner)
+    if result.returncode != 0:
+        raise ReviewError(f"git diff failed: {(result.stderr or '').strip()}")
+    return truncate_diff(result.stdout, max_bytes)
+
+
+# --- run --------------------------------------------------------------------
+
+
+@dataclass
+class ReviewManifest:
+    ticket: int | None
+    base: str
+    role: str
+    diff_path: str
+    prompt_path: str
+    synthesis_prompt_path: str
+    provider_manifest: dict
+    response_paths: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.provider_manifest.get("ok"))
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def run_review(
+    ticket: TicketContext,
+    worktree: str | Path,
+    base: str,
+    output_dir: str | Path,
+    *,
+    template: str,
+    checklist: str | None = None,
+    epic_sections: Iterable[tuple[str, str]] = (),
+    role: str = "reviewer",
+    config: dict | None = None,
+    execute: Callable[[providers.Provider, str], str] | None = None,
+    runner: Runner = subprocess.run,
+    max_diff_bytes: int = DEFAULT_MAX_DIFF_BYTES,
+) -> ReviewManifest:
+    """Assemble the review prompt, run the reviewer quorum, write synthesis inputs.
+
+    Refuses to run outside a git repo or when ``base`` cannot be resolved.
+    ``execute`` (the provider call) is injected so the pipeline is testable.
+    """
+    assert_git_repo(worktree, runner=runner)
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    diff = capture_diff(worktree, base, runner=runner, max_bytes=max_diff_bytes)
+    diff_path = out / "impl-diff.txt"
+    diff_path.write_text(diff)
+
+    prompt = assemble_review_prompt(
+        template, ticket, diff, checklist=checklist, epic_sections=epic_sections
+    )
+    prompt_path = out / "review-prompt.md"
+    prompt_path.write_text(prompt)
+
+    if config is None:
+        config = providers.load_config()
+    plan = providers.plan_role(role, config)
+    if not plan.ok:
+        raise ReviewError(
+            f"role {role} missing required providers: {', '.join(plan.missing_required)}"
+        )
+    if execute is None:
+        raise ReviewError("an execute callable is required to run the reviewer quorum")
+
+    # The quorum calls execute(provider); bind the assembled prompt here.
+    quorum = providers.run_role_quorum(plan, lambda p: execute(p, prompt), out)
+    response_paths = [r.path for r in quorum.results if r.path]
+
+    synthesis = build_synthesis_prompt(response_paths)
+    synthesis_path = out / "synthesis-prompt.md"
+    synthesis_path.write_text(synthesis)
+
+    manifest = ReviewManifest(
+        ticket=ticket.number,
+        base=base,
+        role=role,
+        diff_path=str(diff_path),
+        prompt_path=str(prompt_path),
+        synthesis_prompt_path=str(synthesis_path),
+        provider_manifest=quorum.to_dict(),
+        response_paths=response_paths,
+    )
+    (out / "review-manifest.json").write_text(json.dumps(manifest.to_dict(), indent=2))
+    return manifest

--- a/scripts/chief_wiggum/review.py
+++ b/scripts/chief_wiggum/review.py
@@ -12,6 +12,7 @@ unit-testable; git and provider execution are injected.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
@@ -68,18 +69,22 @@ def assemble_review_prompt(
 ) -> str:
     """Substitute the review template and append the checklist + epic context.
 
-    Uses plain ``str.replace`` (not ``str.format``) so braces in the diff are
-    never interpreted as format fields.
+    Substitution is **single-pass** (one regex sweep over the template), so a
+    value that itself contains a token name (e.g. a ticket body mentioning
+    ``{{DIFF}}``) is never re-scanned and replaced. Braces in the diff are not
+    interpreted as format fields.
     """
-    prompt = template
     replacements = {
-        "{{TICKET_TITLE}}": ticket.title or "(untitled)",
-        "{{TICKET_DESCRIPTION}}": ticket.body or "(no description)",
-        "{{ACCEPTANCE_CRITERIA}}": _format_acceptance(ticket.acceptance_criteria),
-        "{{DIFF}}": diff,
+        "TICKET_TITLE": ticket.title or "(untitled)",
+        "TICKET_DESCRIPTION": ticket.body or "(no description)",
+        "ACCEPTANCE_CRITERIA": _format_acceptance(ticket.acceptance_criteria),
+        "DIFF": diff,
     }
-    for token, value in replacements.items():
-        prompt = prompt.replace(token, value)
+    prompt = re.sub(
+        r"\{\{(TICKET_TITLE|TICKET_DESCRIPTION|ACCEPTANCE_CRITERIA|DIFF)\}\}",
+        lambda m: replacements[m.group(1)],
+        template,
+    )
 
     extra: list[str] = []
     for title, content in epic_sections:

--- a/scripts/run_review.py
+++ b/scripts/run_review.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""CLI for the review prompt assembly + review run (P1-7).
+
+Captures the worktree diff, assembles a review prompt from the templates (plus
+optional epic artifacts), runs the reviewer provider quorum, and writes the
+synthesis inputs + a manifest. Replaces the bespoke Step 7 shell in /implement.
+
+Example:
+    python3 scripts/run_review.py \
+      --ticket-context "$TICKET_TMP/ticket.json" \
+      --worktree "$WORKTREE" --base "$DEFAULT_BRANCH" \
+      --output-dir "$TICKET_TMP/reviews"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import review  # noqa: E402
+from consult_ai import consult_provider  # noqa: E402
+
+DEFAULT_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "review-prompt.md"
+DEFAULT_CHECKLIST = Path(__file__).resolve().parents[1] / "templates" / "review-checklist.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Assemble and run a code review")
+    parser.add_argument("--ticket-context", required=True, help="JSON file with ticket title/body/AC")
+    parser.add_argument("--worktree", required=True, help="Worktree to diff and review")
+    parser.add_argument("--base", required=True, help="Base branch/ref for the diff")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--role", default="reviewer")
+    parser.add_argument("--template", default=str(DEFAULT_TEMPLATE))
+    parser.add_argument("--checklist", default=str(DEFAULT_CHECKLIST))
+    parser.add_argument(
+        "--epic-artifact",
+        action="append",
+        default=[],
+        metavar="TITLE=PATH",
+        help="Optional epic artifact to include (e.g. Contracts=docs/epics/x/contracts.md)",
+    )
+    args = parser.parse_args(argv)
+
+    ticket = review.TicketContext.from_dict(json.loads(Path(args.ticket_context).read_text()))
+    template = Path(args.template).read_text()
+    checklist = Path(args.checklist).read_text() if Path(args.checklist).exists() else None
+
+    epic_sections: list[tuple[str, str]] = []
+    for spec in args.epic_artifact:
+        if "=" not in spec:
+            continue
+        title, path = spec.split("=", 1)
+        p = Path(path)
+        if p.exists():
+            epic_sections.append((title, p.read_text()))
+
+    def execute(provider, prompt):
+        return consult_provider(provider, prompt, None, args.worktree)
+
+    try:
+        manifest = review.run_review(
+            ticket,
+            args.worktree,
+            args.base,
+            args.output_dir,
+            template=template,
+            checklist=checklist,
+            epic_sections=epic_sections,
+            role=args.role,
+            execute=execute,
+        )
+    except review.ReviewError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(manifest.to_dict(), indent=2))
+    return 0 if manifest.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -49,6 +49,15 @@ def test_diff_with_braces_is_not_format_interpreted():
     assert "{ return {a: 1}; }" in out
 
 
+def test_single_pass_does_not_rescan_injected_values():
+    # A ticket title containing a later token must NOT get the diff injected.
+    ticket = _ticket(title="see {{DIFF}} below")
+    out = review.assemble_review_prompt(TEMPLATE, ticket, "REAL_DIFF_BODY")
+    # The literal token survives in the title line; the diff appears once.
+    assert "Ticket: see {{DIFF}} below" in out
+    assert out.count("REAL_DIFF_BODY") == 1
+
+
 def test_checklist_and_epic_sections_appended():
     out = review.assemble_review_prompt(
         TEMPLATE, _ticket(), "d",

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -1,0 +1,197 @@
+"""Tests for review prompt assembly and review run (P1-7)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from chief_wiggum import review
+from providers import Provider, Role, RolePlan
+
+TEMPLATE = """# Review
+Ticket: {{TICKET_TITLE}}
+Desc: {{TICKET_DESCRIPTION}}
+AC:
+{{ACCEPTANCE_CRITERIA}}
+Diff:
+```diff
+{{DIFF}}
+```
+"""
+
+
+def _ticket(**kw):
+    base = {"number": 42, "title": "Add thing", "body": "Do the thing", "acceptance_criteria": ["AC one", "AC two"]}
+    base.update(kw)
+    return review.TicketContext(**base)
+
+
+# --- template substitution --------------------------------------------------
+
+
+def test_assemble_substitutes_all_placeholders():
+    out = review.assemble_review_prompt(TEMPLATE, _ticket(), "the diff body")
+    assert "Ticket: Add thing" in out
+    assert "Desc: Do the thing" in out
+    assert "- AC one" in out and "- AC two" in out
+    assert "the diff body" in out
+    assert "{{" not in out
+
+
+def test_missing_ac_renders_placeholder_text():
+    out = review.assemble_review_prompt(TEMPLATE, _ticket(acceptance_criteria=[]), "d")
+    assert "(none specified)" in out
+
+
+def test_diff_with_braces_is_not_format_interpreted():
+    # A diff containing { } must not break substitution.
+    out = review.assemble_review_prompt(TEMPLATE, _ticket(), "func() { return {a: 1}; }")
+    assert "{ return {a: 1}; }" in out
+
+
+def test_checklist_and_epic_sections_appended():
+    out = review.assemble_review_prompt(
+        TEMPLATE, _ticket(), "d",
+        checklist="# Checklist\n- item",
+        epic_sections=[("Contracts", "REQUIRES x"), ("Empty", "  ")],
+    )
+    assert "## Contracts" in out and "REQUIRES x" in out
+    assert "# Checklist" in out
+    # Empty epic section is skipped.
+    assert "## Empty" not in out
+
+
+# --- diff truncation --------------------------------------------------------
+
+
+def test_truncate_small_diff_unchanged():
+    assert review.truncate_diff("small", max_bytes=100) == "small"
+
+
+def test_truncate_large_diff():
+    big = "x" * 5000
+    out = review.truncate_diff(big, max_bytes=1000)
+    assert "diff truncated at 1000 bytes of 5000" in out
+    assert len(out.encode()) < 5000
+
+
+# --- ticket context parsing -------------------------------------------------
+
+
+def test_ticket_from_dict_parses_string_ac():
+    t = review.TicketContext.from_dict({"number": 1, "title": "t", "acceptance_criteria": "- one\n- two"})
+    assert t.acceptance_criteria == ["one", "two"]
+
+
+# --- git guards (mocked) ----------------------------------------------------
+
+
+def _runner(mapping):
+    def run(args, **kwargs):
+        key = " ".join(args)
+        for needle, (rc, out) in mapping.items():
+            if needle in key:
+                return subprocess.CompletedProcess(args, rc, stdout=out, stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    return run
+
+
+def test_assert_git_repo_refuses_non_repo(tmp_path):
+    with pytest.raises(review.ReviewError, match="not a git"):
+        review.assert_git_repo(tmp_path, runner=_runner({"rev-parse --show-toplevel": (128, "")}))
+
+
+def test_capture_diff_refuses_unresolvable_base(tmp_path):
+    runner = _runner({"rev-parse --verify": (1, "")})
+    with pytest.raises(review.ReviewError, match="base ref"):
+        review.capture_diff(tmp_path, "nope", runner=runner)
+
+
+def test_capture_diff_returns_truncated(tmp_path):
+    runner = _runner({"rev-parse --verify": (0, "abc"), "diff": (0, "y" * 5000)})
+    out = review.capture_diff(tmp_path, "main", runner=runner, max_bytes=1000)
+    assert "diff truncated" in out
+
+
+# --- synthesis prompt -------------------------------------------------------
+
+
+def test_synthesis_prompt_lists_responses():
+    p = review.build_synthesis_prompt(["a/reviewer-codex.md", "a/reviewer-gemini.md"])
+    assert "reviewer-codex.md" in p and "reviewer-gemini.md" in p
+
+
+# --- full run (mocked git + provider) ---------------------------------------
+
+
+def _plan():
+    role = Role(name="reviewer", required=("codex",), optional=("gemini",))
+    return RolePlan(
+        role=role,
+        required=(Provider("codex", "tool", True, tool="codex"),),
+        optional=(Provider("gemini", "tool", True, tool="gemini"),),
+        missing_required=(),
+        skipped_optional=(),
+    )
+
+
+def test_run_review_end_to_end(tmp_path, monkeypatch):
+    out = tmp_path / "reviews"
+    runner = _runner(
+        {
+            "rev-parse --show-toplevel": (0, str(tmp_path)),
+            "rev-parse --verify": (0, "abc"),
+            "diff": (0, "diff --git a b\n+added line"),
+        }
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: _plan())
+
+    captured = {}
+
+    def execute(provider, prompt):
+        captured["prompt"] = prompt
+        return "A substantive review with findings to report here."
+
+    manifest = review.run_review(
+        _ticket(), tmp_path, "main", out,
+        template=TEMPLATE, checklist="# Checklist\n- item",
+        config={}, execute=execute, runner=runner,
+    )
+
+    assert manifest.ok is True
+    assert manifest.base == "main"
+    # Files written.
+    assert (out / "impl-diff.txt").exists()
+    assert (out / "review-prompt.md").exists()
+    assert (out / "synthesis-prompt.md").exists()
+    assert (out / "review-manifest.json").exists()
+    # Provider manifest integrated.
+    assert manifest.provider_manifest["ok"] is True
+    assert any("reviewer-codex.md" in p for p in manifest.response_paths)
+    # The assembled prompt (with diff + AC) reached the provider.
+    assert "added line" in captured["prompt"]
+    assert "- AC one" in captured["prompt"]
+
+
+def test_run_review_refuses_without_execute(tmp_path, monkeypatch):
+    runner = _runner(
+        {"rev-parse --show-toplevel": (0, str(tmp_path)), "rev-parse --verify": (0, "abc"), "diff": (0, "d")}
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: _plan())
+    with pytest.raises(review.ReviewError, match="execute callable"):
+        review.run_review(_ticket(), tmp_path, "main", tmp_path / "o", template=TEMPLATE, config={}, runner=runner)
+
+
+def test_run_review_missing_required_provider_raises(tmp_path, monkeypatch):
+    runner = _runner({"rev-parse --show-toplevel": (0, str(tmp_path)), "rev-parse --verify": (0, "abc"), "diff": (0, "d")})
+    bad_plan = RolePlan(
+        role=Role("reviewer", ("codex",), ()),
+        required=(), optional=(), missing_required=("codex",), skipped_optional=(),
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: bad_plan)
+    with pytest.raises(review.ReviewError, match="missing required"):
+        review.run_review(
+            _ticket(), tmp_path, "main", tmp_path / "o",
+            template=TEMPLATE, config={}, execute=lambda p, pr: "x", runner=runner,
+        )


### PR DESCRIPTION
## Summary

P1-7 of the Portable Python Orchestration Core epic. `/implement` Step 7 (mandatory, and repeated in wave sub-agent prompts) assembled a review prompt, ran providers, checked outputs, and synthesized findings. This makes that deterministic pipeline one tested helper built on the quorum runner (#40).

Closes #43.

## Changes

- **`scripts/chief_wiggum/review.py`**
  - `assemble_review_prompt` — plain `str.replace` (braces in the diff aren't format-interpreted), `(none specified)` for missing AC, appends the checklist + epic sections (skipping empty ones).
  - `truncate_diff` — bounds large diffs; `capture_diff` / `assert_git_repo` — **refuse outside a git repo or when the base ref can't be resolved**.
  - `run_review` — captures diff → assembles prompt → runs the reviewer quorum → writes synthesis prompt + `review-manifest.json`. Git and provider execution injected.
- **`scripts/run_review.py`** — CLI (`--ticket-context --worktree --base --output-dir --role --epic-artifact`).
- **`implement.md` Step 7** — calls `run_review.py` instead of bespoke shell.

## Acceptance criteria

- [x] Tests cover template substitution, missing AC, large diff path, missing optional epic artifacts, provider manifest integration, and synthesis inputs (14 tests).
- [x] `/implement` Step 7 calls the helper.
- [x] The helper refuses to run outside a git repo or when the base branch cannot be resolved.

## Verification

- `make lint` clean; `make test` — 244 passed (14 new).