### PR TITLE
Replace Claude sub-agent semantics with harness-neutral worker contracts (#24)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -91,9 +91,9 @@ Responses land at `$CW_TMP/architect-consult/architecture_critic-<provider>.md` 
 
 Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) to reconcile all three consultations into **structured formal models** (JSON) plus supporting prose artifacts. Each artifact is a separate file in `$CW_TMP/`.
 
-**The sub-agent MUST produce structured JSON models first.** The prose markdown is then generated mechanically from the JSON — never the other way around. This ensures the machine-readable and human-readable artifacts stay in sync.
+**The worker MUST produce structured JSON models first.** The prose markdown is then generated mechanically from the JSON — never the other way around. This ensures the machine-readable and human-readable artifacts stay in sync.
 
-Include the JSON Schema files from `$CW_HOME/templates/formal-models/` in the sub-agent prompt as reference, plus the worked example from `$CW_HOME/docs/formal-methods/examples/order-lifecycle.*.json` as a concrete template to follow.
+Include the JSON Schema files from `$CW_HOME/templates/formal-models/` in the worker prompt as reference, plus the worked example from `$CW_HOME/docs/formal-methods/examples/order-lifecycle.*.json` as a concrete template to follow.
 
 #### 4a. Data Contracts — structured model (`contracts.json`)
 
@@ -107,11 +107,11 @@ For every entity and API endpoint the epic touches, define:
 
 **Ground every data fact in a real source.** Field names, metric definitions, and external identifiers must come from `docs/domain-context.md` (or direct introspection) — cite the source in `notes`. Where a fact genuinely cannot be confirmed yet (external system unavailable, awaiting client answer), write an explicit `TBD:` marker in the field — e.g. `"notes": "TBD: confirm column name against dbt model orders_daily"`. Markers are machine-detected and **gate dependent tickets** in `/implement-wave`; a silent guess does not.
 
-**Verifier-in-the-loop**: After the sub-agent produces `contracts.json`, validate it:
+**Verifier-in-the-loop**: After the worker produces `contracts.json`, validate it:
 ```bash
 python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/contracts.json"
 ```
-If validation fails, feed the errors back to the sub-agent and have it fix the JSON. Repeat until valid.
+If validation fails, feed the errors back to the worker and have it fix the JSON. Repeat until valid.
 
 #### 4b. State Machines — structured model (`state-machines.json`)
 
@@ -153,7 +153,7 @@ python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view
 
 Produce a JSON file conforming to `$CW_HOME/templates/formal-models/ui-spec-schema.json`.
 
-This is the **UI contract** that prevents sub-agents from making conflicting design decisions. Without it, one agent builds a sidebar panel, another builds a separate page, and a third uses a dropdown — for the same feature.
+This is the **UI contract** that prevents workers from making conflicting design decisions. Without it, one agent builds a sidebar panel, another builds a separate page, and a third uses a dropdown — for the same feature.
 
 The UI spec defines:
 
@@ -173,7 +173,7 @@ The UI spec defines:
    **If no `docs/design/` exists** and the epic has frontend tickets, recommend running `/design` first — a brainstormed token list is a weaker contract than an approved rendered design. If the user declines, author the section from the seed decisions:
    - `source`: where the design comes from — the design system / reference product / brand kit discovered by `/seed` Step 3, with references (URLs, repo paths, reference screenshots). Only `net-new` if `/seed` confirmed nothing exists to match.
    - `tokens`: concrete values — colors (primary required; include brand gradients), typography (fonts + scale), spacing, radii, shadows. Derived from the seed design source when present; deliberate choices (with rationale in the ADR) when net-new. **Never leave a component library's default theme as the implicit answer.**
-   - `component_library`: which library and whether to `adopt`, `extend`, or go `custom` — sub-agents must not hand-roll components when the contract says adopt.
+   - `component_library`: which library and whether to `adopt`, `extend`, or go `custom` — workers must not hand-roll components when the contract says adopt.
    - `assets`: logo/wordmark/illustrations/reference screenshots, each with `applies_to` pages. Per-page `design_refs` link pages to the reference screenshots they must visually match.
    - `voice`: tone and empty-state guidelines, so empty states get personality instead of "No data".
 
@@ -181,9 +181,9 @@ The UI spec defines:
 
 **Critical constraint**: Every component that could be implemented as multiple UI patterns (dropdown vs tab vs modal vs page) MUST have an explicit interaction contract specifying which pattern to use.
 
-Include the worked example from `$CW_HOME/docs/formal-methods/examples/kanban-app-ui-spec.json` in the sub-agent prompt as a template.
+Include the worked example from `$CW_HOME/docs/formal-methods/examples/kanban-app-ui-spec.json` in the worker prompt as a template.
 
-**Verifier-in-the-loop**: After the sub-agent produces `ui-spec.json`, validate it:
+**Verifier-in-the-loop**: After the worker produces `ui-spec.json`, validate it:
 ```bash
 python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/ui-spec.json"
 ```

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -52,7 +52,7 @@ ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 
 ### Step 2: Explore the codebase
 
-Launch an **Explore sub-agent** (`subagent_type: "Explore"`, thoroughness: "very thorough") to understand the current state of the areas this epic will touch. The agent should report:
+Launch an **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) to understand the current state of the areas this epic will touch. *Claude Code adapter:* `subagent_type: "Explore"`, thoroughness "very thorough". The worker should report:
 
 - Current data models (structs, types, schemas) relevant to the epic
 - Existing API endpoints that will be extended or consumed
@@ -83,13 +83,13 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role architecture_critic $CW_TMP/arch
   --output-dir "$CW_TMP/architect-consult" --cwd "$TARGET_REPO"
 ```
 
-Responses land at `$CW_TMP/architect-consult/architecture_critic-<provider>.md` with status in `architecture_critic-manifest.json`. Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) in parallel to explore the codebase and produce its own architectural analysis at `$CW_TMP/architect-opus.md`.
+Responses land at `$CW_TMP/architect-consult/architecture_critic-<provider>.md` with status in `architecture_critic-manifest.json`. Launch an **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) in parallel to explore the codebase and produce its own architectural analysis at `$CW_TMP/architect-opus.md`. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`.
 
 **HARD RULE**: Wait for ALL THREE before proceeding.
 
 ### Step 4: Synthesise into architectural artifacts
 
-Launch a **second Opus sub-agent** to reconcile all three consultations into **structured formal models** (JSON) plus supporting prose artifacts. Each artifact is a separate file in `$CW_TMP/`.
+Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) to reconcile all three consultations into **structured formal models** (JSON) plus supporting prose artifacts. Each artifact is a separate file in `$CW_TMP/`.
 
 **The sub-agent MUST produce structured JSON models first.** The prose markdown is then generated mechanically from the JSON — never the other way around. This ensures the machine-readable and human-readable artifacts stay in sync.
 

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -232,12 +232,12 @@ The worker returns a manifest at `$CW_TMP/ux-audit/manifest.json`:
 
 If the target repo has no Playwright or browser-use setup, flag the gap and skip to the findings report.
 
-#### Opus UX review
+#### UX review
 
 Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) with: *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`.
 - Epic goal and the original ticket requirements for each ticket referenced in the journeys
 - `contracts.md`, `state-machines.md`, and `invariants.md` from the epic
-- The full journey manifest with screenshot paths (Opus can view images)
+- The full journey manifest with screenshot paths (the worker can view images)
 
 The worker should evaluate each journey for epic-level UX concerns:
 

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -136,7 +136,7 @@ For each integration test:
 
 If the target repo has Playwright or E2E infrastructure, use it for UI-surface assertions. Otherwise, use API calls and database queries.
 
-**Run inside a sub-agent** (`subagent_type: "general-purpose"`, `model: "sonnet"`) to keep the heavy test execution out of the main context. The sub-agent should:
+**Run inside a worker** (contract: `docs/worker-contracts.md#review-worker`) to keep the heavy test execution out of the orchestrator context. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. The worker should:
 - Start services if needed (`docker compose up -d`)
 - Execute each integration test
 - Capture results
@@ -201,7 +201,7 @@ If `integration-tests.md` has no UI-facing journeys, skip this step and note the
 
 #### Walk each journey with Playwright/browser-use
 
-Run inside a sub-agent (`subagent_type: "general-purpose"`, `model: "sonnet"`) that has access to the target repo's Playwright or browser-use setup. For each journey:
+Run inside a worker (contract: `docs/worker-contracts.md#review-worker`) that has access to the target repo's Playwright or browser-use setup. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. For each journey:
 
 1. Start from a clean authenticated session (or unauthenticated if the journey requires it)
 2. Follow every step in the journey spec
@@ -234,7 +234,7 @@ If the target repo has no Playwright or browser-use setup, flag the gap and skip
 
 #### Opus UX review
 
-Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) with:
+Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) with: *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`.
 - Epic goal and the original ticket requirements for each ticket referenced in the journeys
 - `contracts.md`, `state-machines.md`, and `invariants.md` from the epic
 - The full journey manifest with screenshot paths (Opus can view images)

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -136,7 +136,7 @@ For each integration test:
 
 If the target repo has Playwright or E2E infrastructure, use it for UI-surface assertions. Otherwise, use API calls and database queries.
 
-**Run inside a worker** (contract: `docs/worker-contracts.md#review-worker`) to keep the heavy test execution out of the orchestrator context. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. The worker should:
+**Run inside a verification worker** (contract: `docs/worker-contracts.md#verification-worker`) to keep the heavy test execution out of the orchestrator context. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. The worker should:
 - Start services if needed (`docker compose up -d`)
 - Execute each integration test
 - Capture results
@@ -201,7 +201,7 @@ If `integration-tests.md` has no UI-facing journeys, skip this step and note the
 
 #### Walk each journey with Playwright/browser-use
 
-Run inside a worker (contract: `docs/worker-contracts.md#review-worker`) that has access to the target repo's Playwright or browser-use setup. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. For each journey:
+Run inside a verification worker (contract: `docs/worker-contracts.md#verification-worker`) that has access to the target repo's Playwright or browser-use setup. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. For each journey:
 
 1. Start from a clean authenticated session (or unauthenticated if the journey requires it)
 2. Follow every step in the journey spec
@@ -214,7 +214,7 @@ Run inside a worker (contract: `docs/worker-contracts.md#review-worker`) that ha
 4. Save screenshots to `$CW_TMP/ux-audit/<journey-slug>/<step-N>.png`
 5. Record the sequence: step label, URL, screenshot path, any console errors
 
