### PR TITLE
feat: extract UX and design-fidelity mechanics (#46)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -398,14 +398,20 @@ If ANY verification fails: fix it directly, or re-launch the coding sub-agent wi
 
 ### Step 9: UX sanity + design-fidelity gate
 
-**Skip this step if**:
-- `--skip-browser-use` was explicitly passed, OR
-- The ticket has no frontend impact. Detect by checking all three signals:
-  1. Labels: if issue has no `frontend`, `ui`, `ux`, or `web` label, skip
-  2. Diff paths: if `git diff "$DEFAULT_BRANCH"...HEAD --name-only` shows no files under `ui/`, `frontend/`, `web/`, `src/components/`, `src/pages/`, `src/views/`, `*.tsx`, `*.vue`, `*.svelte`, `*.html`, `*.css`, `*.scss`, or similar front-end paths, skip
-  3. Frontend files: if the target repo has no `ui/` or `frontend/` directory at all, skip
+Run the tested gate to do all the mechanical setup — frontend-impact detection (diff paths + labels), ui-spec design-binding check, reference-screenshot discovery, and screenshot-capture planning — and emit a manifest:
 
-If any signal is positive, run the step.
+```bash
+git diff "$DEFAULT_BRANCH"...HEAD --name-only > "$TICKET_TMP/changed.txt"
+python3 "$CW_HOME/scripts/ux_gate.py" \
+  --changed-files "$TICKET_TMP/changed.txt" \
+  $(gh issue view "$issue_number" --repo "$owner_repo" --json labels -q '.labels[].name' | sed 's/^/--label /') \
+  --ui-spec "$MODELS_DIR/ui-spec.json" --design-dir "$TARGET_REPO/docs/design" \
+  --screenshot-dir "$TICKET_TMP/ux-screenshots" --markdown > "$TICKET_TMP/ux-manifest.md"
+```
+
+(Add `--have-browser-use` / `--have-playwright` based on the target repo's tooling.)
+
+**Skip this step if** `--skip-browser-use` was passed, or the manifest's `should_run_gate` is false (no frontend impact). If the manifest is **blocked** (frontend ticket with a design contract but no screenshot tooling), resolve the tooling — do not silently skip the design-fidelity gate. Otherwise run the judgment-heavy review below against the discovered reference screenshots.
 
 **Goal**: Verify that the implemented UI aligns with the *spirit* of the requirements — information architecture, menu coherence, field exposure, contextual clarity — AND with the **visual design contract** (`ui-spec.json` → `design` section): tokens applied, brand assets present, reference screenshots matched. Functional tests can pass while screens feel wrong or ship off-brand; this is the only step in the loop that actually *looks* at the result. "Build + tests green" is NOT sufficient to call a frontend ticket done.
 

--- a/scripts/chief_wiggum/ux.py
+++ b/scripts/chief_wiggum/ux.py
@@ -1,0 +1,229 @@
+"""UX and design-fidelity mechanics (P1-10).
+
+`/implement` Step 9 is high-value but currently long, fragile prose with inline
+shell/Python. The judgment-heavy review stays with an agent, but the mechanical
+parts — deciding whether a ticket is frontend, checking the ui-spec's design
+binding, discovering reference screenshots, and planning screenshot capture —
+should be tested code. This module produces a UX manifest the agent consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# File signals that a change touches the frontend.
+FRONTEND_EXTS = frozenset(
+    {".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte", ".css", ".scss", ".sass", ".less", ".html"}
+)
+FRONTEND_DIR_HINTS = frozenset(
+    {"components", "component", "pages", "page", "views", "view", "app", "ui", "styles", "style", "frontend", "client", "web"}
+)
+FRONTEND_LABELS = frozenset({"frontend", "ui", "ux", "design", "css", "styling"})
+
+IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+
+
+@dataclass
+class FrontendImpact:
+    is_frontend: bool
+    frontend_files: list[str] = field(default_factory=list)
+    reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def detect_frontend_impact(changed_files: list[str], labels: list[str] | None = None) -> FrontendImpact:
+    """Decide whether a ticket touches the frontend from its diff paths + labels."""
+    labels = [str(label).lower() for label in (labels or [])]
+    frontend_files: list[str] = []
+    for path in changed_files:
+        p = Path(path)
+        parts = {part.lower() for part in p.parts}
+        if p.suffix.lower() in FRONTEND_EXTS or (parts & FRONTEND_DIR_HINTS):
+            frontend_files.append(path)
+
+    reasons: list[str] = []
+    if frontend_files:
+        reasons.append(f"{len(frontend_files)} frontend file(s) changed")
+    matched_labels = sorted(set(labels) & FRONTEND_LABELS)
+    if matched_labels:
+        reasons.append(f"frontend label(s): {', '.join(matched_labels)}")
+
+    return FrontendImpact(
+        is_frontend=bool(frontend_files or matched_labels),
+        frontend_files=frontend_files,
+        reasons=reasons,
+    )
+
+
+@dataclass
+class DesignBinding:
+    has_design_section: bool
+    has_tokens: bool
+    has_component_library: bool
+    component_library: str | None = None
+    missing: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def check_design_tokens(ui_spec: dict | None) -> DesignBinding:
+    """Check the ui-spec ``design`` section binds tokens + a component library."""
+    design = (ui_spec or {}).get("design") or {}
+    has_design = bool(design)
+    tokens = design.get("tokens") or {}
+    lib = design.get("component_library")
+    lib_name = lib.get("name") if isinstance(lib, dict) else lib
+
+    missing: list[str] = []
+    if not has_design:
+        missing.append("design section")
+    else:
+        if not tokens:
+            missing.append("tokens")
+        if not lib_name:
+            missing.append("component_library")
+
+    return DesignBinding(
+        has_design_section=has_design,
+        has_tokens=bool(tokens),
+        has_component_library=bool(lib_name),
+        component_library=lib_name,
+        missing=missing,
+    )
+
+
+def discover_reference_screenshots(design_dir: str | Path | None, ui_spec: dict | None = None) -> list[str]:
+    """Find approved reference screenshots from docs/design/ and the ui-spec."""
+    found: list[str] = []
+    if design_dir:
+        base = Path(design_dir)
+        for sub in ("reference", "reference-screenshots"):
+            d = base / sub
+            if d.is_dir():
+                found.extend(
+                    str(p) for p in sorted(d.iterdir()) if p.suffix.lower() in IMAGE_EXTS
+                )
+    # Asset references declared in the ui-spec design section.
+    design = (ui_spec or {}).get("design") or {}
+    assets = design.get("assets") or []
+    if isinstance(assets, list):
+        for asset in assets:
+            ref = asset.get("path") if isinstance(asset, dict) else asset
+            if isinstance(ref, str) and Path(ref).suffix.lower() in IMAGE_EXTS:
+                found.append(ref)
+    # Deduplicate, preserve order.
+    seen: set[str] = set()
+    return [f for f in found if not (f in seen or seen.add(f))]
+
+
+@dataclass
+class CapturePlan:
+    tool: str | None
+    available: bool
+    blocker: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def plan_screenshot_capture(
+    *,
+    browser_use_available: bool = False,
+    playwright_available: bool = False,
+    has_design_contract: bool = False,
+) -> CapturePlan:
+    """Pick a screenshot tool, or report a structured blocker.
+
+    For a frontend ticket *with* a design contract, missing tooling is a blocker
+    (the design-fidelity gate can't run); without a contract it's just skipped.
+    """
+    if browser_use_available:
+        return CapturePlan(tool="browser-use", available=True)
+    if playwright_available:
+        return CapturePlan(tool="playwright", available=True)
+    blocker = (
+        "no screenshot tooling (browser-use / Playwright) available; "
+        "design-fidelity gate cannot run"
+        if has_design_contract
+        else None
+    )
+    return CapturePlan(tool=None, available=False, blocker=blocker)
+
+
+@dataclass
+class UXManifest:
+    frontend: FrontendImpact
+    design_binding: DesignBinding
+    reference_screenshots: list[str]
+    capture_plan: CapturePlan
+    screenshot_dir: str | None = None
+
+    @property
+    def should_run_gate(self) -> bool:
+        return self.frontend.is_frontend
+
+    @property
+    def blocked(self) -> bool:
+        return bool(self.capture_plan.blocker)
+
+    def to_dict(self) -> dict:
+        return {
+            "should_run_gate": self.should_run_gate,
+            "blocked": self.blocked,
+            "frontend": self.frontend.to_dict(),
+            "design_binding": self.design_binding.to_dict(),
+            "reference_screenshots": self.reference_screenshots,
+            "capture_plan": self.capture_plan.to_dict(),
+            "screenshot_dir": self.screenshot_dir,
+        }
+
+    def render_markdown(self) -> str:
+        lines = ["# UX Gate Manifest", ""]
+        lines.append(f"- Frontend ticket: {'yes' if self.frontend.is_frontend else 'no'}")
+        for r in self.frontend.reasons:
+            lines.append(f"  - {r}")
+        if not self.frontend.is_frontend:
+            lines.append("- Design-fidelity gate skipped (no frontend impact).")
+            return "\n".join(lines) + "\n"
+        db = self.design_binding
+        lines.append(f"- Design contract: {'present' if db.has_design_section else 'absent'}")
+        if db.missing:
+            lines.append(f"  - missing: {', '.join(db.missing)}")
+        if db.component_library:
+            lines.append(f"  - component library: {db.component_library}")
+        lines.append(f"- Reference screenshots: {len(self.reference_screenshots)}")
+        lines.append(f"- Capture tool: {self.capture_plan.tool or 'none'}")
+        if self.capture_plan.blocker:
+            lines.append(f"- ⚠️ BLOCKER: {self.capture_plan.blocker}")
+        return "\n".join(lines) + "\n"
+
+
+def build_ux_manifest(
+    changed_files: list[str],
+    *,
+    labels: list[str] | None = None,
+    ui_spec: dict | None = None,
+    design_dir: str | Path | None = None,
+    browser_use_available: bool = False,
+    playwright_available: bool = False,
+    screenshot_dir: str | None = None,
+) -> UXManifest:
+    frontend = detect_frontend_impact(changed_files, labels)
+    binding = check_design_tokens(ui_spec)
+    refs = discover_reference_screenshots(design_dir, ui_spec)
+    plan = plan_screenshot_capture(
+        browser_use_available=browser_use_available,
+        playwright_available=playwright_available,
+        has_design_contract=frontend.is_frontend and binding.has_design_section,
+    )
+    return UXManifest(
+        frontend=frontend,
+        design_binding=binding,
+        reference_screenshots=refs,
+        capture_plan=plan,
+        screenshot_dir=screenshot_dir,
+    )

--- a/scripts/chief_wiggum/ux.py
+++ b/scripts/chief_wiggum/ux.py
@@ -9,6 +9,7 @@ should be tested code. This module produces a UX manifest the agent consumes.
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -16,8 +17,11 @@ from pathlib import Path
 FRONTEND_EXTS = frozenset(
     {".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte", ".css", ".scss", ".sass", ".less", ".html"}
 )
+# Strong, unambiguous frontend directory names only — generic segments like
+# "app"/"web"/"client"/"page"/"view" are excluded because they also appear in
+# backend paths (app/models.py, internal/web/server.go, pkg/client/http.go).
 FRONTEND_DIR_HINTS = frozenset(
-    {"components", "component", "pages", "page", "views", "view", "app", "ui", "styles", "style", "frontend", "client", "web"}
+    {"components", "pages", "views", "ui", "styles", "stylesheets", "frontend", "webapp"}
 )
 FRONTEND_LABELS = frozenset({"frontend", "ui", "ux", "design", "css", "styling"})
 
@@ -34,9 +38,15 @@ class FrontendImpact:
         return asdict(self)
 
 
+def _label_is_frontend(label: str) -> bool:
+    # Normalize separators (area/frontend, type: ui, frontend-impact) into tokens.
+    tokens = {t for t in re.split(r"[^a-z0-9]+", label.lower()) if t}
+    return bool(tokens & FRONTEND_LABELS)
+
+
 def detect_frontend_impact(changed_files: list[str], labels: list[str] | None = None) -> FrontendImpact:
     """Decide whether a ticket touches the frontend from its diff paths + labels."""
-    labels = [str(label).lower() for label in (labels or [])]
+    raw_labels = [str(label) for label in (labels or [])]
     frontend_files: list[str] = []
     for path in changed_files:
         p = Path(path)
@@ -47,7 +57,7 @@ def detect_frontend_impact(changed_files: list[str], labels: list[str] | None = 
     reasons: list[str] = []
     if frontend_files:
         reasons.append(f"{len(frontend_files)} frontend file(s) changed")
-    matched_labels = sorted(set(labels) & FRONTEND_LABELS)
+    matched_labels = sorted(label for label in raw_labels if _label_is_frontend(label))
     if matched_labels:
         reasons.append(f"frontend label(s): {', '.join(matched_labels)}")
 
@@ -70,11 +80,31 @@ class DesignBinding:
         return asdict(self)
 
 
+def _has_concrete_tokens(tokens: dict) -> bool:
+    """True if tokens hold real values (not just empty containers)."""
+    if not isinstance(tokens, dict) or not tokens:
+        return False
+    # A concrete primary colour is the strongest signal per the ui-spec schema.
+    primary = (tokens.get("colors") or {}).get("primary") if isinstance(tokens.get("colors"), dict) else None
+    if primary:
+        return True
+
+    def _any_leaf(node) -> bool:
+        if isinstance(node, dict):
+            return any(_any_leaf(v) for v in node.values())
+        if isinstance(node, list):
+            return any(_any_leaf(v) for v in node)
+        return bool(node) or node == 0
+
+    return _any_leaf(tokens)
+
+
 def check_design_tokens(ui_spec: dict | None) -> DesignBinding:
     """Check the ui-spec ``design`` section binds tokens + a component library."""
     design = (ui_spec or {}).get("design") or {}
     has_design = bool(design)
     tokens = design.get("tokens") or {}
+    has_tokens = _has_concrete_tokens(tokens)
     lib = design.get("component_library")
     lib_name = lib.get("name") if isinstance(lib, dict) else lib
 
@@ -82,14 +112,14 @@ def check_design_tokens(ui_spec: dict | None) -> DesignBinding:
     if not has_design:
         missing.append("design section")
     else:
-        if not tokens:
+        if not has_tokens:
             missing.append("tokens")
         if not lib_name:
             missing.append("component_library")
 
     return DesignBinding(
         has_design_section=has_design,
-        has_tokens=bool(tokens),
+        has_tokens=has_tokens,
         has_component_library=bool(lib_name),
         component_library=lib_name,
         missing=missing,
@@ -107,12 +137,15 @@ def discover_reference_screenshots(design_dir: str | Path | None, ui_spec: dict 
                 found.extend(
                     str(p) for p in sorted(d.iterdir()) if p.suffix.lower() in IMAGE_EXTS
                 )
-    # Asset references declared in the ui-spec design section.
+    # Reference-screenshot assets declared in the ui-spec design section. Only
+    # assets explicitly typed as reference-screenshot count — not logos/icons.
     design = (ui_spec or {}).get("design") or {}
     assets = design.get("assets") or []
     if isinstance(assets, list):
         for asset in assets:
-            ref = asset.get("path") if isinstance(asset, dict) else asset
+            if not isinstance(asset, dict) or asset.get("type") != "reference-screenshot":
+                continue
+            ref = asset.get("path")
             if isinstance(ref, str) and Path(ref).suffix.lower() in IMAGE_EXTS:
                 found.append(ref)
     # Deduplicate, preserve order.

--- a/scripts/ux_gate.py
+++ b/scripts/ux_gate.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""CLI for UX and design-fidelity mechanics (P1-10).
+
+Does the cheap, mechanical setup for /implement Step 9 — frontend-impact
+detection, ui-spec design-binding check, reference-screenshot discovery, and
+screenshot-capture planning — and emits a UX manifest the agent consumes before
+the judgment-heavy review.
+
+Example:
+    python3 scripts/ux_gate.py \
+      --changed-files "$TICKET_TMP/changed.txt" \
+      --label frontend --ui-spec "$MODELS_DIR/ui-spec.json" \
+      --design-dir "$TARGET_REPO/docs/design" \
+      --have-playwright --screenshot-dir "$TICKET_TMP/ux-screenshots" --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import ux  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="UX / design-fidelity gate setup")
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--changed-files", help="File with one changed path per line")
+    src.add_argument("--changed", action="append", default=[], help="A changed path (repeatable)")
+    parser.add_argument("--label", action="append", default=[], help="Issue label (repeatable)")
+    parser.add_argument("--ui-spec", help="Path to ui-spec.json")
+    parser.add_argument("--design-dir", help="Path to docs/design/")
+    parser.add_argument("--have-browser-use", action="store_true")
+    parser.add_argument("--have-playwright", action="store_true")
+    parser.add_argument("--screenshot-dir")
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument("--json", action="store_true")
+    out.add_argument("--markdown", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.changed_files:
+        changed = [ln.strip() for ln in Path(args.changed_files).read_text().splitlines() if ln.strip()]
+    else:
+        changed = args.changed
+
+    ui_spec = None
+    if args.ui_spec and Path(args.ui_spec).exists():
+        try:
+            ui_spec = json.loads(Path(args.ui_spec).read_text())
+        except json.JSONDecodeError as exc:
+            print(f"Error: malformed ui-spec: {exc}", file=sys.stderr)
+            return 1
+
+    manifest = ux.build_ux_manifest(
+        changed,
+        labels=args.label,
+        ui_spec=ui_spec,
+        design_dir=args.design_dir,
+        browser_use_available=args.have_browser_use,
+        playwright_available=args.have_playwright,
+        screenshot_dir=args.screenshot_dir,
+    )
+
+    if args.markdown:
+        print(manifest.render_markdown())
+    else:
+        print(json.dumps(manifest.to_dict(), indent=2))
+
+    # A frontend ticket with a design contract but no capture tooling is blocked.
+    return 1 if manifest.blocked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ux_gate.py
+++ b/tests/test_ux_gate.py
@@ -33,6 +33,20 @@ def test_no_frontend_impact():
     assert impact.frontend_files == []
 
 
+def test_generic_dirs_are_not_frontend():
+    # app/web/client are ambiguous and must not trigger frontend on their own.
+    impact = ux.detect_frontend_impact(
+        ["app/models.py", "internal/web/server.go", "pkg/client/http.go"]
+    )
+    assert impact.is_frontend is False
+
+
+def test_normalized_label_formats_match():
+    for label in ["area/frontend", "type: ui", "frontend-impact"]:
+        impact = ux.detect_frontend_impact(["server/api.go"], labels=[label])
+        assert impact.is_frontend is True, label
+
+
 # --- design token binding ---------------------------------------------------
 
 
@@ -45,9 +59,16 @@ def test_design_tokens_present():
 
 
 def test_design_tokens_missing_library():
-    spec = {"design": {"tokens": {"colors": {}}}}
+    spec = {"design": {"tokens": {"colors": {"primary": "#000"}}}}
     db = ux.check_design_tokens(spec)
     assert "component_library" in db.missing
+
+
+def test_hollow_tokens_are_not_concrete():
+    # Empty token containers must not count as having tokens.
+    db = ux.check_design_tokens({"design": {"tokens": {"colors": {}}, "component_library": "x"}})
+    assert db.has_tokens is False
+    assert "tokens" in db.missing
 
 
 def test_no_design_section():
@@ -73,10 +94,18 @@ def test_discover_reference_screenshots_from_dir(tmp_path):
     assert len(found) == 1 and found[0].endswith("home.png")
 
 
-def test_discover_reference_screenshots_from_ui_spec_assets():
-    spec = {"design": {"assets": [{"path": "docs/design/mock.png"}, {"path": "notes.md"}]}}
+def test_discover_reference_screenshots_filters_by_asset_type():
+    spec = {
+        "design": {
+            "assets": [
+                {"type": "reference-screenshot", "path": "docs/design/home.png"},
+                {"type": "logo", "path": "docs/design/logo.png"},  # not a screenshot
+                {"path": "docs/design/untyped.png"},  # no type -> excluded
+            ]
+        }
+    }
     found = ux.discover_reference_screenshots(None, spec)
-    assert found == ["docs/design/mock.png"]
+    assert found == ["docs/design/home.png"]
 
 
 # --- capture planning -------------------------------------------------------

--- a/tests/test_ux_gate.py
+++ b/tests/test_ux_gate.py
@@ -1,0 +1,143 @@
+"""Tests for UX and design-fidelity mechanics (P1-10)."""
+
+from __future__ import annotations
+
+import json
+
+import ux_gate
+from chief_wiggum import ux
+
+# --- frontend impact detection ----------------------------------------------
+
+
+def test_frontend_detected_by_extension():
+    impact = ux.detect_frontend_impact(["src/components/Button.tsx", "README.md"])
+    assert impact.is_frontend is True
+    assert impact.frontend_files == ["src/components/Button.tsx"]
+
+
+def test_frontend_detected_by_dir_hint():
+    impact = ux.detect_frontend_impact(["app/pages/home.py"])
+    assert impact.is_frontend is True
+
+
+def test_frontend_detected_by_label():
+    impact = ux.detect_frontend_impact(["server/api.go"], labels=["backend", "UI"])
+    assert impact.is_frontend is True
+    assert any("label" in r for r in impact.reasons)
+
+
+def test_no_frontend_impact():
+    impact = ux.detect_frontend_impact(["server/api.go", "db/schema.sql"], labels=["backend"])
+    assert impact.is_frontend is False
+    assert impact.frontend_files == []
+
+
+# --- design token binding ---------------------------------------------------
+
+
+def test_design_tokens_present():
+    spec = {"design": {"tokens": {"colors": {"primary": "#000"}}, "component_library": {"name": "shadcn"}}}
+    db = ux.check_design_tokens(spec)
+    assert db.has_design_section and db.has_tokens and db.has_component_library
+    assert db.component_library == "shadcn"
+    assert db.missing == []
+
+
+def test_design_tokens_missing_library():
+    spec = {"design": {"tokens": {"colors": {}}}}
+    db = ux.check_design_tokens(spec)
+    assert "component_library" in db.missing
+
+
+def test_no_design_section():
+    db = ux.check_design_tokens({"pages": []})
+    assert db.has_design_section is False
+    assert "design section" in db.missing
+
+
+def test_component_library_as_plain_string():
+    db = ux.check_design_tokens({"design": {"tokens": {"x": 1}, "component_library": "mui"}})
+    assert db.component_library == "mui"
+
+
+# --- reference screenshot discovery -----------------------------------------
+
+
+def test_discover_reference_screenshots_from_dir(tmp_path):
+    ref = tmp_path / "reference"
+    ref.mkdir()
+    (ref / "home.png").write_bytes(b"x")
+    (ref / "notes.txt").write_text("ignore")
+    found = ux.discover_reference_screenshots(tmp_path)
+    assert len(found) == 1 and found[0].endswith("home.png")
+
+
+def test_discover_reference_screenshots_from_ui_spec_assets():
+    spec = {"design": {"assets": [{"path": "docs/design/mock.png"}, {"path": "notes.md"}]}}
+    found = ux.discover_reference_screenshots(None, spec)
+    assert found == ["docs/design/mock.png"]
+
+
+# --- capture planning -------------------------------------------------------
+
+
+def test_capture_prefers_browser_use():
+    plan = ux.plan_screenshot_capture(browser_use_available=True, playwright_available=True)
+    assert plan.tool == "browser-use" and plan.available
+
+
+def test_capture_falls_back_to_playwright():
+    plan = ux.plan_screenshot_capture(playwright_available=True)
+    assert plan.tool == "playwright"
+
+
+def test_capture_blocker_when_contract_but_no_tooling():
+    plan = ux.plan_screenshot_capture(has_design_contract=True)
+    assert plan.available is False and plan.blocker
+
+
+def test_capture_no_blocker_without_contract():
+    plan = ux.plan_screenshot_capture(has_design_contract=False)
+    assert plan.blocker is None
+
+
+# --- manifest ---------------------------------------------------------------
+
+
+def test_manifest_skips_gate_for_non_frontend():
+    m = ux.build_ux_manifest(["server/api.go"], labels=["backend"])
+    assert m.should_run_gate is False
+    assert "skipped" in m.render_markdown()
+
+
+def test_manifest_blocked_for_frontend_with_contract_no_tooling():
+    spec = {"design": {"tokens": {"c": 1}, "component_library": "x"}}
+    m = ux.build_ux_manifest(["ui/App.tsx"], labels=["frontend"], ui_spec=spec)
+    assert m.should_run_gate is True
+    assert m.blocked is True
+    assert "BLOCKER" in m.render_markdown()
+
+
+def test_manifest_serializable(tmp_path):
+    m = ux.build_ux_manifest(["ui/App.tsx"], playwright_available=True)
+    json.loads(json.dumps(m.to_dict()))
+    assert m.to_dict()["capture_plan"]["tool"] == "playwright"
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_json_non_frontend(tmp_path, capsys):
+    changed = tmp_path / "changed.txt"
+    changed.write_text("server/api.go\n")
+    rc = ux_gate.main(["--changed-files", str(changed), "--label", "backend"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["should_run_gate"] is False
+
+
+def test_cli_exit_1_when_blocked(tmp_path, capsys):
+    spec = tmp_path / "ui-spec.json"
+    spec.write_text(json.dumps({"design": {"tokens": {"c": 1}, "component_library": "x"}}))
+    rc = ux_gate.main(["--changed", "ui/App.tsx", "--label", "frontend", "--ui-spec", str(spec)])
+    assert rc == 1  # design contract present, no capture tooling


### PR DESCRIPTION
## Summary

P1-10 of the Portable Python Orchestration Core epic. `/implement` Step 9 was long, fragile prose with inline shell/Python for frontend detection, design-token checks, screenshot discovery, and capture planning. This extracts the mechanical parts into tested code; the judgment-heavy review stays with the agent.

Closes #46.

## Changes

- **`scripts/chief_wiggum/ux.py`**
  - `detect_frontend_impact` — from diff paths (ext + dir hints) and labels.
  - `check_design_tokens` — ui-spec `design` section binds `tokens` + `component_library`; reports what's missing.
  - `discover_reference_screenshots` — `docs/design/reference[-screenshots]/` images + ui-spec `design.assets`.
  - `plan_screenshot_capture` — browser-use → Playwright → **structured blocker** when a frontend ticket has a design contract but no tooling.
  - `build_ux_manifest` — combined JSON/markdown manifest with `should_run_gate` / `blocked`.
- **`scripts/ux_gate.py`** — CLI emitting the manifest; exit 1 when blocked.
- **`implement.md` Step 9** — runs `ux_gate.py` for the mechanical setup.

## Acceptance criteria

- [x] Tests cover frontend path detection, label detection, no-frontend skip, token present/missing checks, design asset discovery, and manifest rendering (19 tests).
- [x] `/implement` Step 9 uses the helper for mechanical setup before launching the UX reviewer.
- [x] For frontend tickets with a design contract, missing screenshot tooling is reported as a structured blocker.

## Verification

- `make lint` clean; `make test` — 282 passed (19 new).