### PR TITLE
models.md: TTS row reflects pinned narrator, no silent fallback

### DIFF
--- a/models.md
+++ b/models.md
@@ -55,7 +55,7 @@ Refresh with `/update`.
 
 | Engine | Model | Notes |
 |--------|-------|-------|
-| ElevenLabs | `eleven_multilingual_v2` | Preferred for `/tutorial-video` (auto when `ELEVENLABS_API_KEY` is in the keyring). Default voice `JBFqnCBsd6RMkjVDRZzb` (George, premade — free-tier API OK). Preferred narrator voices `5GZaeOOG7yqLdoTRsaa6` / `U9VgC8Xinl7nnNsyDd3J` are voice-library voices — API use needs a paid plan; pass via `--voice` |
+| ElevenLabs | `eleven_multilingual_v2` | Preferred for `/tutorial-video` (auto when `ELEVENLABS_API_KEY` is in the keyring). Narrator voice comes from the target repo's `docs/tutorials/voice.json` (chosen: Sally the Aussie, `5GZaeOOG7yqLdoTRsaa6` — paid plan is active). George (`JBFqnCBsd6RMkjVDRZzb`) is only reachable via explicit `--allow-voice-fallback`; a refused/unavailable voice is a hard failure, never a silent fallback |
 | OpenAI TTS | `gpt-4o-mini-tts` | Fallback; voices: alloy, ash, coral, echo, fable, nova, onyx, sage, shimmer |
 | OpenAI TTS | `tts-1-hd` | Higher fidelity, slower |
 | macOS `say` | system voices | Offline fallback (`--engine say`), no API key needed |


### PR DESCRIPTION
Docs-only. The ElevenLabs TTS row in `models.md` still called George the default voice and described the library narrator voices as paid-plan-gated "pass via --voice". Since e21ccb0 (merged in #82) the narrator is pinned in the target repo's `docs/tutorials/voice.json` (Sally the Aussie, `5GZaeOOG7yqLdoTRsaa6`; paid plan active) and a refused voice is a hard failure — George is only reachable via explicit `--allow-voice-fallback`.

Companion to plwp/dogeared-coach#153, which fixes the same stale claim in that repo's tutorials README.