### PR TITLE
Package Chief Wiggum workflows as harness-portable agent skills (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,25 @@ claude /implement owner/repo#42
 
 ### Portable Skills
 
-Harness-portable skills are stored under `skills/`. To install the Claude interactive delegate skill in Codex:
+Harness-portable skills are stored under `skills/`. The umbrella **`skills/chief-wiggum`** skill packages the whole SDLC loop: a short `SKILL.md` routes to per-workflow references under `references/workflows/` (loaded on demand), with Codex metadata isolated in `agents/openai.yaml`. The workflow references are the same canonical bodies the Claude Code `.claude/commands/` adapter uses (single source of truth), so the two stay in sync.
+
+Install paths — the skill runs from the repo checkout (symlink the skill directory; do not copy, as the references are repo-relative symlinks):
+
+- **Claude Code** — point `commandDirs` at `.claude/commands` (above); the slash commands and the skill share the same workflow bodies.
+- **Codex** — symlink the skill into Codex's skill discovery path:
+  ```bash
+  ln -sfn ~/repos/chief-wiggum/skills/chief-wiggum ~/.codex/skills/chief-wiggum
+  ```
+- **Generic skill-aware harness** — symlink `skills/chief-wiggum` into the harness's skill directory; it reads `SKILL.md` + `references/`.
+
+The standalone Claude interactive delegate skill installs the same way:
 
 ```bash
 ln -sfn ~/repos/chief-wiggum/skills/claude-interactive-delegate ~/.codex/skills/claude-interactive-delegate
 python3 ~/.codex/skills/claude-interactive-delegate/scripts/claude_delegate.py start
 ```
 
-For other harnesses, install or symlink `skills/<name>` into the harness's skill discovery path. See `AGENTS.md` and `docs/harnesses.md` for the portable core and adapter model.
+See `AGENTS.md` and `docs/harnesses.md` for the portable core and adapter model.
 
 **Important**: Run skills from your target project directory, not from chief-wiggum itself.
 

--- a/skills/chief-wiggum/SKILL.md
+++ b/skills/chief-wiggum/SKILL.md
@@ -7,11 +7,17 @@ description: Harness-portable agentic SDLC orchestration. Routes to the design, 
 
 Portable SDLC orchestration. The workflow "brains" are reference files loaded
 on demand (progressive disclosure); the deterministic mechanics are tested
-Python helpers under `scripts/`; AI backends are selected by **provider role**,
-not hard-coded model names. Sub-tasks are run by **workers** described by
-harness-neutral contracts (`docs/worker-contracts.md`).
+Python helpers; AI backends are selected by **provider role**, not hard-coded
+model names. Sub-tasks are run by **workers** described by harness-neutral
+contracts.
 
 Run workflows from the **target repo**, not from the Chief Wiggum checkout.
+
+> **Paths in this skill** — `scripts/`, `docs/`, and `config/` referenced below
+> live at the **Chief Wiggum checkout root**, not inside this skill directory.
+> This skill installs as a symlink back into that checkout; workflows resolve
+> the checkout root at runtime with `python3 "$CW_HOME/scripts/env.py" home`
+> (the workflow references already do this).
 
 ## Workflows
 

--- a/skills/chief-wiggum/SKILL.md
+++ b/skills/chief-wiggum/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: chief-wiggum
+description: Harness-portable agentic SDLC orchestration. Routes to the design, plan-epic, architect, implement, implement-wave, and close-epic workflows that turn vague tickets into a disciplined delivery loop — requirements capture, epic planning, architecture with executable contracts, test-first implementation, structured multi-AI review, and PR-ready output. Use when an orchestrator (Claude Code, Codex, or another skill-aware harness) should run any stage of the SDLC loop against a target repo.
+---
+
+# Chief Wiggum
+
+Portable SDLC orchestration. The workflow "brains" are reference files loaded
+on demand (progressive disclosure); the deterministic mechanics are tested
+Python helpers under `scripts/`; AI backends are selected by **provider role**,
+not hard-coded model names. Sub-tasks are run by **workers** described by
+harness-neutral contracts (`docs/worker-contracts.md`).
+
+Run workflows from the **target repo**, not from the Chief Wiggum checkout.
+
+## Workflows
+
+Load the reference for the stage you need from `references/workflows/`:
+
+- **`design`** — product design: divergent rendered mockups → human choice → `docs/design/` tokens. Runs once per product.
+- **`plan-epic`** — group issues into an epic with a dependency graph.
+- **`architect`** — define contracts, invariants, state machines, and integration tests before implementation.
+- **`implement`** — TDD implementation loop for one ticket (consult → test-first → implement → review → verify → ship).
+- **`implement-wave`** — parallel implementation of an epic in dependency-ordered waves.
+- **`close-epic`** — epic-level quality gate.
+
+Supporting: `seed`, `create-issue`, `ship`, `transcribe`, `setup`, `update`, `stitch-audit` (also under `references/workflows/`).
+
+## Conventions
+
+- **Provider roles** (`config/providers.json`): `reviewer`, `architecture_critic`, `design_critic`, … — not model names.
+- **Workers**: each delegated sub-task names a contract in `docs/worker-contracts.md` (role, inputs, output paths, write scope, isolation, stop condition).
+- **Scripts** are Python helpers in `scripts/` (a `cw` facade lists them: `python3 scripts/cw.py`).
+- **Harness adapters**: Claude Code-specific surfaces are inventoried in `docs/harness-adapters.md`; harness metadata lives beside the skill (e.g. `agents/openai.yaml`), never in this core contract.
+
+See `references/overview.md` for the portable concept model, and `docs/harnesses.md` for install/adapter details.

--- a/skills/chief-wiggum/agents/openai.yaml
+++ b/skills/chief-wiggum/agents/openai.yaml
@@ -1,0 +1,36 @@
+# Codex / OpenAI harness metadata for the chief-wiggum skill.
+# Optional adapter data only — the portable workflow contract lives in SKILL.md
+# and references/. Do not put workflow semantics here.
+name: chief-wiggum
+description: >-
+  Harness-portable agentic SDLC orchestration. Routes to the SDLC workflows
+  (design, plan-epic, architect, implement, implement-wave, close-epic) and
+  supporting workflows, each loaded on demand from references/workflows/.
+entrypoint: SKILL.md
+workflows:
+  - id: design
+    reference: references/workflows/design.md
+  - id: plan-epic
+    reference: references/workflows/plan-epic.md
+  - id: architect
+    reference: references/workflows/architect.md
+  - id: implement
+    reference: references/workflows/implement.md
+  - id: implement-wave
+    reference: references/workflows/implement-wave.md
+  - id: close-epic
+    reference: references/workflows/close-epic.md
+  - id: seed
+    reference: references/workflows/seed.md
+  - id: create-issue
+    reference: references/workflows/create-issue.md
+  - id: ship
+    reference: references/workflows/ship.md
+  - id: transcribe
+    reference: references/workflows/transcribe.md
+  - id: setup
+    reference: references/workflows/setup.md
+  - id: update
+    reference: references/workflows/update.md
+  - id: stitch-audit
+    reference: references/workflows/stitch-audit.md

--- a/skills/chief-wiggum/references/overview.md
+++ b/skills/chief-wiggum/references/overview.md
@@ -1,0 +1,38 @@
+# Chief Wiggum — Portable Concept Model
+
+The Chief Wiggum skill is harness-portable: the same workflow contract runs from
+Claude Code, Codex, or another skill-aware harness. This reference defines the
+portable concepts so a harness can map them to its own mechanisms.
+
+## Concepts
+
+- **Skill** — the umbrella entrypoint (`SKILL.md`) plus its `references/`,
+  `agents/` (harness metadata), and the shared `scripts/`.
+- **Reference** — a workflow body under `references/workflows/<id>.md`, loaded
+  only when that stage runs (progressive disclosure). Each reference is the
+  canonical workflow procedure (it resolves to the same body the Claude Code
+  `.claude/commands/<id>.md` adapter uses — single source of truth).
+- **Script** — a tested Python helper in `scripts/` that performs deterministic
+  mechanics (context resolution, planning, verification, PR drafting, …). The
+  `cw` facade lists them.
+- **Provider** — an AI backend selected by **role** (`config/providers.json`),
+  not by model name. Roles: `reviewer`, `architecture_critic`, `design_critic`,
+  `explorer`, `implementer`, `risky_diff_review`.
+- **Worker** — a delegated sub-task described by a harness-neutral contract in
+  `docs/worker-contracts.md` (role, inputs, output artifact paths, write scope,
+  isolation, stop condition). A harness that supports sub-agents may spawn them;
+  otherwise the orchestrator runs the contract locally or via a provider adapter.
+
+## Adapters
+
+Claude Code-specific surfaces (sub-agent parameters, `Cron*` tools, slash-command
+invocation) are inventoried in `docs/harness-adapters.md`. Harness-specific
+metadata lives beside the skill (`agents/openai.yaml` for Codex) and is optional
+— it never carries workflow semantics.
+
+## Running
+
+Workflows operate on a **target repo** (resolved/cloned via `gh`), not on the
+Chief Wiggum checkout. Install paths (Claude Code command dirs, Codex skill
+symlink, generic skill-aware harness) are in the top-level `README.md` and
+`docs/harnesses.md`.

--- a/skills/chief-wiggum/references/overview.md
+++ b/skills/chief-wiggum/references/overview.md
@@ -4,6 +4,11 @@ The Chief Wiggum skill is harness-portable: the same workflow contract runs from
 Claude Code, Codex, or another skill-aware harness. This reference defines the
 portable concepts so a harness can map them to its own mechanisms.
 
+> **Paths** — `scripts/`, `docs/`, and `config/` mentioned here live at the
+> **Chief Wiggum checkout root**, not inside `skills/chief-wiggum/`. The skill
+> installs as a symlink back into the checkout; workflows resolve the checkout
+> root at runtime via `scripts/env.py home` (`$CW_HOME`).
+
 ## Concepts
 
 - **Skill** — the umbrella entrypoint (`SKILL.md`) plus its `references/`,

--- a/skills/chief-wiggum/references/workflows/architect.md
+++ b/skills/chief-wiggum/references/workflows/architect.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/architect.md

--- a/skills/chief-wiggum/references/workflows/close-epic.md
+++ b/skills/chief-wiggum/references/workflows/close-epic.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/close-epic.md

--- a/skills/chief-wiggum/references/workflows/create-issue.md
+++ b/skills/chief-wiggum/references/workflows/create-issue.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/create-issue.md

--- a/skills/chief-wiggum/references/workflows/design.md
+++ b/skills/chief-wiggum/references/workflows/design.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/design.md

--- a/skills/chief-wiggum/references/workflows/implement-wave.md
+++ b/skills/chief-wiggum/references/workflows/implement-wave.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/implement-wave.md

--- a/skills/chief-wiggum/references/workflows/implement.md
+++ b/skills/chief-wiggum/references/workflows/implement.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/implement.md

--- a/skills/chief-wiggum/references/workflows/plan-epic.md
+++ b/skills/chief-wiggum/references/workflows/plan-epic.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/plan-epic.md

--- a/skills/chief-wiggum/references/workflows/seed.md
+++ b/skills/chief-wiggum/references/workflows/seed.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/seed.md

--- a/skills/chief-wiggum/references/workflows/setup.md
+++ b/skills/chief-wiggum/references/workflows/setup.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/setup.md

--- a/skills/chief-wiggum/references/workflows/ship.md
+++ b/skills/chief-wiggum/references/workflows/ship.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/ship.md

--- a/skills/chief-wiggum/references/workflows/stitch-audit.md
+++ b/skills/chief-wiggum/references/workflows/stitch-audit.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/stitch-audit.md

--- a/skills/chief-wiggum/references/workflows/transcribe.md
+++ b/skills/chief-wiggum/references/workflows/transcribe.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/transcribe.md

--- a/skills/chief-wiggum/references/workflows/update.md
+++ b/skills/chief-wiggum/references/workflows/update.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/update.md

--- a/tests/test_skill_packaging.py
+++ b/tests/test_skill_packaging.py
@@ -1,0 +1,84 @@
+"""Portable skill packaging conformance tests (#25).
+
+The umbrella `skills/chief-wiggum/` skill must be a valid, portable skill:
+short SKILL.md with clean frontmatter, per-workflow references that resolve to
+the canonical `.claude/commands/*.md` bodies (single source of truth, no drift),
+isolated Codex metadata, and `.claude/commands/` left intact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO / "skills" / "chief-wiggum"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+WORKFLOWS = SKILL_DIR / "references" / "workflows"
+
+CORE_WORKFLOWS = ("design", "plan-epic", "architect", "implement", "implement-wave", "close-epic")
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Parse the leading ``---`` frontmatter block into key/value pairs."""
+    lines = text.splitlines()
+    assert lines and lines[0].strip() == "---", "SKILL.md must start with a --- frontmatter block"
+    fm: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return fm
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fm[key.strip()] = value.strip()
+    raise AssertionError("unterminated frontmatter block")
+
+
+def test_skill_md_exists_with_clean_frontmatter():
+    assert SKILL_MD.is_file(), "skills/chief-wiggum/SKILL.md must exist"
+    fm = _frontmatter(SKILL_MD.read_text())
+    assert set(fm) == {"name", "description"}, f"frontmatter keys must be name+description, got {set(fm)}"
+    assert fm["name"] == "chief-wiggum"
+    assert len(fm["description"]) > 20
+
+
+def test_skill_md_is_short_progressive_disclosure():
+    # The umbrella must route to references, not inline every procedure.
+    body = SKILL_MD.read_text()
+    assert len(body.splitlines()) < 120, "SKILL.md should be short (<120 lines)"
+    assert len(body.encode()) < 6000, "SKILL.md should be small (<6 KB)"
+
+
+def test_core_workflow_references_resolve_to_command_bodies():
+    for wf in CORE_WORKFLOWS:
+        ref = WORKFLOWS / f"{wf}.md"
+        assert ref.is_file(), f"missing workflow reference: {ref}"
+        # It must resolve to a real, non-empty command body (single source of truth).
+        assert ref.resolve().is_file()
+        assert ref.read_text().strip(), f"workflow reference {wf} resolves to empty content"
+
+
+def test_workflow_reference_symlinks_are_relative():
+    for ref in WORKFLOWS.glob("*.md"):
+        if ref.is_symlink():
+            target = Path(ref.readlink() if hasattr(ref, "readlink") else __import__("os").readlink(ref))
+            assert not target.is_absolute(), f"{ref.name} symlink target must be relative, got {target}"
+
+
+def test_command_bodies_still_intact():
+    for wf in CORE_WORKFLOWS:
+        cmd = REPO / ".claude" / "commands" / f"{wf}.md"
+        assert cmd.is_file() and cmd.read_text().strip(), f".claude/commands/{wf}.md must remain usable"
+
+
+def test_codex_metadata_isolated():
+    openai = SKILL_DIR / "agents" / "openai.yaml"
+    assert openai.is_file(), "Codex metadata must live in agents/openai.yaml"
+    assert openai.read_text().strip()
+    # The umbrella SKILL.md must not carry harness-specific frontmatter.
+    fm = _frontmatter(SKILL_MD.read_text())
+    assert "openai" not in fm and "agents" not in fm
+
+
+def test_readme_documents_install_paths():
+    readme = (REPO / "README.md").read_text().lower()
+    assert "commanddirs" in readme, "README must document the Claude Code command-dir install"
+    assert "skills/chief-wiggum" in readme, "README must document the portable skill install"

--- a/tests/test_skill_packaging.py
+++ b/tests/test_skill_packaging.py
@@ -47,20 +47,21 @@ def test_skill_md_is_short_progressive_disclosure():
     assert len(body.encode()) < 6000, "SKILL.md should be small (<6 KB)"
 
 
-def test_core_workflow_references_resolve_to_command_bodies():
+def test_core_workflow_references_are_symlinks_to_command_bodies():
     for wf in CORE_WORKFLOWS:
         ref = WORKFLOWS / f"{wf}.md"
-        assert ref.is_file(), f"missing workflow reference: {ref}"
-        # It must resolve to a real, non-empty command body (single source of truth).
+        # Single source of truth: it must be a *symlink* to the canonical command
+        # body (a copy would drift and is rejected), with the exact relative target.
+        assert ref.is_symlink(), f"{ref} must be a symlink to the command body, not a copy"
+        assert ref.readlink() == Path(f"../../../../.claude/commands/{wf}.md")
         assert ref.resolve().is_file()
         assert ref.read_text().strip(), f"workflow reference {wf} resolves to empty content"
 
 
-def test_workflow_reference_symlinks_are_relative():
+def test_all_workflow_references_are_relative_symlinks():
     for ref in WORKFLOWS.glob("*.md"):
-        if ref.is_symlink():
-            target = Path(ref.readlink() if hasattr(ref, "readlink") else __import__("os").readlink(ref))
-            assert not target.is_absolute(), f"{ref.name} symlink target must be relative, got {target}"
+        assert ref.is_symlink(), f"{ref.name} must be a symlink"
+        assert not ref.readlink().is_absolute(), f"{ref.name} symlink target must be relative"
 
 
 def test_command_bodies_still_intact():


### PR DESCRIPTION
## Summary

Final ticket of the Harness Generalization epic. Packages the SDLC loop as an umbrella `skills/chief-wiggum` skill — short `SKILL.md` routing to per-workflow references (progressive disclosure), Codex metadata isolated, `.claude/commands/` kept canonical and usable.

Closes #25.

## Changes

- **`skills/chief-wiggum/SKILL.md`** — short umbrella (frontmatter `name`+`description`) routing to `references/workflows/`; portable terms (skill/reference/script/provider/worker); notes that `scripts/`/`docs/`/`config/` are checkout-root paths resolved via `$CW_HOME`.
- **`references/workflows/<wf>.md`** — **relative symlinks** to the canonical `.claude/commands/<wf>.md` bodies (single source of truth, no drift): `design`, `plan-epic`, `architect`, `implement`, `implement-wave`, `close-epic` + supporting.
- **`references/overview.md`** — portable concept model.
- **`agents/openai.yaml`** — Codex metadata isolated from the core contract.
- **`README`** — documents Claude Code / Codex / generic skill-install paths (symlink the skill dir from the checkout).
- **`tests/test_skill_packaging.py`** — conformance gate: frontmatter validity, short SKILL.md, references are relative symlinks to real command bodies, commands intact, Codex metadata isolated, README install paths.

## Acceptance criteria

- [x] Portable skill entrypoint under `skills/` with valid `SKILL.md` frontmatter and portable core instructions.
- [x] Core workflow bodies mirrored into `references/` (symlinks), loaded on demand.
- [x] Harness-specific metadata isolated under `agents/openai.yaml`.
- [x] Existing `.claude/commands/` workflows remain usable.
- [x] README documents Claude Code, Codex, and generic skill-installation paths.

## Process notes

- **TDD**: packaging conformance test written first (RED), package made it GREEN.
- **Review**: codex (gemini unavailable — account tier ended); fixed the checkout-root path ambiguity and the copy-vs-symlink test gap.
- **Verification**: `make lint` (incl. #24 portability gate) + `make test` — 401 passed.