-The sub-agent returns a manifest at `$CW_TMP/ux-audit/manifest.json`:
+The worker returns a manifest at `$CW_TMP/ux-audit/manifest.json`:
 ```json
 [
   {
@@ -239,7 +239,7 @@ Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-wor
 - `contracts.md`, `state-machines.md`, and `invariants.md` from the epic
 - The full journey manifest with screenshot paths (Opus can view images)
 
-The sub-agent should evaluate each journey for epic-level UX concerns:
+The worker should evaluate each journey for epic-level UX concerns:
 
 1. **Menu and navigation consistency**: Do menus, breadcrumbs, and navigation patterns behave the same way across features introduced by different tickets? Does a menu item added by ticket A disappear or change label on pages owned by ticket B?
 2. **Information architecture**: Is data grouped and labelled logically across the full flow? Does the same entity surface under different headings or in unexpected sections depending on how the user arrived there?
@@ -254,7 +254,7 @@ For each finding, record:
 - What the finding is
 - A suggested fix
 
-The sub-agent writes findings to `$CW_TMP/ux-audit-findings.md`.
+The worker writes findings to `$CW_TMP/ux-audit-findings.md`.
 
 #### Report format
 

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -102,6 +102,8 @@ This is the **only** step that blocks on the user. Do not add approval gates els
 
 ### Step 4: Multi-AI design critique
 
+The critique is a **review worker** task (contract: `docs/worker-contracts.md#review-worker`) run through the `design_critic` provider role rather than a Claude sub-agent — so it is portable across harnesses.
+
 Unless `--skip-critique`: send the approved direction's screenshots to the `design_critic` quorum with the **same prompt** (value is in natural divergence). The role runs its providers in parallel with retries + output validation:
 
 ```bash

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -66,7 +66,7 @@ Each direction is **mockups-as-code**: one self-contained HTML file per represen
 3. **Real content from the domain**: populate with realistic data, names, and copy from `docs/domain-context.md` — never lorem ipsum, never `Item 1`. Include at least one empty state with real voice ("No sessions yet — upload your first video to get started"), not "No data".
 4. **High design quality is the point**: distinctive typography pairing with a reason, a purposeful palette with rationale, deliberate spacing rhythm. If a direction looks like a component library's default theme, that direction failed — regenerate it.
 
-Generate each direction with a **parallel worker** (use Opus — design quality is the product here). All workers get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
+Generate each direction with a **parallel worker** — design quality is the product here, so use a high-capability model. All workers get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
 
 **Render and look.** Screenshot every mock with Playwright at desktop (1440×900) and mobile (390×844) widths:
 

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -66,7 +66,7 @@ Each direction is **mockups-as-code**: one self-contained HTML file per represen
 3. **Real content from the domain**: populate with realistic data, names, and copy from `docs/domain-context.md` — never lorem ipsum, never `Item 1`. Include at least one empty state with real voice ("No sessions yet — upload your first video to get started"), not "No data".
 4. **High design quality is the point**: distinctive typography pairing with a reason, a purposeful palette with rationale, deliberate spacing rhythm. If a direction looks like a component library's default theme, that direction failed — regenerate it.
 
-Generate each direction with a **parallel worker** — design quality is the product here, so use a high-capability model. All workers get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
+Generate each direction with a **design-direction worker** (contract: `docs/worker-contracts.md#design-direction-worker`) — design quality is the product here, so use a high-capability model. All workers get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
 
 **Render and look.** Screenshot every mock with Playwright at desktop (1440×900) and mobile (390×844) widths:
 

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -66,7 +66,7 @@ Each direction is **mockups-as-code**: one self-contained HTML file per represen
 3. **Real content from the domain**: populate with realistic data, names, and copy from `docs/domain-context.md` — never lorem ipsum, never `Item 1`. Include at least one empty state with real voice ("No sessions yet — upload your first video to get started"), not "No data".
 4. **High design quality is the point**: distinctive typography pairing with a reason, a purposeful palette with rationale, deliberate spacing rhythm. If a direction looks like a component library's default theme, that direction failed — regenerate it.
 
-Generate each direction with a **parallel sub-agent** (use Opus — design quality is the product here). All sub-agents get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
+Generate each direction with a **parallel worker** (use Opus — design quality is the product here). All workers get identical context (domain context, screens, token convention, quality bar); only the direction brief differs. Divergence comes from the briefs, not from temperature.
 
 **Render and look.** Screenshot every mock with Playwright at desktop (1440×900) and mobile (390×844) widths:
 
@@ -102,7 +102,7 @@ This is the **only** step that blocks on the user. Do not add approval gates els
 
 ### Step 4: Multi-AI design critique
 
-The critique is a **review worker** task (contract: `docs/worker-contracts.md#review-worker`) run through the `design_critic` provider role rather than a Claude sub-agent — so it is portable across harnesses.
+The critique is a **review worker** task (contract: `docs/worker-contracts.md#review-worker`) run through the `design_critic` provider role rather than a Claude worker — so it is portable across harnesses.
 
 Unless `--skip-critique`: send the approved direction's screenshots to the `design_critic` quorum with the **same prompt** (value is in natural divergence). The role runs its providers in parallel with retries + output validation:
 

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -1,6 +1,6 @@
 # Implement Wave - Parallel Epic Implementation
 
-Takes an epic and implements all its tickets in dependency-ordered waves. Tickets within a wave have no interdependencies and run as parallel sub-agents, each in its own worktree. After each wave lands, the next wave starts from an updated main.
+Takes an epic and implements all its tickets in dependency-ordered waves. Tickets within a wave have no interdependencies and run as parallel workers, each in its own worktree. After each wave lands, the next wave starts from an updated main.
 
 This is the high-throughput alternative to running `/implement` sequentially per ticket. Use it when:
 - The epic has 3+ tickets
@@ -10,7 +10,7 @@ This is the high-throughput alternative to running `/implement` sequentially per
 ## Ownership
 
 Same principles as `/implement`: you own the solution, not just the code. The validation loop is not negotiable. But here, validation happens at **two levels**:
-- **Per-ticket**: Each parallel sub-agent runs the full `/implement` loop (Steps 5-8)
+- **Per-ticket**: Each parallel worker runs the full `/implement` loop (Steps 5-8)
 - **Per-wave**: After merging a wave, the orchestrator runs integration checks before starting the next wave
 
 ## Usage
@@ -188,7 +188,7 @@ Revised Wave 3: #45, #46
 
 #### 4a: Generate formal test artifacts (if formal models exist)
 
-**Before launching any sub-agents**, the orchestrator generates mechanical test artifacts from the formal models. This is deterministic — no LLM involved — and provides test scaffolding that sub-agents adapt rather than inventing tests from scratch.
+**Before launching any workers**, the orchestrator generates mechanical test artifacts from the formal models. This is deterministic — no LLM involved — and provides test scaffolding that workers adapt rather than inventing tests from scratch.
 
 ```bash
 if [ "$HAS_FORMAL_MODELS" = true ]; then
@@ -200,9 +200,9 @@ if [ "$HAS_FORMAL_MODELS" = true ]; then
 fi
 ```
 
-The shared `$CW_TMP/formal-test-artifacts/formal-artifacts-manifest.json` lists the generated files; every sub-agent in the wave adapts the same artifacts to its ticket.
+The shared `$CW_TMP/formal-test-artifacts/formal-artifacts-manifest.json` lists the generated files; every worker in the wave adapts the same artifacts to its ticket.
 
-These artifacts are shared across all tickets in the wave — each sub-agent receives the same test plan and adapts the relevant portions for its ticket.
+These artifacts are shared across all tickets in the wave — each worker receives the same test plan and adapts the relevant portions for its ticket.
 
 #### 4b: Launch parallel implementations
 
@@ -216,10 +216,10 @@ For each ticket in the current wave (up to `--max-parallel`):
 
 2. Launch a background **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) — it operates in its own isolated checkout, never the main checkout, and signals completion by writing its status/diff artifacts. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`, `run_in_background: true`.
 
-   The sub-agent prompt must include:
+   The worker prompt must include:
    - The full ticket details (title, body, acceptance criteria)
    - The epic context (contracts, invariants, state machines, traceability)
-   - **Formal test artifacts** (if they exist): the test plan (`$CW_TMP/formal-test-artifacts/test-plan.md`), test paths (`test-paths.json`), contract assertions (`contract-assertions.md`), guard templates, and Hypothesis skeleton. Instruct the sub-agent: "Adapt the model-derived test cases to the target repo's test framework. Each test path becomes a test case. Each invalid transition becomes a negative test. Tag model-derived tests with `// DERIVED: model` for traceability."
+   - **Formal test artifacts** (if they exist): the test plan (`$CW_TMP/formal-test-artifacts/test-plan.md`), test paths (`test-paths.json`), contract assertions (`contract-assertions.md`), guard templates, and Hypothesis skeleton. Instruct the worker: "Adapt the model-derived test cases to the target repo's test framework. Each test path becomes a test case. Each invalid transition becomes a negative test. Tag model-derived tests with `// DERIVED: model` for traceability."
    - The implementation plan approach: run the **full `/implement` Steps 4-9** internally:
      - Step 4: Consult 3 AIs on approach (Codex + Gemini as background processes, self as the third perspective), reconcile into plan
      - Step 5: Write failing tests (TDD) — **use model-derived test cases as the starting point**, supplement with LLM-written tests for edge cases
@@ -237,41 +237,41 @@ For each ticket in the current wave (up to `--max-parallel`):
    - The target repo path and default branch name
    - Instructions to report back: branch name, test results, review findings, any issues
 
-3. If the wave has more tickets than `--max-parallel`, queue the excess. As each sub-agent completes, launch the next queued ticket.
+3. If the wave has more tickets than `--max-parallel`, queue the excess. As each worker completes, launch the next queued ticket.
 
-**Sub-agent timeout**: If a sub-agent has not completed after **3 hours**, consider it hung. Implementation sub-agents run the full /implement loop internally (AI consultations, TDD, review, validation) which legitimately takes 60-120 minutes per ticket. Only after the 3-hour mark should you log a warning, note the ticket as failed for this wave, and proceed with collecting results from completed agents. The hung ticket can be retried in a later wave or handled manually with `/implement`.
+**Worker timeout**: If a worker has not completed after **3 hours**, consider it hung. Implementation workers run the full /implement loop internally (AI consultations, TDD, review, validation) which legitimately takes 60-120 minutes per ticket. Only after the 3-hour mark should you log a warning, note the ticket as failed for this wave, and proceed with collecting results from completed agents. The hung ticket can be retried in a later wave or handled manually with `/implement`.
 
-**While sub-agents run**, the orchestrator should monitor for completion notifications. Do not poll — the Agent tool will notify when each background agent finishes.
+**While workers run**, the orchestrator waits for each worker's completion signal — its output/status artifact appearing at the agreed path (see `docs/worker-contracts.md` → completion signalling). *Claude Code adapter:* a background Agent's task-notification fires when a worker finishes; treat it as the "artifact is ready" signal, not the contract itself.
 
 #### 4c: Collect and verify results
 
-As each sub-agent in the wave completes, collect:
+As each worker in the wave completes, collect:
 - **Branch name** and worktree path
 - **Test results**: did the full suite pass?
 - **Review findings**: what was flagged, what was fixed?
 - **Issues**: any blockers or unresolved items?
 
-If a sub-agent reports failure:
+If a worker reports failure:
 - **Test failures**: Attempt to diagnose. If it's a real issue, flag it. If it's a flaky test or pre-existing failure, note it.
 - **Blocking errors**: Log the error. The ticket may need to be moved to a later wave or handled manually.
-- **Timeout**: The sub-agent may still be running. Check its status before declaring failure.
+- **Timeout**: The worker may still be running. Check its status before declaring failure.
 
-Do not proceed to the merge step until ALL sub-agents in the wave have completed (successfully or with documented failures).
+Do not proceed to the merge step until ALL workers in the wave have completed (successfully or with documented failures).
 
-**Rogue PR detection**: After all sub-agents complete, check for unauthorized PRs:
+**Rogue PR detection**: After all workers complete, check for unauthorized PRs:
 ```bash
 gh pr list --repo "$owner_repo" --state open --limit 10 --json number,title,author,headRefName
 ```
-If any PRs were created by a sub-agent during this wave (matching ticket branch names), close them with a comment explaining the orchestrator handles PR creation. Warn the user.
+If any PRs were created by a worker during this wave (matching ticket branch names), close them with a comment explaining the orchestrator handles PR creation. Warn the user.
 
