### PR TITLE
feat: add thin cw CLI facade (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,14 @@ python3 scripts/consult_ai.py --role reviewer prompt.md --output-dir ~/.chief-wi
 ```
 
 Role config controls which providers are required or optional. Optional providers can fail or be disabled without blocking the quorum; required providers must be enabled and return successfully.
+
+## Helper CLI (`cw`)
+
+The portable workflow mechanics are tested Python helpers under `scripts/`. The `cw` facade lists and dispatches to them for discoverability — each command forwards its args to the matching `scripts/<helper>.py`, whose standalone entrypoint remains valid:
+
+```bash
+python3 scripts/cw.py                       # list helpers
+python3 scripts/cw.py context acme/app#42   # shared workflow context
+python3 scripts/cw.py plan-waves --edges '{"1": [], "2": [1]}'
+python3 scripts/cw.py run-verification --repo . --profile test,lint --dry-run
+```

--- a/scripts/cw.py
+++ b/scripts/cw.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""``cw`` — a thin facade over the Chief Wiggum Python helpers (P3-17).
+
+Each subcommand simply dispatches to the matching helper's ``main(argv)``; the
+business logic stays in (and is tested in) the underlying modules. The
+standalone script entrypoints remain valid — this only adds discoverability.
+
+    python3 scripts/cw.py                      # list helpers
+    python3 scripts/cw.py context acme/app#42  # == workflow_context.py acme/app#42
+    python3 scripts/cw.py plan-waves --edges '{"1": []}'
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# subcommand -> (module, one-line description). Every target module exposes a
+# main(argv) entrypoint, so dispatch is a single uniform call.
+SUBCOMMANDS: dict[str, tuple[str, str]] = {
+    "context": ("workflow_context", "Resolve shared workflow context (home/tmp/repo/branch/epic)"),
+    "epic-metadata": ("epic_metadata", "GitHub issue/milestone/dependency metadata"),
+    "plan-waves": ("plan_waves", "Dependency-ordered wave planning + gating"),
+    "epic-inventory": ("epic_inventory", "Discover epic/model/design artifacts + gates"),
+    "formal-artifacts": ("generate_formal_test_artifacts", "Generate model-derived test artifacts"),
+    "run-review": ("run_review", "Assemble + run the code-review quorum"),
+    "git-safety": ("git_safety", "Worktree/branch safety checks"),
+    "run-verification": ("run_verification", "Detect + run project verification"),
+    "ux-gate": ("ux_gate", "UX / design-fidelity gate setup"),
+    "draft-pr": ("draft_pr", "Draft a PR body from manifests"),
+    "install-epic": ("install_epic_artifacts", "Install epic architecture artifacts"),
+    "traceability": ("traceability", "Traceability matrix parse/update/audit"),
+    "close-epic-audit": ("close_epic_audit", "Close-epic audit orchestrator"),
+    "install-design": ("install_design_artifacts", "Install product design artifacts"),
+}
+
+
+def _print_help() -> None:
+    print("cw — Chief Wiggum helper facade\n")
+    print("Usage: cw <command> [args...]\n")
+    print("Commands:")
+    width = max(len(name) for name in SUBCOMMANDS)
+    for name in SUBCOMMANDS:
+        _module, desc = SUBCOMMANDS[name]
+        print(f"  {name.ljust(width)}  {desc}")
+    print("\nEach command forwards its args to the matching helper. The standalone")
+    print("scripts/<helper>.py entrypoints remain valid.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] in ("-h", "--help", "help"):
+        _print_help()
+        return 0
+
+    command = argv[0]
+    if command not in SUBCOMMANDS:
+        print(f"Error: unknown command {command!r}. Run `cw --help`.", file=sys.stderr)
+        return 2
+
+    module_name, _desc = SUBCOMMANDS[command]
+    module = importlib.import_module(module_name)
+    return module.main(argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cw_cli.py
+++ b/tests/test_cw_cli.py
@@ -1,0 +1,57 @@
+"""Tests for the cw CLI facade (P3-17) — argument dispatch only.
+
+Business logic is tested in each helper's own test module; here we only verify
+the facade lists helpers and forwards args to the right module's main().
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import cw
+import pytest
+
+
+def test_help_lists_all_commands(capsys):
+    assert cw.main([]) == 0
+    out = capsys.readouterr().out
+    for name in cw.SUBCOMMANDS:
+        assert name in out
+
+
+def test_help_flag(capsys):
+    assert cw.main(["--help"]) == 0
+    assert "Commands:" in capsys.readouterr().out
+
+
+def test_unknown_command_exits_2(capsys):
+    assert cw.main(["bogus"]) == 2
+    assert "unknown command" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("command", list(cw.SUBCOMMANDS))
+def test_every_command_maps_to_an_importable_main(command):
+    module_name, _desc = cw.SUBCOMMANDS[command]
+    module = importlib.import_module(module_name)
+    assert callable(module.main)
+
+
+def test_dispatch_forwards_args(monkeypatch):
+    captured = {}
+
+    def fake_main(argv):
+        captured["argv"] = argv
+        return 0
+
+    # plan-waves -> plan_waves.main
+    module = importlib.import_module("plan_waves")
+    monkeypatch.setattr(module, "main", fake_main)
+    rc = cw.main(["plan-waves", "--edges", '{"1": []}'])
+    assert rc == 0
+    assert captured["argv"] == ["--edges", '{"1": []}']
+
+
+def test_dispatch_returns_helper_exit_code(monkeypatch):
+    module = importlib.import_module("git_safety")
+    monkeypatch.setattr(module, "main", lambda argv: 7)
+    assert cw.main(["git-safety", "check-branch", "x"]) == 7


### PR DESCRIPTION
## Summary

P3-17 (final ticket) of the Portable Python Orchestration Core epic. Adds a single optional CLI facade over the helpers built in this epic — for discoverability, without a giant orchestrator.

Closes #53.

## Changes

- **`scripts/cw.py`** — `SUBCOMMANDS` registry maps each command (`context`, `epic-metadata`, `plan-waves`, `epic-inventory`, `formal-artifacts`, `run-review`, `git-safety`, `run-verification`, `ux-gate`, `draft-pr`, `install-epic`, `traceability`, `close-epic-audit`, `install-design`) to a helper module; dispatch is a uniform `module.main(argv)` call. `cw` / `--help` lists every helper with a one-liner.
- **`tests/test_cw_cli.py`** — 19 dispatch-only tests.
- **README** — documents the facade.

## Acceptance criteria

- [x] CLI help lists all available helpers.
- [x] Existing script entrypoints remain valid (facade only forwards args; modules untouched).
- [x] Tests cover argument dispatch only; business logic remains tested in modules.

## Verification

- `make lint` clean; `make test` — 382 passed (19 new).