### PR TITLE
docs: isolate and inventory Claude-specific behaviors behind adapters (#28)

### DIFF
--- a/.claude/commands/keep-going.md
+++ b/.claude/commands/keep-going.md
@@ -1,5 +1,7 @@
 # Keep Going — Session Keep-Alive
 
+> **Claude Code only.** This skill depends on Claude Code's `CronCreate`/`CronDelete` tools and has no portable equivalent (see `docs/harness-adapters.md`). Other harnesses run long workflows their own way, or omit this entirely — they must not assume it exists.
+
 Prevents Claude Code sessions from going idle during long-running workflows by scheduling a periodic nudge.
 
 ## Usage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Chief Wiggum is a harness-portable SDLC orchestration layer. Treat the workflow 
 
 ## Harness Adapters
 
+The Claude Code adapter invokes the portable workflows through Claude-only mechanisms (sub-agent `subagent_type`/`model`/`isolation` parameters, `Cron*` tools, slash-command syntax). `docs/harness-adapters.md` inventories these surfaces with file/line references and names the portable concept each stands for — read it before assuming a behavior is portable. Claude model names map to provider roles in `config/providers.json` where portability matters; `/keep-going` and the `Cron*` tools are Claude-only.
+
 - Claude Code: use `.claude/commands/` and `CLAUDE.md`.
 - Codex or other skill-aware harnesses: install portable skills from `skills/` and use any harness-specific metadata as optional UI/config data.
 - Claude interactive delegation: use `$claude-interactive-delegate` only as an optional provider configured through `config/providers.json`.

--- a/docs/harness-adapters.md
+++ b/docs/harness-adapters.md
@@ -1,0 +1,41 @@
+# Claude Code Adapter Surface
+
+Chief Wiggum's workflow contracts are harness-neutral (see `AGENTS.md`), but the
+Claude Code adapter under `.claude/commands/` invokes them through Claude-only
+mechanisms. This file inventories those Claude-specific surfaces, names the
+portable concept each one stands for, and marks what is Claude-only.
+
+A non-Claude harness should map each surface to its own equivalent, or fail
+clearly when it has none — never silently inherit a broken Claude assumption.
+
+## Inventory
+
+| Claude surface | Where | Portable concept |
+|----------------|-------|------------------|
+| `subagent_type: "general-purpose"` | `implement.md:166,202,238,266,294,472`; `close-epic.md:139,204,237`; `architect.md:86`; `seed.md:170`; `implement-wave.md:217` | A **worker** with a role, inputs, output artifact paths, and a write scope (see `AGENTS.md` → worker contracts). |
+| `subagent_type: "Explore"` + `thoroughness:` | `implement.md:171`; `architect.md:55`; `seed.md:43` | A **read-only explorer worker** that returns a findings artifact. |
+| `model: "opus" \| "sonnet"` | `implement.md:166,202,238,266,294,472`; `architect.md:86`; `close-epic.md:139,204,237`; `implement-wave.md:217` | A **provider role** (`config/providers.json`), not a hard-coded model name. Use roles where portability matters; the model tier is an adapter hint. |
+| `isolation: "worktree"` | `implement.md:238,246,266`; `implement-wave.md:217` | A required **isolation behavior**: the worker writes only inside its own checkout, never the main checkout (enforce with `scripts/git_safety.py assert-worktree`). |
+| `run_in_background` + Agent completion notifications | `implement.md:171`; `implement-wave.md:217,244` | **Asynchronous worker completion** signalled through files / a harness-neutral status, not Claude's task-notification stream (see `scripts/delegates/`). |
+| `/keep-going`, `CronCreate`, `CronDelete` | `keep-going.md:7,26,35` | **Claude-only.** Session keep-alive via Claude Code cron. No portable equivalent is required; other harnesses run the loop their own way or omit it. |
+| Slash-command invocation (`/implement`, `/architect`, …) | all command files | The **Claude Code adapter's** invocation syntax. Portable skills are invoked by the host harness; workflow text describing portable behavior should not assume slash-command syntax. |
+
+## Rules for keeping workflows portable
+
+- **Describe workers by contract, not by Claude parameter.** When portability
+  matters, say "launch a read-only explorer worker that writes findings to
+  `$TICKET_TMP/...`", and add the `subagent_type`/`model`/`isolation` values as
+  a Claude Code adapter note — not as the only description.
+- **Prefer provider roles over model names.** `config/providers.json` roles
+  (`reviewer`, `architecture_critic`, `design_critic`, …) are the portable
+  selector; `opus`/`sonnet` are Claude tiers.
+- **Express isolation and completion as behaviors.** "Work only in your
+  worktree" and "signal completion by writing `<file>`" are portable; the
+  Claude `isolation`/notification mechanisms are how the adapter realizes them.
+- **Mark Claude-only surfaces explicitly.** `/keep-going` and the `Cron*` tools
+  are Claude Code only. An unsupported harness should fail clearly (e.g. "this
+  step requires Claude Code cron") rather than assume the behavior exists.
+
+This inventory is the basis for the deeper rewrites tracked in the Harness
+Generalization epic: harness-neutral worker contracts (#24) and portable skill
+packaging (#25).


### PR DESCRIPTION
## Summary

Phase-1 of the Harness Generalization epic. Inventories Claude-specific behaviors in the command prompts and frames them as adapter surfaces, so unsupported harnesses fail clearly or use an equivalent instead of inheriting broken assumptions.

Closes #28.

## Changes

- **`docs/harness-adapters.md`** (new) — inventories every Claude-only surface with **file/line references** (`subagent_type`/`model`/`isolation` params, `run_in_background` + Agent notifications, `Cron*`/`keep-going`, slash-command invocation) and names the portable concept each stands for, plus rules for keeping workflow text portable.
- **`keep-going.md`** — marked **Claude Code only** (depends on `CronCreate`/`CronDelete`; no portable equivalent).
- **`AGENTS.md`** — points at the inventory; states the model-name → provider-role rule and the Claude-only surfaces.

## Acceptance criteria

- [x] Claude-only commands and tool references are inventoried with file and line references.
- [x] `/keep-going` is marked as Claude-only.
- [x] Workflow text avoids assuming Claude slash-command invocation when describing portable behavior (rules documented).
- [x] Claude model names are mapped to provider roles where portability matters (rule documented; deep rewrite tracked in #24).
- [x] Unsupported harness behavior should fail clearly (rule documented).

## Scope

Documentation + adapter-marking. The deeper worker-contract rewrite (#24) and portable skill packaging (#25) build on this inventory.