### PR TITLE
fix(traceability): e2e dirs are test infrastructure

### DIFF
--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -214,7 +214,14 @@ def scan_source(source_root: str | Path) -> list[Annotation]:
         except OSError:
             continue
         rel = str(path.relative_to(root))
-        is_test = "test" in rel.lower() or "spec" in rel.lower()
+        rel_lower = rel.lower()
+        # e2e directories are test infrastructure (setup/fixtures/helpers) even when
+        # the filename itself carries no test/spec marker (e.g. ui/e2e/global-setup.ts).
+        is_test = (
+            "test" in rel_lower
+            or "spec" in rel_lower
+            or any(part == "e2e" for part in Path(rel_lower).parts)
+        )
         for i, line in enumerate(lines, start=1):
             for verb, ids in parse_annotations(line):
                 for target in ids:


### PR DESCRIPTION
Follow-up to #86, also found live on the admin-panel epic: `ui/e2e/global-setup.ts` holds `verifies` annotations but was classified as code (no test/spec in the path segments the heuristic saw), so the link was rejected as invalid. Any path with an `e2e` directory segment now classifies as test. 23/23 tests pass.