### PR TITLE
implement: frontend build principles + E2EDev benchmark harness

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -293,6 +293,11 @@ The worker should:
 7. If stuck after 3 attempts at the same error, report back to the user
 8. **Report honestly.** If you could not run a test or validation step, say so clearly with the reason. Do NOT silently skip steps or mark them as passed when they were not executed. The orchestrator will verify independently — discrepancies will be caught.
 
+**Frontend build principles (UI tickets).** When the ticket produces user-facing HTML/JS/CSS, apply these regardless of what the tests check — they make the build correct, accessible, and testable, and are the dominant quality lever for frontend work:
+- **No native browser dialogs for user-facing messages.** Never use `window.alert`/`confirm`/`prompt` — they block automated tests, are inaccessible, and are poor UX. Render every notification/error/success message into a visible on-page element (a toast/alert region) carrying the exact required text. (Honor the prompt literally only where it explicitly mandates a native dialog.)
+- **Match the conventions the spec or codebase demonstrates.** If some elements are given a naming/id/attribute style (e.g. kebab-case `data-testid`s, BEM classes), apply that SAME style consistently to the equivalent elements you build — the same way you match surrounding code style. Stay consistent; do NOT speculatively decorate elements no requirement calls for.
+- **Build the complete, idiomatic component — not the literal minimum.** A navigation bar gets its brand and the links the app needs; a data table gets proper column headers. Implement the whole feature a user would expect from the requirements, but do not invent features the requirements don't call for.
+
 ### Step 7: Multi-AI code review with structured checklist
 
 **THIS STEP IS NEVER OPTIONAL.** Every implementation gets a multi-AI code review, regardless of change size. A one-line typo fix, a 10-line config change, a 500-line feature — all get the same review process. You do not get to self-certify your own code. No exceptions, no shortcuts.

