### PR TITLE
Add /saas-gate non-functional-requirements validation skill (#2)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -134,6 +134,16 @@ python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_R
 
 **Uncovered contracts** (no code `@cw-trace guards/ensures`) and **untested contracts** (no test `@cw-trace verifies`) are findings — the contract isn't proven implemented/tested. Dangling annotations (a tag referencing an ID that no longer exists) indicate a refactor left a stale link; fix the link or the ID. Degrades gracefully when the epic uses no annotations.
 
+### Step 2e: SaaS NFR gate (optional)
+
+For SaaS products, validate non-functional requirements (security headers + CSRF posture, auth rate-limiting, tenant isolation, health + structured logging) against the running app. Start the app if needed (don't punt), then:
+
+```bash
+python3 "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" --base-url "$BASE_URL" --gate --markdown
+```
+
+It reports five statuses (`pass`/`fail`/`warn`/`skipped`/`not_applicable`); a real `fail` (e.g. missing CSP, a cross-tenant data leak) blocks the epic close, while `warn`/`skipped` are surfaced but don't block. See `/saas-gate` for the full check list (tenant isolation, performance, data integrity need the live multi-user app).
+
 ### Step 3: Integration test execution
 
 Run the integration tests defined in `integration-tests.md`. These test cross-ticket behaviour that no individual ticket validates.

--- a/.claude/commands/saas-gate.md
+++ b/.claude/commands/saas-gate.md
@@ -1,0 +1,54 @@
+# SaaS Gate - Non-Functional Requirements Validation
+
+Validates common SaaS non-functional requirements (security, tenant isolation, performance, data integrity, observability) against a running app, and reports actionable pass/fail per category. Run standalone or as an extra gate in `/close-epic`.
+
+The build-side complement to a SaaS baseline: it proves a chief-wiggum-built (or cloned) SaaS app meets production standards before shipping.
+
+## Usage
+```
+/saas-gate <owner/repo> --base-url <url> [--auth-mode cookie|bearer]
+```
+
+## Statuses
+
+The gate reports five statuses so it never claims more than it proved: `pass`, `fail`, `warn`, `skipped`, `not_applicable`. As a `/close-epic` gate it fails the epic **only on a real `fail`** (real evidence or an explicit contract), not on `warn`/`skipped`.
+
+## Workflow
+
+### Step 1: Resolve paths and detect the stack
+
+```bash
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+```
+
+`saas_gate.py` auto-detects the stack (Go/Node/Python) from the repo. Confirm the dependency profile if needed: `python3 "$CW_HOME/scripts/check_deps.py" --for core`.
+
+### Step 2: Get a running app
+
+The runtime checks need a live base URL. If the app isn't already running, **start it** (don't punt): `docker compose up -d` (wait for healthy), or the repo's run command. Use the local URL (e.g. `http://localhost:8080`). For an already-deployed environment, pass its URL.
+
+If you genuinely cannot start the app, run the gate without `--base-url` — it still reports the static/structured-log checks and marks the runtime checks `skipped` (honest, not a false pass).
+
+### Step 3: Run the gate
+
+```bash
+python3 "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" \
+  --base-url "$BASE_URL" --auth-mode cookie \
+  --rate-limit-path /login --markdown
+```
+
+Options: `--require-https` (require HSTS), `--rate-limit-path` / `--rate-limit-required` (fail if no limiter on a known endpoint), `--auth-mode bearer` (CSRF marked not-applicable for API/token auth), `--log-sample <file>` (validate structured logging), `--gate` (exit non-zero on any `fail`), `--json`.
+
+### Step 4: The live-app checks
+
+`saas_gate.py` covers what it can hermetically (security headers, CSRF cookie posture, rate-limit probe, health, structured-log format). Some checks genuinely need a live multi-user app — run them as part of this step and record the result:
+
+- **Tenant isolation**: create two users, have user A create a resource, confirm user B gets `401/403/404` fetching it (a `200` is a data-leak `fail`). The helper exposes `check_tenant_isolation(make_user, create_resource, fetch_resource)` for this.
+- **Performance**: sample representative endpoints under a realistic load and compare against the target SLOs.
+- **Data integrity**: confirm an audit trail is written and soft-delete is honored (verify in the datastore / via the API).
+
+### Step 5: Report
+
+Present the per-category pass/fail. Flag every `fail` with the actionable fix. As a `/close-epic` gate, a `fail` blocks the epic close; `warn`/`skipped` are surfaced but don't block.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 
 /ship                           # Create PR with mermaid diagrams (standalone)
 /stitch-audit owner/repo --trace keyword   # Cross-layer data flow audit
+/saas-gate owner/repo --base-url <url>     # SaaS non-functional-requirements gate (security/isolation/perf/observability)
 /update                         # Refresh model IDs and library versions
 ```
 

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -180,6 +180,7 @@ WORKFLOW_PROFILES = {
     "ship": ["core"],
     "transcribe": ["transcription"],
     "stitch-audit": ["core", "gemini"],
+    "saas-gate": ["core"],
     "update": ["core"],
     "keep-going": ["core"],
 }

--- a/scripts/saas_gate.py
+++ b/scripts/saas_gate.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""SaaS non-functional-requirements gate (#2).
+
+Validates common SaaS NFRs — security headers + CSRF posture, auth rate-limiting,
+tenant isolation, performance, observability (health + structured logging) —
+against a running app, and reports actionable pass/fail per category.
+
+Results use five statuses so the gate never claims more than it proved:
+``pass`` / ``fail`` / ``warn`` / ``skipped`` / ``not_applicable``. ``/close-epic``
+fails only on a real ``fail`` (real evidence or an explicit contract). All
+runtime I/O (the HTTP getter, user factory, resource fetcher, log sample) is
+injectable, so the check logic is hermetically testable.
+
+Run standalone or as a `/close-epic` gate:
+    python3 scripts/saas_gate.py --repo . --base-url http://localhost:8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+PASS, FAIL, WARN, SKIPPED, NA = "pass", "fail", "warn", "skipped", "not_applicable"
+
+# http_get(url) -> (status_code, headers_lower_dict, body_text)
+HttpGet = Callable[[str], tuple[int, dict, str]]
+
+
+@dataclass
+class Finding:
+    category: str
+    name: str
+    status: str
+    detail: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SaasGateReport:
+    base_url: str | None = None
+    stack: list[str] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, *args, **kwargs) -> None:
+        self.findings.append(Finding(*args, **kwargs))
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.status == FAIL for f in self.findings)
+
+    def by_category(self) -> dict[str, list[Finding]]:
+        out: dict[str, list[Finding]] = {}
+        for f in self.findings:
+            out.setdefault(f.category, []).append(f)
+        return out
+
+    def to_dict(self) -> dict:
+        return {
+            "base_url": self.base_url,
+            "stack": self.stack,
+            "ok": self.ok,
+            "counts": {s: sum(1 for f in self.findings if f.status == s) for s in (PASS, FAIL, WARN, SKIPPED, NA)},
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+    def render_markdown(self) -> str:
+        marks = {PASS: "✓", FAIL: "✗", WARN: "⚠", SKIPPED: "–", NA: "·"}
+        lines = ["# SaaS NFR Gate", "", f"Status: {'PASS' if self.ok else 'FAIL'}", f"Stack: {', '.join(self.stack) or 'unknown'}", ""]
+        for category, items in self.by_category().items():
+            lines.append(f"## {category}")
+            for f in items:
+                lines.append(f"- {marks.get(f.status, '?')} **{f.name}** ({f.status}): {f.detail}")
+            lines.append("")
+        return "\n".join(lines) + "\n"
+
+
+# --- stack detection --------------------------------------------------------
+
+
+def detect_stack(repo: str | Path) -> list[str]:
+    root = Path(repo)
+    stack = []
+    if (root / "go.mod").is_file():
+        stack.append("go")
+    if (root / "package.json").is_file():
+        stack.append("node")
+    if (root / "pyproject.toml").is_file() or (root / "setup.py").is_file() or (root / "requirements.txt").is_file():
+        stack.append("python")
+    return stack
+
+
+# --- pure checks ------------------------------------------------------------
+
+REQUIRED_HEADERS = {
+    "x-content-type-options": "nosniff",
+    "referrer-policy": None,
+}
+
+
+def _hget(headers: dict, name: str) -> str | None:
+    for k, v in headers.items():
+        if k.lower() == name.lower():
+            return v
+    return None
+
+
+def check_security_headers(headers: dict, *, https: bool = False) -> list[Finding]:
+    """Classify response security headers (pure)."""
+    findings: list[Finding] = []
+    csp = _hget(headers, "content-security-policy")
+    xcto = _hget(headers, "x-content-type-options")
+    findings.append(Finding(
+        "security", "x-content-type-options",
+        PASS if (xcto or "").lower() == "nosniff" else FAIL,
+        xcto or "missing (want nosniff)",
+    ))
+    findings.append(Finding(
+        "security", "content-security-policy",
+        PASS if csp else FAIL, csp or "missing",
+    ))
+    if csp and ("unsafe-inline" in csp or "default-src *" in csp.replace("'", "")):
+        findings.append(Finding("security", "csp-strength", WARN, "weak CSP (unsafe-inline / default-src *)"))
+    xfo = _hget(headers, "x-frame-options")
+    frame_ancestors = bool(csp and "frame-ancestors" in csp)
+    findings.append(Finding(
+        "security", "clickjacking",
+        PASS if (xfo or frame_ancestors) else FAIL,
+        xfo or ("CSP frame-ancestors" if frame_ancestors else "no X-Frame-Options or CSP frame-ancestors"),
+    ))
+    findings.append(Finding(
+        "security", "referrer-policy",
+        PASS if _hget(headers, "referrer-policy") else FAIL,
+        _hget(headers, "referrer-policy") or "missing",
+    ))
+    hsts = _hget(headers, "strict-transport-security")
+    if https:
+        findings.append(Finding("security", "hsts", PASS if hsts else FAIL, hsts or "missing on HTTPS"))
+    elif not hsts:
+        findings.append(Finding("security", "hsts", WARN, "no HSTS (base URL is not HTTPS)"))
+    return findings
+
+
+def check_csrf(set_cookie_headers: list[str], *, auth_mode: str = "cookie", https: bool = False) -> Finding:
+    """CSRF posture from Set-Cookie (cookie auth) or N/A for bearer/API auth."""
+    if auth_mode == "bearer":
+        return Finding("security", "csrf", NA, "bearer/API auth — CSRF tokens not applicable")
+    if not set_cookie_headers:
+        return Finding("security", "csrf", WARN, "no session cookie observed; cannot assess SameSite")
+    problems = []
+    for cookie in set_cookie_headers:
+        low = cookie.lower()
+        if "samesite" not in low:
+            problems.append("missing SameSite")
+        if "httponly" not in low:
+            problems.append("missing HttpOnly")
+        if https and "secure" not in low:
+            problems.append("missing Secure on HTTPS")
+    if any("samesite" in p.lower() for p in problems):
+        return Finding("security", "csrf", FAIL, "; ".join(sorted(set(problems))))
+    if problems:
+        return Finding("security", "csrf", WARN, "; ".join(sorted(set(problems))))
+    return Finding("security", "csrf", PASS, "session cookie has SameSite + HttpOnly")
+
+
+def check_structured_logging(log_lines: list[str]) -> Finding:
+    if not log_lines:
+        return Finding("observability", "structured-logging", SKIPPED, "no log sample provided")
+    parsed = 0
+    for line in log_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            return Finding("observability", "structured-logging", FAIL, f"non-JSON log line: {line[:60]!r}")
+        if not isinstance(obj, dict) or not ({"level", "severity"} & set(obj)):
+            return Finding("observability", "structured-logging", WARN, "JSON logs lack a level/severity field")
+        parsed += 1
+    return Finding("observability", "structured-logging", PASS, f"{parsed} structured log line(s)")
+
+
+# --- runtime checks (injectable HTTP) ---------------------------------------
+
+
+def check_health(http_get: HttpGet, base_url: str, path: str = "/health") -> Finding:
+    url = base_url.rstrip("/") + path
+    try:
+        status, _, _ = http_get(url)
+    except Exception as exc:  # noqa: BLE001
+        return Finding("observability", "health", FAIL, f"{url} unreachable: {exc}")
+    return Finding("observability", "health", PASS if status == 200 else FAIL, f"GET {path} -> {status}")
+
+
+def check_rate_limit(
+    http_get: HttpGet, base_url: str, path: str = "/login",
+    *, attempts: int = 20, required: bool = False,
+) -> Finding:
+    url = base_url.rstrip("/") + path
+    saw_429 = False
+    retry_after = False
+    for _ in range(attempts):
+        try:
+            status, headers, _ = http_get(url)
+        except Exception as exc:  # noqa: BLE001
+            return Finding("security", "rate-limit", WARN, f"probe error: {exc}")
+        if status == 429:
+            saw_429 = True
+            retry_after = _hget(headers, "retry-after") is not None
+            break
+    if saw_429:
+        detail = "429 observed" + ("" if retry_after else " (no Retry-After header)")
+        return Finding("security", "rate-limit", PASS if retry_after else WARN, detail)
+    status_label = FAIL if required else WARN
+    return Finding("security", "rate-limit", status_label, f"no 429 in {attempts} requests to {path}")
+
+
+def check_tenant_isolation(
+    make_user: Callable[[], object],
+    create_resource: Callable[[object], object],
+    fetch_resource: Callable[[object, object], int],
+) -> Finding:
+    """Two users; user B must not fetch user A's resource (injectable)."""
+    try:
+        user_a = make_user()
+        user_b = make_user()
+        resource = create_resource(user_a)
+        status = fetch_resource(user_b, resource)
+    except Exception as exc:  # noqa: BLE001
+        return Finding("isolation", "tenant-isolation", SKIPPED, f"could not run isolation check: {exc}")
+    if status in (401, 403, 404):
+        return Finding("isolation", "tenant-isolation", PASS, f"cross-tenant fetch denied ({status})")
+    return Finding("isolation", "tenant-isolation", FAIL, f"cross-tenant fetch allowed ({status}) — data leak")
+
+
+# --- default HTTP getter ----------------------------------------------------
+
+
+def default_http_get(url: str, *, timeout: float = 10.0) -> tuple[int, dict, str]:
+    req = urllib.request.Request(url, headers={"User-Agent": "chief-wiggum-saas-gate"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - gate probes a user-supplied URL
+            return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read(8192).decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, {k.lower(): v for k, v in (exc.headers or {}).items()}, ""
+
+
+# --- orchestration ----------------------------------------------------------
+
+
+def run_gate(
+    repo: str | Path,
+    base_url: str | None,
+    *,
+    http_get: HttpGet = default_http_get,
+    auth_mode: str = "cookie",
+    health_path: str = "/health",
+    rate_limit_path: str = "/login",
+    rate_limit_required: bool = False,
+    require_https: bool = False,
+    log_sample: list[str] | None = None,
+) -> SaasGateReport:
+    report = SaasGateReport(base_url=base_url, stack=detect_stack(repo))
+    if base_url:
+        https = base_url.startswith("https://") or require_https
+        try:
+            _, headers, _ = http_get(base_url)
+            set_cookie = [v for k, v in headers.items() if k.lower() == "set-cookie"]
+            for f in check_security_headers(headers, https=https):
+                report.findings.append(f)
+            report.findings.append(check_csrf(set_cookie, auth_mode=auth_mode, https=https))
+        except Exception as exc:  # noqa: BLE001
+            report.add("security", "headers", SKIPPED, f"could not fetch {base_url}: {exc}")
+        report.findings.append(check_health(http_get, base_url, health_path))
+        report.findings.append(check_rate_limit(http_get, base_url, rate_limit_path, required=rate_limit_required))
+    else:
+        report.add("security", "headers", SKIPPED, "no --base-url; runtime checks skipped")
+    report.findings.append(check_structured_logging(log_sample or []))
+    report.add("isolation", "tenant-isolation", SKIPPED, "needs a live multi-user app; run via the /saas-gate skill")
+    report.add("performance", "response-time", SKIPPED, "needs a representative deployment; run via the /saas-gate skill")
+    report.add("data-integrity", "audit-trail/soft-delete", SKIPPED, "code-level; verify in review / a follow-up check")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SaaS NFR validation gate")
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--base-url")
+    parser.add_argument("--auth-mode", choices=["cookie", "bearer"], default="cookie")
+    parser.add_argument("--health-path", default="/health")
+    parser.add_argument("--rate-limit-path", default="/login")
+    parser.add_argument("--rate-limit-required", action="store_true")
+    parser.add_argument("--require-https", action="store_true")
+    parser.add_argument("--log-sample", help="File with sample log lines for structured-logging check")
+    parser.add_argument("--gate", action="store_true", help="Exit 1 if any check failed")
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument("--json", action="store_true")
+    out.add_argument("--markdown", action="store_true")
+    args = parser.parse_args(argv)
+
+    log_sample = None
+    if args.log_sample and Path(args.log_sample).exists():
+        log_sample = Path(args.log_sample).read_text().splitlines()
+
+    report = run_gate(
+        args.repo, args.base_url, auth_mode=args.auth_mode, health_path=args.health_path,
+        rate_limit_path=args.rate_limit_path, rate_limit_required=args.rate_limit_required,
+        require_https=args.require_https, log_sample=log_sample,
+    )
+
+    if args.markdown:
+        print(report.render_markdown())
+    else:
+        print(json.dumps(report.to_dict(), indent=2))
+    return 1 if (args.gate and not report.ok) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/saas_gate.py
+++ b/scripts/saas_gate.py
@@ -129,11 +129,20 @@ def check_security_headers(headers: dict, *, https: bool = False) -> list[Findin
     if csp and ("unsafe-inline" in csp or "default-src *" in csp.replace("'", "")):
         findings.append(Finding("security", "csp-strength", WARN, "weak CSP (unsafe-inline / default-src *)"))
     xfo = _hget(headers, "x-frame-options")
-    frame_ancestors = bool(csp and "frame-ancestors" in csp)
+    xfo_ok = (xfo or "").strip().lower() in ("deny", "sameorigin")
+    # frame-ancestors must be present and not the wildcard *.
+    fa_ok = False
+    if csp:
+        for directive in csp.split(";"):
+            directive = directive.strip()
+            if directive.lower().startswith("frame-ancestors"):
+                value = directive[len("frame-ancestors"):].strip()
+                fa_ok = bool(value) and "*" not in value
     findings.append(Finding(
         "security", "clickjacking",
-        PASS if (xfo or frame_ancestors) else FAIL,
-        xfo or ("CSP frame-ancestors" if frame_ancestors else "no X-Frame-Options or CSP frame-ancestors"),
+        PASS if (xfo_ok or fa_ok) else FAIL,
+        ("X-Frame-Options=" + xfo if xfo_ok else "")
+        or ("CSP frame-ancestors" if fa_ok else (f"unsafe/absent (X-Frame-Options={xfo!r})")),
     ))
     findings.append(Finding(
         "security", "referrer-policy",
@@ -148,43 +157,71 @@ def check_security_headers(headers: dict, *, https: bool = False) -> list[Findin
     return findings
 
 
+def _cookie_attrs(cookie: str) -> dict[str, str | bool]:
+    """Parse a Set-Cookie value's attributes (everything after ``name=value``)."""
+    attrs: dict[str, str | bool] = {}
+    for part in cookie.split(";")[1:]:
+        part = part.strip()
+        if not part:
+            continue
+        if "=" in part:
+            key, _, value = part.partition("=")
+            attrs[key.strip().lower()] = value.strip()
+        else:
+            attrs[part.lower()] = True
+    return attrs
+
+
 def check_csrf(set_cookie_headers: list[str], *, auth_mode: str = "cookie", https: bool = False) -> Finding:
-    """CSRF posture from Set-Cookie (cookie auth) or N/A for bearer/API auth."""
+    """CSRF posture from Set-Cookie (cookie auth) or N/A for bearer/API auth.
+
+    Attributes are parsed, not substring-matched: ``SameSite=None`` does NOT
+    mitigate CSRF (only ``Lax``/``Strict`` do), so it is treated as a failure.
+    """
     if auth_mode == "bearer":
         return Finding("security", "csrf", NA, "bearer/API auth — CSRF tokens not applicable")
     if not set_cookie_headers:
         return Finding("security", "csrf", WARN, "no session cookie observed; cannot assess SameSite")
-    problems = []
+    fails: list[str] = []
+    warns: list[str] = []
     for cookie in set_cookie_headers:
-        low = cookie.lower()
-        if "samesite" not in low:
-            problems.append("missing SameSite")
-        if "httponly" not in low:
-            problems.append("missing HttpOnly")
-        if https and "secure" not in low:
-            problems.append("missing Secure on HTTPS")
-    if any("samesite" in p.lower() for p in problems):
-        return Finding("security", "csrf", FAIL, "; ".join(sorted(set(problems))))
-    if problems:
-        return Finding("security", "csrf", WARN, "; ".join(sorted(set(problems))))
-    return Finding("security", "csrf", PASS, "session cookie has SameSite + HttpOnly")
+        attrs = _cookie_attrs(cookie)
+        samesite = str(attrs.get("samesite", "")).lower()
+        if samesite not in ("lax", "strict"):
+            fails.append(f"SameSite={samesite or 'missing'} (need Lax/Strict)")
+        if "httponly" not in attrs:
+            warns.append("missing HttpOnly")
+        if https and "secure" not in attrs:
+            fails.append("missing Secure on HTTPS")
+    if fails:
+        return Finding("security", "csrf", FAIL, "; ".join(sorted(set(fails + warns))))
+    if warns:
+        return Finding("security", "csrf", WARN, "; ".join(sorted(set(warns))))
+    return Finding("security", "csrf", PASS, "session cookie(s) have SameSite=Lax/Strict + HttpOnly")
 
 
 def check_structured_logging(log_lines: list[str]) -> Finding:
-    if not log_lines:
-        return Finding("observability", "structured-logging", SKIPPED, "no log sample provided")
+    """Scan ALL non-blank log lines; FAIL (non-JSON) takes precedence over WARN."""
+    non_blank = [ln.strip() for ln in log_lines if ln.strip()]
+    if not non_blank:
+        return Finding("observability", "structured-logging", SKIPPED, "no (non-blank) log sample provided")
+    fail_detail: str | None = None
+    warned = False
     parsed = 0
-    for line in log_lines:
-        line = line.strip()
-        if not line:
-            continue
+    for line in non_blank:
         try:
             obj = json.loads(line)
         except json.JSONDecodeError:
-            return Finding("observability", "structured-logging", FAIL, f"non-JSON log line: {line[:60]!r}")
+            fail_detail = fail_detail or f"non-JSON log line: {line[:60]!r}"
+            continue
         if not isinstance(obj, dict) or not ({"level", "severity"} & set(obj)):
-            return Finding("observability", "structured-logging", WARN, "JSON logs lack a level/severity field")
+            warned = True
+            continue
         parsed += 1
+    if fail_detail:
+        return Finding("observability", "structured-logging", FAIL, fail_detail)
+    if warned:
+        return Finding("observability", "structured-logging", WARN, "some JSON logs lack a level/severity field")
     return Finding("observability", "structured-logging", PASS, f"{parsed} structured log line(s)")
 
 
@@ -244,16 +281,43 @@ def check_tenant_isolation(
 # --- default HTTP getter ----------------------------------------------------
 
 
+def _headers_to_dict(message) -> dict:
+    """Lower-case header dict, preserving ALL Set-Cookie values as a list.
+
+    A plain ``dict`` comprehension collapses duplicate headers, dropping all but
+    the last Set-Cookie — and the session cookie is frequently not the last one.
+    ``email.message.Message.get_all`` keeps every value.
+    """
+    headers = {k.lower(): v for k, v in message.items()}
+    if message is not None:
+        headers["set-cookie"] = message.get_all("set-cookie") or []
+    return headers
+
+
 def default_http_get(url: str, *, timeout: float = 10.0) -> tuple[int, dict, str]:
     req = urllib.request.Request(url, headers={"User-Agent": "chief-wiggum-saas-gate"})
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - gate probes a user-supplied URL
-            return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read(8192).decode("utf-8", "replace")
+            return resp.status, _headers_to_dict(resp.headers), resp.read(8192).decode("utf-8", "replace")
     except urllib.error.HTTPError as exc:
-        return exc.code, {k.lower(): v for k, v in (exc.headers or {}).items()}, ""
+        return exc.code, _headers_to_dict(exc.headers) if exc.headers else {}, ""
 
 
 # --- orchestration ----------------------------------------------------------
+
+
+def _extract_set_cookies(headers: dict) -> list[str]:
+    """Normalise Set-Cookie from a headers dict into a list of cookie strings.
+
+    ``default_http_get`` stores a list (all values preserved); simpler/injected
+    getters may store a single string. Other key casings are tolerated.
+    """
+    for k, v in headers.items():
+        if k.lower() == "set-cookie":
+            if isinstance(v, (list, tuple)):
+                return [str(c) for c in v]
+            return [str(v)]
+    return []
 
 
 def run_gate(
@@ -273,7 +337,7 @@ def run_gate(
         https = base_url.startswith("https://") or require_https
         try:
             _, headers, _ = http_get(base_url)
-            set_cookie = [v for k, v in headers.items() if k.lower() == "set-cookie"]
+            set_cookie = _extract_set_cookies(headers)
             for f in check_security_headers(headers, https=https):
                 report.findings.append(f)
             report.findings.append(check_csrf(set_cookie, auth_mode=auth_mode, https=https))

--- a/tests/test_saas_gate.py
+++ b/tests/test_saas_gate.py
@@ -1,0 +1,220 @@
+"""Tests for the SaaS NFR gate (#2)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+import saas_gate as sg
+
+# --- stack detection --------------------------------------------------------
+
+
+def test_detect_stack(tmp_path):
+    (tmp_path / "go.mod").write_text("module x\n")
+    (tmp_path / "package.json").write_text("{}")
+    assert set(sg.detect_stack(tmp_path)) == {"go", "node"}
+
+
+# --- security headers (pure) ------------------------------------------------
+
+
+GOOD_HEADERS = {
+    "content-security-policy": "default-src 'self'; frame-ancestors 'none'",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "referrer-policy": "no-referrer",
+}
+
+
+def _status(findings, name):
+    return next(f.status for f in findings if f.name == name)
+
+
+def test_security_headers_all_good():
+    fs = sg.check_security_headers(GOOD_HEADERS)
+    assert _status(fs, "x-content-type-options") == sg.PASS
+    assert _status(fs, "content-security-policy") == sg.PASS
+    assert _status(fs, "clickjacking") == sg.PASS
+    assert _status(fs, "referrer-policy") == sg.PASS
+
+
+def test_security_headers_missing_fail():
+    fs = sg.check_security_headers({})
+    assert _status(fs, "x-content-type-options") == sg.FAIL
+    assert _status(fs, "content-security-policy") == sg.FAIL
+    assert _status(fs, "clickjacking") == sg.FAIL
+
+
+def test_weak_csp_warns():
+    fs = sg.check_security_headers({**GOOD_HEADERS, "content-security-policy": "default-src 'self' 'unsafe-inline'"})
+    assert any(f.name == "csp-strength" and f.status == sg.WARN for f in fs)
+
+
+def test_clickjacking_via_csp_frame_ancestors():
+    h = {**GOOD_HEADERS}
+    del h["x-frame-options"]
+    assert _status(sg.check_security_headers(h), "clickjacking") == sg.PASS  # frame-ancestors present
+
+
+def test_hsts_warn_on_http_fail_on_https():
+    assert _status(sg.check_security_headers({}, https=False), "hsts") == sg.WARN
+    assert _status(sg.check_security_headers({}, https=True), "hsts") == sg.FAIL
+
+
+# --- CSRF (pure) ------------------------------------------------------------
+
+
+def test_csrf_cookie_good():
+    f = sg.check_csrf(["sid=abc; HttpOnly; SameSite=Lax"], auth_mode="cookie")
+    assert f.status == sg.PASS
+
+
+def test_csrf_missing_samesite_fails():
+    f = sg.check_csrf(["sid=abc; HttpOnly"], auth_mode="cookie")
+    assert f.status == sg.FAIL
+
+
+def test_csrf_bearer_not_applicable():
+    assert sg.check_csrf([], auth_mode="bearer").status == sg.NA
+
+
+def test_csrf_no_cookie_warns():
+    assert sg.check_csrf([], auth_mode="cookie").status == sg.WARN
+
+
+# --- structured logging (pure) ----------------------------------------------
+
+
+def test_structured_logging_pass():
+    assert sg.check_structured_logging(['{"level":"info","msg":"x"}']).status == sg.PASS
+
+
+def test_structured_logging_non_json_fails():
+    assert sg.check_structured_logging(["plain text log"]).status == sg.FAIL
+
+
+def test_structured_logging_no_level_warns():
+    assert sg.check_structured_logging(['{"msg":"x"}']).status == sg.WARN
+
+
+def test_structured_logging_empty_skipped():
+    assert sg.check_structured_logging([]).status == sg.SKIPPED
+
+
+# --- runtime checks (injected getter) ---------------------------------------
+
+
+def test_health_pass_and_fail():
+    assert sg.check_health(lambda u: (200, {}, ""), "http://x").status == sg.PASS
+    assert sg.check_health(lambda u: (503, {}, ""), "http://x").status == sg.FAIL
+
+
+def test_health_unreachable_fails():
+    def boom(u):
+        raise OSError("refused")
+
+    assert sg.check_health(boom, "http://x").status == sg.FAIL
+
+
+def test_rate_limit_pass_on_429_with_retry_after():
+    assert sg.check_rate_limit(lambda u: (429, {"retry-after": "5"}, ""), "http://x").status == sg.PASS
+
+
+def test_rate_limit_warn_on_429_without_retry_after():
+    assert sg.check_rate_limit(lambda u: (429, {}, ""), "http://x").status == sg.WARN
+
+
+def test_rate_limit_warn_when_no_limiter():
+    assert sg.check_rate_limit(lambda u: (200, {}, ""), "http://x", attempts=5).status == sg.WARN
+
+
+def test_rate_limit_fail_when_required():
+    assert sg.check_rate_limit(lambda u: (200, {}, ""), "http://x", attempts=5, required=True).status == sg.FAIL
+
+
+def test_tenant_isolation_pass_and_fail():
+    ok = sg.check_tenant_isolation(lambda: object(), lambda u: "r", lambda u, r: 403)
+    assert ok.status == sg.PASS
+    leak = sg.check_tenant_isolation(lambda: object(), lambda u: "r", lambda u, r: 200)
+    assert leak.status == sg.FAIL
+
+
+# --- report + CLI -----------------------------------------------------------
+
+
+def test_report_ok_only_on_no_fail():
+    r = sg.SaasGateReport()
+    r.add("security", "x", sg.WARN)
+    assert r.ok is True
+    r.add("security", "y", sg.FAIL)
+    assert r.ok is False
+
+
+def test_run_gate_without_base_url_skips_runtime(tmp_path):
+    r = sg.run_gate(tmp_path, None)
+    json.loads(json.dumps(r.to_dict()))
+    assert any(f.status == sg.SKIPPED for f in r.findings)
+
+
+def test_cli_markdown(tmp_path, capsys):
+    rc = sg.main(["--repo", str(tmp_path), "--markdown"])
+    assert rc == 0
+    assert "# SaaS NFR Gate" in capsys.readouterr().out
+
+
+# --- hermetic integration against a real local HTTP server ------------------
+
+
+class _Handler(BaseHTTPRequestHandler):
+    hits = {"login": 0}
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            return
+        if self.path == "/login":
+            _Handler.hits["login"] += 1
+            if _Handler.hits["login"] > 3:
+                self.send_response(429)
+                self.send_header("Retry-After", "5")
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.end_headers()
+            return
+        # root: serve good security headers
+        self.send_response(200)
+        self.send_header("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Set-Cookie", "sid=abc; HttpOnly; SameSite=Lax")
+        self.end_headers()
+
+
+@pytest.fixture()
+def live_server():
+    _Handler.hits["login"] = 0
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+
+
+def test_integration_against_real_http_server(live_server):
+    r = sg.run_gate(".", live_server, rate_limit_path="/login")
+    statuses = {f.name: f.status for f in r.findings}
+    assert statuses["x-content-type-options"] == sg.PASS
+    assert statuses["clickjacking"] == sg.PASS
+    assert statuses["csrf"] == sg.PASS
+    assert statuses["health"] == sg.PASS
+    assert statuses["rate-limit"] == sg.PASS  # 429 + Retry-After observed
+    assert r.ok is True

--- a/tests/test_saas_gate.py
+++ b/tests/test_saas_gate.py
@@ -85,6 +85,35 @@ def test_csrf_no_cookie_warns():
     assert sg.check_csrf([], auth_mode="cookie").status == sg.WARN
 
 
+def test_csrf_samesite_none_fails():
+    f = sg.check_csrf(["sid=abc; HttpOnly; SameSite=None"], auth_mode="cookie")
+    assert f.status == sg.FAIL
+
+
+def test_csrf_weakest_cookie_fails_among_many():
+    # A strong CSRF cookie does not excuse a weak session cookie.
+    f = sg.check_csrf(
+        ["csrf=xyz; HttpOnly; SameSite=Strict", "sid=abc; HttpOnly; SameSite=None"],
+        auth_mode="cookie",
+    )
+    assert f.status == sg.FAIL
+
+
+# --- Set-Cookie extraction (pure) -------------------------------------------
+
+
+def test_extract_set_cookies_from_list():
+    assert sg._extract_set_cookies({"set-cookie": ["a=1", "b=2"]}) == ["a=1", "b=2"]
+
+
+def test_extract_set_cookies_from_str():
+    assert sg._extract_set_cookies({"Set-Cookie": "a=1"}) == ["a=1"]
+
+
+def test_extract_set_cookies_absent():
+    assert sg._extract_set_cookies({"content-type": "text/html"}) == []
+
+
 # --- structured logging (pure) ----------------------------------------------
 
 
@@ -218,3 +247,38 @@ def test_integration_against_real_http_server(live_server):
     assert statuses["health"] == sg.PASS
     assert statuses["rate-limit"] == sg.PASS  # 429 + Retry-After observed
     assert r.ok is True
+
+
+class _MultiCookieHandler(BaseHTTPRequestHandler):
+    """Sends two Set-Cookie headers; the weak session cookie is NOT last."""
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        # Weak session cookie FIRST, strong cookie LAST: a dict-collapse would
+        # keep only the strong one and wrongly PASS.
+        self.send_header("Set-Cookie", "sid=abc; HttpOnly; SameSite=None")
+        self.send_header("Set-Cookie", "csrf=xyz; HttpOnly; SameSite=Strict")
+        self.end_headers()
+
+
+@pytest.fixture()
+def multi_cookie_server():
+    server = HTTPServer(("127.0.0.1", 0), _MultiCookieHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+
+
+def test_integration_multiple_set_cookie_not_collapsed(multi_cookie_server):
+    # The weak session cookie must be seen even though a later cookie is strong.
+    r = sg.run_gate(".", multi_cookie_server)
+    statuses = {f.name: f.status for f in r.findings}
+    assert statuses["csrf"] == sg.FAIL


### PR DESCRIPTION
## Summary

Adds a `/saas-gate` skill that validates common SaaS non-functional requirements (security, tenant isolation, performance, data integrity, observability) against a running app, and reports actionable pass/fail per category. Runs standalone or as a `/close-epic` gate.

Closes #2.

## Changes

- **`scripts/saas_gate.py`** — **five statuses** (`pass`/`fail`/`warn`/`skipped`/`not_applicable`) so the gate never overclaims; the report is `ok` only when there's no real `fail`. Checks:
  - **Security** (pure): required headers (X-Content-Type-Options, CSP, clickjacking via X-Frame-Options or CSP frame-ancestors, Referrer-Policy), weak-CSP warning, HSTS (warn on HTTP / fail on HTTPS); **CSRF cookie posture** (SameSite/HttpOnly/Secure; `not_applicable` for bearer auth).
  - **Runtime** (injectable HTTP getter): health endpoint, rate-limit probe (429 ⇒ pass; absence ⇒ warn unless `--rate-limit-required`).
  - **Tenant isolation** (injectable user/resource callables), **structured logging** (JSON + level field).
  - `detect_stack`, `SaasGateReport` (JSON + markdown), CLI with `--gate`/`--require-https`/`--rate-limit-required`/`--auth-mode`.
- **`tests/test_saas_gate.py`** — 25 tests incl. a **hermetic integration test** running the gate against a real local `http.server` with controlled headers + `/health` + eventually-429.
- **`.claude/commands/saas-gate.md`** skill; **`close-epic.md`** Step 2e optional NFR gate; **`check_deps`** mapping; **`CLAUDE.md`** usage.

## Acceptance criteria

- [x] `/saas-gate` skill exists.
- [x] Detects project stack automatically.
- [x] Runs security, isolation, performance, and observability checks.
- [x] Reports actionable pass/fail results.
- [x] Can be run standalone or as part of `/close-epic`.

Honest coverage: real tenant isolation / auth boundary / perf / audit-trail need a live multi-user app — the orchestration is tested; those assertions are the skill's runtime job (with injectable helpers provided).

## Verification

- `make lint` clean; `make test` — 470 passed (25 new), incl. the real-HTTP integration test.

> gemini reviewer unavailable this session (account tier ended); review ran codex-only.