### PR TITLE
gopls/LSP semantic code intelligence for /implement (+ pyright) (#35)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -271,6 +271,12 @@ Launch an **implementation worker** (contract: `docs/worker-contracts.md#impleme
 
 The worker should:
 1. Implement the approved approach — the primary objective is **making the failing tests from Step 5 turn green**
+
+   **Semantic code intelligence (optional, Go/Python)**: while writing, resolve ground-truth facts with the LSP helper instead of guessing — go-to-definition, references, hover types, and live diagnostics. It degrades gracefully (if the language server isn't installed it returns `available: false` and you fall back):
+   ```bash
+   python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" --line <L> --col <C> hover path/to/file.go
+   python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics path/to/file.py
+   ```
 2. Enforce epic contracts as runtime guards:
    - Every REQUIRES block → input validation / guard clause at function entry
    - Every ENSURES block → verify postcondition before returning (or via integration test)
@@ -333,6 +339,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 1. **Apply clear-cut fixes** directly (don't re-run a worker for trivial changes)
 2. **Flag ambiguous feedback** for user decision — only block on items that genuinely need input
 3. **Run static analysis** on the changed files:
+   - **Live LSP diagnostics first (Go/Python, optional)** — surface semantic errors (undefined symbols, type mismatches) before the linter gate, per changed file: `python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics <changed-file>`. This augments, never replaces, the linter; it returns `available: false` and is skipped when the language server isn't installed.
    - Go: `golangci-lint run ./...`
    - TypeScript/JavaScript: `npx eslint --no-warn-ignored` or `npx biome check`
    - Python: `ruff check` or `flake8`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Chief Wiggum dependency checks are profile-based:
 - `transcription` - ffmpeg and OpenAI Whisper
 - `browser-validation` - browser-use, Playwright, and Anthropic browser-use integration
 - `vertex` - Vertex AI packages and project configuration
+- `go-lsp` - `gopls` + Go toolchain, for semantic code intelligence in `/implement` (optional; `scripts/lsp_query.py`)
+- `python-lsp` - `pyright-langserver`, for Python semantic code intelligence (optional; same helper)
 
 Example:
 

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -90,6 +90,16 @@ WORKFLOW_REQUIREMENTS = {
         "pkgs": {"langchain-google-vertexai", "google-cloud-aiplatform"},
         "secrets": {"GOOGLE_CLOUD_PROJECT"},
     },
+    "go-lsp": {
+        "cmds": {"gopls", "go"},
+        "pkgs": set(),
+        "secrets": set(),
+    },
+    "python-lsp": {
+        "cmds": {"pyright-langserver"},
+        "pkgs": set(),
+        "secrets": set(),
+    },
 }
 
 
@@ -311,6 +321,9 @@ def main():
     check_cmd("tmux", "tmux", "-V", is_required("cmds", "tmux", workflows))
     check_cmd("ffmpeg", "ffmpeg", "-version", is_required("cmds", "ffmpeg", workflows))
     check_cmd("git", "git", "--version", is_required("cmds", "git", workflows))
+    check_cmd("go", "go", "version", is_required("cmds", "go", workflows))
+    check_cmd("gopls", "gopls", "version", is_required("cmds", "gopls", workflows))
+    check_cmd("pyright-langserver", "pyright-langserver", "--version", is_required("cmds", "pyright-langserver", workflows))
 
     print("\n--- Python Packages ---")
     check_python_pkg("keyring", "keyring", is_required("pkgs", "keyring", workflows))

--- a/scripts/chief_wiggum/lsp.py
+++ b/scripts/chief_wiggum/lsp.py
@@ -1,0 +1,385 @@
+"""Minimal LSP client for semantic code intelligence (#35).
+
+Speaks LSP over JSON-RPC/stdio to a language server (``gopls`` for Go first) so a
+workflow can query ground-truth semantic facts — go-to-definition, references,
+hover types, and live diagnostics — instead of only shelling out to a linter at
+gate time.
+
+The wire framing is pure and unit-tested independently of any subprocess; the
+client lifecycle drives a real server. The server is configured by a small
+:class:`LspServer` record so other servers (pyright, rust-analyzer) can slot in
+behind the same API later — gopls is just the first.
+
+Positions are LSP UTF-16 code units (0-based line/character), per the spec.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+CONTENT_LENGTH = "content-length"
+
+
+class LspError(RuntimeError):
+    """Raised on protocol/transport errors."""
+
+
+# --- pure wire framing ------------------------------------------------------
+
+
+def encode_message(obj: dict) -> bytes:
+    """Encode a JSON-RPC object with an LSP ``Content-Length`` header."""
+    body = json.dumps(obj).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    return header + body
+
+
+def _content_length(header_block: str) -> int | None:
+    for line in header_block.split("\r\n"):
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        if key.strip().lower() == CONTENT_LENGTH:
+            try:
+                n = int(value.strip())
+            except ValueError:
+                return None
+            return n if n >= 0 else None
+    return None
+
+
+class MessageBuffer:
+    """Accumulates raw bytes and yields complete JSON-RPC messages.
+
+    Handles partial reads (a message split across chunks), multiple messages in
+    one chunk, and preserves an incomplete trailing message for the next push.
+    """
+
+    def __init__(self) -> None:
+        self._buf = b""
+
+    def push(self, chunk: bytes) -> list[dict]:
+        self._buf += chunk
+        messages: list[dict] = []
+        while True:
+            sep = self._buf.find(b"\r\n\r\n")
+            if sep == -1:
+                break
+            header = self._buf[:sep].decode("ascii", errors="replace")
+            length = _content_length(header)
+            if length is None:
+                raise LspError(f"missing/invalid Content-Length in header: {header!r}")
+            start = sep + 4
+            if len(self._buf) - start < length:
+                break  # payload not fully arrived yet
+            payload = self._buf[start: start + length]
+            self._buf = self._buf[start + length:]
+            messages.append(json.loads(payload.decode("utf-8")))
+        return messages
+
+
+# --- server config ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LspServer:
+    name: str
+    command: tuple[str, ...]
+    language_id: str
+    extensions: tuple[str, ...]
+
+
+GOPLS = LspServer(name="gopls", command=("gopls",), language_id="go", extensions=(".go",))
+# pyright (pyright-langserver --stdio) — Python LSP, installable via npm.
+PYRIGHT = LspServer(
+    name="pyright",
+    command=("pyright-langserver", "--stdio"),
+    language_id="python",
+    extensions=(".py", ".pyi"),
+)
+SERVERS = {GOPLS.name: GOPLS, PYRIGHT.name: PYRIGHT}
+
+
+def server_for_file(path: str | Path) -> LspServer | None:
+    suffix = Path(path).suffix
+    for server in SERVERS.values():
+        if suffix in server.extensions:
+            return server
+    return None
+
+
+def server_available(server: LspServer) -> bool:
+    return shutil.which(server.command[0]) is not None
+
+
+def path_to_uri(path: str | Path) -> str:
+    return Path(path).resolve().as_uri()
+
+
+# --- client -----------------------------------------------------------------
+
+Spawner = Callable[..., subprocess.Popen]
+
+
+@dataclass
+class _Pending:
+    event: threading.Event = field(default_factory=threading.Event)
+    result: object = None
+    error: object = None
+
+
+class LspClient:
+    """Drives a language server over stdio. Use as a context manager."""
+
+    def __init__(
+        self,
+        server: LspServer,
+        root_path: str | Path,
+        *,
+        spawner: Spawner = subprocess.Popen,
+        timeout: float = 30.0,
+    ) -> None:
+        self.server = server
+        self.root_path = Path(root_path).resolve()
+        self._spawner = spawner
+        self._timeout = timeout
+        self._proc: subprocess.Popen | None = None
+        self._buf = MessageBuffer()
+        self._reader: threading.Thread | None = None
+        self._next_id = 0
+        self._pending: dict[int, _Pending] = {}
+        self._diagnostics: dict[str, list[dict]] = {}
+        self._diag_seen: set[str] = set()
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+
+    # -- transport --
+    def start(self) -> None:
+        self._proc = self._spawner(
+            list(self.server.command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(self.root_path),
+        )
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        # Drain stderr so a chatty server (gopls logs there) can't block on a full pipe.
+        threading.Thread(target=self._drain_stderr, daemon=True).start()
+
+    def _read_loop(self) -> None:
+        assert self._proc and self._proc.stdout
+        stdout = self._proc.stdout
+        # read1() returns as soon as *some* data is available (read() would block
+        # until the full count or EOF, deadlocking on a single small response).
+        reader = getattr(stdout, "read1", None) or stdout.read
+        while True:
+            chunk = reader(65536)
+            if not chunk:
+                break
+            try:
+                for msg in self._buf.push(chunk):
+                    self._dispatch(msg)
+            except LspError:
+                break
+
+    def _drain_stderr(self) -> None:
+        if not self._proc or not self._proc.stderr:
+            return
+        for _ in iter(lambda: self._proc.stderr.read1(65536) if hasattr(self._proc.stderr, "read1") else self._proc.stderr.read(65536), b""):
+            pass
+
+    def _dispatch(self, msg: dict) -> None:
+        if "id" in msg and ("result" in msg or "error" in msg):
+            with self._cond:
+                pending = self._pending.get(msg["id"])
+                if pending:
+                    pending.result = msg.get("result")
+                    pending.error = msg.get("error")
+                    pending.event.set()
+        elif msg.get("method") == "textDocument/publishDiagnostics":
+            params = msg.get("params", {})
+            uri = params.get("uri")
+            if uri is not None:
+                with self._cond:
+                    self._diagnostics[uri] = params.get("diagnostics", [])
+                    self._diag_seen.add(uri)
+                    self._cond.notify_all()
+
+    def _send(self, obj: dict) -> None:
+        if not self._proc or not self._proc.stdin:
+            raise LspError("server not started")
+        self._proc.stdin.write(encode_message(obj))
+        self._proc.stdin.flush()
+
+    def _request(self, method: str, params: dict, *, timeout: float | None = None) -> object:
+        with self._cond:
+            self._next_id += 1
+            req_id = self._next_id
+            pending = _Pending()
+            self._pending[req_id] = pending
+        self._send({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+        if not pending.event.wait(timeout or self._timeout):
+            raise LspError(f"timeout waiting for {method}")
+        with self._cond:
+            self._pending.pop(req_id, None)
+        if pending.error:
+            raise LspError(f"{method} failed: {pending.error}")
+        return pending.result
+
+    def _notify(self, method: str, params: dict) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    # -- lifecycle --
+    def initialize(self) -> dict:
+        root_uri = self.root_path.as_uri()
+        result = self._request("initialize", {
+            "processId": None,
+            "rootUri": root_uri,
+            "workspaceFolders": [{"uri": root_uri, "name": self.root_path.name}],
+            "capabilities": {
+                "workspace": {"workspaceFolders": True},
+                "textDocument": {
+                    "definition": {},
+                    "references": {},
+                    "hover": {"contentFormat": ["plaintext", "markdown"]},
+                    "publishDiagnostics": {"relatedInformation": True},
+                },
+            },
+            "initializationOptions": {},
+        })
+        self._notify("initialized", {})
+        return result  # type: ignore[return-value]
+
+    def did_open(self, path: str | Path, text: str | None = None) -> None:
+        p = Path(path)
+        if text is None:
+            text = p.read_text()
+        self._notify("textDocument/didOpen", {
+            "textDocument": {
+                "uri": path_to_uri(p),
+                "languageId": self.server.language_id,
+                "version": 1,
+                "text": text,
+            }
+        })
+
+    # -- queries --
+    def _loc_request(self, method: str, path, line, col, extra=None) -> list[dict]:
+        params = {
+            "textDocument": {"uri": path_to_uri(path)},
+            "position": {"line": line, "character": col},
+        }
+        if extra:
+            params.update(extra)
+        result = self._request(method, params)
+        if result is None:
+            return []
+        items = result if isinstance(result, list) else [result]
+        return [_location_to_dict(i) for i in items if i]
+
+    def definition(self, path, line, col) -> list[dict]:
+        return self._loc_request("textDocument/definition", path, line, col)
+
+    def references(self, path, line, col, *, include_declaration: bool = True) -> list[dict]:
+        return self._loc_request(
+            "textDocument/references", path, line, col,
+            extra={"context": {"includeDeclaration": include_declaration}},
+        )
+
+    def hover(self, path, line, col) -> dict:
+        result = self._request("textDocument/hover", {
+            "textDocument": {"uri": path_to_uri(path)},
+            "position": {"line": line, "character": col},
+        })
+        if not result:
+            return {"signature": None}
+        contents = result.get("contents") if isinstance(result, dict) else None
+        return {"signature": _hover_text(contents)}
+
+    def diagnostics(self, path, *, timeout: float | None = None) -> list[dict]:
+        """Return the latest diagnostics published for ``path``.
+
+        Waits (up to a deadline) for at least one publishDiagnostics for the URI,
+        since diagnostics arrive asynchronously after didOpen.
+        """
+        uri = path_to_uri(path)
+        deadline = timeout or self._timeout
+        with self._cond:
+            self._cond.wait_for(lambda: uri in self._diag_seen, timeout=deadline)
+            raw = list(self._diagnostics.get(uri, []))
+        return [_diagnostic_to_dict(d) for d in raw]
+
+    def shutdown(self) -> None:
+        try:
+            if self._proc and self._proc.poll() is None:
+                self._request("shutdown", {}, timeout=5)
+                self._notify("exit", {})
+        except LspError:
+            pass
+        finally:
+            if self._proc:
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._proc.terminate()
+
+    def __enter__(self) -> LspClient:
+        self.start()
+        self.initialize()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.shutdown()
+
+
+# --- result normalization ---------------------------------------------------
+
+
+def _location_to_dict(loc: dict) -> dict:
+    # LSP Location or LocationLink.
+    uri = loc.get("uri") or loc.get("targetUri")
+    rng = loc.get("range") or loc.get("targetSelectionRange") or loc.get("targetRange") or {}
+    start = rng.get("start", {})
+    path = _uri_to_path(uri) if uri else None
+    return {"file": path, "line": start.get("line"), "col": start.get("character"), "uri": uri}
+
+
+def _diagnostic_to_dict(d: dict) -> dict:
+    severities = {1: "error", 2: "warning", 3: "information", 4: "hint"}
+    start = d.get("range", {}).get("start", {})
+    return {
+        "line": start.get("line"),
+        "col": start.get("character"),
+        "severity": severities.get(d.get("severity"), "unknown"),
+        "message": d.get("message", ""),
+        "source": d.get("source"),
+    }
+
+
+def _hover_text(contents) -> str | None:
+    if contents is None:
+        return None
+    if isinstance(contents, str):
+        return contents.strip() or None
+    if isinstance(contents, dict):
+        return (contents.get("value") or "").strip() or None
+    if isinstance(contents, list):
+        parts = [_hover_text(c) for c in contents]
+        joined = "\n".join(p for p in parts if p)
+        return joined or None
+    return None
+
+
+def _uri_to_path(uri: str) -> str:
+    if uri.startswith("file://"):
+        from urllib.parse import unquote, urlparse
+
+        return unquote(urlparse(uri).path)
+    return uri

--- a/scripts/chief_wiggum/lsp.py
+++ b/scripts/chief_wiggum/lsp.py
@@ -19,6 +19,7 @@ import json
 import shutil
 import subprocess
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -156,6 +157,8 @@ class LspClient:
         self._pending: dict[int, _Pending] = {}
         self._diagnostics: dict[str, list[dict]] = {}
         self._diag_seen: set[str] = set()
+        self._diag_seq = 0  # bumped on every publishDiagnostics (settle tracking)
+        self._closed = False  # set when the transport dies (reader exits)
         self._lock = threading.Lock()
         self._cond = threading.Condition(self._lock)
 
@@ -179,15 +182,27 @@ class LspClient:
         # read1() returns as soon as *some* data is available (read() would block
         # until the full count or EOF, deadlocking on a single small response).
         reader = getattr(stdout, "read1", None) or stdout.read
-        while True:
-            chunk = reader(65536)
-            if not chunk:
-                break
-            try:
+        try:
+            while True:
+                chunk = reader(65536)
+                if not chunk:
+                    break
                 for msg in self._buf.push(chunk):
                     self._dispatch(msg)
-            except LspError:
-                break
+        except (LspError, ValueError, OSError):
+            pass
+        finally:
+            # EOF or transport error: wake every waiter rather than stranding it
+            # until its own timeout.
+            self._fail_all_pending("server closed the connection")
+
+    def _fail_all_pending(self, reason: str) -> None:
+        with self._cond:
+            self._closed = True
+            for pending in self._pending.values():
+                if not pending.event.is_set():
+                    pending.error = {"message": reason}
+                    pending.event.set()
 
     def _drain_stderr(self) -> None:
         if not self._proc or not self._proc.stderr:
@@ -210,6 +225,7 @@ class LspClient:
                 with self._cond:
                     self._diagnostics[uri] = params.get("diagnostics", [])
                     self._diag_seen.add(uri)
+                    self._diag_seq += 1
                     self._cond.notify_all()
 
     def _send(self, obj: dict) -> None:
@@ -220,15 +236,19 @@ class LspClient:
 
     def _request(self, method: str, params: dict, *, timeout: float | None = None) -> object:
         with self._cond:
+            if self._closed:
+                raise LspError(f"{method} failed: server closed the connection")
             self._next_id += 1
             req_id = self._next_id
             pending = _Pending()
             self._pending[req_id] = pending
         self._send({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
-        if not pending.event.wait(timeout or self._timeout):
-            raise LspError(f"timeout waiting for {method}")
-        with self._cond:
-            self._pending.pop(req_id, None)
+        try:
+            if not pending.event.wait(timeout or self._timeout):
+                raise LspError(f"timeout waiting for {method}")
+        finally:
+            with self._cond:
+                self._pending.pop(req_id, None)
         if pending.error:
             raise LspError(f"{method} failed: {pending.error}")
         return pending.result
@@ -303,16 +323,27 @@ class LspClient:
         contents = result.get("contents") if isinstance(result, dict) else None
         return {"signature": _hover_text(contents)}
 
-    def diagnostics(self, path, *, timeout: float | None = None) -> list[dict]:
+    def diagnostics(self, path, *, timeout: float | None = None, settle: float = 0.6) -> list[dict]:
         """Return the latest diagnostics published for ``path``.
 
-        Waits (up to a deadline) for at least one publishDiagnostics for the URI,
-        since diagnostics arrive asynchronously after didOpen.
+        Diagnostics arrive asynchronously after didOpen, and a server may publish
+        an initial empty/stale set before analysis completes. So this waits for
+        the first publish, then for the stream to *settle* (no new publish for
+        ``settle`` seconds) before returning the latest — bounded by the deadline.
         """
         uri = path_to_uri(path)
-        deadline = timeout or self._timeout
+        end = time.monotonic() + (timeout or self._timeout)
         with self._cond:
-            self._cond.wait_for(lambda: uri in self._diag_seen, timeout=deadline)
+            self._cond.wait_for(lambda: uri in self._diag_seen, timeout=max(0.0, end - time.monotonic()))
+            while True:
+                seq = self._diag_seq
+                remaining = min(settle, end - time.monotonic())
+                if remaining <= 0:
+                    break
+                # Wait for a *newer* publish; if none arrives within the settle
+                # window, the diagnostics have settled.
+                if not self._cond.wait_for(lambda s=seq: self._diag_seq > s, timeout=remaining):
+                    break
             raw = list(self._diagnostics.get(uri, []))
         return [_diagnostic_to_dict(d) for d in raw]
 
@@ -324,15 +355,29 @@ class LspClient:
         except LspError:
             pass
         finally:
-            if self._proc:
+            self._fail_all_pending("client shutting down")
+            if self._proc and self._proc.poll() is None:
                 try:
-                    self._proc.wait(timeout=5)
+                    self._proc.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     self._proc.terminate()
+                    try:
+                        self._proc.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        self._proc.kill()
+                        try:
+                            self._proc.wait(timeout=3)
+                        except subprocess.TimeoutExpired:
+                            pass
 
     def __enter__(self) -> LspClient:
         self.start()
-        self.initialize()
+        try:
+            self.initialize()
+        except BaseException:
+            # Never leak the server process if the handshake fails.
+            self.shutdown()
+            raise
         return self
 
     def __exit__(self, *exc) -> None:

--- a/scripts/lsp_query.py
+++ b/scripts/lsp_query.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""CLI for semantic code intelligence via LSP (#35).
+
+Queries a language server (gopls for Go, pyright for Python) for go-to-definition,
+references, hover types, and live diagnostics — structured JSON an agent can
+consume. Picks the server from the file extension.
+
+**Graceful degradation**: if no server is configured/installed for the file, this
+prints ``{"available": false, "reason": ...}`` and exits 0 — it never blocks the
+workflow; the caller falls back to its existing behavior.
+
+Examples:
+    python3 scripts/lsp_query.py --root . diagnostics path/to/file.go
+    python3 scripts/lsp_query.py --root . --line 41 --col 6 definition app/x.py
+    python3 scripts/lsp_query.py --root . --line 41 --col 6 hover app/x.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import lsp  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Semantic code intelligence via LSP")
+    parser.add_argument("query", choices=["definition", "references", "hover", "diagnostics"])
+    parser.add_argument("file", help="Source file to query")
+    parser.add_argument("--root", default=".", help="Project/repo root (resolved by the server)")
+    parser.add_argument("--line", type=int, default=0, help="0-based line (LSP)")
+    parser.add_argument("--col", type=int, default=0, help="0-based UTF-16 character (LSP)")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    args = parser.parse_args(argv)
+
+    file_path = Path(args.file)
+    server = lsp.server_for_file(file_path)
+    if server is None:
+        print(json.dumps({"available": False, "reason": f"no LSP server for {file_path.suffix or 'this file'}"}))
+        return 0
+    if not lsp.server_available(server):
+        print(json.dumps({
+            "available": False,
+            "server": server.name,
+            "reason": f"{server.command[0]} not installed; falling back to existing behavior",
+        }))
+        return 0
+
+    try:
+        with lsp.LspClient(server, args.root, timeout=args.timeout) as client:
+            client.did_open(file_path)
+            if args.query == "definition":
+                result = client.definition(file_path, args.line, args.col)
+            elif args.query == "references":
+                result = client.references(file_path, args.line, args.col)
+            elif args.query == "hover":
+                result = client.hover(file_path, args.line, args.col)
+            else:  # diagnostics
+                result = client.diagnostics(file_path, timeout=min(args.timeout, 15))
+    except lsp.LspError as exc:
+        # A server error must not block the workflow either.
+        print(json.dumps({"available": False, "server": server.name, "reason": str(exc)}))
+        return 0
+
+    print(json.dumps({"available": True, "server": server.name, "query": args.query, "result": result}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -110,3 +110,13 @@ def test_recommend_workflows_include_direct_provider_usage():
 
 def test_keep_going_workflow_is_mapped():
     assert check_deps.recommend_profiles(workflows=["keep-going"]) == ["core"]
+
+
+def test_go_lsp_profile_requires_gopls():
+    assert check_deps.is_required("cmds", "gopls", ["go-lsp"])
+    assert check_deps.is_required("cmds", "go", ["go-lsp"])
+    assert not check_deps.is_required("cmds", "gopls", ["core"])
+
+
+def test_python_lsp_profile_requires_pyright():
+    assert check_deps.is_required("cmds", "pyright-langserver", ["python-lsp"])

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,0 +1,180 @@
+"""Tests for the LSP semantic-intelligence client (#35).
+
+Framing/normalization are unit-tested with no subprocess. Integration tests run
+against real ``gopls`` / ``pyright`` and are skipped when those aren't installed,
+so CI without them stays green; they are exercised locally where they exist.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import lsp_query
+import pytest
+from chief_wiggum import lsp
+
+HAVE_GOPLS = shutil.which("gopls") is not None and shutil.which("go") is not None
+HAVE_PYRIGHT = shutil.which("pyright-langserver") is not None
+
+
+# --- pure framing -----------------------------------------------------------
+
+
+def test_encode_uses_byte_length_not_char_length():
+    msg = {"k": "é"}  # 'é' is 2 bytes in UTF-8
+    raw = lsp.encode_message(msg)
+    header, _, body = raw.partition(b"\r\n\r\n")
+    assert f"Content-Length: {len(body)}".encode() in header
+    assert len(body) == len(json.dumps(msg).encode("utf-8"))
+
+
+def test_buffer_parses_single_message():
+    buf = lsp.MessageBuffer()
+    assert buf.push(lsp.encode_message({"id": 1, "result": "ok"})) == [{"id": 1, "result": "ok"}]
+
+
+def test_buffer_handles_partial_reads():
+    buf = lsp.MessageBuffer()
+    raw = lsp.encode_message({"id": 1, "result": "ok"})
+    out = []
+    for i in range(0, len(raw)):  # one byte at a time
+        out += buf.push(raw[i: i + 1])
+    assert out == [{"id": 1, "result": "ok"}]
+
+
+def test_buffer_handles_multiple_messages_in_one_chunk():
+    buf = lsp.MessageBuffer()
+    raw = lsp.encode_message({"id": 1}) + lsp.encode_message({"id": 2})
+    assert buf.push(raw) == [{"id": 1}, {"id": 2}]
+
+
+def test_buffer_preserves_incomplete_trailing():
+    buf = lsp.MessageBuffer()
+    raw = lsp.encode_message({"id": 1}) + lsp.encode_message({"id": 2})
+    first = buf.push(raw[: len(raw) - 5])  # cut the 2nd message short
+    assert first == [{"id": 1}]
+    assert buf.push(raw[len(raw) - 5:]) == [{"id": 2}]
+
+
+def test_buffer_case_insensitive_header():
+    buf = lsp.MessageBuffer()
+    body = b'{"id": 9}'
+    raw = b"content-length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    assert buf.push(raw) == [{"id": 9}]
+
+
+def test_buffer_rejects_missing_content_length():
+    buf = lsp.MessageBuffer()
+    with pytest.raises(lsp.LspError):
+        buf.push(b"X-Other: 1\r\n\r\n{}")
+
+
+# --- server config ----------------------------------------------------------
+
+
+def test_server_for_file_by_extension():
+    assert lsp.server_for_file("a.go") is lsp.GOPLS
+    assert lsp.server_for_file("a.py") is lsp.PYRIGHT
+    assert lsp.server_for_file("a.txt") is None
+
+
+def test_server_available(monkeypatch):
+    monkeypatch.setattr(lsp.shutil, "which", lambda c: "/bin/" + c if c == "gopls" else None)
+    assert lsp.server_available(lsp.GOPLS) is True
+    assert lsp.server_available(lsp.PYRIGHT) is False
+
+
+# --- result normalization ---------------------------------------------------
+
+
+def test_location_to_dict():
+    loc = {"uri": "file:///tmp/x.go", "range": {"start": {"line": 4, "character": 6}}}
+    d = lsp._location_to_dict(loc)
+    assert d == {"file": "/tmp/x.go", "line": 4, "col": 6, "uri": "file:///tmp/x.go"}
+
+
+def test_diagnostic_to_dict_maps_severity():
+    d = lsp._diagnostic_to_dict({"range": {"start": {"line": 2, "character": 8}}, "severity": 1, "message": "boom"})
+    assert d["severity"] == "error" and d["line"] == 2 and d["message"] == "boom"
+
+
+def test_hover_text_from_markup_and_list():
+    assert lsp._hover_text({"kind": "markdown", "value": "func F()"}) == "func F()"
+    assert lsp._hover_text([{"value": "a"}, {"value": "b"}]) == "a\nb"
+
+
+# --- CLI graceful degradation -----------------------------------------------
+
+
+def test_cli_unknown_extension_is_graceful(tmp_path, capsys):
+    f = tmp_path / "x.txt"
+    f.write_text("hi")
+    rc = lsp_query.main(["diagnostics", str(f), "--root", str(tmp_path)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["available"] is False
+
+
+def test_cli_missing_server_is_graceful(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(lsp, "server_available", lambda s: False)
+    f = tmp_path / "x.go"
+    f.write_text("package main\n")
+    rc = lsp_query.main(["diagnostics", str(f), "--root", str(tmp_path)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["available"] is False and "not installed" in out["reason"]
+
+
+# --- integration: real gopls ------------------------------------------------
+
+
+def _go_module(tmp_path):
+    mod = tmp_path / "mod"
+    mod.mkdir()
+    (mod / "go.mod").write_text("module example.com/fix\n\ngo 1.21\n")
+    (mod / "main.go").write_text(
+        'package main\n\nfunc Greet(name string) string {\n\treturn "hi " + name\n}\n\n'
+        'func main() {\n\t_ = Greet("x")\n}\n'
+    )
+    (mod / "broken.go").write_text("package main\n\nvar _ = DoesNotExist\n")
+    return mod
+
+
+@pytest.mark.skipif(not HAVE_GOPLS, reason="gopls/go not installed")
+def test_gopls_definition_hover_diagnostics(tmp_path):
+    mod = _go_module(tmp_path)
+    with lsp.LspClient(lsp.GOPLS, mod, timeout=40) as c:
+        c.did_open(mod / "main.go")
+        # 'Greet' usage on the `_ = Greet("x")` line (0-based line 7, col on Greet).
+        defs = c.definition(mod / "main.go", 7, 6)
+        assert defs and defs[0]["file"].endswith("main.go") and defs[0]["line"] == 2
+        hover = c.hover(mod / "main.go", 2, 5)
+        assert "Greet" in (hover["signature"] or "")
+        c.did_open(mod / "broken.go")
+        diags = c.diagnostics(mod / "broken.go", timeout=20)
+        assert any("DoesNotExist" in d["message"] for d in diags)
+
+
+@pytest.mark.skipif(not HAVE_GOPLS, reason="gopls/go not installed")
+def test_cli_diagnostics_against_real_gopls(tmp_path, capsys):
+    mod = _go_module(tmp_path)
+    rc = lsp_query.main(["diagnostics", str(mod / "broken.go"), "--root", str(mod), "--timeout", "30"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["available"] is True
+    assert any("DoesNotExist" in d["message"] for d in out["result"])
+
+
+# --- integration: real pyright ----------------------------------------------
+
+
+@pytest.mark.skipif(not HAVE_PYRIGHT, reason="pyright-langserver not installed")
+def test_pyright_definition_and_diagnostics(tmp_path):
+    f = tmp_path / "sample.py"
+    f.write_text('def greet(name):\n    return "hi " + name\n\n\nx = greet("a")\ny = undefined_symbol\n')
+    with lsp.LspClient(lsp.PYRIGHT, tmp_path, timeout=40) as c:
+        c.did_open(f)
+        defs = c.definition(f, 4, 4)  # greet() call -> def greet (line 0)
+        assert defs and defs[0]["line"] == 0
+        diags = c.diagnostics(f, timeout=20)
+        assert any("undefined_symbol" in d["message"] for d in diags)

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -125,6 +125,55 @@ def test_cli_missing_server_is_graceful(tmp_path, capsys, monkeypatch):
     assert out["available"] is False and "not installed" in out["reason"]
 
 
+# --- lifecycle robustness (no real server) ----------------------------------
+
+
+class _FakeProc:
+    def __init__(self):
+        import io
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO()  # EOF immediately
+        self.stderr = io.BytesIO()
+        self.terminated = self.killed = False
+        self._alive = True
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def wait(self, timeout=None):
+        self._alive = False
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+
+
+def test_enter_cleans_up_when_initialize_fails(monkeypatch):
+    proc = _FakeProc()
+    client = lsp.LspClient(lsp.GOPLS, ".", spawner=lambda *a, **k: proc, timeout=0.3)
+    # initialize will time out (the fake server never responds) -> __enter__ must
+    # not leak the process.
+    with pytest.raises(lsp.LspError):
+        client.__enter__()
+    assert proc.poll() == 0  # reaped/cleaned up
+
+
+def test_transport_eof_wakes_pending_request(monkeypatch):
+    proc = _FakeProc()  # stdout is EOF -> reader exits immediately
+    client = lsp.LspClient(lsp.GOPLS, ".", spawner=lambda *a, **k: proc, timeout=2.0)
+    client.start()
+    # A request must fail fast with a transport error, not hang for the timeout.
+    import time as _t
+    t0 = _t.monotonic()
+    with pytest.raises(lsp.LspError, match="closed"):
+        client._request("initialize", {})
+    assert _t.monotonic() - t0 < 1.5  # woken by EOF, not the 2s timeout
+
+
 # --- integration: real gopls ------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds an LSP client so `/implement` can query ground-truth semantic facts (go-to-definition, references, hover types, **live diagnostics**) instead of only shelling out to linters at gate time. Ships **gopls (Go) and pyright (Python)** — language-agnostic by design (one client; server picked by file extension), so rust-analyzer/etc. slot in later.

Closes #35.

## Changes
- **`scripts/chief_wiggum/lsp.py`** — pure JSON-RPC framing (`encode_message` + `MessageBuffer`, unit-tested), `LspServer` registry (gopls/pyright), and `LspClient` driving a real server over stdio (lifecycle + definition/references/hover/diagnostics; async `publishDiagnostics` collected with a settle window). Structured JSON results.
- **`scripts/lsp_query.py`** — CLI; **graceful degradation** (missing/unconfigured server → `{available:false, reason}`, exit 0; never blocks).
- **`check_deps.py`** — `go-lsp` / `python-lsp` profiles.
- **`implement.md`** — optional semantic intelligence in the coding step + live LSP diagnostics before the lint gate (augments, never replaces, the linter).
- **`CLAUDE.md`** — Required Tools entries.
- **`tests/test_lsp.py`** — 19 tests: framing edge cases, server config, normalization, CLI graceful degradation, lifecycle robustness, and **real gopls + pyright integration** (skipped when the servers aren't installed → CI stays green).

## Acceptance criteria
- [x] `go-lsp` dependency profile verifying `gopls` (+ Go toolchain); also `python-lsp` for pyright.
- [x] Python LSP wrapper exposing `definition`, `references`, `hover`, `diagnostics`.
- [x] Structured JSON output (file:line:col, type signature, severity).
- [x] `/implement` can optionally call it; live diagnostics before the lint gate.
- [x] Graceful degradation: missing server → fall back, log why, never block.
- [x] Docs: CLAUDE.md Required Tools + the `/implement` step.

## Verification
- `make lint` clean; `make test` — **445 passed** (19 new), with the gopls + pyright integration tests run against the **real, installed** language servers locally.

> gemini reviewer unavailable this session (account tier ended); review ran codex-only.