### PR TITLE
feat: extract PR body and mermaid diagram scaffolding (#47)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -563,9 +563,8 @@ If no browser-use or E2E setup exists at all, note it as a gap in the final summ
    #ffa600 (amber)        — highlights
    ```
 
-   Every diagram MUST include the theme init block and classDef styles:
+   Write the diagram body (without the `%%{init}%%` line — `draft_pr.py` injects the themed init block in step 3) to `$TICKET_TMP/architecture.mmd`, using these classDef styles:
    ```mermaid
-   %%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
    graph TD
        classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
        classDef modified fill:#665191,stroke:#a05195,color:#fff
@@ -573,45 +572,28 @@ If no browser-use or E2E setup exists at all, note it as a gap in the final summ
        classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff
    ```
 
-   Include at minimum a **Component Relationship Diagram** showing what was added/modified. Add a **Sequence Diagram** if data flow changed. Keep diagrams focused (max 15 nodes).
+   Include at minimum a **Component Relationship Diagram** showing what was added/modified. Add a **Sequence Diagram** if data flow changed (pass `--mermaid-sequence` to `draft_pr.py`). Keep diagrams focused (max 15 nodes).
 
-3. Create the PR with full documentation using a HEREDOC:
+3. Draft the PR body with the tested helper. It folds in the verification evidence and (when present) the review/UX/model-conformance manifests, themes the Mermaid diagram with the shared palette automatically, validates the required sections, and links the issue:
 
 ```bash
-gh pr create \
-  --repo "$owner_repo" \
-  --title "$pr_title" \
-  --body "$(cat <<'EOF'
-## Summary
-[2-3 sentences]
-
-## Architecture
-[Mermaid diagrams here — REQUIRED]
-
-## Changes
-[Bullet list of significant changes]
-
-## Test plan
-[Test evidence — include TDD summary: N tests written first, all passing]
-[If formal models exist: N model-derived tests, M LLM-written tests]
-
-## Contract compliance
-[Which epic contracts/invariants this implementation satisfies — omit if no epic context]
-
-## Model conformance
-[If formal models exist — include conformance summary from Step 8:]
-[Test paths: X/Y | Invalid transitions: X/Y | Guard clauses: X/Y | Invariants: X/Y]
-[Omit this section if no formal models]
-
-Closes #issue_number
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)" \
-  --base "$DEFAULT_BRANCH"
+python3 "$CW_HOME/scripts/draft_pr.py" \
+  --issue "$issue_number" --title "$pr_title" --summary "$summary" \
+  --change "Change 1" --change "Change 2" \
+  --mermaid-file "$TICKET_TMP/architecture.mmd" \
+  --verification "$TICKET_TMP/verification.json" \
+  --review "$TICKET_TMP/reviews/review-manifest.json" \
+  --model-conformance "$TICKET_TMP/model-conformance.md" \
+  --base "$DEFAULT_BRANCH" --out "$TICKET_TMP/pr-body.md"
 ```
 
-4. Link to the original issue via `Closes #N` in the body
+(Omit `--model-conformance` / `--review` when they don't apply — those sections are then omitted.) Then create the PR from the body file:
+
+```bash
+gh pr create --repo "$owner_repo" --title "$pr_title" --body-file "$TICKET_TMP/pr-body.md" --base "$DEFAULT_BRANCH"
+```
+
+4. The helper links the original issue via `Closes #N` from `--issue`.
 
 ### Step 12: Verify CI green
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -121,20 +121,18 @@ If browser-use screenshots exist, reference them.
 
 ### Step 4: Draft the PR
 
-Using the template at `$CW_HOME/templates/pr.md`, fill in:
+Assemble the PR body with the tested helper. It folds in the verification evidence, optional model-conformance/UX manifests, and a Mermaid diagram (themed with the shared palette automatically), validates the required sections, and can print the `gh pr create` command:
 
-- **Title**: From the ticket title or derived from changes. Keep under 70 characters.
-  - Format: `feat: Add dark mode toggle` or `fix: Resolve login crash on empty form`
+```bash
+python3 "$CW_HOME/scripts/draft_pr.py" \
+  --issue "$issue_number" --title "$title" --summary "$summary" \
+  --change "Change 1" --change "Change 2" \
+  --mermaid-file "$CW_TMP/architecture.mmd" \
+  --verification "$CW_TMP/verification.json" \
+  --base "$base_branch" --out "$CW_TMP/pr-body.md" --print-command
+```
 
-- **Summary**: 2-3 sentences on what was done and why.
-
-- **Architecture**: The mermaid diagrams from Step 2.
-
-- **Changes**: Bullet list of significant changes (not every line, but the meaningful ones).
-
-- **Test Evidence**: Test output and browser-use results.
-
-- **Review Checklist**: Pre-filled based on what was actually done.
+The Mermaid palette no longer needs to be hand-copied — `draft_pr.py` injects the `%%{init}%%` theme (use `--mermaid-sequence` for sequence diagrams). The diagram *content* is still yours to author. It exits non-zero if a required section (Summary, Changes, Test Evidence) is missing.
 
 ### Step 5: Preview and confirm
 
@@ -154,7 +152,7 @@ git push -u origin HEAD
 gh pr create \
   --repo "$owner_repo" \
   --title "$title" \
-  --body "$body" \
+  --body-file "$CW_TMP/pr-body.md" \
   --base "$base_branch"
 ```
 

--- a/scripts/chief_wiggum/shipping.py
+++ b/scripts/chief_wiggum/shipping.py
@@ -1,0 +1,160 @@
+"""PR body and Mermaid diagram scaffolding (P1-11).
+
+`/ship` and `/implement` both require PR bodies with diagrams, verification
+evidence, contract/model conformance, and UX results — and they duplicate the
+Mermaid colour palette and section requirements in prose. This assembles the PR
+body from the upstream manifests (review, verification, UX, model conformance,
+issue context), enforces required sections, and provides reusable Mermaid theme
+helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# The shared Mermaid palette (kept in one place instead of copied into prose).
+PALETTE = {
+    "theme": "base",
+    "themeVariables": {
+        "primaryColor": "#003f5c",
+        "primaryTextColor": "#fff",
+        "primaryBorderColor": "#2f4b7c",
+        "secondaryColor": "#665191",
+        "tertiaryColor": "#a05195",
+        "lineColor": "#2f4b7c",
+        "textColor": "#333",
+    },
+}
+_SEQUENCE_EXTRA = {
+    "actorTextColor": "#fff",
+    "actorBkg": "#003f5c",
+    "actorBorder": "#2f4b7c",
+    "activationBorderColor": "#d45087",
+    "activationBkgColor": "#f95d6a",
+    "signalColor": "#2f4b7c",
+}
+
+REQUIRED_SECTIONS = ("Summary", "Changes", "Test Evidence")
+
+
+def mermaid_theme_directive(*, sequence: bool = False) -> str:
+    """Return the ``%%{init: ...}%%`` theme line for a diagram."""
+    palette = {"theme": PALETTE["theme"], "themeVariables": dict(PALETTE["themeVariables"])}
+    if sequence:
+        palette["themeVariables"].update(_SEQUENCE_EXTRA)
+    # Mermaid expects single-quoted JSON-ish; json.dumps then swap quotes.
+    body = json.dumps(palette).replace('"', "'")
+    return f"%%{{init: {body}}}%%"
+
+
+def mermaid_block(diagram: str, *, sequence: bool = False) -> str:
+    """Wrap a diagram body in a themed ```mermaid fenced block."""
+    directive = mermaid_theme_directive(sequence=sequence)
+    return f"```mermaid\n{directive}\n{diagram.strip()}\n```"
+
+
+def _verification_evidence(verification: dict | None) -> str:
+    if not verification:
+        return "```\n<!-- paste test output -->\n```"
+    lines = []
+    for step in verification.get("steps", []):
+        cmd = " ".join(step.get("command", []))
+        if step.get("planned_only"):
+            lines.append(f"- [plan] `{cmd}`")
+        else:
+            mark = "✓" if step.get("ok") else "✗"
+            lines.append(f"- {mark} `{cmd}` — exit {step.get('exit_code')}")
+    status = "all green" if verification.get("ok") else "FAILURES"
+    return f"**Verification: {status}**\n" + "\n".join(lines)
+
+
+def _review_summary(review: dict | None) -> str | None:
+    if not review:
+        return None
+    pm = review.get("provider_manifest", review)
+    providers = ", ".join(
+        f"{r['name']} ({r['status']})" for r in pm.get("results", [])
+    )
+    state = "passed" if pm.get("ok") else "had failures"
+    return f"Multi-AI review {state}: {providers}" if providers else f"Multi-AI review {state}."
+
+
+@dataclass
+class PRDraft:
+    title: str
+    body: str
+
+    def to_dict(self) -> dict:
+        return {"title": self.title, "body": self.body}
+
+
+def build_pr_body(
+    *,
+    issue: int | None = None,
+    summary: str = "",
+    changes: list[str] | None = None,
+    mermaid: str | None = None,
+    mermaid_sequence: bool = False,
+    verification: dict | None = None,
+    review: dict | None = None,
+    ux: dict | None = None,
+    model_conformance: str | None = None,
+) -> str:
+    """Assemble a PR body from the upstream manifests + issue context."""
+    parts: list[str] = ["## Summary", "", summary or "<!-- what was implemented and why -->"]
+    if issue is not None:
+        parts += ["", f"Closes #{issue}"]
+
+    if mermaid:
+        parts += ["", "## Architecture", "", mermaid_block(mermaid, sequence=mermaid_sequence)]
+
+    parts += ["", "## Changes", ""]
+    parts += [f"- {c}" for c in (changes or ["<!-- change -->"])]
+
+    parts += ["", "## Test Evidence", "", _verification_evidence(verification)]
+
+    if model_conformance:
+        parts += ["", "## Model Conformance", "", model_conformance.strip()]
+
+    if ux:
+        parts += ["", "## UX / Design Fidelity", ""]
+        status = ux.get("status") or ("ok" if ux.get("ok") else "see notes")
+        parts.append(f"Design-fidelity gate: {status}")
+        for shot in ux.get("screenshots", []):
+            parts.append(f"- `{shot}`")
+
+    review_line = _review_summary(review)
+    if review_line:
+        parts += ["", "## Review", "", review_line]
+
+    parts += [
+        "", "## Review Checklist", "",
+        "- [ ] Tests pass locally",
+        "- [ ] No new warnings or lint errors",
+        "- [ ] Multi-AI review feedback addressed",
+        "- [ ] No secrets or credentials committed",
+    ]
+    return "\n".join(parts) + "\n"
+
+
+def validate_sections(body: str, required: tuple[str, ...] = REQUIRED_SECTIONS) -> list[str]:
+    """Return the names of any required ``## `` sections missing from ``body``."""
+    return [name for name in required if f"## {name}" not in body]
+
+
+def suggest_title(issue_title: str | None, *, issue: int | None = None, prefix: str = "feat") -> str:
+    base = (issue_title or "update").strip()
+    if issue is not None and f"#{issue}" not in base:
+        return f"{prefix}: {base} (#{issue})"
+    return f"{prefix}: {base}"
+
+
+def gh_pr_create_command(title: str, body_file: str | Path, *, base: str | None = None, draft: bool = False) -> list[str]:
+    cmd = ["gh", "pr", "create", "--title", title, "--body-file", str(body_file)]
+    if base:
+        cmd += ["--base", base]
+    if draft:
+        cmd.append("--draft")
+    return cmd

--- a/scripts/chief_wiggum/shipping.py
+++ b/scripts/chief_wiggum/shipping.py
@@ -11,6 +11,7 @@ helpers.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -44,8 +45,10 @@ def mermaid_theme_directive(*, sequence: bool = False) -> str:
     palette = {"theme": PALETTE["theme"], "themeVariables": dict(PALETTE["themeVariables"])}
     if sequence:
         palette["themeVariables"].update(_SEQUENCE_EXTRA)
-    # Mermaid expects single-quoted JSON-ish; json.dumps then swap quotes.
-    body = json.dumps(palette).replace('"', "'")
+    # Mermaid expects single-quoted JSON-ish. Escape any pre-existing single
+    # quotes in values before swapping double->single so a value containing an
+    # apostrophe can't break out of the init object.
+    body = json.dumps(palette).replace("'", "\\'").replace('"', "'")
     return f"%%{{init: {body}}}%%"
 
 
@@ -140,8 +143,17 @@ def build_pr_body(
 
 
 def validate_sections(body: str, required: tuple[str, ...] = REQUIRED_SECTIONS) -> list[str]:
-    """Return the names of any required ``## `` sections missing from ``body``."""
-    return [name for name in required if f"## {name}" not in body]
+    """Return the names of any required ``## `` sections missing from ``body``.
+
+    Matches exact ``## <Name>`` heading lines (not substrings), so ``### Summary``
+    or ``## Summary Details`` don't satisfy a required ``Summary`` section.
+    """
+    missing = []
+    for name in required:
+        pattern = re.compile(rf"^##\s+{re.escape(name)}\s*$", re.MULTILINE)
+        if not pattern.search(body):
+            missing.append(name)
+    return missing
 
 
 def suggest_title(issue_title: str | None, *, issue: int | None = None, prefix: str = "feat") -> str:

--- a/scripts/draft_pr.py
+++ b/scripts/draft_pr.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""CLI to draft a PR body from upstream manifests (P1-11).
+
+Assembles a PR body with a themed Mermaid diagram, verification evidence,
+optional model-conformance and UX sections, validates the required sections, and
+optionally prints the `gh pr create` command. Used by /ship and /implement.
+
+Example:
+    python3 scripts/draft_pr.py --issue 42 --summary "Add X" \
+      --change "Add module" --change "Wire CLI" \
+      --verification "$TICKET_TMP/reviews/../verification.json" \
+      --review "$TICKET_TMP/reviews/review-manifest.json" \
+      --mermaid-file diagram.mmd --out "$TICKET_TMP/pr-body.md"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import shipping  # noqa: E402
+
+
+def _load_json(path: str | None) -> dict | None:
+    if not path:
+        return None
+    p = Path(path)
+    return json.loads(p.read_text()) if p.exists() else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Draft a PR body from manifests")
+    parser.add_argument("--issue", type=int)
+    parser.add_argument("--title", help="Issue/PR title for the suggested PR title")
+    parser.add_argument("--summary", default="")
+    parser.add_argument("--change", action="append", default=[], help="A bullet for the Changes section")
+    parser.add_argument("--mermaid-file", help="File with a mermaid diagram body")
+    parser.add_argument("--mermaid-sequence", action="store_true")
+    parser.add_argument("--verification", help="verification report JSON")
+    parser.add_argument("--review", help="review-manifest.json")
+    parser.add_argument("--ux", help="UX gate manifest JSON")
+    parser.add_argument("--model-conformance", help="Markdown text or file for the Model Conformance section")
+    parser.add_argument("--base")
+    parser.add_argument("--out", help="Write the PR body to this file (else stdout)")
+    parser.add_argument("--print-command", action="store_true", help="Also print the gh pr create command")
+    args = parser.parse_args(argv)
+
+    mermaid = None
+    if args.mermaid_file and Path(args.mermaid_file).exists():
+        mermaid = Path(args.mermaid_file).read_text()
+
+    conformance = args.model_conformance
+    if conformance and Path(conformance).exists():
+        conformance = Path(conformance).read_text()
+
+    body = shipping.build_pr_body(
+        issue=args.issue,
+        summary=args.summary,
+        changes=args.change or None,
+        mermaid=mermaid,
+        mermaid_sequence=args.mermaid_sequence,
+        verification=_load_json(args.verification),
+        review=_load_json(args.review),
+        ux=_load_json(args.ux),
+        model_conformance=conformance,
+    )
+
+    missing = shipping.validate_sections(body)
+    if missing:
+        print(f"Error: PR body missing required sections: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    if args.out:
+        Path(args.out).write_text(body)
+        print(f"OK: PR body written to {args.out}")
+    else:
+        print(body)
+
+    if args.print_command:
+        title = shipping.suggest_title(args.title, issue=args.issue)
+        body_file = args.out or "<pr-body-file>"
+        print("\n# Suggested command:")
+        print(" ".join(shipping.gh_pr_create_command(title, body_file, base=args.base)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/draft_pr.py
+++ b/scripts/draft_pr.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from pathlib import Path
 
@@ -84,7 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         title = shipping.suggest_title(args.title, issue=args.issue)
         body_file = args.out or "<pr-body-file>"
         print("\n# Suggested command:")
-        print(" ".join(shipping.gh_pr_create_command(title, body_file, base=args.base)))
+        print(shlex.join(shipping.gh_pr_create_command(title, body_file, base=args.base)))
     return 0
 
 

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -1,0 +1,135 @@
+"""Tests for PR body and Mermaid diagram scaffolding (P1-11)."""
+
+from __future__ import annotations
+
+import json
+
+import draft_pr
+from chief_wiggum import shipping
+
+# --- mermaid ----------------------------------------------------------------
+
+
+def test_mermaid_theme_directive_uses_palette():
+    d = shipping.mermaid_theme_directive()
+    assert d.startswith("%%{init:") and d.endswith("}%%")
+    assert "'primaryColor': '#003f5c'" in d
+    assert '"' not in d  # single-quoted for mermaid
+
+
+def test_mermaid_sequence_adds_actor_vars():
+    d = shipping.mermaid_theme_directive(sequence=True)
+    assert "actorBkg" in d
+
+
+def test_mermaid_block_wraps_with_theme_and_fences():
+    block = shipping.mermaid_block("graph TD\n  A --> B")
+    assert block.startswith("```mermaid")
+    assert block.rstrip().endswith("```")
+    assert "%%{init:" in block
+    assert "A --> B" in block
+
+
+# --- required sections ------------------------------------------------------
+
+
+def test_validate_sections_flags_missing():
+    assert shipping.validate_sections("## Summary\n## Changes") == ["Test Evidence"]
+
+
+def test_build_pr_body_has_all_required_sections():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"])
+    assert shipping.validate_sections(body) == []
+
+
+# --- issue linking ----------------------------------------------------------
+
+
+def test_issue_linking():
+    body = shipping.build_pr_body(issue=42, summary="x", changes=["a"])
+    assert "Closes #42" in body
+
+
+def test_no_issue_no_closes_line():
+    body = shipping.build_pr_body(summary="x", changes=["a"])
+    assert "Closes #" not in body
+
+
+# --- conditional sections ---------------------------------------------------
+
+
+def test_model_conformance_included_when_provided():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"], model_conformance="all guards present")
+    assert "## Model Conformance" in body and "all guards present" in body
+
+
+def test_model_conformance_omitted_when_absent():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"])
+    assert "## Model Conformance" not in body
+
+
+def test_ux_section_included_when_provided():
+    body = shipping.build_pr_body(
+        issue=1, summary="x", changes=["a"],
+        ux={"status": "matches contract", "screenshots": ["a.png", "b.png"]},
+    )
+    assert "## UX / Design Fidelity" in body
+    assert "matches contract" in body
+    assert "`a.png`" in body
+
+
+def test_ux_section_omitted_when_absent():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"])
+    assert "## UX / Design Fidelity" not in body
+
+
+# --- evidence + review integration ------------------------------------------
+
+
+def test_verification_evidence_rendered():
+    verification = {
+        "ok": False,
+        "steps": [
+            {"command": ["make", "test"], "ok": False, "exit_code": 1},
+            {"command": ["make", "lint"], "ok": True, "exit_code": 0},
+        ],
+    }
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"], verification=verification)
+    assert "FAILURES" in body
+    assert "`make test` — exit 1" in body
+
+
+def test_review_summary_rendered():
+    review = {"provider_manifest": {"ok": True, "results": [{"name": "codex", "status": "ok"}]}}
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"], review=review)
+    assert "Multi-AI review passed" in body
+    assert "codex (ok)" in body
+
+
+# --- title + command --------------------------------------------------------
+
+
+def test_suggest_title_adds_issue_suffix():
+    assert shipping.suggest_title("Add widget", issue=7) == "feat: Add widget (#7)"
+
+
+def test_gh_pr_create_command():
+    cmd = shipping.gh_pr_create_command("t", "/tmp/body.md", base="main", draft=True)
+    assert cmd == ["gh", "pr", "create", "--title", "t", "--body-file", "/tmp/body.md", "--base", "main", "--draft"]
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_writes_body_and_validates(tmp_path, capsys):
+    verification = tmp_path / "v.json"
+    verification.write_text(json.dumps({"ok": True, "steps": [{"command": ["make", "test"], "ok": True, "exit_code": 0}]}))
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--verification", str(verification), "--out", str(out), "--print-command",
+    ])
+    assert rc == 0
+    body = out.read_text()
+    assert "Closes #9" in body and "## Test Evidence" in body
+    assert "gh pr create" in capsys.readouterr().out

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -37,6 +37,12 @@ def test_validate_sections_flags_missing():
     assert shipping.validate_sections("## Summary\n## Changes") == ["Test Evidence"]
 
 
+def test_validate_sections_rejects_substring_false_positives():
+    # ### Summary and ## Summary Details must NOT satisfy a required Summary.
+    body = "### Summary\n## Summary Details\n## Changes\n## Test Evidence"
+    assert "Summary" in shipping.validate_sections(body)
+
+
 def test_build_pr_body_has_all_required_sections():
     body = shipping.build_pr_body(issue=1, summary="x", changes=["a"])
     assert shipping.validate_sections(body) == []
@@ -116,6 +122,21 @@ def test_suggest_title_adds_issue_suffix():
 def test_gh_pr_create_command():
     cmd = shipping.gh_pr_create_command("t", "/tmp/body.md", base="main", draft=True)
     assert cmd == ["gh", "pr", "create", "--title", "t", "--body-file", "/tmp/body.md", "--base", "main", "--draft"]
+
+
+def test_mermaid_directive_escapes_apostrophe_values():
+    # A theme value with an apostrophe must not break out of the single-quoted object.
+    import chief_wiggum.shipping as s
+
+    monkey = dict(s.PALETTE["themeVariables"])
+    monkey["primaryColor"] = "it's-navy"
+    saved = s.PALETTE["themeVariables"]
+    s.PALETTE["themeVariables"] = monkey
+    try:
+        d = s.mermaid_theme_directive()
+        assert "it\\'s-navy" in d
+    finally:
+        s.PALETTE["themeVariables"] = saved
 
 
 # --- CLI --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

P1-11 of the Portable Python Orchestration Core epic. `/ship` and `/implement` both require PR bodies with diagrams, evidence, contract/model conformance, and UX results — duplicating the Mermaid palette and section requirements in prose. This centralizes that.

Closes #47.

## Changes

- **`scripts/chief_wiggum/shipping.py`** — `build_pr_body()` assembles Summary / `Closes #N` / Architecture (themed Mermaid) / Changes / Test Evidence (from the verification manifest) / optional Model Conformance + UX + Review sections / checklist. `mermaid_theme_directive` + `mermaid_block` inject the shared palette (sequence variant). `validate_sections` enforces required sections; `suggest_title` / `gh_pr_create_command` wire the create step.
- **`scripts/draft_pr.py`** — CLI consuming verification/review/ux manifests + issue context; exits 1 if a required section is missing; can print the `gh pr create` command.
- **Command prompts** — `ship.md` Step 4 and `implement.md` Step 11 use `draft_pr.py` instead of a hand-copied palette + HEREDOC body.

## Acceptance criteria

- [x] Tests cover required section validation, issue linking, model conformance inclusion/omission, UX section inclusion, and Mermaid theme injection (16 tests).
- [x] `/ship` uses this helper to draft the PR body.
- [x] `/implement` Step 11 reuses the same helper.

## Verification

- `make lint` clean; `make test` — 261 passed (16 new).