-**Orchestrator independent verification**: For each successfully completed ticket, the orchestrator must independently verify (not just trust the sub-agent's report):
+**Orchestrator independent verification**: For each successfully completed ticket, the orchestrator must independently verify (not just trust the worker's report):
 1. Check out the ticket's branch in its worktree
 2. Run the full test suite
 3. Run linting
 4. Verify the branch has the expected commits
-5. **For frontend tickets**: verify screenshots exist in `$TICKET_TMP/ux-screenshots/` and LOOK at them. A sub-agent reporting "design review passed" without screenshots is a sub-agent that skipped the gate. If the epic has a design contract and the screenshots show default-theme output, the ticket is not done.
+5. **For frontend tickets**: verify screenshots exist in `$TICKET_TMP/ux-screenshots/` and LOOK at them. A worker reporting "design review passed" without screenshots is a worker that skipped the gate. If the epic has a design contract and the screenshots show default-theme output, the ticket is not done.
 
-This is the same principle as `/implement` Step 8 — the orchestrator is the quality gate, not the sub-agent.
+This is the same principle as `/implement` Step 8 — the orchestrator is the quality gate, not the worker.
 
 #### 4d: Merge wave to a staging branch
 
@@ -433,8 +433,8 @@ After all waves complete:
 ## Key Principles
 
 - **Waves respect the dependency graph.** A ticket never starts until all its dependencies have merged to main. This is a hard constraint, not an optimisation hint.
-- **Each sub-agent runs the full /implement loop.** No shortcuts — TDD, multi-AI review, linting, tests. The parallelism is in running multiple tickets simultaneously, not in cutting steps per ticket.
-- **The orchestrator owns the merge.** Sub-agents produce branches. The orchestrator merges, resolves conflicts, and runs integration checks. Sub-agents never merge or create PRs.
+- **Each worker runs the full /implement loop.** No shortcuts — TDD, multi-AI review, linting, tests. The parallelism is in running multiple tickets simultaneously, not in cutting steps per ticket.
+- **The orchestrator owns the merge.** Workers produce branches. The orchestrator merges, resolves conflicts, and runs integration checks. Workers never merge or create PRs.
 - **Integration checks between waves catch seam bugs early.** A test that passes in isolation but fails after merge is exactly the kind of bug this workflow is designed to catch.
 - **Max-parallel limits API pressure.** Two concurrent tickets means up to 8 simultaneous AI API calls (3-4 consultations per ticket). Respect rate limits. Increase only with high-tier API access.
 - **Failed tickets don't block the wave.** If one ticket in a wave fails, the other tickets in that wave can still merge. The failed ticket is retried or deferred to a later wave.

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -214,7 +214,7 @@ For each ticket in the current wave (up to `--max-parallel`):
    mkdir -p "$TICKET_TMP"
    ```
 
-2. Launch a **sub-agent in a worktree** (`subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`, `run_in_background: true`).
+2. Launch a background **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) — it operates in its own isolated checkout, never the main checkout, and signals completion by writing its status/diff artifacts. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`, `run_in_background: true`.
 
    The sub-agent prompt must include:
    - The full ticket details (title, body, acceptance criteria)
@@ -293,7 +293,7 @@ This is the same principle as `/implement` Step 8 — the orchestrator is the qu
 3. **If merge conflicts occur** (expected when tickets in the same wave touch shared files):
    - Log which files conflict
    - Attempt automatic resolution for trivial conflicts (e.g., both sides added different imports)
-   - For non-trivial conflicts: launch a **Sonnet sub-agent** to resolve the conflict, passing it both branches' changes and the epic contracts as constraints
+   - For non-trivial conflicts: launch an **implementation worker** to resolve the conflict, passing it both branches' changes and the epic contracts as constraints
    - After resolution, run the full test suite to verify the merge is clean
 
 #### 4e: Wave integration check
@@ -306,7 +306,7 @@ Run the integration check **on the staging branch, before promoting to main**:
 4. **Smoke test**: If services can be started, start them and verify health endpoints respond
 
 If the integration check fails:
-- **Test failure caused by merge**: Fix it on the staging branch. Launch a Sonnet sub-agent to diagnose and fix.
+- **Test failure caused by merge**: Fix it on the staging branch. Launch an implementation worker to diagnose and fix.
 - **Build failure**: This is a hard blocker. Fix before proceeding.
 - Do NOT push until all checks pass.
 

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -188,7 +188,7 @@ Revised Wave 3: #45, #46
 
 #### 4a: Generate formal test artifacts (if formal models exist)
 
-**Before launching any workers**, the orchestrator generates mechanical test artifacts from the formal models. This is deterministic — no LLM involved — and provides test scaffolding that workers adapt rather than inventing tests from scratch.
+**Before any workers run**, the orchestrator generates mechanical test artifacts from the formal models. This is deterministic — no LLM involved — and provides test scaffolding that workers adapt rather than inventing tests from scratch.
 
 ```bash
 if [ "$HAS_FORMAL_MODELS" = true ]; then
@@ -293,7 +293,7 @@ This is the same principle as `/implement` Step 8 — the orchestrator is the qu
 3. **If merge conflicts occur** (expected when tickets in the same wave touch shared files):
    - Log which files conflict
    - Attempt automatic resolution for trivial conflicts (e.g., both sides added different imports)
-   - For non-trivial conflicts: launch an **implementation worker** to resolve the conflict, passing it both branches' changes and the epic contracts as constraints
+   - For non-trivial conflicts: launch an **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) to resolve the conflict, passing it both branches' changes and the epic contracts as constraints
    - After resolution, run the full test suite to verify the merge is clean
 
 #### 4e: Wave integration check
@@ -306,7 +306,7 @@ Run the integration check **on the staging branch, before promoting to main**:
 4. **Smoke test**: If services can be started, start them and verify health endpoints respond
 
 If the integration check fails:
-- **Test failure caused by merge**: Fix it on the staging branch. Launch an implementation worker to diagnose and fix.
+- **Test failure caused by merge**: Fix it on the staging branch. Launch an implementation worker (contract: `docs/worker-contracts.md#implementation-worker`) to diagnose and fix.
 - **Build failure**: This is a hard blocker. Fix before proceeding.
 - Do NOT push until all checks pass.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -11,7 +11,7 @@ The core orchestration skill. Takes a ticket and drives it through the full impl
 
 If the answer to any of these is no — fix it. Don't ship "good enough."
 
-**The validation loop is not negotiable.** Sub-agents will take shortcuts. The orchestrator is the quality gate. Never trust a sub-agent's self-reported "tests pass" — independently verify.
+**The validation loop is not negotiable.** Workers will take shortcuts. The orchestrator is the quality gate. Never trust a worker's self-reported "tests pass" — independently verify.
 
 **Never punt to the user.** If Docker isn't running, start it. If a dependency is missing, install it. If you can't run the tests, that's YOUR problem to solve. "Want to skip this step?" is never the right question.
 
@@ -112,7 +112,7 @@ HAS_TRANSITION_MAP=$(jq -r '.flags.HAS_TRANSITION_MAP' "$TICKET_TMP/inventory.js
 ```
 The inventory's `blocked_tickets` and `warnings` (e.g. malformed model JSON) feed the unresolved-unknowns gate below.
 
-These artifacts are **hard constraints** on the implementation. The coding sub-agent MUST satisfy them. The review checklist MUST verify them. When formal models exist, test generation in Step 5 uses them for mechanical path coverage.
+These artifacts are **hard constraints** on the implementation. The coding worker MUST satisfy them. The review checklist MUST verify them. When formal models exist, test generation in Step 5 uses them for mechanical path coverage.
 
 **Unresolved-unknowns gate**: scan the epic artifacts for markers this ticket would inherit:
 ```bash
@@ -150,7 +150,7 @@ If you do need to ask, keep it tight:
 
 ### Step 4: Consult AIs on approach
 
-This step has two phases, each in its own sub-agent. This keeps the heavy codebase exploration and synthesis out of the main context window.
+This step has two phases, each in its own worker. This keeps the heavy codebase exploration and synthesis out of the main context window.
 
 #### Phase A: Gather approaches (parallel)
 
@@ -222,7 +222,7 @@ Present a concise summary to the user. If there are open questions that genuinel
 
 **Write failing tests before writing implementation code.** This transforms the objective from "implement this feature" to "make these tests pass" — a more constrained and verifiable target.
 
-**If formal models exist** (`$HAS_FORMAL_MODELS == true`), generate mechanical test artifacts BEFORE launching the sub-agent. The orchestrator does this directly — it's a deterministic script call, not LLM work:
+**If formal models exist** (`$HAS_FORMAL_MODELS == true`), generate mechanical test artifacts BEFORE launching the worker. The orchestrator does this directly — it's a deterministic script call, not LLM work:
 
 ```bash
 # One idempotent call generates every model-derived test artifact (test paths,
@@ -233,19 +233,19 @@ python3 "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" --out
 
 The manifest (`$TICKET_TMP/formal-artifacts-manifest.json`) lists the generated files and per-model status; a non-zero exit means a present model failed validation — fix the model before building on it.
 
-These mechanically generated artifacts are passed to the sub-agent as inputs — the sub-agent adapts them to the target repo's test framework and conventions, not invents tests from scratch.
+These mechanically generated artifacts are passed to the worker as inputs — the worker adapts them to the target repo's test framework and conventions, not invents tests from scratch.
 
 Launch an **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) — it must operate in its own isolated checkout and never touch the main checkout. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`. Pass it:
 - The implementation plan from Step 4
 - The epic contracts and traceability matrix (if they exist)
 - The target repo's test framework and conventions
 - **If formal models exist**: the generated test plan (`$TICKET_TMP/test-plan.md`), test paths (`$TICKET_TMP/test-paths.json`), contract assertions (`$TICKET_TMP/contract-assertions.md`), Hypothesis skeleton (`$TICKET_TMP/test_state_machine.py`), and guard templates (`$TICKET_TMP/guards.py`) — all listed in `$TICKET_TMP/formal-artifacts-manifest.json`
-- **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
-**HARD RULES for sub-agent**:
+- **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The worker MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
+**HARD RULES for worker**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).
 - You work in an **isolated checkout** (required isolation behavior). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the checkout root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 
-The sub-agent should:
+The worker should:
 
 1. Create a feature branch named after the ticket (e.g., `feat/42-add-dark-mode`)
 2. Write test files FIRST, covering:
@@ -259,17 +259,17 @@ The sub-agent should:
 4. Commit the test files with message: `test: add failing tests for #[number] — [title]`
 5. Report back: which tests were written (noting which are model-derived vs LLM-written), which frameworks used, any gaps in the traceability matrix
 
-**Important**: The sub-agent should report the worktree path and branch name. The implementation sub-agent in Step 6 will work in the SAME worktree.
+**Important**: The worker should report the worktree path and branch name. The implementation worker in Step 6 will work in the SAME worktree.
 
 ### Step 6: Implement
 
 Launch an **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) in the **same isolated checkout** from Step 5. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`. Pass it the **full implementation plan** from `$TICKET_TMP/implementation-plan.md` plus any user feedback, plus the fact that failing tests already exist on the branch.
 
-**HARD RULES for sub-agent**:
+**HARD RULES for worker**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code, run tests, and commit. The orchestrator owns PR creation (Step 11).
 - You are working in a **git worktree** (the same one from Step 5). Confirm isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 
-The sub-agent should:
+The worker should:
 1. Implement the approved approach — the primary objective is **making the failing tests from Step 5 turn green**
 2. Enforce epic contracts as runtime guards:
    - Every REQUIRES block → input validation / guard clause at function entry
@@ -293,7 +293,7 @@ The sub-agent should:
 
 **IMPORTANT**: Run this entire step inside a **review worker** (contract: `docs/worker-contracts.md#review-worker`). The orchestrator should only receive the synthesized review summary with actionable items. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`.
 
-The sub-agent should:
+The worker should:
 
 1. Get the diff from the implementation:
    ```bash
@@ -330,7 +330,7 @@ The sub-agent should:
 
 Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then **the orchestrator independently verifies the final state** — this is not delegatable.
 
-1. **Apply clear-cut fixes** directly (don't re-launch a sub-agent for trivial changes)
+1. **Apply clear-cut fixes** directly (don't re-launch a worker for trivial changes)
 2. **Flag ambiguous feedback** for user decision — only block on items that genuinely need input
 3. **Run static analysis** on the changed files:
    - Go: `golangci-lint run ./...`
@@ -356,7 +356,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    - Check that invalid state transitions are rejected (try one via curl or test)
    - Check that ENSURES postconditions hold after operations complete
 8. **Formal model conformance check** (if `$HAS_FORMAL_MODELS == true`):
-   This is the mechanical verification step that doesn't rely on sub-agent self-reports.
+   This is the mechanical verification step that doesn't rely on worker self-reports.
    - **State machine coverage**: For each test path in `test-paths.json`, verify a corresponding test exists and passes. Count: paths covered / paths total.
    - **Invalid transition coverage**: For each invalid transition in the model, verify a negative test exists that asserts rejection. Count: invalid transitions tested / invalid transitions total.
    - **Guard clause presence**: For each REQUIRES precondition in `contracts.json`, grep the implementation for a corresponding guard clause or validation check. Flag missing guards.
@@ -394,7 +394,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    - Would you be proud to ship this?
 10. **Clean up** — Stop any services you started (`docker compose down`)
 
-If ANY verification fails: fix it directly, or re-launch the coding sub-agent with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
+If ANY verification fails: fix it directly, or re-launch the coding worker with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
 
 ### Step 9: UX sanity + design-fidelity gate
 
@@ -477,7 +477,7 @@ Launch a **review worker** (contract: `docs/worker-contracts.md#review-worker`) 
 4. **The visual design contract** (if `ui-spec.json` has a `design` section): the design tokens, component-library binding, brand assets, voice guidelines, and — critically — any `reference-screenshot` assets whose `applies_to` covers the pages this ticket touches. Pass the reference image paths so the reviewer can compare side by side. If the target repo has `docs/design/` (produced by `/design`), the approved-mock screenshots in `docs/design/reference/` are the comparison baseline — pass them even if the epic's ui-spec assets don't list one for these pages, and treat `docs/design/mockups/*.html` as the living reference implementation when layout questions arise. Include the Phase 1b token-check output.
 5. **The AC bullets** — for reference, but instruct the reviewer: *"These bullets define the floor, not the ceiling. Your job is to evaluate whether the screens make sense to a user trying to accomplish the goal described in the prose, and whether they honor the visual design contract."*
 
-The sub-agent should evaluate:
+The worker should evaluate:
 
 - **Information architecture**: Is the right information on the right screen? Is anything missing that a user would expect to see? Is anything shown that shouldn't be visible at this stage?
 - **Menu and navigation coherence**: If menus or navigation changed, do the new entries make sense in context? Are they in the right place, with the right label? Do they appear/disappear at the right times?
@@ -492,13 +492,13 @@ The sub-agent should evaluate:
   - Does visible copy match the voice guidelines (empty states with personality, not "No data")?
   - **Surface-level correctness a human would catch in 2 seconds**: 0-indexed lists shown to users, raw enum values in labels, placeholder copy, truncated text, misaligned elements, debug output visible in the UI.
 
-The sub-agent returns findings in the same confidence categories as the code review:
+The worker returns findings in the same confidence categories as the code review:
 
 - **High-confidence**: Clear UX problems — missing confirmation message after submit, a Cancel button that should not appear in PENDING state, a form field exposing an internal DB ID — and clear design-contract violations: design tokens not applied (Phase 1b MISSING), a page that plainly doesn't match its reference screenshot, a missing brand asset, user-visible 0-indexing or debug output. These have an obvious fix and **fail the ticket until fixed**.
 - **Medium-confidence**: Likely issues that need a quick look — a menu label that's technically correct but potentially confusing, an empty state with no guidance copy. These should be applied but are worth a quick sanity check.
 - **Low-confidence**: Subjective observations or minor polish — layout density, label wording choices, optional affordances the ticket doesn't require. Flag for awareness, do not block.
 
-The sub-agent writes findings to `$TICKET_TMP/ux-review.md` and returns a concise summary.
+The worker writes findings to `$TICKET_TMP/ux-review.md` and returns a concise summary.
 
 #### Phase 3: Apply findings
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -17,7 +17,7 @@ If the answer to any of these is no — fix it. Don't ship "good enough."
 
 **Every step is mandatory.** You do NOT get to decide that a change is "too small" to warrant code review, or that consultations are "good enough" with only 2 of 3 responses. The process exists for a reason — follow it completely every time, no exceptions. Specifically:
 - **Never skip the multi-AI code review** (Step 7), regardless of change size. A one-line fix gets the same review process as a 500-line feature. No developer gets to self-certify their own code.
-- **Never skip AI consultations** (Step 4). Wait for ALL consultations (Codex, Gemini, Opus) to complete. If one times out, retry it. Never proceed to reconciliation with partial results.
+- **Never skip AI consultations** (Step 4). Wait for ALL consultations (codex, gemini, and the exploration worker) to complete. If one times out, retry it. Never proceed to reconciliation with partial results.
 - **Never skip browser-use/E2E validation** (Step 10) unless `--skip-browser-use` was explicitly passed by the user.
 - **Never create a PR before review is complete.** The PR is the final artifact (Step 11), not an intermediate checkpoint.
 
@@ -186,7 +186,7 @@ Before launching, prepare the approach prompt at `$TICKET_TMP/approach-prompt.md
   - **Do NOT include**: specific files suspected to be relevant, suggested root causes, or preliminary solution directions. Let each AI discover what's relevant independently — the divergence is the value.
 - Question: "Propose an implementation approach including: files to modify/create, step-by-step plan, design decisions and trade-offs, risks/gotchas, testing strategy"
 
-**HARD RULE**: Do NOT proceed to Phase B until ALL THREE approaches (Codex, Gemini, Opus) have completed successfully. If any consultation times out or fails, retry it — do not proceed with partial results. The value of multi-AI consultation comes from diverse perspectives; 2 of 3 is not acceptable.
+**HARD RULE**: Do NOT proceed to Phase B until ALL THREE approaches (codex, gemini, and the exploration worker) have completed successfully. If any consultation times out or fails, retry it — do not proceed with partial results. The value of multi-AI consultation comes from diverse perspectives; 2 of 3 is not acceptable.
 
 **Validate consultation output after `wait`**: After all background processes complete, check each output file:
 ```bash
@@ -205,7 +205,7 @@ Once all three approaches are ready, ensure the codebase deep-dive explorer work
 2. Read the codebase context file (`$TICKET_TMP/codebase-context.md`) from the deep-dive agent
 3. Read the epic context files (contracts, invariants, state machines) if they exist
 4. Identify consensus, conflicts, and unique insights
-5. Produce a **comprehensive implementation plan** detailed enough that a Sonnet coding agent can execute it mechanically. The plan must include:
+5. Produce a **comprehensive implementation plan** detailed enough that the implementation worker can execute it mechanically. The plan must include:
    - **Files to create/modify** with specific paths
    - **Ordered implementation steps** — each step should specify exactly what to do, in which file, with enough detail that no further codebase exploration is needed
    - **Code patterns to follow** — reference specific existing files/functions as templates
@@ -222,7 +222,7 @@ Present a concise summary to the user. If there are open questions that genuinel
 
 **Write failing tests before writing implementation code.** This transforms the objective from "implement this feature" to "make these tests pass" — a more constrained and verifiable target.
 
-**If formal models exist** (`$HAS_FORMAL_MODELS == true`), generate mechanical test artifacts BEFORE launching the worker. The orchestrator does this directly — it's a deterministic script call, not LLM work:
+**If formal models exist** (`$HAS_FORMAL_MODELS == true`), generate mechanical test artifacts BEFORE the implementation worker runs. The orchestrator does this directly — it's a deterministic script call, not LLM work:
 
 ```bash
 # One idempotent call generates every model-derived test artifact (test paths,
@@ -330,7 +330,7 @@ The worker should:
 
 Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then **the orchestrator independently verifies the final state** — this is not delegatable.
 
-1. **Apply clear-cut fixes** directly (don't re-launch a worker for trivial changes)
+1. **Apply clear-cut fixes** directly (don't re-run a worker for trivial changes)
 2. **Flag ambiguous feedback** for user decision — only block on items that genuinely need input
 3. **Run static analysis** on the changed files:
    - Go: `golangci-lint run ./...`
@@ -394,7 +394,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    - Would you be proud to ship this?
 10. **Clean up** — Stop any services you started (`docker compose down`)
 
-If ANY verification fails: fix it directly, or re-launch the coding worker with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
+If ANY verification fails: fix it directly, or re-launch the coding worker (contract: `docs/worker-contracts.md#implementation-worker`) with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
 
 ### Step 9: UX sanity + design-fidelity gate
 
@@ -467,7 +467,7 @@ for name, value in spec.get('design', {}).get('tokens', {}).get('colors', {}).it
 done
 ```
 
-#### Phase 2: Opus UX + design-fidelity review
+#### Phase 2: UX + design-fidelity review
 
 Launch a **review worker** (contract: `docs/worker-contracts.md#review-worker`) and give it: *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -163,12 +163,12 @@ Run **four** tasks in parallel — three AI consultations plus a codebase explor
    wait
    ```
 
-2. **Opus exploration** — Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) in parallel with the above. This sub-agent should:
+2. **Opus exploration** — Launch an **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) in parallel with the above. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`. This worker should:
    - Explore the target repo codebase thoroughly (read key files, understand patterns)
    - Form its own implementation approach
    - Write its findings to `$TICKET_TMP/approach-opus.md`
 
-3. **Codebase deep-dive** — Launch a **Sonnet Explore sub-agent** (`subagent_type: "Explore"`, thoroughness: "very thorough") in parallel with all of the above, running in the background (`run_in_background: true`). This sub-agent should:
+3. **Codebase deep-dive** — Launch a background **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) in parallel with all of the above; it signals completion by writing its findings artifact (and a status file), not via a harness notification. *Claude Code adapter:* `subagent_type: "Explore"`, thoroughness "very thorough", `run_in_background: true`. This worker should:
    - Read key files in the areas the ticket will touch (based on ticket description and labels)
    - Document existing patterns, conventions, test infrastructure, and relevant data models
    - Write findings to `$TICKET_TMP/codebase-context.md`