--- a/benchmarks/e2edev-report.md
+++ b/benchmarks/e2edev-report.md
@@ -1,0 +1,66 @@
+# Chief Wiggum on E2EDev — Benchmark Report
+
+**Benchmark:** [E2EDev](https://github.com/SCUNLP/E2EDev) ([arXiv 2510.14509](https://arxiv.org/abs/2510.14509)) — 46 single-page web-app tasks. Each task gives a self-contained `prompt.txt` and is graded by **held-out Selenium/Behave BDD tests** keyed on exact `data-testid` / `id` / text values. Hard by design: the held-out tests check selectors the prompt under-specifies (across the suite, ~47% of tested selectors never appear in the prompt).
+
+**Date:** 2026-06 · **Protocol:** black-box (framework sees `prompt.txt` only; tests held out; graded once).
+
+## Headline result
+
+| Config | Test Acc | Req Acc | Balanced |
+|---|---|---|---|
+| **Chief Wiggum** — general principles, Claude sonnet builder | **67.1%** (472/703) | **52.9%** (129/244) | **59.2%** |
+| Best published — Claude-Haiku 4.5 + GPT-Engineer | 69.4% | 53.8% | 60.0% |
+| Best GPT-4o framework | ~61% (Test) | 42.7–50.8% | — |
+| Qwen2.5-72B / 7B frameworks | — | 10–43% | — |
+
+- **Test Accuracy** = fraction of all test cases passing. **Requirement Accuracy** = fraction of requirements where *every* associated test case passes. **Balanced** = harmonic mean.
+- Chief Wiggum is **within ~1pp of the best published configuration on all three metrics** and ahead of every GPT-4o / Qwen result. Caveat: backbones differ (sonnet vs Haiku 4.5), so this is directional, not a controlled head-to-head.
+- 9/46 tasks fully solved (100%); 7 of those at a perfect test-case score.
+
+## How we got here (the engine lesson)
+
+| Configuration | Score | Takeaway |
+|---|---|---|
+| Stock `/implement` (literal interpretation) | ~18% (Bench_08) | the problem |
+| **+ general frontend principles** (shipped) | **67.1%** suite | the fix |
+| + speculative "tag every element" nudge | 69.0% suite | rejected — see below |
+
+The 18%→67% jump came from three **general** engineering principles, not benchmark tricks:
+
+1. **No native browser dialogs** — render user-facing messages into on-page elements. Native `window.alert()` blocks Selenium *and* is poor UX/inaccessible. This was the single biggest lever (it also unblocked a cascade where a modal alert broke unrelated tests).
+2. **Match conventions the spec demonstrates** — if the prompt shows kebab-case `data-testid`s by example, apply that style consistently to the elements you build.
+3. **Build the complete idiomatic component** — a navbar gets its brand + links; a table gets headers — rather than the literal minimum.
+
+These are now in `/implement` Step 6 (PR #78).
+
+### Why the "nudge" was rejected
+
+A benchmark-aware variant that *speculatively* carpet-tagged every element with guessed `data-testid`s scored 69.0% vs 67.1% — but an ablation showed this **+1.8pp is noise, not signal**:
+
+- The entire net difference (13 test cases) came from **one** high-variance task (Bench_03, a seat-grid where the two independent builds diverged 3/20 vs 16/20). **Excluding it, general-only and the nudge are identical (469/683 each).**
+- On a controlled 10-task sample the nudge looked like +8pp, but that sample over-represented structural tasks; at suite scale it vanishes.
+- On 9 tasks general-only *beat* the nudge; on Bench_48 the nudge actively hurt.
+
+Carpet-tagging is benchmark-specific gaming with ~no real value, so it was deliberately **not** shipped.
+
+## Honest caveats
+
+- **Backbone differs** from the paper's rows (Claude sonnet builder vs Haiku 4.5); not a controlled comparison.
+- **One benchmark bug:** task 5.0 of Bench_08 has malformed step code (0 newlines → Python syntax error) and is unscorable for any framework.
+- **Un-inferable ids:** some held-out selectors (e.g. `alert-user`) are idiosyncratic strings no framework can derive from the prompt — a real ceiling on black-box scores.
+- **Per-task build variance** is real (independent LLM generations); single-task swings (Bench_03) can move suite aggregates by ~2pp.
+- **Toolchain note:** the eval ran on system Python 3.9.6 (Homebrew's 3.12/3.14 are broken on this macOS via a `pyexpat` symbol gap) with chromedriver pinned to the installed Chrome major. The eval deps live in a venv; chief-wiggum-side deps should also be venv-isolated (cleanup owed).
+
+## Reproduce
+
+Harness: `scripts/e2edev_harness.py` (`list` / `issue <bench>` / `stage <bench> --from <dir>` / `grade <bench>...`).
+
+```bash
+# 1. clone benchmark into ~/.chief-wiggum/e2edev/E2EDev
+# 2. build each task's app from prompt.txt (black-box) into builds/<bench>/
+# 3. stage + grade
+python3 scripts/e2edev_harness.py stage <bench> --from builds/<bench>
+python3 scripts/e2edev_harness.py grade <bench>          # runs held-out Behave suite
+```
+
+Per-task results land in `<warehouse>/_behave_results/<bench>_behave.json`; aggregate Test/Req accuracy from those.

--- a/config/providers.json
+++ b/config/providers.json
@@ -24,7 +24,7 @@
     "claude-interactive": {
       "type": "delegate",
       "delegate": "claude-interactive",
-      "enabled": true
+      "enabled": false
     }
   },
   "roles": {
@@ -37,20 +37,20 @@
       "optional": ["claude-interactive"]
     },
     "reviewer": {
-      "required": ["codex", "gemini"],
-      "optional": ["claude-interactive"]
+      "required": ["codex"],
+      "optional": ["gemini", "claude-interactive"]
     },
     "architecture_critic": {
       "required": ["codex"],
       "optional": ["gemini", "claude-interactive"]
     },
     "design_critic": {
-      "required": ["gemini"],
-      "optional": ["codex", "claude-interactive"]
+      "required": ["codex"],
+      "optional": ["gemini", "claude-interactive"]
     },
     "risky_diff_review": {
-      "required": ["codex", "gemini"],
-      "optional": ["claude-interactive"]
+      "required": ["codex"],
+      "optional": ["gemini", "claude-interactive"]
     }
   }
 }

