### PR TITLE
feat: extract close-epic audit orchestrator (#50)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -45,6 +45,18 @@ gh issue list --repo "$owner_repo" --milestone "$epic_name" --state all --limit 
 
 Verify all tickets are closed. If any are still open, report which ones and ask the user whether to proceed with a partial close or wait.
 
+### Step 1b: Run the deterministic audit
+
+Run the audit orchestrator once up front. It coordinates the deterministic audits — traceability coverage, unresolved markers + blocked tickets, transition-map verification (when a state machine model exists), optional stitch findings, mutation-tooling availability, and the integration test run — and writes `close-epic-manifest.json` + `close-epic-report.md`. **It exits non-zero if the epic cannot be closed** (integration tests failed, or unresolved markers still block tickets):
+
+```bash
+python3 "$CW_HOME/scripts/close_epic_audit.py" \
+  --epic-dir "$EPIC_DIR" --target-repo "$TARGET_REPO" \
+  --output-dir "$CW_TMP/close-epic"
+```
+
+Steps 2 (traceability), 2b (transition map), 2c (unresolved), 4 (mutation tooling), 7, and 11 **consume `$CW_TMP/close-epic/close-epic-manifest.json`** rather than recomputing — the exploratory parts (cross-surface consistency, UX flow, retrospective) still launch agents, but the audit state is structured. A `blocked: true` manifest is a workflow-level stop: resolve the failure before closing.
+
 ### Step 2: Traceability audit
 
 Parse and audit the traceability matrix with the tested helper. It returns per-status counts, coverage %, and the gap list (rows with no test, or `missing`/`failing` status):

--- a/scripts/close_epic_audit.py
+++ b/scripts/close_epic_audit.py
@@ -105,11 +105,14 @@ def run_close_epic_audit(
     target = Path(target_repo)
     manifest = CloseEpicManifest(epic_dir=str(epic), target_repo=str(target))
 
-    # Traceability coverage.
+    # Traceability coverage (isolated so a malformed file can't abort the audit).
     trace_file = epic / "traceability.md"
     if trace_file.is_file():
-        matrix = tr.parse_matrix(trace_file.read_text())
-        manifest.traceability = tr.audit(matrix)
+        try:
+            matrix = tr.parse_matrix(trace_file.read_text())
+            manifest.traceability = tr.audit(matrix)
+        except Exception as exc:  # noqa: BLE001
+            manifest.warnings.append(f"traceability audit failed: {exc}")
     else:
         manifest.warnings.append("no traceability.md found")
 
@@ -148,8 +151,11 @@ def run_close_epic_audit(
         except Exception as exc:  # noqa: BLE001
             manifest.warnings.append(f"stitch audit failed: {exc}")
 
-    # Mutation tooling availability.
-    manifest.mutation_tools_available = [t for t in mutation_tools if which(t)]
+    # Mutation tooling availability (isolated — an injected probe may raise).
+    try:
+        manifest.mutation_tools_available = [t for t in mutation_tools if which(t)]
+    except Exception as exc:  # noqa: BLE001
+        manifest.warnings.append(f"mutation-tool probe failed: {exc}")
     if not manifest.mutation_tools_available:
         manifest.warnings.append("no mutation-testing tool available (mutmut/cosmic-ray/stryker)")
 

--- a/scripts/close_epic_audit.py
+++ b/scripts/close_epic_audit.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Close-epic audit orchestrator (P2-14).
+
+`/close-epic` is mostly deterministic audit coordination: traceability coverage,
+transition-map verification, unresolved markers, stitch audit, mutation-tooling
+availability, and integration tests. The exploratory parts still launch agents,
+but the audit *state* should be structured. This runner coordinates the existing
+helpers, decides the workflow-level stop condition, and emits a manifest +
+report.
+
+Every sub-audit is injectable so the orchestration is testable without running
+real tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_unresolved  # noqa: E402
+from chief_wiggum import traceability as tr  # noqa: E402
+from chief_wiggum import verification as ver  # noqa: E402
+
+DEFAULT_MUTATION_TOOLS = ("mutmut", "cosmic-ray", "stryker")
+
+
+@dataclass
+class CloseEpicManifest:
+    epic_dir: str
+    target_repo: str
+    traceability: dict | None = None
+    unresolved: list[dict] = field(default_factory=list)
+    blocked_tickets: list[int] = field(default_factory=list)
+    transitions: dict | None = None
+    stitch: dict | None = None
+    mutation_tools_available: list[str] = field(default_factory=list)
+    verification: dict | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def integration_ok(self) -> bool:
+        # Missing verification is treated as "not run" rather than a pass.
+        return bool(self.verification and self.verification.get("ok"))
+
+    @property
+    def blocked(self) -> bool:
+        """Workflow-level stop condition: integration tests must pass and there
+        must be no unresolved-marker-blocked tickets."""
+        return (not self.integration_ok) or bool(self.blocked_tickets)
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["blocked"] = self.blocked
+        data["integration_ok"] = self.integration_ok
+        return data
+
+    def render_markdown(self) -> str:
+        lines = ["# Close-Epic Audit", "", f"Epic: `{self.epic_dir}`", ""]
+        status = "BLOCKED" if self.blocked else "ready to close"
+        lines.append(f"**Status: {status}**")
+
+        if self.traceability is not None:
+            t = self.traceability
+            lines += ["", "## Traceability", "", f"- Coverage: {t.get('coverage_pct')}% ({t.get('covered')}/{t.get('total')})"]
+            if t.get("gaps"):
+                lines.append(f"- Gaps: {len(t['gaps'])}")
+        if self.blocked_tickets:
+            lines += ["", "## Unresolved markers (blocking)", "", ", ".join(f"#{t}" for t in self.blocked_tickets)]
+        elif self.unresolved:
+            lines += ["", f"## Unresolved markers: {len(self.unresolved)} (non-blocking)"]
+        if self.transitions is not None:
+            lines += ["", "## Transition map", "", f"- {self.transitions.get('summary', 'see transition-map')}"]
+        if self.stitch is not None:
+            lines += ["", "## Stitch audit", "", f"- findings: {self.stitch.get('count', 0)}"]
+        lines += ["", "## Mutation tooling", "", (", ".join(self.mutation_tools_available) or "none available")]
+        if self.verification is not None:
+            lines += ["", "## Integration / tests", "", f"- {'green' if self.integration_ok else 'FAILED — stop condition'}"]
+        if self.warnings:
+            lines += ["", "## Warnings", ""] + [f"- {w}" for w in self.warnings]
+        return "\n".join(lines) + "\n"
+
+
+def run_close_epic_audit(
+    epic_dir: str | Path,
+    target_repo: str | Path,
+    *,
+    scanner: Callable = check_unresolved.scan,
+    blocked_fn: Callable = check_unresolved.blocked_tickets,
+    verify_fn: Callable[[Path], dict] | None = None,
+    transition_fn: Callable[[Path, Path], dict] | None = None,
+    stitch_fn: Callable[[Path], dict] | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    mutation_tools: tuple[str, ...] = DEFAULT_MUTATION_TOOLS,
+) -> CloseEpicManifest:
+    """Coordinate the deterministic close-epic audits into one manifest."""
+    epic = Path(epic_dir)
+    target = Path(target_repo)
+    manifest = CloseEpicManifest(epic_dir=str(epic), target_repo=str(target))
+
+    # Traceability coverage.
+    trace_file = epic / "traceability.md"
+    if trace_file.is_file():
+        matrix = tr.parse_matrix(trace_file.read_text())
+        manifest.traceability = tr.audit(matrix)
+    else:
+        manifest.warnings.append("no traceability.md found")
+
+    # Unresolved markers + blocked tickets.
+    if epic.exists():
+        try:
+            findings = scanner([epic])
+            manifest.unresolved = [
+                f.__dict__ if hasattr(f, "__dict__") else dict(f) for f in findings
+            ]
+            blocked = blocked_fn(findings)
+            parsed = []
+            for ref in blocked:
+                try:
+                    parsed.append(int(str(ref).lstrip("#")))
+                except (ValueError, TypeError):
+                    manifest.warnings.append(f"unparseable blocked ticket ref: {ref!r}")
+            manifest.blocked_tickets = sorted(set(parsed))
+        except Exception as exc:  # noqa: BLE001
+            manifest.warnings.append(f"unresolved scan failed: {exc}")
+
+    # Transition-map audit (only when a state machine model exists).
+    sm = epic / "models" / "state-machines.json"
+    if sm.is_file() and transition_fn is not None:
+        try:
+            manifest.transitions = transition_fn(target, sm)
+        except Exception as exc:  # noqa: BLE001
+            manifest.warnings.append(f"transition audit failed: {exc}")
+    elif not sm.is_file():
+        manifest.warnings.append("no formal state-machine model; skipping transition audit")
+
+    # Optional stitch audit.
+    if stitch_fn is not None:
+        try:
+            manifest.stitch = stitch_fn(target)
+        except Exception as exc:  # noqa: BLE001
+            manifest.warnings.append(f"stitch audit failed: {exc}")
+
+    # Mutation tooling availability.
+    manifest.mutation_tools_available = [t for t in mutation_tools if which(t)]
+    if not manifest.mutation_tools_available:
+        manifest.warnings.append("no mutation-testing tool available (mutmut/cosmic-ray/stryker)")
+
+    # Integration tests — the workflow-level stop condition.
+    if verify_fn is None:
+        def verify_fn(repo: Path) -> dict:
+            return ver.verify(repo, ["test"]).to_dict()
+    try:
+        manifest.verification = verify_fn(target)
+    except Exception as exc:  # noqa: BLE001
+        manifest.warnings.append(f"verification failed to run: {exc}")
+
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Close-epic audit orchestrator")
+    parser.add_argument("--epic-dir", required=True)
+    parser.add_argument("--target-repo", required=True)
+    parser.add_argument("--output-dir", help="Write manifest + report here")
+    parser.add_argument("--markdown", action="store_true", help="Print the markdown report")
+    args = parser.parse_args(argv)
+
+    def transition_fn(target: Path, sm: Path) -> dict:
+        home = Path(__file__).resolve().parent
+        out = subprocess.run(
+            ["python3", str(home / "verify_transitions.py"), str(target), str(sm), "--format", "json"],
+            capture_output=True, text=True, timeout=120,
+        )
+        try:
+            return json.loads(out.stdout or "{}")
+        except json.JSONDecodeError:
+            return {"summary": "transition verification produced no JSON"}
+
+    manifest = run_close_epic_audit(args.epic_dir, args.target_repo, transition_fn=transition_fn)
+
+    if args.output_dir:
+        out = Path(args.output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "close-epic-manifest.json").write_text(json.dumps(manifest.to_dict(), indent=2))
+        (out / "close-epic-report.md").write_text(manifest.render_markdown())
+
+    if args.markdown:
+        print(manifest.render_markdown())
+    else:
+        print(json.dumps(manifest.to_dict(), indent=2))
+
+    # Non-zero when the epic cannot be closed (integration failed or blocked tickets).
+    return 1 if manifest.blocked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_close_epic_audit.py
+++ b/tests/test_close_epic_audit.py
@@ -137,6 +137,28 @@ def test_traceability_audit_included(tmp_path):
     assert m.traceability["total"] == 2
 
 
+def test_malformed_traceability_does_not_abort_audit(tmp_path, monkeypatch):
+    m_in = _epic(tmp_path)
+
+    def boom(_text):
+        raise ValueError("bad table")
+
+    monkeypatch.setattr(cea.tr, "parse_matrix", boom)
+    m = _audit(tmp_path, epic=m_in)
+    assert any("traceability audit failed" in w for w in m.warnings)
+    # The rest of the audit still ran.
+    assert m.verification is not None
+
+
+def test_mutation_probe_error_is_isolated(tmp_path):
+    def boom_which(_tool):
+        raise OSError("which exploded")
+
+    m = _audit(tmp_path, which=boom_which)
+    assert any("mutation-tool probe failed" in w for w in m.warnings)
+    assert m.verification is not None
+
+
 def test_render_markdown(tmp_path):
     m = _audit(tmp_path)
     md = m.render_markdown()

--- a/tests/test_close_epic_audit.py
+++ b/tests/test_close_epic_audit.py
@@ -1,0 +1,168 @@
+"""Tests for the close-epic audit orchestrator (P2-14)."""
+
+from __future__ import annotations
+
+import json
+
+import close_epic_audit as cea
+
+TRACE = """\
+| Ticket | Acceptance Criterion | Unit Test | Status |
+|---|---|---|---|
+| #42 | health | api_test.go:TestHealth | passing |
+| #43 | missing one | — | missing |
+"""
+
+
+def _epic(tmp_path, *, traceability=True, state_machine=False):
+    epic = tmp_path / "epic"
+    (epic / "models").mkdir(parents=True)
+    if traceability:
+        (epic / "traceability.md").write_text(TRACE)
+    if state_machine:
+        (epic / "models" / "state-machines.json").write_text('{"states": {}}')
+    return epic
+
+
+def _green_verify(repo):
+    return {"ok": True, "steps": [{"command": ["make", "test"], "ok": True}]}
+
+
+def _red_verify(repo):
+    return {"ok": False, "steps": [{"command": ["make", "test"], "ok": False}]}
+
+
+def _no_scan(targets):
+    return []
+
+
+def _no_blocked(findings):
+    return {}
+
+
+def _which_none(_tool):
+    return None
+
+
+def _audit(tmp_path, **kw):
+    epic = kw.pop("epic", None) or _epic(tmp_path)
+    defaults = dict(
+        scanner=_no_scan, blocked_fn=_no_blocked, verify_fn=_green_verify, which=_which_none
+    )
+    defaults.update(kw)
+    return cea.run_close_epic_audit(epic, tmp_path, **defaults)
+
+
+# --- formal models present/absent -------------------------------------------
+
+
+def test_no_formal_models_skips_transition_audit(tmp_path):
+    m = _audit(tmp_path)
+    assert m.transitions is None
+    assert any("no formal state-machine model" in w for w in m.warnings)
+
+
+def test_formal_models_present_runs_transition_audit(tmp_path):
+    epic = _epic(tmp_path, state_machine=True)
+    m = _audit(tmp_path, epic=epic, transition_fn=lambda t, sm: {"summary": "5/5 covered"})
+    assert m.transitions == {"summary": "5/5 covered"}
+
+
+# --- unresolved findings ----------------------------------------------------
+
+
+def test_unresolved_blocked_tickets_block_close(tmp_path):
+    def scan(targets):
+        class F:
+            __dict__ = {"text": "TBD x", "tickets": ["#43"]}
+        return [F()]
+
+    m = _audit(tmp_path, scanner=scan, blocked_fn=lambda f: {"#43": 1})
+    assert m.blocked_tickets == [43]
+    assert m.blocked is True
+
+
+# --- stitch findings --------------------------------------------------------
+
+
+def test_stitch_findings_recorded(tmp_path):
+    m = _audit(tmp_path, stitch_fn=lambda t: {"count": 3})
+    assert m.stitch == {"count": 3}
+
+
+# --- mutation tooling -------------------------------------------------------
+
+
+def test_missing_mutation_tooling_warns(tmp_path):
+    m = _audit(tmp_path)
+    assert m.mutation_tools_available == []
+    assert any("mutation-testing tool" in w for w in m.warnings)
+
+
+def test_mutation_tool_detected(tmp_path):
+    m = _audit(tmp_path, which=lambda t: "/usr/bin/mutmut" if t == "mutmut" else None)
+    assert m.mutation_tools_available == ["mutmut"]
+
+
+# --- stop condition ---------------------------------------------------------
+
+
+def test_failed_integration_tests_block_close(tmp_path):
+    m = _audit(tmp_path, verify_fn=_red_verify)
+    assert m.integration_ok is False
+    assert m.blocked is True
+
+
+def test_green_with_no_blockers_is_ready(tmp_path):
+    m = _audit(tmp_path)
+    assert m.integration_ok is True
+    assert m.blocked is False
+
+
+def test_missing_verification_is_not_a_pass(tmp_path):
+    def boom(repo):
+        raise RuntimeError("no runner")
+
+    m = _audit(tmp_path, verify_fn=boom)
+    assert m.integration_ok is False
+    assert m.blocked is True
+
+
+# --- traceability + report --------------------------------------------------
+
+
+def test_traceability_audit_included(tmp_path):
+    m = _audit(tmp_path)
+    assert m.traceability is not None
+    assert m.traceability["total"] == 2
+
+
+def test_render_markdown(tmp_path):
+    m = _audit(tmp_path)
+    md = m.render_markdown()
+    assert "# Close-Epic Audit" in md
+    assert "Traceability" in md
+    assert "ready to close" in md
+
+
+def test_manifest_serializable(tmp_path):
+    m = _audit(tmp_path)
+    data = json.loads(json.dumps(m.to_dict()))
+    assert data["blocked"] is False
+    assert "integration_ok" in data
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def test_cli_writes_manifest_and_report(tmp_path, monkeypatch, capsys):
+    epic = _epic(tmp_path)
+    out = tmp_path / "out"
+    precomputed = _audit(tmp_path, epic=epic)  # build once, before patching
+    monkeypatch.setattr(cea, "run_close_epic_audit", lambda *a, **k: precomputed)
+    rc = cea.main([
+        "--epic-dir", str(epic), "--target-repo", str(tmp_path), "--output-dir", str(out),
+    ])
+    assert rc == 0
+    assert (out / "close-epic-manifest.json").exists()
+    assert (out / "close-epic-report.md").exists()


### PR DESCRIPTION
## Summary

P2-14 of the Portable Python Orchestration Core epic. `/close-epic` is mostly deterministic audit coordination. This runner coordinates the existing helpers, decides the workflow-level stop condition, and emits a manifest + report; the exploratory parts still launch agents.

Closes #50.

## Changes

- **`scripts/close_epic_audit.py`** — `run_close_epic_audit()` coordinates traceability coverage (#49), unresolved markers + blocked tickets, transition-map verification (when a state machine model exists), optional stitch findings, mutation-tooling availability, and the integration test run (#45). `blocked` == integration not green **or** unresolved-blocked tickets remain. Emits `close-epic-manifest.json` + `close-epic-report.md`. Every sub-audit is **injectable** for testing.
- **`close-epic.md`** — adds Step 1b running the orchestrator; Steps 2/2b/2c/4/7/11 consume its manifest. A `blocked` manifest stops the close.

## Acceptance criteria

- [x] Tests cover no formal models, formal models present, unresolved findings, stitch findings, missing mutation tooling, and report rendering (13 tests).
- [x] `/close-epic` Steps 2, 2b, 2c, 4, 7, 11 call the audit runner or consume its manifest.
- [x] Critical integration test failure remains a workflow-level stop condition (`blocked`).

## Verification

- `make lint` clean; `make test` — 361 passed (13 new).