@@ -199,7 +199,7 @@ If any output is empty, missing, or contains only an error message, **retry that
 
 #### Phase B: Reconcile into implementation plan
 
-Once all three approaches are ready, ensure the codebase deep-dive agent (Phase A, task 3) has also completed. Then launch a **second Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) to reconcile them. This sub-agent should:
+Once all three approaches are ready, ensure the codebase deep-dive explorer worker (Phase A, task 3) has also completed (its findings artifact exists). Then launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) to reconcile them. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`. This worker should:
 
 1. Read all three approach files (`approach-codex.md`, `approach-gemini.md`, `approach-opus.md`)
 2. Read the codebase context file (`$TICKET_TMP/codebase-context.md`) from the deep-dive agent
@@ -235,7 +235,7 @@ The manifest (`$TICKET_TMP/formal-artifacts-manifest.json`) lists the generated 
 
 These mechanically generated artifacts are passed to the sub-agent as inputs — the sub-agent adapts them to the target repo's test framework and conventions, not invents tests from scratch.
 
-Launch a **Sonnet sub-agent** in a worktree (`subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`). Pass it:
+Launch an **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) — it must operate in its own isolated checkout and never touch the main checkout. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`. Pass it:
 - The implementation plan from Step 4
 - The epic contracts and traceability matrix (if they exist)
 - The target repo's test framework and conventions
@@ -243,7 +243,7 @@ Launch a **Sonnet sub-agent** in a worktree (`subagent_type: "general-purpose"`,
 - **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The sub-agent MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).
-- You are working in a **git worktree** (created by the `isolation: "worktree"` parameter). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the worktree root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
+- You work in an **isolated checkout** (required isolation behavior). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the checkout root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 
 The sub-agent should:
 
@@ -263,7 +263,7 @@ The sub-agent should:
 
 ### Step 6: Implement
 
-Launch a **Sonnet sub-agent** in the **same worktree** from Step 5 (`subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`). Pass it the **full implementation plan** from `$TICKET_TMP/implementation-plan.md` plus any user feedback, plus the fact that failing tests already exist on the branch.
+Launch an **implementation worker** (contract: `docs/worker-contracts.md#implementation-worker`) in the **same isolated checkout** from Step 5. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`, `isolation: "worktree"`. Pass it the **full implementation plan** from `$TICKET_TMP/implementation-plan.md` plus any user feedback, plus the fact that failing tests already exist on the branch.
 
 **HARD RULES for sub-agent**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code, run tests, and commit. The orchestrator owns PR creation (Step 11).
@@ -291,7 +291,7 @@ The sub-agent should:
 
 **THIS STEP IS NEVER OPTIONAL.** Every implementation gets a multi-AI code review, regardless of change size. A one-line typo fix, a 10-line config change, a 500-line feature — all get the same review process. You do not get to self-certify your own code. No exceptions, no shortcuts.
 
-**IMPORTANT**: Run this entire step inside a **Sonnet sub-agent** (`subagent_type: "general-purpose"`, `model: "sonnet"`). The main thread should only receive the synthesized review summary with actionable items.
+**IMPORTANT**: Run this entire step inside a **review worker** (contract: `docs/worker-contracts.md#review-worker`). The orchestrator should only receive the synthesized review summary with actionable items. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`.
 
 The sub-agent should:
 