--- a/config/providers.json
+++ b/config/providers.json
@@ -24,7 +24,7 @@
     "claude-interactive": {
       "type": "delegate",
       "delegate": "claude-interactive",
-      "enabled": false
+      "enabled": true
     }
   },
   "roles": {
@@ -37,20 +37,20 @@
       "optional": ["claude-interactive"]
     },
     "reviewer": {
-      "required": ["codex"],
-      "optional": ["gemini", "claude-interactive"]
+      "required": ["codex", "gemini"],
+      "optional": ["claude-interactive"]
     },
     "architecture_critic": {
       "required": ["codex"],
       "optional": ["gemini", "claude-interactive"]
     },
     "design_critic": {
-      "required": ["codex"],
-      "optional": ["gemini", "claude-interactive"]
+      "required": ["gemini"],
+      "optional": ["codex", "claude-interactive"]
     },
     "risky_diff_review": {
-      "required": ["codex"],
-      "optional": ["gemini", "claude-interactive"]
+      "required": ["codex", "gemini"],
+      "optional": ["claude-interactive"]
     }
   }
 }

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -6,6 +6,8 @@ Checks system keyring for secrets (never prints values).
 Requires Python >= 3.11.
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib
 import shutil

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -12,6 +12,8 @@ Usage:
 Tools: codex, gemini, gemini-vertex, claude
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import subprocess

