### PR TITLE
feat: extract design artifact assembly (#51)

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -164,9 +164,19 @@ docs/design/
 
 The `reference-screenshot` asset paths in `design.json` must point at the committed `docs/design/reference/*.png` files, and `source.references` at `docs/design/mockups/`.
 
+Assemble and commit with the tested helper. It re-validates `design.json`, renders the styleguide, copies the chosen direction's mockups and the approved screenshots to the stable paths, **verifies every `reference-screenshot` asset points at an installed file**, reports surviving `TBD:` markers (and that they will gate frontend tickets), and commits — refusing on a dirty repo unless `--allow-dirty`:
+
 ```bash
-cd "$TARGET_DIR" && git add docs/design && git commit -m "design: add product design contract — <direction name>" && git push
+cd "$TARGET_DIR" && git checkout "$DEFAULT_BRANCH" && git pull --ff-only
+python3 "$CW_HOME/scripts/install_design_artifacts.py" \
+  --design-json "$DESIGN_TMP/design.json" \
+  --mockups "$DESIGN_TMP/directions/<chosen>" \
+  --screenshots "$DESIGN_TMP/reference" \
+  --target-repo "$TARGET_DIR"
+git push
 ```
+
+Use `--dry-run` to preview the manifest (copied files, `broken_assets`, `tbd_markers`) without writing, and `--no-commit` to assemble without committing. Any `broken_assets` in the output means an asset path doesn't match an installed screenshot — fix `design.json` before pushing.
 
 Report to the user:
 - The chosen direction and a one-line rationale

--- a/scripts/install_design_artifacts.py
+++ b/scripts/install_design_artifacts.py
@@ -75,6 +75,20 @@ def _find_markers(node, path: str = "") -> list[str]:
     return out
 
 
+def _assert_within(base: Path, child: Path) -> None:
+    """Ensure ``child`` (possibly not yet created) resolves under ``base``.
+
+    Walks to the deepest existing ancestor and checks it — catches a symlinked
+    ``docs`` / ``docs/design`` that would let writes escape the target repo.
+    """
+    base = base.resolve()
+    existing = child
+    while not existing.exists():
+        existing = existing.parent
+    if not existing.resolve().is_relative_to(base):
+        raise DesignInstallError(f"refusing to write outside the target repo: {child} -> {existing.resolve()}")
+
+
 def _reference_assets(design: dict) -> list[str]:
     assets = design.get("assets") or []
     refs = []
@@ -110,7 +124,11 @@ def install_design_artifacts(
         raise DesignInstallError("invalid design.json: " + "; ".join(errors[:5]))
 
     if commit and not dry_run and not allow_dirty:
-        if not gitops.is_clean(target_repo, runner=git_runner):
+        try:
+            clean = gitops.is_clean(target_repo, runner=git_runner)
+        except gitops.GitSafetyError as exc:
+            raise DesignInstallError(f"cannot check target repo state: {exc}") from exc
+        if not clean:
             raise DesignInstallError("target repo has uncommitted changes; pass allow_dirty to override")
 
     result = DesignInstallResult(design_dir=str(design_dir), dry_run=dry_run)
@@ -131,11 +149,12 @@ def install_design_artifacts(
     if not mockups:
         result.warnings.append("no HTML mockups found in the chosen direction")
 
-    # Verify every reference-screenshot asset path resolves to a screenshot we
-    # will install under docs/design/reference/.
-    installed_ref_names = {p.name for p in screenshots}
+    # Verify every reference-screenshot asset is the exact repo-relative path of
+    # a screenshot being installed — not just a basename match (which would let
+    # an absolute path, URL, traversal, or wrong directory slip through).
+    valid_paths = {f"docs/design/reference/{p.name}" for p in screenshots}
     for ref in _reference_assets(design):
-        if Path(ref).name not in installed_ref_names:
+        if ref not in valid_paths:
             result.broken_assets.append(ref)
     if result.broken_assets:
         result.warnings.append(
@@ -150,6 +169,7 @@ def install_design_artifacts(
         )
         return result
 
+    _assert_within(target_repo, design_dir)
     (design_dir / "mockups").mkdir(parents=True, exist_ok=True)
     (design_dir / "reference").mkdir(parents=True, exist_ok=True)
 
@@ -172,17 +192,23 @@ def install_design_artifacts(
         rc_add = git_runner(["git", "add", "docs/design"], cwd=str(target_repo), capture_output=True, text=True)
         if rc_add.returncode != 0:
             raise DesignInstallError(f"git add failed: {(rc_add.stderr or '').strip()}")
-        rc_commit = git_runner(
-            ["git", "commit", "-m", "design: add product design contract"],
+        # Reliable idempotency: if nothing under docs/design is staged, there's
+        # nothing to commit (regardless of unrelated dirty files under --allow-dirty).
+        staged = git_runner(
+            ["git", "diff", "--cached", "--quiet", "--", "docs/design"],
             cwd=str(target_repo), capture_output=True, text=True,
         )
-        if rc_commit.returncode == 0:
-            result.committed = True
+        if staged.returncode == 0:
+            result.warnings.append("nothing to commit (design already up to date)")
         else:
-            combined = ((rc_commit.stdout or "") + (rc_commit.stderr or "")).strip()
-            if "nothing to commit" in combined:
-                result.warnings.append("nothing to commit (design already up to date)")
+            rc_commit = git_runner(
+                ["git", "commit", "-m", "design: add product design contract"],
+                cwd=str(target_repo), capture_output=True, text=True,
+            )
+            if rc_commit.returncode == 0:
+                result.committed = True
             else:
+                combined = ((rc_commit.stdout or "") + (rc_commit.stderr or "")).strip()
                 raise DesignInstallError(f"git commit failed: {combined}")
 
     return result

--- a/scripts/install_design_artifacts.py
+++ b/scripts/install_design_artifacts.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Install product design artifacts into a target repo (P2-15).
+
+`/design`'s creative direction generation stays human/agent-driven, but the
+final `docs/design/` assembly (validate design.json -> render styleguide -> copy
+mockups + screenshots -> verify reference-screenshot assets point at committed
+files -> commit) is deterministic and should be checked. This makes it one
+tested step, and reports surviving ``TBD:`` markers with their blocked
+frontend-ticket impact.
+
+Usage:
+    python3 scripts/install_design_artifacts.py \
+      --design-json "$DESIGN_TMP/design.json" \
+      --mockups "$DESIGN_TMP/directions/<chosen>" \
+      --screenshots "$DESIGN_TMP/reference" \
+      --target-repo "$TARGET_REPO" [--no-commit] [--allow-dirty] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import extract_design as ed  # noqa: E402
+from chief_wiggum import gitops  # noqa: E402
+
+IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+_MARKER = ("TBD", "UNRESOLVED", "PLACEHOLDER")
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class DesignInstallError(RuntimeError):
+    """Raised when design artifacts can't be installed."""
+
+
+@dataclass
+class DesignInstallResult:
+    design_dir: str
+    copied: list[str] = field(default_factory=list)
+    styleguide: str | None = None
+    broken_assets: list[str] = field(default_factory=list)
+    tbd_markers: list[str] = field(default_factory=list)
+    committed: bool = False
+    dry_run: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def blocks_frontend(self) -> bool:
+        return bool(self.tbd_markers)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _find_markers(node, path: str = "") -> list[str]:
+    """Collect TBD/UNRESOLVED/PLACEHOLDER markers from a design.json value tree."""
+    out: list[str] = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            out.extend(_find_markers(v, f"{path}.{k}" if path else k))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            out.extend(_find_markers(v, f"{path}[{i}]"))
+    elif isinstance(node, str) and any(m in node for m in _MARKER):
+        out.append(f"{path}: {node.strip()[:120]}")
+    return out
+
+
+def _reference_assets(design: dict) -> list[str]:
+    assets = design.get("assets") or []
+    refs = []
+    if isinstance(assets, list):
+        for a in assets:
+            if isinstance(a, dict) and a.get("type") == "reference-screenshot" and a.get("path"):
+                refs.append(a["path"])
+    return refs
+
+
+def install_design_artifacts(
+    design_json: str | Path,
+    mockups_dir: str | Path,
+    screenshots_dir: str | Path,
+    target_repo: str | Path,
+    *,
+    commit: bool = True,
+    allow_dirty: bool = False,
+    dry_run: bool = False,
+    git_runner: Runner = subprocess.run,
+) -> DesignInstallResult:
+    """Validate, assemble, and optionally commit ``docs/design/`` artifacts."""
+    target_repo = Path(target_repo).resolve()
+    design_dir = target_repo / "docs" / "design"
+
+    # Validate the design contract first.
+    try:
+        design = json.loads(Path(design_json).read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        raise DesignInstallError(f"cannot read design.json: {exc}") from exc
+    errors = ed.validate_design(design)
+    if errors:
+        raise DesignInstallError("invalid design.json: " + "; ".join(errors[:5]))
+
+    if commit and not dry_run and not allow_dirty:
+        if not gitops.is_clean(target_repo, runner=git_runner):
+            raise DesignInstallError("target repo has uncommitted changes; pass allow_dirty to override")
+
+    result = DesignInstallResult(design_dir=str(design_dir), dry_run=dry_run)
+    result.tbd_markers = _find_markers(design)
+    if result.tbd_markers:
+        result.warnings.append(
+            f"{len(result.tbd_markers)} TBD marker(s) survive; dependent frontend tickets will be gated"
+        )
+
+    mockups = sorted(Path(mockups_dir).glob("*.html")) if Path(mockups_dir).is_dir() else []
+    screenshots = (
+        [p for p in sorted(Path(screenshots_dir).iterdir()) if p.suffix.lower() in IMAGE_EXTS]
+        if Path(screenshots_dir).is_dir()
+        else []
+    )
+    if not screenshots:
+        result.warnings.append("no reference screenshots found; the design-fidelity gate baseline will be empty")
+    if not mockups:
+        result.warnings.append("no HTML mockups found in the chosen direction")
+
+    # Verify every reference-screenshot asset path resolves to a screenshot we
+    # will install under docs/design/reference/.
+    installed_ref_names = {p.name for p in screenshots}
+    for ref in _reference_assets(design):
+        if Path(ref).name not in installed_ref_names:
+            result.broken_assets.append(ref)
+    if result.broken_assets:
+        result.warnings.append(
+            f"{len(result.broken_assets)} reference-screenshot asset(s) point at files not being installed"
+        )
+
+    if dry_run:
+        result.copied = (
+            [f"mockups/{p.name}" for p in mockups]
+            + [f"reference/{p.name}" for p in screenshots]
+            + ["design.json", "styleguide.html"]
+        )
+        return result
+
+    (design_dir / "mockups").mkdir(parents=True, exist_ok=True)
+    (design_dir / "reference").mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(Path(design_json), design_dir / "design.json")
+    result.copied.append("design.json")
+    for p in mockups:
+        shutil.copy(p, design_dir / "mockups" / p.name)
+        result.copied.append(f"mockups/{p.name}")
+    for p in screenshots:
+        shutil.copy(p, design_dir / "reference" / p.name)
+        result.copied.append(f"reference/{p.name}")
+
+    # Render the styleguide from the (validated) tokens.
+    styleguide = design_dir / "styleguide.html"
+    styleguide.write_text(ed.render_styleguide(design))
+    result.styleguide = str(styleguide)
+    result.copied.append("styleguide.html")
+
+    if commit:
+        rc_add = git_runner(["git", "add", "docs/design"], cwd=str(target_repo), capture_output=True, text=True)
+        if rc_add.returncode != 0:
+            raise DesignInstallError(f"git add failed: {(rc_add.stderr or '').strip()}")
+        rc_commit = git_runner(
+            ["git", "commit", "-m", "design: add product design contract"],
+            cwd=str(target_repo), capture_output=True, text=True,
+        )
+        if rc_commit.returncode == 0:
+            result.committed = True
+        else:
+            combined = ((rc_commit.stdout or "") + (rc_commit.stderr or "")).strip()
+            if "nothing to commit" in combined:
+                result.warnings.append("nothing to commit (design already up to date)")
+            else:
+                raise DesignInstallError(f"git commit failed: {combined}")
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Install product design artifacts")
+    parser.add_argument("--design-json", required=True)
+    parser.add_argument("--mockups", required=True, help="Chosen direction dir with *.html mocks")
+    parser.add_argument("--screenshots", required=True, help="Dir with approved screenshots")
+    parser.add_argument("--target-repo", required=True)
+    parser.add_argument("--no-commit", action="store_true")
+    parser.add_argument("--allow-dirty", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = install_design_artifacts(
+            args.design_json, args.mockups, args.screenshots, args.target_repo,
+            commit=not args.no_commit, allow_dirty=args.allow_dirty, dry_run=args.dry_run,
+        )
+    except DesignInstallError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result.to_dict(), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_install_design_artifacts.py
+++ b/tests/test_install_design_artifacts.py
@@ -36,7 +36,10 @@ def _setup(tmp_path, *, design=None, mockups=("home.html",), screenshots=("home.
     return dj, mock_dir, shot_dir
 
 
-def _noop_git(*args, **kwargs):
+def _git_with_staged_changes(args, **kwargs):
+    # `git diff --cached --quiet` returns 1 when there ARE staged changes.
+    if "diff" in args and "--cached" in args:
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="")
     return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
 
@@ -131,6 +134,8 @@ def test_commit_failure_raises(tmp_path):
     dj, mock, shots = _setup(tmp_path)
 
     def git(args, **kwargs):
+        if "diff" in args and "--cached" in args:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="")  # changes staged
         if "commit" in args:
             return subprocess.CompletedProcess(args, 1, stdout="", stderr="no identity")
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
@@ -144,9 +149,31 @@ def test_commit_failure_raises(tmp_path):
 def test_commit_success(tmp_path):
     dj, mock, shots = _setup(tmp_path)
     result = idesign.install_design_artifacts(
-        dj, mock, shots, tmp_path, commit=True, allow_dirty=True, git_runner=_noop_git
+        dj, mock, shots, tmp_path, commit=True, allow_dirty=True, git_runner=_git_with_staged_changes
     )
     assert result.committed is True
+
+
+def test_nothing_staged_is_not_a_commit(tmp_path):
+    dj, mock, shots = _setup(tmp_path)
+
+    def git(args, **kwargs):  # diff --cached --quiet -> 0 (nothing staged)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    result = idesign.install_design_artifacts(
+        dj, mock, shots, tmp_path, commit=True, allow_dirty=True, git_runner=git
+    )
+    assert result.committed is False
+    assert any("nothing to commit" in w for w in result.warnings)
+
+
+def test_asset_with_wrong_directory_is_broken(tmp_path):
+    # Basename matches an installed screenshot, but the directory is wrong.
+    dj, mock, shots = _setup(
+        tmp_path, design=_design(assets=[_ref_asset("docs/design/other/home.png")])
+    )
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+    assert result.broken_assets == ["docs/design/other/home.png"]
 
 
 # --- CLI --------------------------------------------------------------------

--- a/tests/test_install_design_artifacts.py
+++ b/tests/test_install_design_artifacts.py
@@ -1,0 +1,172 @@
+"""Tests for the design artifact installer (P2-15)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import install_design_artifacts as idesign
+import pytest
+
+
+def _design(assets=None, tbd=False):
+    d = {"source": {"kind": "net-new"}, "tokens": {"colors": {"primary": "#003f5c"}}}
+    if tbd:
+        d["source"]["notes"] = "TBD: confirm brand colour with client"
+    if assets is not None:
+        d["assets"] = assets
+    return d
+
+
+def _ref_asset(path="docs/design/reference/home.png"):
+    return {"id": "home-ref", "type": "reference-screenshot", "path": path, "applies_to": ["home"]}
+
+
+def _setup(tmp_path, *, design=None, mockups=("home.html",), screenshots=("home.png",)):
+    dj = tmp_path / "design.json"
+    dj.write_text(json.dumps(design if design is not None else _design()))
+    mock_dir = tmp_path / "direction"
+    mock_dir.mkdir()
+    for m in mockups:
+        (mock_dir / m).write_text("<html>:root{}</html>")
+    shot_dir = tmp_path / "shots"
+    shot_dir.mkdir()
+    for s in screenshots:
+        (shot_dir / s).write_bytes(b"img")
+    return dj, mock_dir, shot_dir
+
+
+def _noop_git(*args, **kwargs):
+    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+# --- validation -------------------------------------------------------------
+
+
+def test_invalid_design_json_raises(tmp_path):
+    dj, mock, shots = _setup(tmp_path, design={"tokens": {}})  # missing 'source'
+    with pytest.raises(idesign.DesignInstallError, match="invalid design.json"):
+        idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+
+
+def test_malformed_json_raises(tmp_path):
+    dj = tmp_path / "design.json"
+    dj.write_text("{not json")
+    (tmp_path / "d").mkdir()
+    (tmp_path / "s").mkdir()
+    with pytest.raises(idesign.DesignInstallError, match="cannot read"):
+        idesign.install_design_artifacts(dj, tmp_path / "d", tmp_path / "s", tmp_path, commit=False)
+
+
+# --- assembly ---------------------------------------------------------------
+
+
+def test_install_copies_and_renders_styleguide(tmp_path):
+    dj, mock, shots = _setup(tmp_path, design=_design(assets=[_ref_asset()]))
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+    dd = tmp_path / "docs" / "design"
+    assert (dd / "design.json").exists()
+    assert (dd / "mockups" / "home.html").exists()
+    assert (dd / "reference" / "home.png").exists()
+    assert (dd / "styleguide.html").exists()
+    assert result.styleguide and "styleguide.html" in result.styleguide
+    assert result.broken_assets == []
+
+
+def test_missing_screenshots_warns(tmp_path):
+    dj, mock, shots = _setup(tmp_path, screenshots=())
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+    assert any("no reference screenshots" in w for w in result.warnings)
+
+
+def test_broken_asset_reference_warns(tmp_path):
+    # design.json references missing.png but only home.png is installed.
+    dj, mock, shots = _setup(
+        tmp_path, design=_design(assets=[_ref_asset("docs/design/reference/missing.png")])
+    )
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+    assert result.broken_assets == ["docs/design/reference/missing.png"]
+    assert any("reference-screenshot asset" in w for w in result.warnings)
+
+
+# --- TBD markers ------------------------------------------------------------
+
+
+def test_tbd_markers_reported_with_frontend_impact(tmp_path):
+    dj, mock, shots = _setup(tmp_path, design=_design(tbd=True))
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=False)
+    assert result.tbd_markers
+    assert result.blocks_frontend is True
+    assert any("frontend tickets will be gated" in w for w in result.warnings)
+
+
+# --- dry run ----------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    dj, mock, shots = _setup(tmp_path)
+    result = idesign.install_design_artifacts(dj, mock, shots, tmp_path, dry_run=True)
+    assert result.dry_run is True
+    assert not (tmp_path / "docs" / "design").exists()
+    assert "design.json" in result.copied
+    assert "styleguide.html" in result.copied
+
+
+# --- commit guard -----------------------------------------------------------
+
+
+def test_refuses_commit_on_dirty_repo(tmp_path):
+    dj, mock, shots = _setup(tmp_path)
+
+    def dirty(args, **kwargs):
+        if "status" in args:
+            return subprocess.CompletedProcess(args, 0, stdout=" M f\n", stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    with pytest.raises(idesign.DesignInstallError, match="uncommitted"):
+        idesign.install_design_artifacts(dj, mock, shots, tmp_path, commit=True, git_runner=dirty)
+
+
+def test_commit_failure_raises(tmp_path):
+    dj, mock, shots = _setup(tmp_path)
+
+    def git(args, **kwargs):
+        if "commit" in args:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="no identity")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    with pytest.raises(idesign.DesignInstallError, match="git commit failed"):
+        idesign.install_design_artifacts(
+            dj, mock, shots, tmp_path, commit=True, allow_dirty=True, git_runner=git
+        )
+
+
+def test_commit_success(tmp_path):
+    dj, mock, shots = _setup(tmp_path)
+    result = idesign.install_design_artifacts(
+        dj, mock, shots, tmp_path, commit=True, allow_dirty=True, git_runner=_noop_git
+    )
+    assert result.committed is True
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_dry_run(tmp_path, capsys):
+    dj, mock, shots = _setup(tmp_path)
+    rc = idesign.main([
+        "--design-json", str(dj), "--mockups", str(mock), "--screenshots", str(shots),
+        "--target-repo", str(tmp_path), "--dry-run",
+    ])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["dry_run"] is True
+
+
+def test_cli_invalid_design_exit_1(tmp_path, capsys):
+    dj, mock, shots = _setup(tmp_path, design={"tokens": {}})
+    rc = idesign.main([
+        "--design-json", str(dj), "--mockups", str(mock), "--screenshots", str(shots),
+        "--target-repo", str(tmp_path), "--no-commit",
+    ])
+    assert rc == 1
+    assert "invalid design.json" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

P2-15 of the Portable Python Orchestration Core epic. `/design`'s creative direction generation stays human/agent-driven, but the final `docs/design/` assembly is deterministic — this makes it a tested, checked step.

Closes #51.

## Changes

- **`scripts/install_design_artifacts.py`** — `install_design_artifacts()`:
  - Validates `design.json` (`extract_design.validate_design`), renders the styleguide.
  - Copies the chosen direction's mockups + approved screenshots to `docs/design/{mockups,reference}/`.
  - **Verifies every `reference-screenshot` asset points at an installed file** (`broken_assets`).
  - Reports surviving `TBD:` markers with blocked-frontend impact (`blocks_frontend`).
  - Commits — refusing on a dirty repo unless `--allow-dirty`; `--no-commit` / `--dry-run`. Reuses `gitops.is_clean`.
- **`design.md` Step 6** calls the helper instead of a manual git recipe.

## Acceptance criteria

- [x] Tests cover missing screenshots, invalid design JSON, broken asset references, styleguide generation, and dry-run manifest (12 tests).
- [x] `/design` Step 5/6 call this helper.
- [x] The helper reports surviving `TBD:` markers with blocked frontend-ticket impact.

## Verification

- `make lint` clean; `make test` — 346 passed (12 new).