@@ -469,7 +469,7 @@ done
 
 #### Phase 2: Opus UX + design-fidelity review
 
-Launch an **Opus sub-agent** (`subagent_type: "general-purpose"`, `model: "opus"`) and give it:
+Launch a **review worker** (contract: `docs/worker-contracts.md#review-worker`) and give it: *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "opus"`.
 
 1. **The screenshots** — pass paths to all captured images in `$TICKET_TMP/ux-screenshots/`
 2. **Requirement prose** — the full ticket body (not just AC bullet points): title, description, user story, and any comments

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -40,7 +40,7 @@ If the repo is empty or has no requirements docs, tell the user and suggest they
 
 Ask the user: "Are there any existing repos I should explore for patterns, tech stack, or lessons learned?"
 
-If yes, send an **Explore sub-agent** (`subagent_type: "Explore"`, thoroughness: "very thorough") in the background to analyse the sister repo. The agent should report on:
+If yes, send a background **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) to analyse the sister repo; it signals completion by writing its findings artifact. *Claude Code adapter:* `subagent_type: "Explore"`, thoroughness "very thorough", in the background. The worker should report on:
 - Tech stack and architecture patterns
 - What works well (patterns worth replicating)
 - What's painful (patterns to avoid)
@@ -56,7 +56,7 @@ Most seed failures are not bad architecture — they're architecture built on **
 1. **Existing data model** — "Does this product read from or write to an existing data source? Where does its truth live?" If yes, ingest it **before any data contracts are written**:
    - The semantic/modeling layer (dbt, Dataform, LookML, a metrics store) — canonical metric definitions, dimensions, measures
    - The physical schema — introspect it (run `\d`/`SHOW CREATE TABLE`/`db.collection.findOne()` against a real instance, or read migration files). Never trust table/column names from memory or docs alone.
-   - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **Explore sub-agent** over the repo history; caveats live in PR descriptions, not schemas.
+   - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **explorer worker** over the repo history; caveats live in PR descriptions, not schemas.
 2. **Real use cases** — "Where do real user requests live?" (issue tracker, support queue, team chat channels, existing dashboards). If accessible, mine them with a sub-agent to derive:
    - The question patterns the product must answer (these become golden eval cases for `/architect` traceability)
    - The dimensions/measures/entities users actually slice by
@@ -167,7 +167,7 @@ For each issue, define:
 
 These go in the first sprint — they're needed as soon as there's code to test and deploy.
 
-Run issue creation in a **sub-agent** (`subagent_type: "general-purpose"`) to keep the main context clean. The sub-agent should use `gh issue create` for each issue and `gh label create` for any new labels.
+Run issue creation in a **worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`, here writing issues rather than findings) to keep the orchestrator context clean. *Claude Code adapter:* `subagent_type: "general-purpose"`. The worker should use `gh issue create` for each issue and `gh label create` for any new labels.
 
 ### Step 9: Report
 

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -57,7 +57,7 @@ Most seed failures are not bad architecture — they're architecture built on **
    - The semantic/modeling layer (dbt, Dataform, LookML, a metrics store) — canonical metric definitions, dimensions, measures
    - The physical schema — introspect it (run `\d`/`SHOW CREATE TABLE`/`db.collection.findOne()` against a real instance, or read migration files). Never trust table/column names from memory or docs alone.
    - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **explorer worker** over the repo history; caveats live in PR descriptions, not schemas.
-2. **Real use cases** — "Where do real user requests live?" (issue tracker, support queue, team chat channels, existing dashboards). If accessible, mine them with a sub-agent to derive:
+2. **Real use cases** — "Where do real user requests live?" (issue tracker, support queue, team chat channels, existing dashboards). If accessible, mine them with a worker to derive:
    - The question patterns the product must answer (these become golden eval cases for `/architect` traceability)
    - The dimensions/measures/entities users actually slice by
    - Domain caveats stated by the team ("ignore test accounts", "EU revenue is net of VAT")
@@ -167,7 +167,7 @@ For each issue, define:
 
 These go in the first sprint — they're needed as soon as there's code to test and deploy.
 
-Run issue creation in a **worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`, here writing issues rather than findings) to keep the orchestrator context clean. *Claude Code adapter:* `subagent_type: "general-purpose"`. The worker should use `gh issue create` for each issue and `gh label create` for any new labels.
+Run issue creation in an **issue-authoring worker** (contract: `docs/worker-contracts.md#issue-authoring-worker`) to keep the orchestrator context clean. *Claude Code adapter:* `subagent_type: "general-purpose"`. The worker should use `gh issue create` for each issue and `gh label create` for any new labels.
 
 ### Step 9: Report
 

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -56,7 +56,7 @@ Most seed failures are not bad architecture — they're architecture built on **
 1. **Existing data model** — "Does this product read from or write to an existing data source? Where does its truth live?" If yes, ingest it **before any data contracts are written**:
    - The semantic/modeling layer (dbt, Dataform, LookML, a metrics store) — canonical metric definitions, dimensions, measures
    - The physical schema — introspect it (run `\d`/`SHOW CREATE TABLE`/`db.collection.findOne()` against a real instance, or read migration files). Never trust table/column names from memory or docs alone.
