### PR TITLE
feat: extract traceability matrix parser and updater (#49)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -47,11 +47,19 @@ Verify all tickets are closed. If any are still open, report which ones and ask 
 
 ### Step 2: Traceability audit
 
-Read the traceability matrix. For each acceptance criterion:
+Parse and audit the traceability matrix with the tested helper. It returns per-status counts, coverage %, and the gap list (rows with no test, or `missing`/`failing` status):
 
-1. Check if a test exists that covers it (grep for test names or patterns referenced in the matrix)
-2. Run the specific test and verify it passes
-3. Mark status: `passing`, `failing`, `missing`
+```bash
+python3 "$CW_HOME/scripts/traceability.py" audit "$EPIC_DIR/traceability.md"
+```
+
+Then, for each acceptance criterion the audit flags as a gap (or still `covered` rather than `passing`):
+
+1. Run the specific test referenced in the row and verify it passes.
+2. Record the verified status with the updater (`passing` / `failing` / `missing`):
+   ```bash
+   python3 "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" --ticket 43 --status passing --ac "Create order"
+   ```
 
 Report:
 ```markdown

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -627,13 +627,16 @@ gh pr create --repo "$owner_repo" --title "$pr_title" --body-file "$TICKET_TMP/p
 
 ### Step 13: Update traceability matrix
 
-If epic context exists, update the traceability matrix to reflect the tests written:
+If epic context exists, flip this ticket's rows from `pending` to `covered` with the tested updater (it parses, updates by ticket/AC, and re-renders the table in place — no brittle manual markdown edits):
 
 ```bash
-# Update status from "pending" to "covered" for each AC this ticket addressed
+python3 "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" \
+  --ticket "$issue_number" --status covered
+# Narrow to specific rows with --ac "<criterion text>" when a ticket only
+# partially addresses its ACs.
 ```
 
-This can be a comment on the epic milestone or a commit to the traceability file, depending on whether other tickets are in flight.
+Commit the updated `traceability.md` (or comment on the epic milestone if other tickets are in flight).
 
 Close the loop:
 - Ask if the issue should be updated with a comment linking to the PR

--- a/scripts/chief_wiggum/traceability.py
+++ b/scripts/chief_wiggum/traceability.py
@@ -18,6 +18,7 @@ STATUSES = ("pending", "covered", "passing", "failing", "missing")
 
 _COLUMN_KEYS = {
     "ticket": "ticket",
+    "ac": "ac",
     "acceptance criterion": "ac",
     "acceptance criteria": "ac",
     "unit test": "unit_test",
@@ -25,6 +26,7 @@ _COLUMN_KEYS = {
     "e2e test": "e2e_test",
     "status": "status",
 }
+_REQUIRED_COLUMNS = ("ticket", "ac", "status")
 
 
 @dataclass
@@ -51,6 +53,9 @@ class TraceRow:
 class TraceMatrix:
     rows: list[TraceRow] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    # Inclusive line span of the parsed table in the source (for in-place edits).
+    table_start: int | None = None
+    table_end: int | None = None
 
     def to_dict(self) -> dict:
         return {"rows": [r.to_dict() for r in self.rows], "warnings": list(self.warnings)}
@@ -99,31 +104,59 @@ def _parse_ticket(value: str) -> int | None:
         return None
 
 
-def parse_matrix(markdown: str) -> TraceMatrix:
-    """Parse the first markdown table in ``markdown`` into a :class:`TraceMatrix`."""
-    matrix = TraceMatrix()
-    header: list[str] | None = None
-    col_index: dict[str, int] = {}
-
-    for raw in markdown.splitlines():
+def _header_candidates(lines: list[str]) -> list[tuple[int, dict[str, int]]]:
+    """Find (index, column-map) for each ``| header |`` line followed by a separator."""
+    candidates: list[tuple[int, dict[str, int]]] = []
+    for i, raw in enumerate(lines):
         line = raw.strip()
         if not line.startswith("|"):
-            if header is not None:
-                break  # table ended
             continue
         cells = _split_cells(line)
-        if header is None:
-            header = [c.lower() for c in cells]
-            col_index = {
-                _COLUMN_KEYS[h]: i for i, h in enumerate(header) if h in _COLUMN_KEYS
-            }
-            for required in ("ticket", "ac", "status"):
-                if required not in col_index:
-                    matrix.warnings.append(f"missing required column: {required}")
-            continue
-        if _is_separator(cells):
-            continue
+        col_index = {
+            _COLUMN_KEYS[c.lower()]: j for j, c in enumerate(cells) if c.lower() in _COLUMN_KEYS
+        }
+        nxt = lines[i + 1].strip() if i + 1 < len(lines) else ""
+        if nxt.startswith("|") and _is_separator(_split_cells(nxt)):
+            candidates.append((i, col_index))
+    return candidates
 
+
+def parse_matrix(markdown: str) -> TraceMatrix:
+    """Parse the traceability table in ``markdown`` into a :class:`TraceMatrix`.
+
+    Detects the real matrix robustly: scans for a ``| header |`` line followed by
+    a separator, preferring the first one that has all required columns (so an
+    unrelated earlier table doesn't shadow it). Tracks the table's line span so a
+    later update can rewrite *only* the table, preserving surrounding prose.
+    """
+    matrix = TraceMatrix()
+    lines = markdown.splitlines()
+    candidates = _header_candidates(lines)
+    if not candidates:
+        matrix.warnings.append("no traceability table found")
+        return matrix
+
+    chosen = next(
+        (c for c in candidates if set(_REQUIRED_COLUMNS) <= set(c[1])),
+        candidates[0],
+    )
+    header_idx, col_index = chosen
+    for required in _REQUIRED_COLUMNS:
+        if required not in col_index:
+            matrix.warnings.append(f"missing required column: {required}")
+
+    matrix.table_start = header_idx
+    matrix.table_end = header_idx + 1  # separator line
+    i = header_idx + 2
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line.startswith("|"):
+            break
+        cells = _split_cells(line)
+        if _is_separator(cells):
+            matrix.table_end = i
+            i += 1
+            continue
         status = _cell(cells, col_index, "status").lower() or "pending"
         if status not in STATUSES:
             matrix.warnings.append(
@@ -139,10 +172,20 @@ def parse_matrix(markdown: str) -> TraceMatrix:
                 status=status,
             )
         )
-
-    if header is None:
-        matrix.warnings.append("no traceability table found")
+        matrix.table_end = i
+        i += 1
     return matrix
+
+
+def replace_table(original: str, matrix: TraceMatrix) -> str:
+    """Rewrite only the table span in ``original``, preserving surrounding prose."""
+    if matrix.table_start is None or matrix.table_end is None:
+        return original
+    lines = original.splitlines()
+    rendered = render_markdown(matrix).rstrip("\n").splitlines()
+    new_lines = lines[: matrix.table_start] + rendered + lines[matrix.table_end + 1 :]
+    text = "\n".join(new_lines)
+    return text + "\n" if original.endswith("\n") else text
 
 
 def update_status(
@@ -179,12 +222,15 @@ def audit(matrix: TraceMatrix) -> dict:
     """Summarize coverage: counts per status, gaps, and ticket rollup."""
     counts = dict.fromkeys(STATUSES, 0)
     gaps: list[dict] = []
+    covered = 0
     for row in matrix.rows:
         counts[row.status] = counts.get(row.status, 0) + 1
+        # Genuinely covered: a covered/passing status backed by a real test ref.
+        if row.status in ("covered", "passing") and row.has_test:
+            covered += 1
         if not row.has_test or row.status in ("missing", "failing"):
             gaps.append({"ticket": row.ticket, "ac": row.ac, "status": row.status})
     total = len(matrix.rows)
-    covered = counts["covered"] + counts["passing"]
     return {
         "total": total,
         "counts": counts,

--- a/scripts/chief_wiggum/traceability.py
+++ b/scripts/chief_wiggum/traceability.py
@@ -1,0 +1,207 @@
+"""Traceability matrix parser and updater (P2-13).
+
+`/architect` writes a ``traceability.md`` markdown table mapping each ticket's
+acceptance criteria to the tests that cover them. ``/implement`` flips a row to
+``covered`` when it writes the test and ``/close-epic`` audits coverage — but
+those updates are described as manual markdown edits. This parses, updates, and
+audits the table with tested code.
+
+Table columns (from /architect):
+    Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+STATUSES = ("pending", "covered", "passing", "failing", "missing")
+
+_COLUMN_KEYS = {
+    "ticket": "ticket",
+    "acceptance criterion": "ac",
+    "acceptance criteria": "ac",
+    "unit test": "unit_test",
+    "integration test": "integration_test",
+    "e2e test": "e2e_test",
+    "status": "status",
+}
+
+
+@dataclass
+class TraceRow:
+    ticket: int | None
+    ac: str
+    unit_test: str = ""
+    integration_test: str = ""
+    e2e_test: str = ""
+    status: str = "pending"
+
+    @property
+    def has_test(self) -> bool:
+        return any(
+            t and t not in ("—", "-", "")
+            for t in (self.unit_test, self.integration_test, self.e2e_test)
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class TraceMatrix:
+    rows: list[TraceRow] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {"rows": [r.to_dict() for r in self.rows], "warnings": list(self.warnings)}
+
+
+def _split_cells(line: str) -> list[str]:
+    """Split a markdown table row on unescaped pipes, trimming the outer ones."""
+    cells: list[str] = []
+    buf = ""
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if ch == "\\" and i + 1 < len(line) and line[i + 1] == "|":
+            buf += "|"  # escaped pipe -> literal
+            i += 2
+            continue
+        if ch == "|":
+            cells.append(buf)
+            buf = ""
+        else:
+            buf += ch
+        i += 1
+    cells.append(buf)
+    # A leading/trailing pipe produces empty first/last cells — drop them.
+    if cells and cells[0].strip() == "":
+        cells = cells[1:]
+    if cells and cells[-1].strip() == "":
+        cells = cells[:-1]
+    return [c.strip() for c in cells]
+
+
+def _is_separator(cells: list[str]) -> bool:
+    return bool(cells) and all(set(c) <= set("-: ") and "-" in c for c in cells)
+
+
+def _cell(cells: list[str], col_index: dict[str, int], key: str) -> str:
+    idx = col_index.get(key)
+    return cells[idx] if idx is not None and idx < len(cells) else ""
+
+
+def _parse_ticket(value: str) -> int | None:
+    v = value.strip().lstrip("#").strip()
+    try:
+        return int(v)
+    except ValueError:
+        return None
+
+
+def parse_matrix(markdown: str) -> TraceMatrix:
+    """Parse the first markdown table in ``markdown`` into a :class:`TraceMatrix`."""
+    matrix = TraceMatrix()
+    header: list[str] | None = None
+    col_index: dict[str, int] = {}
+
+    for raw in markdown.splitlines():
+        line = raw.strip()
+        if not line.startswith("|"):
+            if header is not None:
+                break  # table ended
+            continue
+        cells = _split_cells(line)
+        if header is None:
+            header = [c.lower() for c in cells]
+            col_index = {
+                _COLUMN_KEYS[h]: i for i, h in enumerate(header) if h in _COLUMN_KEYS
+            }
+            for required in ("ticket", "ac", "status"):
+                if required not in col_index:
+                    matrix.warnings.append(f"missing required column: {required}")
+            continue
+        if _is_separator(cells):
+            continue
+
+        status = _cell(cells, col_index, "status").lower() or "pending"
+        if status not in STATUSES:
+            matrix.warnings.append(
+                f"unknown status {status!r} for ticket {_cell(cells, col_index, 'ticket')!r}"
+            )
+        matrix.rows.append(
+            TraceRow(
+                ticket=_parse_ticket(_cell(cells, col_index, "ticket")),
+                ac=_cell(cells, col_index, "ac"),
+                unit_test=_cell(cells, col_index, "unit_test"),
+                integration_test=_cell(cells, col_index, "integration_test"),
+                e2e_test=_cell(cells, col_index, "e2e_test"),
+                status=status,
+            )
+        )
+
+    if header is None:
+        matrix.warnings.append("no traceability table found")
+    return matrix
+
+
+def update_status(
+    matrix: TraceMatrix,
+    *,
+    ticket: int,
+    status: str,
+    ac_contains: str | None = None,
+    test_contains: str | None = None,
+) -> int:
+    """Set ``status`` on matching rows; return the number updated.
+
+    Matches rows by ticket, optionally narrowed by an acceptance-criterion
+    substring and/or a test-reference substring.
+    """
+    if status not in STATUSES:
+        raise ValueError(f"invalid status: {status!r} (expected one of {', '.join(STATUSES)})")
+    updated = 0
+    for row in matrix.rows:
+        if row.ticket != ticket:
+            continue
+        if ac_contains and ac_contains.lower() not in row.ac.lower():
+            continue
+        if test_contains:
+            joined = " ".join((row.unit_test, row.integration_test, row.e2e_test)).lower()
+            if test_contains.lower() not in joined:
+                continue
+        row.status = status
+        updated += 1
+    return updated
+
+
+def audit(matrix: TraceMatrix) -> dict:
+    """Summarize coverage: counts per status, gaps, and ticket rollup."""
+    counts = dict.fromkeys(STATUSES, 0)
+    gaps: list[dict] = []
+    for row in matrix.rows:
+        counts[row.status] = counts.get(row.status, 0) + 1
+        if not row.has_test or row.status in ("missing", "failing"):
+            gaps.append({"ticket": row.ticket, "ac": row.ac, "status": row.status})
+    total = len(matrix.rows)
+    covered = counts["covered"] + counts["passing"]
+    return {
+        "total": total,
+        "counts": counts,
+        "covered": covered,
+        "coverage_pct": round(100 * covered / total, 1) if total else 0.0,
+        "gaps": gaps,
+        "warnings": list(matrix.warnings),
+    }
+
+
+def render_markdown(matrix: TraceMatrix) -> str:
+    header = "| Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status |"
+    sep = "|--------|---------------------|-----------|-----------------|----------|--------|"
+    lines = [header, sep]
+    for r in matrix.rows:
+        ticket = f"#{r.ticket}" if r.ticket is not None else ""
+        cells = [ticket, r.ac, r.unit_test or "—", r.integration_test or "—", r.e2e_test or "—", r.status]
+        escaped = [c.replace("|", "\\|") for c in cells]
+        lines.append("| " + " | ".join(escaped) + " |")
+    return "\n".join(lines) + "\n"

--- a/scripts/traceability.py
+++ b/scripts/traceability.py
@@ -65,7 +65,8 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         if n == 0:
             print(f"Warning: no rows matched ticket #{args.ticket}", file=sys.stderr)
-        path.write_text(tr.render_markdown(matrix))
+        # Rewrite only the table span, preserving surrounding prose.
+        path.write_text(tr.replace_table(path.read_text(), matrix))
         print(f"OK: updated {n} row(s) to {args.status}")
     return 0
 

--- a/scripts/traceability.py
+++ b/scripts/traceability.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""CLI for the traceability matrix parser/updater (P2-13).
+
+Parses, audits, and updates the ``traceability.md`` table /architect generates.
+``/implement`` Step 13 flips rows to covered; ``/close-epic`` Step 2 audits.
+
+Examples:
+    # Audit coverage as JSON
+    python3 scripts/traceability.py audit docs/epics/x/traceability.md
+
+    # Mark a ticket's rows covered (in place)
+    python3 scripts/traceability.py update docs/epics/x/traceability.md \
+      --ticket 42 --status covered --ac "GET /health"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import traceability as tr  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Traceability matrix parser/updater")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_audit = sub.add_parser("audit", help="Parse and summarize coverage")
+    p_audit.add_argument("path")
+
+    p_render = sub.add_parser("render", help="Re-render the parsed table")
+    p_render.add_argument("path")
+
+    p_update = sub.add_parser("update", help="Set status on matching rows, in place")
+    p_update.add_argument("path")
+    p_update.add_argument("--ticket", type=int, required=True)
+    p_update.add_argument("--status", required=True, choices=tr.STATUSES)
+    p_update.add_argument("--ac", help="Narrow to rows whose AC contains this text")
+    p_update.add_argument("--test", help="Narrow to rows whose test refs contain this text")
+
+    args = parser.parse_args(argv)
+    path = Path(args.path)
+    if not path.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        return 1
+
+    matrix = tr.parse_matrix(path.read_text())
+
+    if args.command == "audit":
+        print(json.dumps(tr.audit(matrix), indent=2))
+    elif args.command == "render":
+        print(tr.render_markdown(matrix))
+    elif args.command == "update":
+        try:
+            n = tr.update_status(
+                matrix, ticket=args.ticket, status=args.status,
+                ac_contains=args.ac, test_contains=args.test,
+            )
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        if n == 0:
+            print(f"Warning: no rows matched ticket #{args.ticket}", file=sys.stderr)
+        path.write_text(tr.render_markdown(matrix))
+        print(f"OK: updated {n} row(s) to {args.status}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -1,0 +1,155 @@
+"""Tests for the traceability matrix parser/updater (P2-13)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import traceability as cli
+from chief_wiggum import traceability as tr
+
+TABLE = """\
+Some intro prose.
+
+| Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status |
+|--------|---------------------|-----------|-----------------|----------|--------|
+| #42 | GET /health returns 200 | api_test.go:TestHealth | — | — | pending |
+| #42 | Order model has all fields | model_test.go:TestOrderFields | — | — | covered |
+| #43 | Create order returns 201 | api_test.go:TestCreateOrder | IT-1 | — | passing |
+| #44 | Admin sees orders | — | — | — | missing |
+
+More prose after.
+"""
+
+
+# --- parsing ----------------------------------------------------------------
+
+
+def test_parse_normal_table():
+    m = tr.parse_matrix(TABLE)
+    assert len(m.rows) == 4
+    assert m.rows[0].ticket == 42
+    assert m.rows[0].ac == "GET /health returns 200"
+    assert m.rows[2].status == "passing"
+    assert m.warnings == []
+
+
+def test_parse_stops_at_blank_after_table():
+    m = tr.parse_matrix(TABLE)
+    # "More prose" must not be parsed as a row.
+    assert all(r.ac != "More prose after." for r in m.rows)
+
+
+def test_parse_escaped_pipes():
+    table = (
+        "| Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status |\n"
+        "|---|---|---|---|---|---|\n"
+        "| #7 | value a \\| value b | t | — | — | pending |\n"
+    )
+    m = tr.parse_matrix(table)
+    assert m.rows[0].ac == "value a | value b"
+
+
+def test_parse_missing_columns_warns():
+    table = "| Ticket | Status |\n|---|---|\n| #1 | pending |\n"
+    m = tr.parse_matrix(table)
+    assert any("missing required column: ac" in w for w in m.warnings)
+
+
+def test_parse_no_table_warns():
+    m = tr.parse_matrix("no table here\n")
+    assert any("no traceability table" in w for w in m.warnings)
+
+
+def test_parse_unknown_status_warns():
+    table = (
+        "| Ticket | Acceptance Criterion | Status |\n|---|---|---|\n| #1 | x | bogus |\n"
+    )
+    m = tr.parse_matrix(table)
+    assert any("unknown status" in w for w in m.warnings)
+
+
+def test_duplicate_acs_kept_as_separate_rows():
+    table = (
+        "| Ticket | Acceptance Criterion | Status |\n|---|---|---|\n"
+        "| #1 | same AC | pending |\n| #1 | same AC | covered |\n"
+    )
+    m = tr.parse_matrix(table)
+    assert len(m.rows) == 2
+    assert [r.status for r in m.rows] == ["pending", "covered"]
+
+
+# --- updates ----------------------------------------------------------------
+
+
+def test_update_all_rows_for_ticket():
+    m = tr.parse_matrix(TABLE)
+    n = tr.update_status(m, ticket=42, status="passing")
+    assert n == 2
+    assert all(r.status == "passing" for r in m.rows if r.ticket == 42)
+
+
+def test_update_narrowed_by_ac():
+    m = tr.parse_matrix(TABLE)
+    n = tr.update_status(m, ticket=42, status="failing", ac_contains="health")
+    assert n == 1
+    assert m.rows[0].status == "failing"
+    assert m.rows[1].status == "covered"  # unchanged
+
+
+def test_update_narrowed_by_test_ref():
+    m = tr.parse_matrix(TABLE)
+    n = tr.update_status(m, ticket=43, status="passing", test_contains="IT-1")
+    assert n == 1
+
+
+def test_update_invalid_status_raises():
+    m = tr.parse_matrix(TABLE)
+    with pytest.raises(ValueError):
+        tr.update_status(m, ticket=42, status="bogus")
+
+
+# --- audit + render ---------------------------------------------------------
+
+
+def test_audit_counts_and_gaps():
+    m = tr.parse_matrix(TABLE)
+    a = tr.audit(m)
+    assert a["total"] == 4
+    assert a["covered"] == 2  # one covered + one passing
+    # #44 missing + no test -> gap.
+    assert any(g["ticket"] == 44 for g in a["gaps"])
+
+
+def test_render_roundtrips_through_parser():
+    m = tr.parse_matrix(TABLE)
+    rendered = tr.render_markdown(m)
+    m2 = tr.parse_matrix(rendered)
+    assert [r.to_dict() for r in m.rows] == [r.to_dict() for r in m2.rows]
+
+
+def test_render_escapes_pipes():
+    m = tr.TraceMatrix(rows=[tr.TraceRow(ticket=1, ac="a | b", status="pending")])
+    rendered = tr.render_markdown(m)
+    assert "a \\| b" in rendered
+    assert tr.parse_matrix(rendered).rows[0].ac == "a | b"
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_audit(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(TABLE)
+    rc = cli.main(["audit", str(f)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["total"] == 4
+
+
+def test_cli_update_in_place(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(TABLE)
+    rc = cli.main(["update", str(f), "--ticket", "44", "--status", "covered"])
+    assert rc == 0
+    m = tr.parse_matrix(f.read_text())
+    assert [r.status for r in m.rows if r.ticket == 44] == ["covered"]

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -61,6 +61,23 @@ def test_parse_no_table_warns():
     assert any("no traceability table" in w for w in m.warnings)
 
 
+def test_parse_accepts_ac_header():
+    table = "| Ticket | AC | Unit Test | Status |\n|---|---|---|---|\n| #1 | do x | t | covered |\n"
+    m = tr.parse_matrix(table)
+    assert m.rows[0].ac == "do x"
+    assert "missing required column: ac" not in " ".join(m.warnings)
+
+
+def test_parse_skips_unrelated_earlier_table():
+    text = (
+        "| Name | Value |\n|---|---|\n| foo | bar |\n\n"
+        "| Ticket | Acceptance Criterion | Status |\n|---|---|---|\n| #5 | real AC | pending |\n"
+    )
+    m = tr.parse_matrix(text)
+    assert len(m.rows) == 1
+    assert m.rows[0].ac == "real AC"
+
+
 def test_parse_unknown_status_warns():
     table = (
         "| Ticket | Acceptance Criterion | Status |\n|---|---|---|\n| #1 | x | bogus |\n"
@@ -153,3 +170,23 @@ def test_cli_update_in_place(tmp_path, capsys):
     assert rc == 0
     m = tr.parse_matrix(f.read_text())
     assert [r.status for r in m.rows if r.ticket == 44] == ["covered"]
+
+
+def test_update_preserves_surrounding_prose(tmp_path):
+    f = tmp_path / "traceability.md"
+    f.write_text(TABLE)
+    cli.main(["update", str(f), "--ticket", "42", "--status", "passing"])
+    out = f.read_text()
+    assert "Some intro prose." in out
+    assert "More prose after." in out
+
+
+def test_audit_does_not_count_covered_without_test():
+    table = (
+        "| Ticket | Acceptance Criterion | Unit Test | Status |\n|---|---|---|---|\n"
+        "| #1 | x | — | covered |\n"
+    )
+    m = tr.parse_matrix(table)
+    a = tr.audit(m)
+    assert a["covered"] == 0  # covered status but no test ref
+    assert a["gaps"]  # still flagged as a gap


### PR DESCRIPTION
## Summary

P2-13 of the Portable Python Orchestration Core epic. Traceability appears in `/architect`, `/implement`, and `/close-epic`, but status updates were described as manual markdown edits. This parses, updates, and audits the table with tested code.

Closes #49.

## Changes

- **`scripts/chief_wiggum/traceability.py`** — `parse_matrix` (escaped pipes, missing columns, unknown statuses, duplicate ACs, surrounding prose), `update_status` (by ticket; narrowable by AC / test-ref substring), `audit` (per-status counts, coverage %, gap list), `render_markdown` (round-trips through the parser, escapes pipes). Statuses: `pending`/`covered`/`passing`/`failing`/`missing`.
- **`scripts/traceability.py`** — CLI: `audit` / `render` / `update` (in place).
- **Command prompts** — `implement.md` Step 13 uses the updater; `close-epic.md` Step 2 uses the parser/audit.

## Acceptance criteria

- [x] Tests cover normal table parsing, escaped pipes, missing columns, duplicate ACs, status updates, and report rendering (16 tests).
- [x] `/implement` Step 13 uses the updater.
- [x] `/close-epic` Step 2 uses the parser for audit setup.

## Verification

- `make lint` clean; `make test` — 320 passed (16 new).