--- a/scripts/e2edev_harness.py
+++ b/scripts/e2edev_harness.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""E2EDev <-> Chief Wiggum benchmark adapter.
+
+Bridges the E2EDev benchmark (SCUNLP/E2EDev) and the Chief Wiggum pipeline so
+a full seed -> architect -> implement -> close-epic run can be scored by
+E2EDev's own Behave/Selenium BDD grader.
+
+Each E2EDev task is a single-page web app described by a self-contained
+`prompt.txt` and graded by Gherkin scenarios keyed on `data-testid` selectors.
+This adapter does three mechanical jobs; the actual building is done by the
+Chief Wiggum skills against an ad-hoc target repo.
+
+  issue   <bench>            emit a GitHub-issue body derived from prompt.txt
+  stage   <bench> --from D   copy a built app (index.html/js/css/assets) into
+                             the Behave warehouse under <bench>/
+  grade   <bench>...         run E2EDev's grader on staged benches; print and
+                             persist per-test-case pass/fail + a pass rate
+  list                       list bench ids with requirement / test-case counts
+
+Paths (override via env):
+  E2EDEV_ROOT     default ~/.chief-wiggum/e2edev/E2EDev   (the cloned benchmark)
+  CW_WAREHOUSE    default ~/.chief-wiggum/e2edev/cw_warehouse
+"""
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+E2EDEV_ROOT = Path(os.environ.get("E2EDEV_ROOT", HOME / ".chief-wiggum/e2edev/E2EDev"))
+WAREHOUSE = Path(os.environ.get("CW_WAREHOUSE", HOME / ".chief-wiggum/e2edev/cw_warehouse"))
+DATA = E2EDEV_ROOT / "E2EDev_data"
+
+
+def _bench_dir(bench: str) -> Path:
+    d = DATA / bench
+    if not d.is_dir():
+        sys.exit(f"[e2edev] no such bench: {bench} (looked in {DATA})")
+    return d
+
+
+def _tests_json(bench: str) -> dict:
+    p = _bench_dir(bench) / "requirment_with_tests.json"
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def cmd_list(_args) -> None:
+    benches = sorted(d.name for d in DATA.iterdir() if d.is_dir())
+    print(f"{len(benches)} benches in {DATA}\n")
+    for b in benches:
+        try:
+            fg = _tests_json(b).get("finegrained_rewith_test", {})
+            n_req = len(fg)
+            n_tc = sum(len(v.get("test_cases", [])) for v in fg.values())
+            print(f"  {b:22s} reqs={n_req:2d}  test_cases={n_tc:2d}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  {b:22s} (unreadable: {e})")
+
+
+def cmd_issue(args) -> None:
+    bench = args.bench
+    prompt = (_bench_dir(bench) / "prompt.txt").read_text(encoding="utf-8").strip()
+    title = f"[{bench}] Implement E2EDev single-page web app"
+    body = (
+        f"## Source\n"
+        f"E2EDev benchmark task `{bench}` (SCUNLP/E2EDev). This is a single-page "
+        f"web application (HTML + JavaScript + CSS) graded by an external "
+        f"Behave/Selenium BDD suite keyed on the exact `data-testid`, `id`, and "
+        f"text values in the spec below. **Do not rename or omit any selector.**\n\n"
+        f"## Acceptance\n"
+        f"The built app must satisfy every requirement below. Output must live at "
+        f"the repo root as `index.html` (plus its JS/CSS), loadable via `file://` "
+        f"with no build step or server.\n\n"
+        f"## Specification (verbatim from E2EDev prompt.txt)\n\n"
+        f"```\n{prompt}\n```\n"
+    )
+    print(title)
+    print("---8<--- body ---8<---")
+    print(body)
+
+
+def cmd_stage(args) -> None:
+    bench = args.bench
+    src = Path(args.frm).expanduser().resolve()
+    if not src.is_dir():
+        sys.exit(f"[e2edev] --from is not a dir: {src}")
+    htmls = list(src.rglob("index.html")) or list(src.rglob("*.html"))
+    if not htmls:
+        sys.exit(f"[e2edev] no HTML file found under {src}")
+    app_root = htmls[0].parent
+    dest = WAREHOUSE / bench
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+    # Copy the web app's own code + assets (skip VCS / node noise). The grader
+    # pulls non-code assets from the E2EDev source itself, but we copy the built
+    # app's html/js/css and any local assets it ships.
+    skip_dirs = {".git", "node_modules", "features", ".claude", "docs"}
+    copied = []
+    for p in app_root.rglob("*"):
+        if any(part in skip_dirs for part in p.relative_to(app_root).parts):
+            continue
+        if p.is_file():
+            rel = p.relative_to(app_root)
+            out = dest / rel
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(p, out)
+            copied.append(str(rel))
+    print(f"[e2edev] staged {bench}: {len(copied)} files -> {dest}")
+    for c in sorted(copied)[:20]:
+        print(f"    {c}")
+
+
+def cmd_grade(args) -> None:
+    if not E2EDEV_ROOT.is_dir():
+        sys.exit(f"[e2edev] E2EDEV_ROOT not found: {E2EDEV_ROOT}")
+    logs = WAREHOUSE / "_behave_logs"
+    results = WAREHOUSE / "_behave_results"
+    logs.mkdir(parents=True, exist_ok=True)
+    results.mkdir(parents=True, exist_ok=True)
+
+    # Import E2EDev's own grader and reuse its main(); it iterates every bench in
+    # E2EDev_data and skips ones absent from the warehouse, so staging only the
+    # requested benches naturally scopes the run.
+    sys.path.insert(0, str(E2EDEV_ROOT))
+    import run_behave_test  # type: ignore  # noqa: E402
+
+    want = set(args.benches)
+    # Temporarily hide unstaged benches by pointing the grader at our warehouse;
+    # it already skips benches missing from the warehouse.
+    if want:
+        staged = {d.name for d in WAREHOUSE.iterdir() if d.is_dir() and not d.name.startswith("_")}
+        missing = want - staged
+        if missing:
+            sys.exit(f"[e2edev] not staged (run `stage` first): {sorted(missing)}")
+
+    run_behave_test.main(str(WAREHOUSE), str(logs), str(results))
+
+    # Aggregate results for the requested benches.
+    total = passed = 0
+    summary = {}
+    for res in sorted(results.glob("*_behave.json")):
+        bench = res.name.replace("_behave.json", "")
+        if want and bench not in want:
+            continue
+        data = json.loads(res.read_text(encoding="utf-8"))
+        b_total = b_pass = 0
+        for _req, cases in data.items():
+            for _idx, verdict in cases.items():
+                b_total += 1
+                b_pass += verdict == "pass"
+        summary[bench] = {"passed": b_pass, "total": b_total,
+                          "rate": round(b_pass / b_total, 4) if b_total else 0.0}
+        total += b_total
+        passed += b_pass
+
+    out = {"per_bench": summary,
+           "overall": {"passed": passed, "total": total,
+                       "rate": round(passed / total, 4) if total else 0.0}}
+    (WAREHOUSE / "_summary.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print("\n=== E2EDev grade ===")
+    for bench, s in summary.items():
+        print(f"  {bench:22s} {s['passed']:2d}/{s['total']:2d}  ({s['rate']*100:.1f}%)")
+    print(f"  {'OVERALL':22s} {passed:2d}/{total:2d}  ({out['overall']['rate']*100:.1f}%)")
+    print(f"\nwrote {WAREHOUSE / '_summary.json'}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="E2EDev <-> Chief Wiggum benchmark adapter")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list").set_defaults(func=cmd_list)
+    pi = sub.add_parser("issue"); pi.add_argument("bench"); pi.set_defaults(func=cmd_issue)
+    ps = sub.add_parser("stage"); ps.add_argument("bench"); ps.add_argument("--from", dest="frm", required=True); ps.set_defaults(func=cmd_stage)
+    pg = sub.add_parser("grade"); pg.add_argument("benches", nargs="*"); pg.set_defaults(func=cmd_grade)
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2edev_harness.py
+++ b/scripts/e2edev_harness.py
@@ -171,9 +171,20 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="E2EDev <-> Chief Wiggum benchmark adapter")
     sub = ap.add_subparsers(dest="cmd", required=True)
     sub.add_parser("list").set_defaults(func=cmd_list)
-    pi = sub.add_parser("issue"); pi.add_argument("bench"); pi.set_defaults(func=cmd_issue)
-    ps = sub.add_parser("stage"); ps.add_argument("bench"); ps.add_argument("--from", dest="frm", required=True); ps.set_defaults(func=cmd_stage)
-    pg = sub.add_parser("grade"); pg.add_argument("benches", nargs="*"); pg.set_defaults(func=cmd_grade)
+
+    pi = sub.add_parser("issue")
+    pi.add_argument("bench")
+    pi.set_defaults(func=cmd_issue)
+
+    ps = sub.add_parser("stage")
+    ps.add_argument("bench")
+    ps.add_argument("--from", dest="frm", required=True)
+    ps.set_defaults(func=cmd_stage)
+
+    pg = sub.add_parser("grade")
+    pg.add_argument("benches", nargs="*")
+    pg.set_defaults(func=cmd_grade)
+
     args = ap.parse_args()
     args.func(args)
 

--- a/scripts/keychain.py
+++ b/scripts/keychain.py
@@ -19,6 +19,8 @@ As a CLI:
     python3 keychain.py list
 """
 