-   - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **explorer worker** over the repo history; caveats live in PR descriptions, not schemas.
+   - The transformation repo's **history and PRs** — deprecations, frozen sources, unit/locale normalisation rules, test-record exclusions, dedup patterns, known-bad data. Send an **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) over the repo history; caveats live in PR descriptions, not schemas.
 2. **Real use cases** — "Where do real user requests live?" (issue tracker, support queue, team chat channels, existing dashboards). If accessible, mine them with a worker to derive:
    - The question patterns the product must answer (these become golden eval cases for `/architect` traceability)
    - The dimensions/measures/entities users actually slice by

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ fmt:
 lint:
 	python3 -m ruff check scripts tests
 	python3 -m py_compile scripts/*.py scripts/extractors/*.py scripts/chief_wiggum/*.py
+	python3 scripts/check_portability.py
 
 test:
 	python3 -m pytest

--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -119,6 +119,17 @@ scope / isolation / stop) is what another harness implements.
 - **Stop condition**: every scenario executed and the evidence artifact written;
   on a critical failure, stop and report instead of continuing.
 
+### design-direction-worker
+
+- **Role**: generate one rendered design direction (mockups-as-code).
+- **Inputs**: the shared design context (domain context, screens, token
+  convention, quality bar) plus this direction's brief.
+- **Output artifact paths**: the direction's HTML mockups under
+  `$DESIGN_TMP/directions/<direction>/`.
+- **Write scope**: its own direction output directory only.
+- **Isolation**: none required.
+- **Stop condition**: the direction's mockups rendered and written.
+
 ### issue-authoring-worker
 
 - **Role**: create GitHub issues/labels from a planned set.

--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -1,0 +1,107 @@
+# Worker Contracts
+
+Chief Wiggum workflows delegate sub-tasks to **workers**. A worker is described
+by a harness-neutral *contract*, not by a Claude Code parameter. Any harness
+(Claude Code sub-agents, Codex, another orchestrator) can run a worker as long
+as it satisfies the contract; the Claude `subagent_type`/`model`/`isolation`
+values are one adapter's way of realizing it (inventoried in
+`docs/harness-adapters.md`).
+
+Where a harness supports sub-agents it may spawn them; otherwise the main
+orchestrator runs the worker contract locally or via a provider adapter. This
+makes the workflow text portable — it does not require parallel worker execution
+in every harness.
+
+## Contract fields
+
+Every worker launch defines:
+
+- **Role** — what the worker is for.
+- **Inputs** — the artifacts/paths it is given.
+- **Output artifact paths** — where it must write its result. The orchestrator
+  reads these; a conversational reply is not the contract.
+- **Write scope** — which files/directories it may modify.
+- **Isolation** — a required *behavior*, not a parameter. A code worker MUST
+  operate in its own checkout and never touch the main checkout (enforce with
+  `scripts/git_safety.py assert-worktree --main "$TARGET_REPO"`).
+- **Stop condition** — when the worker is done, and when it must stop and report
+  instead of guessing.
+
+## Completion signalling
+
+A worker's completion is signalled through its **output artifact** (a file at a
+known path) and, for background workers, a status file (`done`/`error` with a
+reason) — not through a harness-specific event stream. An orchestrator polls
+for / reads those files. Claude Code's background-agent notifications are one
+adapter for the same "the artifact now exists" signal; the file-based
+delegated-worker protocol in `scripts/delegates/` is the portable form. Do not
+rely on Claude Agent notifications as the portable completion contract.
+
+## Claude Code adapter mapping
+
+| Contract concept | Claude Code adapter |
+|------------------|---------------------|
+| explorer worker | `subagent_type: "Explore"` (or `"general-purpose"`), `thoroughness:` |
+| any worker, model tier | `model: "opus" \| "sonnet"` — prefer a provider role where portability matters |
+| worktree isolation | `isolation: "worktree"` |
+| async completion | `run_in_background` + task-notification → a status file |
+
+When a workflow names these Claude parameters, they appear on a
+`Claude Code adapter:` note — the portable description (role / inputs / outputs /
+scope / isolation / stop) is what another harness implements.
+
+## Standard workers
+
+### read-only-explorer-worker
+
+- **Role**: explore the target repo / context; read-only.
+- **Inputs**: a focus area (ticket description, labels, paths to investigate).
+- **Output artifact paths**: a findings file (e.g. `$TICKET_TMP/codebase-context.md`)
+  plus, when run in the background, a status file under `$TICKET_TMP/workers/`.
+- **Write scope**: its own output/status artifacts only.
+- **Isolation**: none required (read-only); must not modify repo files.
+- **Stop condition**: findings artifact written (status `done`); on failure,
+  status `error` with a concise reason.
+
+### approach-worker
+
+- **Role**: propose an implementation approach for the ticket.
+- **Inputs**: the approach prompt (ticket + AC + orientation context).
+- **Output artifact paths**: an approach file (e.g. `$TICKET_TMP/approach-<id>.md`).
+- **Write scope**: its own output artifact only.
+- **Isolation**: none required.
+- **Stop condition**: approach artifact written.
+
+### implementation-worker
+
+- **Role**: write failing tests then implementation from the approved plan.
+- **Inputs**: `$TICKET_TMP/implementation-plan.md`, ticket details, epic context,
+  generated test artifacts, the target repo path.
+- **Output artifact paths**: the feature branch + worktree (committed code),
+  test results, and `$TICKET_TMP/impl-diff.txt`.
+- **Write scope**: its own git worktree and `$TICKET_TMP` only — never the main
+  checkout; never `gh pr create`/`merge` (the orchestrator owns shipping).
+- **Isolation**: required — operate in a dedicated git worktree and assert it is
+  not the main checkout with `scripts/git_safety.py assert-worktree`.
+- **Stop condition**: tests green, lint clean, acceptance verified; or a blocking
+  error reported after the retry budget is exhausted.
+
+### review-worker
+
+- **Role**: review the diff / run the reviewer quorum and synthesize findings.
+- **Inputs**: the diff, ticket context, optional epic artifacts.
+- **Output artifact paths**: review responses + a synthesis/report file under
+  `$TICKET_TMP/reviews/`.
+- **Write scope**: its review/output artifacts only.
+- **Isolation**: none required (reads the diff).
+- **Stop condition**: synthesis report written.
+
+### synthesis-worker
+
+- **Role**: reconcile multiple inputs (approaches, reviews) into one artifact.
+- **Inputs**: the artifacts to reconcile (e.g. the approach files + codebase context).
+- **Output artifact paths**: the synthesized artifact (e.g.
+  `$TICKET_TMP/implementation-plan.md`).
+- **Write scope**: its own output artifact only.
+- **Isolation**: none required.
+- **Stop condition**: synthesized artifact written.

--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -105,3 +105,26 @@ scope / isolation / stop) is what another harness implements.
 - **Write scope**: its own output artifact only.
 - **Isolation**: none required.
 - **Stop condition**: synthesized artifact written.
+
+### verification-worker
+
+- **Role**: execute integration tests / browser journeys — starts services, runs
+  tests, captures evidence. Distinct from review-worker (which only reads a diff).
+- **Inputs**: the test scenarios / integration-test spec, the target repo.
+- **Output artifact paths**: a results/evidence file (pass/fail summary,
+  screenshots, manifests) under `$CW_TMP/`.
+- **Write scope**: its evidence artifacts only; it may start/stop services but
+  must not modify repo source.
+- **Isolation**: none required against the repo; runs against the target repo.
+- **Stop condition**: every scenario executed and the evidence artifact written;
+  on a critical failure, stop and report instead of continuing.
+
+### issue-authoring-worker
+
+- **Role**: create GitHub issues/labels from a planned set.
+- **Inputs**: the planned issues and labels.
+- **Output artifact paths**: the created issue numbers / a summary artifact.
+- **Write scope**: GitHub issues/labels via `gh` only; it must not modify repo
+  files.
+- **Isolation**: none required (no repo writes).
+- **Stop condition**: every planned issue/label created and reported.

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -35,6 +35,9 @@ MARKER_PATTERNS = (
     (re.compile(r"\bsub-agent\b", re.IGNORECASE), "sub-agent"),
     (re.compile(r"general-purpose"), "general-purpose"),
     (re.compile(r"""model:\s*['"]?\s*(?:opus|sonnet)""", re.IGNORECASE), "model tier"),
+    # Bare Claude model-tier names (capitalized proper nouns) in prose.
+    (re.compile(r"\bOpus\b"), "Opus model tier"),
+    (re.compile(r"\bSonnet\b"), "Sonnet model tier"),
     (re.compile(r"""isolation:\s*['"]?\s*worktree"""), 'isolation: "worktree"'),
     (re.compile(r"run_in_background"), "run_in_background"),
     (re.compile(r"\bthoroughness\b"), "thoroughness"),
@@ -42,6 +45,13 @@ MARKER_PATTERNS = (
     (re.compile(r"\bwill notify\b", re.IGNORECASE), "completion notification"),
     (re.compile(r"Agent notification", re.IGNORECASE), "Agent notification"),
     (re.compile(r"Do not poll", re.IGNORECASE), "Do not poll"),
+)
+
+# A line that *launches* a worker (vs. merely describing one) must bind a contract.
+LAUNCH_RE = re.compile(
+    r"\b(?:launch(?:es|ing)?|send|spawn|run(?:s|ning)?\s+[a-z0-9 ,'`\"-]*?\b(?:in|inside))\b"
+    r"[^.\n]*?\bworkers?\b",
+    re.IGNORECASE,
 )
 
 ADAPTER_TAG = "Claude Code adapter"
@@ -85,21 +95,27 @@ def check_command_markers(path: Path) -> tuple[list[Violation], set[str]]:
     for a in (ANCHOR_RE.findall(line) for line in lines):
         anchors.update(a)
     for i, line in enumerate(lines):
-        markers = _markers_on(line)
-        if not markers:
-            continue
-        if ADAPTER_TAG not in line:
-            violations.append(
-                Violation(path.name, i + 1,
-                          f"Claude-only marker(s) {markers} outside an adapter note")
-            )
-            continue
         window = lines[max(0, i - ADAPTER_LOOKBACK): i + 1]
-        if not any(ANCHOR_RE.search(w) for w in window):
+        anchored = any(ANCHOR_RE.search(w) for w in window)
+        markers = _markers_on(line)
+        if markers:
+            if ADAPTER_TAG not in line:
+                violations.append(
+                    Violation(path.name, i + 1,
+                              f"Claude-only marker(s) {markers} outside an adapter note")
+                )
+            elif not anchored:
+                violations.append(
+                    Violation(path.name, i + 1,
+                              f"adapter note with marker(s) {markers} is not bound to a "
+                              f"worker-contracts.md#<anchor> (launder guard)")
+                )
+        elif LAUNCH_RE.search(line) and not anchored:
+            # A worker launch with no Claude marker still must bind a contract,
+            # otherwise an unanchored "launch a worker" launders the gate.
             violations.append(
                 Violation(path.name, i + 1,
-                          f"adapter note with marker(s) {markers} is not bound to a "
-                          f"worker-contracts.md#<anchor> (launder guard)")
+                          "worker launch is not bound to a worker-contracts.md#<anchor>")
             )
     return violations, anchors
 
@@ -134,14 +150,18 @@ def check_contract_doc(doc: Path, referenced_anchors: set[str]) -> list[Violatio
     for anchor in sorted(referenced_anchors):
         if anchor not in sections:
             violations.append(Violation(doc.name, 0, f"referenced anchor #{anchor} not defined"))
-    # Every *-worker section must define all required fields.
+    # Every *-worker section must define all required fields as labeled fields
+    # (a bold label containing the field word, followed by ':'), not just mention
+    # the words in prose.
     for anchor, body in sections.items():
         if not anchor.endswith("-worker"):
             continue
-        low = body.lower()
-        missing = [f for f in REQUIRED_CONTRACT_FIELDS if f not in low]
+        missing = [
+            f for f in REQUIRED_CONTRACT_FIELDS
+            if not re.search(rf"\*\*[^*]*{f}[^*]*\*\*\s*:", body, re.IGNORECASE)
+        ]
         if missing:
-            violations.append(Violation(doc.name, 0, f"#{anchor} missing fields: {missing}"))
+            violations.append(Violation(doc.name, 0, f"#{anchor} missing labeled fields: {missing}"))
     return violations
 
 

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -2,55 +2,62 @@
 """Workflow portability conformance checker (#24).
 
 Asserts that the Claude Code adapter prompts under ``.claude/commands/*.md`` keep
-their worker launches harness-neutral: a Claude-only execution mechanism may
-only appear as an explicit *adapter note*, and every worker-launching command
-points at the harness-neutral worker-contract reference.
+their worker launches harness-neutral. The invariant is deliberately stronger
+than a keyword scan so it cannot be laundered by sprinkling an adapter tag:
 
-This is the conformance gate for the Harness Generalization epic — it fails if a
-portable workflow reference starts *requiring* a Claude-only param again.
+1. **Markers only as bound adapter notes.** Any Claude-only execution/completion
+   marker (``subagent_type``, generic ``sub-agent``, ``general-purpose``,
+   ``model: opus|sonnet``, ``isolation: worktree``, ``run_in_background``,
+   ``thoroughness``, and Claude completion language) may appear only on a line
+   tagged ``Claude Code adapter`` that is **bound to a worker contract** — a
+   ``docs/worker-contracts.md#<anchor>`` reference within the same/preceding
+   lines.
+2. **Referenced anchors exist.** Every ``worker-contracts.md#<anchor>`` named in
+   a command resolves to a ``### <anchor>`` heading in the contract doc.
+3. **Contracts are complete.** Every ``### *-worker`` section defines all six
+   contract fields (role / inputs / output / write scope / isolation / stop).
 
-Run: ``python3 scripts/check_portability.py`` (exit 1 on violations).
+This is the conformance gate for the Harness Generalization epic. Run:
+``python3 scripts/check_portability.py`` (exit 1 on violations).
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# Claude-only execution markers. Each maps to a portable concept inventoried in
-# docs/harness-adapters.md — keep this list in sync with that inventory.
-CLAUDE_EXECUTION_MARKERS = (
-    "subagent_type",          # -> worker
-    "general-purpose",        # -> worker (Claude generic sub-agent)
-    "Explore sub-agent",      # -> read-only explorer worker
-    "Opus sub-agent",         # -> worker, model tier
-    "Sonnet sub-agent",       # -> worker, model tier
-    'model: "opus"',          # -> provider role / model tier
-    'model: "sonnet"',        # -> provider role / model tier
-    'isolation: "worktree"',  # -> required isolation behavior
-    "run_in_background",      # -> async completion via status file
+# Claude-only markers (regex), each mapping to a portable concept inventoried in
+# docs/harness-adapters.md. Keep in sync with that inventory.
+MARKER_PATTERNS = (
+    (re.compile(r"subagent_type"), "subagent_type"),
+    (re.compile(r"\bsub-agent\b", re.IGNORECASE), "sub-agent"),
+    (re.compile(r"general-purpose"), "general-purpose"),
+    (re.compile(r"""model:\s*['"]?\s*(?:opus|sonnet)""", re.IGNORECASE), "model tier"),
+    (re.compile(r"""isolation:\s*['"]?\s*worktree"""), 'isolation: "worktree"'),
+    (re.compile(r"run_in_background"), "run_in_background"),
+    (re.compile(r"\bthoroughness\b"), "thoroughness"),
+    (re.compile(r"Agent tool"), "Agent tool"),
+    (re.compile(r"\bwill notify\b", re.IGNORECASE), "completion notification"),
+    (re.compile(r"Agent notification", re.IGNORECASE), "Agent notification"),
+    (re.compile(r"Do not poll", re.IGNORECASE), "Do not poll"),
 )
 
-# Marker lines must carry this tag to be a legitimate adapter note.
 ADAPTER_TAG = "Claude Code adapter"
+CONTRACT_DOC_NAME = "worker-contracts.md"
+ANCHOR_RE = re.compile(r"worker-contracts\.md#([a-z0-9-]+)")
+ADAPTER_LOOKBACK = 3  # lines a contract anchor may precede the adapter note by
 
-# Worker-launching commands must point at the portable contract reference.
-WORKER_CONTRACT_REF = "worker-contracts.md"
 WORKER_LAUNCHING_COMMANDS = (
-    "implement.md",
-    "implement-wave.md",
-    "architect.md",
-    "design.md",
-    "seed.md",
-    "close-epic.md",
+    "implement.md", "implement-wave.md", "architect.md",
+    "design.md", "seed.md", "close-epic.md",
 )
+# Files that document the Claude-only surfaces, or are explicitly Claude-only.
+EXEMPT_NAMES = {"harness-adapters.md", "worker-contracts.md", "keep-going.md"}
 
-# Docs that legitimately name the Claude-only surfaces (they document the mapping).
-EXEMPT_NAMES = {"harness-adapters.md", "worker-contracts.md"}
-
-# Required contract fields each worker section in worker-contracts.md must define.
 REQUIRED_CONTRACT_FIELDS = ("role", "inputs", "output", "write scope", "isolation", "stop")
+_SECTION_RE = re.compile(r"^###\s+(?P<anchor>[a-z0-9-]+)\s*$", re.MULTILINE)
 
 
 @dataclass
@@ -64,56 +71,93 @@ class Violation:
 
 
 def _markers_on(line: str) -> list[str]:
-    return [m for m in CLAUDE_EXECUTION_MARKERS if m in line]
+    return [name for pat, name in MARKER_PATTERNS if pat.search(line)]
 
 
-def check_command_file(path: Path) -> list[Violation]:
-    """Layer 1: every marker line must be tagged as an adapter note."""
+def check_command_markers(path: Path) -> tuple[list[Violation], set[str]]:
+    """Layer 1: every marker line must be an adapter note bound to a contract.
+
+    Returns (violations, anchors_referenced).
+    """
     violations: list[Violation] = []
-    text = path.read_text()
-    for i, line in enumerate(text.splitlines(), start=1):
+    anchors: set[str] = set()
+    lines = path.read_text().splitlines()
+    for a in (ANCHOR_RE.findall(line) for line in lines):
+        anchors.update(a)
+    for i, line in enumerate(lines):
         markers = _markers_on(line)
-        if markers and ADAPTER_TAG not in line:
+        if not markers:
+            continue
+        if ADAPTER_TAG not in line:
             violations.append(
-                Violation(
-                    path.name, i,
-                    f"Claude-only marker(s) {markers} outside an adapter note; "
-                    f"name a worker contract first and put params under '{ADAPTER_TAG}:'",
-                )
+                Violation(path.name, i + 1,
+                          f"Claude-only marker(s) {markers} outside an adapter note")
             )
-    return violations
+            continue
+        window = lines[max(0, i - ADAPTER_LOOKBACK): i + 1]
+        if not any(ANCHOR_RE.search(w) for w in window):
+            violations.append(
+                Violation(path.name, i + 1,
+                          f"adapter note with marker(s) {markers} is not bound to a "
+                          f"worker-contracts.md#<anchor> (launder guard)")
+            )
+    return violations, anchors
 
 
 def check_contract_reference(path: Path) -> list[Violation]:
-    """Layer 2: worker-launching commands must reference the contract doc."""
+    """Layer 2: worker-launching commands must reference a contract anchor."""
     if path.name not in WORKER_LAUNCHING_COMMANDS:
         return []
-    if WORKER_CONTRACT_REF in path.read_text():
+    if ANCHOR_RE.search(path.read_text()):
         return []
-    return [Violation(path.name, 0, f"does not reference {WORKER_CONTRACT_REF}")]
+    return [Violation(path.name, 0, f"does not reference a {CONTRACT_DOC_NAME}#<anchor>")]
 
 
-def check_worker_contracts_doc(doc: Path) -> list[Violation]:
-    """Structural: the contract doc must define the required fields."""
+def parse_contract_sections(doc_text: str) -> dict[str, str]:
+    """Map each ``### <anchor>`` to its section body."""
+    sections: dict[str, str] = {}
+    matches = list(_SECTION_RE.finditer(doc_text))
+    for idx, m in enumerate(matches):
+        start = m.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(doc_text)
+        sections[m.group("anchor")] = doc_text[start:end]
+    return sections
+
+
+def check_contract_doc(doc: Path, referenced_anchors: set[str]) -> list[Violation]:
+    """Validate the contract doc: anchors exist, worker sections are complete."""
     if not doc.is_file():
         return [Violation(doc.name, 0, "worker-contracts.md is missing")]
-    body = doc.read_text().lower()
-    missing = [f for f in REQUIRED_CONTRACT_FIELDS if f not in body]
-    if missing:
-        return [Violation(doc.name, 0, f"missing required contract field labels: {missing}")]
-    return []
+    sections = parse_contract_sections(doc.read_text())
+    violations: list[Violation] = []
+    # Every referenced anchor must exist.
+    for anchor in sorted(referenced_anchors):
+        if anchor not in sections:
+            violations.append(Violation(doc.name, 0, f"referenced anchor #{anchor} not defined"))
+    # Every *-worker section must define all required fields.
+    for anchor, body in sections.items():
+        if not anchor.endswith("-worker"):
+            continue
+        low = body.lower()
+        missing = [f for f in REQUIRED_CONTRACT_FIELDS if f not in low]
+        if missing:
+            violations.append(Violation(doc.name, 0, f"#{anchor} missing fields: {missing}"))
+    return violations
 
 
 def check_repo(repo_root: str | Path) -> list[Violation]:
     root = Path(repo_root)
     commands_dir = root / ".claude" / "commands"
     violations: list[Violation] = []
+    referenced_anchors: set[str] = set()
     for path in sorted(commands_dir.glob("*.md")):
         if path.name in EXEMPT_NAMES:
             continue
-        violations.extend(check_command_file(path))
+        v, anchors = check_command_markers(path)
+        violations.extend(v)
+        referenced_anchors.update(anchors)
         violations.extend(check_contract_reference(path))
-    violations.extend(check_worker_contracts_doc(root / "docs" / "worker-contracts.md"))
+    violations.extend(check_contract_doc(root / "docs" / "worker-contracts.md", referenced_anchors))
     return violations
 
 

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -47,10 +47,17 @@ MARKER_PATTERNS = (
     (re.compile(r"Do not poll", re.IGNORECASE), "Do not poll"),
 )
 
-# A line that *launches* a worker (vs. merely describing one) must bind a contract.
+# A line that *delegates* to a worker (vs. merely describing one) must bind a
+# contract. Covers launch/send/spawn, run-inside, generate-with, use/delegate/
+# hand-off, and "with a/the ... worker" phrasings so a launch can't be laundered
+# by swapping the verb.
 LAUNCH_RE = re.compile(
-    r"\b(?:launch(?:es|ing)?|send|spawn|run(?:s|ning)?\s+[a-z0-9 ,'`\"-]*?\b(?:in|inside))\b"
-    r"[^.\n]*?\bworkers?\b",
+    r"\b(?:"
+    r"launch(?:es|ing)?|send|spawn|delegat\w*|hand(?:s|ed|ing)?\s+\w+\s+to|"
+    r"run(?:s|ning)?\s+[a-z0-9 ,'`\"-]*?\b(?:in|inside)|"
+    r"generat\w*\s+[a-z0-9 ,'`\"-]*?\bwith|"
+    r"use|using|with)\b"
+    r"\s+(?:a|an|the|each)?\s*[a-z0-9 ,'`\"-]*?\bworkers?\b",
     re.IGNORECASE,
 )
 

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Workflow portability conformance checker (#24).
+
+Asserts that the Claude Code adapter prompts under ``.claude/commands/*.md`` keep
+their worker launches harness-neutral: a Claude-only execution mechanism may
+only appear as an explicit *adapter note*, and every worker-launching command
+points at the harness-neutral worker-contract reference.
+
+This is the conformance gate for the Harness Generalization epic — it fails if a
+portable workflow reference starts *requiring* a Claude-only param again.
+
+Run: ``python3 scripts/check_portability.py`` (exit 1 on violations).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Claude-only execution markers. Each maps to a portable concept inventoried in
+# docs/harness-adapters.md — keep this list in sync with that inventory.
+CLAUDE_EXECUTION_MARKERS = (
+    "subagent_type",          # -> worker
+    "general-purpose",        # -> worker (Claude generic sub-agent)
+    "Explore sub-agent",      # -> read-only explorer worker
+    "Opus sub-agent",         # -> worker, model tier
+    "Sonnet sub-agent",       # -> worker, model tier
+    'model: "opus"',          # -> provider role / model tier
+    'model: "sonnet"',        # -> provider role / model tier
+    'isolation: "worktree"',  # -> required isolation behavior
+    "run_in_background",      # -> async completion via status file
+)
+
+# Marker lines must carry this tag to be a legitimate adapter note.
+ADAPTER_TAG = "Claude Code adapter"
+
+# Worker-launching commands must point at the portable contract reference.
+WORKER_CONTRACT_REF = "worker-contracts.md"
+WORKER_LAUNCHING_COMMANDS = (
+    "implement.md",
+    "implement-wave.md",
+    "architect.md",
+    "design.md",
+    "seed.md",
+    "close-epic.md",
+)
+
+# Docs that legitimately name the Claude-only surfaces (they document the mapping).
+EXEMPT_NAMES = {"harness-adapters.md", "worker-contracts.md"}
+
+# Required contract fields each worker section in worker-contracts.md must define.
+REQUIRED_CONTRACT_FIELDS = ("role", "inputs", "output", "write scope", "isolation", "stop")
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.detail}"
+
+
+def _markers_on(line: str) -> list[str]:
+    return [m for m in CLAUDE_EXECUTION_MARKERS if m in line]
+
+
+def check_command_file(path: Path) -> list[Violation]:
+    """Layer 1: every marker line must be tagged as an adapter note."""
+    violations: list[Violation] = []
+    text = path.read_text()
+    for i, line in enumerate(text.splitlines(), start=1):
+        markers = _markers_on(line)
+        if markers and ADAPTER_TAG not in line:
+            violations.append(
+                Violation(
+                    path.name, i,
+                    f"Claude-only marker(s) {markers} outside an adapter note; "
+                    f"name a worker contract first and put params under '{ADAPTER_TAG}:'",
+                )
+            )
+    return violations
+
+
+def check_contract_reference(path: Path) -> list[Violation]:
+    """Layer 2: worker-launching commands must reference the contract doc."""
+    if path.name not in WORKER_LAUNCHING_COMMANDS:
+        return []
+    if WORKER_CONTRACT_REF in path.read_text():
+        return []
+    return [Violation(path.name, 0, f"does not reference {WORKER_CONTRACT_REF}")]
+
+
+def check_worker_contracts_doc(doc: Path) -> list[Violation]:
+    """Structural: the contract doc must define the required fields."""
+    if not doc.is_file():
+        return [Violation(doc.name, 0, "worker-contracts.md is missing")]
+    body = doc.read_text().lower()
+    missing = [f for f in REQUIRED_CONTRACT_FIELDS if f not in body]
+    if missing:
+        return [Violation(doc.name, 0, f"missing required contract field labels: {missing}")]
+    return []
+
+
+def check_repo(repo_root: str | Path) -> list[Violation]:
+    root = Path(repo_root)
+    commands_dir = root / ".claude" / "commands"
+    violations: list[Violation] = []
+    for path in sorted(commands_dir.glob("*.md")):
+        if path.name in EXEMPT_NAMES:
+            continue
+        violations.extend(check_command_file(path))
+        violations.extend(check_contract_reference(path))
+    violations.extend(check_worker_contracts_doc(root / "docs" / "worker-contracts.md"))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    repo_root = argv[0] if argv else str(Path(__file__).resolve().parents[1])
+    violations = check_repo(repo_root)
+    if violations:
+        print(f"Portability check FAILED ({len(violations)} violation(s)):", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+    print("Portability check passed: workflows are harness-neutral.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_portability.py
+++ b/tests/test_portability.py
@@ -68,6 +68,18 @@ def test_adapter_tag_without_contract_anchor_is_rejected(tmp_path):
     assert any("launder guard" in v.detail for v in cp.check_repo(repo))
 
 
+def test_unanchored_worker_delegation_is_caught(tmp_path):
+    # A delegation that swaps the verb ("generate with a worker", "use a worker")
+    # must still bind a contract — no launder path.
+    for phrasing in (
+        "Generate each direction with a parallel worker (use a good model).",
+        "Use a synthesis worker to reconcile the inputs.",
+        "Delegate this to an implementation worker.",
+    ):
+        repo = _repo(tmp_path / phrasing[:8], phrasing + "\n")
+        assert any("not bound" in v.detail for v in cp.check_repo(repo)), phrasing
+
+
 def test_bound_adapter_note_passes(tmp_path):
     repo = _repo(
         tmp_path,

--- a/tests/test_portability.py
+++ b/tests/test_portability.py
@@ -13,11 +13,11 @@ import check_portability as cp
 
 REPO = Path(__file__).resolve().parents[1]
 
-# A complete contract doc body for synthetic repos.
+# A complete contract doc body for synthetic repos (labeled-field format).
 GOOD_DOC = (
     "### implementation-worker\n"
-    "- role: x\n- inputs: x\n- output artifact paths: x\n"
-    "- write scope: x\n- isolation: x\n- stop condition: x\n"
+    "- **Role**: x\n- **Inputs**: x\n- **Output artifact paths**: x\n"
+    "- **Write scope**: x\n- **Isolation**: x\n- **Stop condition**: x\n"
 )
 
 
@@ -92,14 +92,14 @@ def test_referenced_anchor_must_exist(tmp_path):
 
 
 def test_incomplete_contract_section_flagged(tmp_path):
-    bad_doc = "### implementation-worker\n- role: x\n- inputs: x\n"  # missing fields
+    bad_doc = "### implementation-worker\n- **Role**: x\n- **Inputs**: x\n"  # missing fields
     repo = _repo(
         tmp_path,
         "Launch a worker (contract: `docs/worker-contracts.md#implementation-worker`). "
         "*Claude Code adapter:* `subagent_type: x`.\n",
         doc=bad_doc, name="implement.md",
     )
-    assert any("missing fields" in v.detail for v in cp.check_repo(repo))
+    assert any("missing labeled fields" in v.detail for v in cp.check_repo(repo))
 
 
 def test_worker_command_must_reference_a_contract_anchor(tmp_path):

--- a/tests/test_portability.py
+++ b/tests/test_portability.py
@@ -1,0 +1,91 @@
+"""Portability conformance tests (#24).
+
+The workflow prompts must keep worker launches harness-neutral: Claude-only
+execution params only as adapter notes, and worker-launching commands point at
+the worker-contract reference.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import check_portability as cp
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_commands_are_harness_neutral():
+    """The live command prompts must have zero portability violations."""
+    violations = cp.check_repo(REPO)
+    assert violations == [], "\n".join(str(v) for v in violations)
+
+
+# --- checker unit behavior (synthetic inputs) -------------------------------
+
+
+def test_bare_marker_is_a_violation(tmp_path):
+    cmds = tmp_path / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "x.md").write_text('Launch a sub-agent (`subagent_type: "general-purpose"`).\n')
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text(
+        "role inputs outputs write scope isolation stop"
+    )
+    violations = cp.check_repo(tmp_path)
+    assert any("subagent_type" in v.detail for v in violations)
+
+
+def test_adapter_tagged_marker_is_allowed(tmp_path):
+    cmds = tmp_path / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "x.md").write_text(
+        'Launch a worker. See worker-contracts.md.\n'
+        'Claude Code adapter: `subagent_type: "general-purpose"`, `model: "sonnet"`.\n'
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text(
+        "role inputs outputs write scope isolation stop"
+    )
+    # x.md is not a worker-launching *command name*, so layer-2 doesn't apply.
+    assert cp.check_repo(tmp_path) == []
+
+
+def test_worker_command_must_reference_contract(tmp_path):
+    cmds = tmp_path / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    # A real worker-launching command name, with a tagged marker but no contract ref.
+    (cmds / "implement.md").write_text(
+        'Claude Code adapter: `subagent_type: "general-purpose"`.\n'
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text(
+        "role inputs outputs write scope isolation stop"
+    )
+    violations = cp.check_repo(tmp_path)
+    assert any("worker-contracts.md" in v.detail for v in violations)
+
+
+def test_missing_contract_doc_is_a_violation(tmp_path):
+    (tmp_path / ".claude" / "commands").mkdir(parents=True)
+    violations = cp.check_repo(tmp_path)
+    assert any("missing" in v.detail for v in violations)
+
+
+def test_contract_doc_missing_fields_flagged(tmp_path):
+    (tmp_path / ".claude" / "commands").mkdir(parents=True)
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text("role and inputs only")
+    violations = cp.check_repo(tmp_path)
+    assert any("required contract field" in v.detail for v in violations)
+
+
+def test_exempt_docs_may_name_markers(tmp_path):
+    cmds = tmp_path / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    # harness-adapters.md is exempt even under .claude/commands (defensive).
+    (cmds / "harness-adapters.md").write_text('subagent_type everywhere\n')
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text(
+        "role inputs outputs write scope isolation stop"
+    )
+    assert cp.check_repo(tmp_path) == []

--- a/tests/test_portability.py
+++ b/tests/test_portability.py
@@ -1,8 +1,8 @@
 """Portability conformance tests (#24).
 
 The workflow prompts must keep worker launches harness-neutral: Claude-only
-execution params only as adapter notes, and worker-launching commands point at
-the worker-contract reference.
+execution params only as adapter notes *bound to a worker contract*, referenced
+anchors exist, and worker contracts are complete.
 """
 
 from __future__ import annotations
@@ -13,79 +13,114 @@ import check_portability as cp
 
 REPO = Path(__file__).resolve().parents[1]
 
+# A complete contract doc body for synthetic repos.
+GOOD_DOC = (
+    "### implementation-worker\n"
+    "- role: x\n- inputs: x\n- output artifact paths: x\n"
+    "- write scope: x\n- isolation: x\n- stop condition: x\n"
+)
+
+
+def _repo(tmp_path, command_text, doc=GOOD_DOC, name="x.md"):
+    cmds = tmp_path / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / name).write_text(command_text)
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "worker-contracts.md").write_text(doc)
+    return tmp_path
+
+
+# --- live prompts ------------------------------------------------------------
+
 
 def test_commands_are_harness_neutral():
-    """The live command prompts must have zero portability violations."""
     violations = cp.check_repo(REPO)
     assert violations == [], "\n".join(str(v) for v in violations)
 
 
-# --- checker unit behavior (synthetic inputs) -------------------------------
+# --- marker detection (broadened) -------------------------------------------
 
 
 def test_bare_marker_is_a_violation(tmp_path):
-    cmds = tmp_path / ".claude" / "commands"
-    cmds.mkdir(parents=True)
-    (cmds / "x.md").write_text('Launch a sub-agent (`subagent_type: "general-purpose"`).\n')
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "worker-contracts.md").write_text(
-        "role inputs outputs write scope isolation stop"
-    )
-    violations = cp.check_repo(tmp_path)
-    assert any("subagent_type" in v.detail for v in violations)
+    repo = _repo(tmp_path, 'Launch a worker (`subagent_type: "general-purpose"`).\n')
+    assert any("outside an adapter note" in v.detail for v in cp.check_repo(repo))
 
 
-def test_adapter_tagged_marker_is_allowed(tmp_path):
-    cmds = tmp_path / ".claude" / "commands"
-    cmds.mkdir(parents=True)
-    (cmds / "x.md").write_text(
-        'Launch a worker. See worker-contracts.md.\n'
-        'Claude Code adapter: `subagent_type: "general-purpose"`, `model: "sonnet"`.\n'
-    )
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "worker-contracts.md").write_text(
-        "role inputs outputs write scope isolation stop"
-    )
-    # x.md is not a worker-launching *command name*, so layer-2 doesn't apply.
-    assert cp.check_repo(tmp_path) == []
+def test_generic_sub_agent_is_a_marker(tmp_path):
+    repo = _repo(tmp_path, "The sub-agent should do the thing.\n")
+    assert any("sub-agent" in v.detail for v in cp.check_repo(repo))
 
 
-def test_worker_command_must_reference_contract(tmp_path):
-    cmds = tmp_path / ".claude" / "commands"
-    cmds.mkdir(parents=True)
-    # A real worker-launching command name, with a tagged marker but no contract ref.
-    (cmds / "implement.md").write_text(
-        'Claude Code adapter: `subagent_type: "general-purpose"`.\n'
+def test_model_tier_without_quotes_is_a_marker(tmp_path):
+    repo = _repo(tmp_path, "Run with model: opus please.\n")
+    assert any("model tier" in v.detail for v in cp.check_repo(repo))
+
+
+# --- launder guard: adapter tag alone is NOT enough -------------------------
+
+
+def test_adapter_tag_without_contract_anchor_is_rejected(tmp_path):
+    # Has the adapter tag but no worker-contracts.md#anchor nearby -> launder guard.
+    repo = _repo(
+        tmp_path,
+        'Claude Code adapter: `subagent_type: "general-purpose"`, `model: "sonnet"`.\n',
     )
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "worker-contracts.md").write_text(
-        "role inputs outputs write scope isolation stop"
+    assert any("launder guard" in v.detail for v in cp.check_repo(repo))
+
+
+def test_bound_adapter_note_passes(tmp_path):
+    repo = _repo(
+        tmp_path,
+        "Launch an implementation worker (contract: `docs/worker-contracts.md#implementation-worker`). "
+        '*Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`.\n',
+        name="implement.md",
     )
-    violations = cp.check_repo(tmp_path)
-    assert any("worker-contracts.md" in v.detail for v in violations)
+    assert cp.check_repo(repo) == []
+
+
+# --- anchor existence + contract completeness -------------------------------
+
+
+def test_referenced_anchor_must_exist(tmp_path):
+    repo = _repo(
+        tmp_path,
+        "Launch a worker (contract: `docs/worker-contracts.md#ghost-worker`). "
+        "*Claude Code adapter:* `subagent_type: x`.\n",
+        name="implement.md",
+    )
+    assert any("anchor #ghost-worker not defined" in v.detail for v in cp.check_repo(repo))
+
+
+def test_incomplete_contract_section_flagged(tmp_path):
+    bad_doc = "### implementation-worker\n- role: x\n- inputs: x\n"  # missing fields
+    repo = _repo(
+        tmp_path,
+        "Launch a worker (contract: `docs/worker-contracts.md#implementation-worker`). "
+        "*Claude Code adapter:* `subagent_type: x`.\n",
+        doc=bad_doc, name="implement.md",
+    )
+    assert any("missing fields" in v.detail for v in cp.check_repo(repo))
+
+
+def test_worker_command_must_reference_a_contract_anchor(tmp_path):
+    # A real command name with a marker but no anchor at all.
+    repo = _repo(
+        tmp_path,
+        "Claude Code adapter: `subagent_type: x`.\n",
+        name="architect.md",
+    )
+    violations = cp.check_repo(repo)
+    assert any("does not reference" in v.detail for v in violations)
 
 
 def test_missing_contract_doc_is_a_violation(tmp_path):
     (tmp_path / ".claude" / "commands").mkdir(parents=True)
-    violations = cp.check_repo(tmp_path)
-    assert any("missing" in v.detail for v in violations)
-
-
-def test_contract_doc_missing_fields_flagged(tmp_path):
-    (tmp_path / ".claude" / "commands").mkdir(parents=True)
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "worker-contracts.md").write_text("role and inputs only")
-    violations = cp.check_repo(tmp_path)
-    assert any("required contract field" in v.detail for v in violations)
+    assert any("missing" in v.detail for v in cp.check_repo(tmp_path))
 
 
 def test_exempt_docs_may_name_markers(tmp_path):
-    cmds = tmp_path / ".claude" / "commands"
-    cmds.mkdir(parents=True)
-    # harness-adapters.md is exempt even under .claude/commands (defensive).
-    (cmds / "harness-adapters.md").write_text('subagent_type everywhere\n')
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "worker-contracts.md").write_text(
-        "role inputs outputs write scope isolation stop"
-    )
-    assert cp.check_repo(tmp_path) == []
+    repo = _repo(tmp_path, "irrelevant\n")
+    cmds = repo / ".claude" / "commands"
+    (cmds / "harness-adapters.md").write_text("subagent_type sub-agent model: opus everywhere\n")
+    (cmds / "keep-going.md").write_text("CronCreate and sub-agent semantics\n")
+    assert cp.check_repo(repo) == []


### PR DESCRIPTION
## Summary

Reframe the worker launches in the command prompts as harness-neutral worker contracts so Codex / another harness can run the same workflows. Each launch names a contract in docs/worker-contracts.md and demotes the Claude-only execution params to a 'Claude Code adapter:' note. A conformance gate (scripts/check_portability.py, wired into make lint) enforces it.

Closes #24

## Architecture

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
graph TD
    Cmds[".claude/commands/*.md<br/>worker launches"]:::modified
    Contracts["docs/worker-contracts.md<br/>worker contracts"]:::new
    Gate["scripts/check_portability.py<br/>conformance gate"]:::new
    Adapters["docs/harness-adapters.md"]:::existing
    Lint["make lint"]:::existing
    Cmds -->|"reference #anchor"| Contracts
    Gate -->|"scans"| Cmds
    Gate -->|"validates anchors + fields"| Contracts
    Gate -->|"marker list"| Adapters
    Lint -->|"runs"| Gate
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
```

## Changes

- Add docs/worker-contracts.md: read-only-explorer / approach / implementation / review / synthesis / verification / issue-authoring / design-direction worker contracts (role/inputs/outputs/write scope/isolation/stop each)
- Reframe every worker launch in implement/implement-wave/architect/design/seed/close-epic; rename generic 'sub-agent' to 'worker'; express worktree isolation as required behavior and background completion via status/output files
- Add scripts/check_portability.py conformance gate (markers + launder-guard + delegation detection + anchor existence + labeled-field completeness) and wire it into make lint
- Add tests/test_portability.py (12 tests incl. the live-prompt conformance assertion)

## Test Evidence

**Verification: all green**
- ✓ `make test` — exit 0
- ✓ `make lint` — exit 0

## Review Checklist

- [ ] Tests pass locally
- [ ] No new warnings or lint errors
- [ ] Multi-AI review feedback addressed
- [ ] No secrets or credentials committed

## Process notes

- **TDD**: the portability conformance gate was written first (RED: 27 violations across all 6 commands) and the reframe made it GREEN.
- **Multi-AI review**: codex reviewed over **4 rounds** — it caught that the first gate was lexical/launderable and that two worker mappings were wrong (seed issue-creation, close-epic test execution); each round's findings were fixed and re-verified. **gemini was unavailable** (account tier ended: `IneligibleTierError`), so the reviewer quorum ran codex-only this session.
- **Verification**: `make lint` (now includes the portability gate) + `make test` — 394 passed.
- UX/browser steps N/A (docs + checker, no frontend).