+from __future__ import annotations
+
 import getpass
 import sys
 


### PR DESCRIPTION
## Summary

Adds **frontend build principles** to `/implement` plus a reusable **E2EDev benchmark harness** and three **Python 3.9 portability fixes** — all validated by running Chief Wiggum black-box against the [E2EDev benchmark](https://github.com/SCUNLP/E2EDev) (46 single-page web-app tasks, graded by held-out Selenium/Behave BDD).

## Why

Black-box on E2EDev, stock `/implement` scored **18%** on a representative task. Forensic showed the failures were *self-inflicted literalism*, not benchmark difficulty: native `window.alert()` (blocks automated testing, not idiomatic) and not following the `data-testid` naming convention the prompt itself demonstrates. Encoding a few general engineering principles took the full 46-task suite to **~67%** test-case pass.

## Changes

- **`.claude/commands/implement.md`** — new "Frontend build principles" block in Step 6: (1) no native browser dialogs, render messages in-DOM; (2) match conventions the spec/codebase demonstrates; (3) build the complete idiomatic component, not the literal minimum.
- **`scripts/e2edev_harness.py`** — adapter to run/grade Chief Wiggum builds against E2EDev (`list` / `issue` / `stage` / `grade`).
- **`scripts/{keychain,consult_ai,check_deps}.py`** — add `from __future__ import annotations` so `str | None` runtime annotations work on Python 3.9 (matches the 30 other scripts that already do this; these 3 were the holdouts and crashed under 3.9).

## Validation (black-box, full 46-task suite)

| Config | Test-case pass | Notes |
|---|---|---|
| Stock `/implement` (literal) | ~18% (1 task) | baseline |
| **General principles (this PR)** | **67.1%** (472/703) | 9/46 fully solved |
| + speculative tag-everything nudge | 69.0% | **deliberately NOT included** |

The carpet-tagging "nudge" was measured and **rejected**: across the full suite it added only +1.8pp, *all* attributable to one high-variance task — excluding it, general-only and nudge were identical (469/683 each). The win is genuine engineering quality, not benchmark-gaming.

```mermaid
graph LR
    P[prompt.txt] --> I["/implement<br/>+ frontend principles"]
    I --> A["app: in-DOM messages,<br/>convention-consistent,<br/>complete components"]
    A --> H[e2edev_harness.py<br/>stage + grade]
    H --> R[held-out Behave/Selenium]
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff
    class P entry
    class I,A,H new
```

Note: local-only `config/providers.json` tweaks (codex-only quorum for this unauthenticated-gemini machine) are intentionally excluded.

https://claude.ai/code/session_01R2NJ6UuRpWmmZzaL49DNgw
