### PR TITLE
Patterns registry: design + improvement-loop as pattern #1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ python3 "$CW_HOME/scripts/repo.py" clean acme/app     # remove cache
 skills/              # Harness-portable skills and bundled resources
 scripts/             # Python helpers called by skills
 templates/           # Issue, PR, review, and checklist templates
+patterns/            # Registry of reusable product patterns CW stamps into built apps (see docs/patterns-registry.md)
 models.md            # AI model IDs and library versions (refresh with /update)
 ```
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -1,0 +1,228 @@
+# Patterns Registry — reusable product patterns Chief Wiggum stamps into apps
+
+> **Status: design proposal.** This document defines the patterns registry and
+> captures the first pattern (the improvement lifecycle loop). The registry entry
+> lives at `patterns/improvement-loop/`. Nothing here is wired into a workflow yet
+> — see [Rollout](#rollout).
+
+## What this is (and what it is not)
+
+Chief Wiggum already installs *artifacts* into the apps it builds: `/design`
+stamps `docs/design/`, `/architect` stamps `docs/epics/*/contracts.md`. Those
+are **per-product** artifacts, generated fresh each time.
+
+A **pattern** is one level up: a proven, opinionated, reusable *architecture +
+process* that CW knows how to stamp into **the app it is building** — the same
+way a senior engineer carries a handful of battle-tested shapes ("put a guarded
+query layer here", "gate deploys on a benchmark ratchet") from project to
+project. The registry is the curated library of those shapes.
+
+The distinction that matters:
+
+| | Home | Scope | Trust model |
+|--|--|--|--|
+| **CW workflows** (`/architect`, `/implement`) | the CW checkout | operate *on* a target repo | the operator (developer at the prompt) is trusted |
+| **A registry pattern** | defined in CW, **installed into the target repo** | becomes part of the *product's* own machinery, runs after CW walks away | the product's **end users may be untrusted** — this is the new axis |
+
+The registry is **not** about Chief Wiggum's own internals. CW itself is improved
+**directly, human-in-the-loop, through Claude Code** — the developer at the
+prompt *is* the admin, so every CW change is already admin-gated by construction.
+CW does not need an autonomous self-improvement loop bolted onto it. (The
+improvement-loop pattern is nonetheless *available* to point at CW or a CW
+subsystem later, if a case appears where an autonomous nightly pass earns its
+keep — see [Applying a pattern to CW itself](#applying-a-pattern-to-cw-itself).)
+
+## Why a registry
+
+Right now the valuable, reusable shapes CW could install are trapped inside the
+one-off apps that happen to implement them (a self-improvement loop is one). When
+CW builds the next analytics agent, nothing carries that loop forward — it would
+be re-derived, or forgotten. A registry:
+
+1. **Captures** each shape once, generically, with its parameters made explicit.
+2. **Catalogs** them so `/seed` and `/architect` can *select* patterns as part
+   of designing a product ("this is an agent over a warehouse → apply the
+   guarded-query + improvement-loop patterns").
+3. **Stamps** the pattern's scaffold into the target repo with its parameters
+   bound, then registers its protected paths with the product's ratchet.
+4. **Governs** the trust boundary — the piece a trusted-insider loop can skip but
+   a public-facing app cannot (see [Trust model](#trust-model-the-core-generalization)).
+
+## Registry layout
+
+```
+patterns/
+├── registry.json                 # the index: id, category, status, trust-class, one-liner
+├── improvement-loop/             # pattern #1 (this proposal)
+│   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
+│   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
+│   └── scaffold/                 # (future) the templated files stamped into the target app
+└── <future patterns>/
+```
+
+Each pattern is a directory. Two files are the contract:
+
+- **`pattern.md`** — the human-facing spec. What the pattern is, when to apply it,
+  the mechanism (as a set of generic components), its parameters, the reference
+  implementation it was distilled from, and its trust requirements.
+- **`manifest.json`** — the machine-readable surface a future `apply-pattern`
+  script consumes: parameter schema, the files/scaffold it installs, the paths it
+  adds to the product's protected pathset, and its trust class.
+
+`registry.json` is a thin index over the directories so a workflow can list and
+filter patterns without opening each manifest.
+
+## How a pattern gets applied (proposed `/apply-pattern`)
+
+A pattern is installed into a target repo by a new thin workflow (or a mode of
+`/architect`):
+
+```
+/apply-pattern owner/repo --pattern improvement-loop
+```
+
+Mechanically:
+
+1. **Resolve** the target repo (`scripts/repo.py`, as every workflow does).
+2. **Bind parameters** — read `manifest.json`'s parameter schema and resolve each
+   from the target app's context (its signal sources, its build/test commands,
+   its model family, its protected paths). Unresolved facts become `TBD:`
+   markers, gated exactly like every other CW artifact
+   (`scripts/check_unresolved.py`).
+3. **Stamp** the scaffold into the target repo with parameters bound.
+4. **Register protected paths** — add the pattern's `protected_paths` to the
+   product's `docs/quality/ratchet.json`, so the pattern's own guards/objective
+   become goalposts the app's autonomous machinery cannot move
+   (reuses the existing [ratchet](ratchet.md)).
+5. **Record adoption** — write `docs/patterns/adopted.json` in the target repo
+   with the pattern id, version, bound parameters, and provenance. This is the
+   product's manifest of "which CW patterns am I running, and how were they
+   configured".
+
+Patterns are **project-agnostic** and installed by *value* into the target — the
+same principle as every other CW skill. CW never hardcodes the target's
+warehouse, model, or channel; those are parameters.
+
+## Trust model — the core generalization
+
+This is the piece a **trusted-insider** loop can skip, and the reason a registry
+(rather than a copy-paste) is worth building.
+
+A baseline autonomous improvement loop runs fully autonomous to production. Its
+*one* human touchpoint is **non-blocking park-and-notify**: when a change touches
+the protected pathset, or needs domain truth the agent can't verify, it posts one
+message to a human channel and **parks** the item — it never waits for a reply.
+That is safe **only because its signal sources are trusted insiders**: the people
+whose feedback and conversations drive the loop are authenticated employees.
+
+Generalize the loop to an app with **untrusted end users** and those same signal
+inputs — user feedback text, conversation transcripts — become a **prompt-injection
+surface**. A malicious user can craft feedback engineered to get the loop to
+diagnose a "fix" that weakens a guardrail, rewrites a business rule, or plants a
+backdoor. Park-and-notify is not enough: a parked-but-eventually-auto-applied
+change is still an attacker-influenced change reaching production.
+
+The registry closes this with two additions to the pattern-as-installed:
+
+### 1. Signal sources carry a trust level
+
+Every signal source declared in the pattern's parameters is tagged
+`trusted` or `untrusted`:
+
+- `trusted` — internal/authenticated-admin origin (named insiders,
+  operator-authored benchmark cases, runtime error logs the app emits about
+  itself).
+- `untrusted` — any end-user-supplied content (public feedback, conversation
+  text from unauthenticated or low-privilege users).
+
+Trust flows through the whole chain: every `Finding` inherits `signal_trust`
+from its source, and every proposed change inherits the *lowest* trust of the
+findings in its cluster. (Runtime error logs the app emits about itself stay
+`trusted` even in a public app — the app is describing its own failure, not
+relaying user words.)
+
+### 2. Untrusted-derived changes require blocking admin approval
+
+The human gate becomes **trust-conditional**:
+
+| Change provenance | Gate |
+|--|--|
+| Derived **only** from `trusted` signals, touches no protected path | Autonomous fix-forward (the baseline model): floor + ratchet, auto-deploy |
+| Touches a **protected path** (any provenance) | Park-and-notify (the baseline model) — goalpost changes always human-reviewed |
+| Derived from **any** `untrusted` signal | **Quarantine → blocking admin approval** before it can enter the deployable set |
+
+The third row is the new one. An untrusted-derived change:
+
+1. Is written to a **quarantine** (`docs/patterns/pending-approval/<id>/` in the
+   target repo): the proposed diff + its full provenance chain (which findings,
+   which signals, verbatim source text) + the trust classification.
+2. **Cannot deploy.** It is not a parked-but-eventual change; it is inert until
+   an admin acts.
+3. Is released only by an **admin-authenticated approval** —
+   `patterns approve <id> --admin <identity>` — where admin identity is verified
+   against a real authority (CODEOWNERS / a signed approval commit / an
+   operator allowlist), **not** self-asserted by the loop.
+4. On approval, the change (and *who* approved it) is appended to the existing
+   **tamper-evident hash-chained journal** (the ratchet journal), so approvals
+   are auditable and un-forgeable — you can always prove an untrusted-derived
+   change reached prod *only* through a named admin.
+
+The result: a malicious end-user's feedback can, at worst, produce a **proposal
+in quarantine**. It can never silently become a deployed guardrail change or a
+business rule. Business rules derived from untrusted feedback are likewise marked
+`unverified` until an admin confirms them — a "domain truth needs a human ruling"
+idea, but promoted from a *domain-uncertainty* trigger to a *trust* trigger and
+hardened from park-notify into a blocking gate.
+
+This trust axis is **declared per pattern** in `manifest.json` and **bound per
+app** at apply time: an internal-only tool binds every source `trusted` and gets
+the frictionless autonomous loop; a public app binds its user-feedback source
+`untrusted` and automatically gets the quarantine gate. Same pattern,
+trust-appropriate behavior, no fork.
+
+## Candidate patterns (the backlog the registry seeds)
+
+The improvement loop distills into a set of mechanisms
+(`patterns/improvement-loop/pattern.md` catalogs them). Several are strong enough
+to stand alone as their own registry entries CW could apply independently:
+
+| Candidate pattern | One-liner | Notes |
+|--|--|--|
+| **improvement-loop** | Autonomous, signal-driven, ratchet-gated fix-forward refinement | Pattern #1, this proposal |
+| **protected-pathset + ratchet** | Monotonic quality high-water mark + fenced goalposts, embedded in the product | CW already runs this on *its own* work; the pattern is embedding it *in the built app* |
+| **decorrelated-judge / shadow-audit** | Referee model family ≠ player model family; blind re-generation to catch shared blind spots | For any product with an LLM-judge or generative success path |
+| **gate-only-holdout** | Train/holdout eval split; holdout withheld from the fixer's context | Anti-overfit for any self-modifying, test-graded product |
+| **signal-ingestion + findings** | Heterogeneous signals → one uniform, pointer-only, idempotent `Finding` shape | The abstraction that makes the loop source-agnostic; carries the trust tag |
+| **business-rules-registry** | Human corrections captured as provenance-bearing, version-controlled rules that outrank inference | The admin-approval trust gate rides on this |
+| **build-test-floor** | Language-agnostic auto-detecting build+test gate | A generic pre-merge check the loop's floor reuses |
+
+Capturing these is future work; the registry structure is built to hold them.
+
+## Applying a pattern to CW itself
+
+Because CW is also just a repo, the improvement-loop pattern *can* target it.
+That is **not the default** and not needed for normal CW development (you improve
+CW directly through Claude Code, and you are the trusted admin). But if a bounded,
+well-benchmarked CW subsystem emerges where an autonomous nightly pass earns its
+keep — say, a suite whose failures are mechanical and gradeable — the pattern is
+available to point at it. If that ever happens, every CW signal source is
+`trusted` (there are no untrusted end users at the CW prompt), so it runs in the
+frictionless autonomous mode with no quarantine gate.
+
+## Rollout
+
+Proposed, smallest-first:
+
+1. **This PR** — the registry structure + pattern #1 captured as a spec
+   (`pattern.md` + `manifest.json`) + this design doc. No workflow wiring yet.
+2. **`/apply-pattern` skill** — the thin installer described above, plus the
+   `scaffold/` for pattern #1 (the generic loop skill + scripts, with the
+   trust/quarantine gate added).
+3. **`/seed` + `/architect` integration** — pattern *selection* becomes part of
+   product design: the architecture stage proposes applicable patterns and
+   records the choice, the way `/design` records a chosen design direction.
+4. **Fill the backlog** — capture the standalone candidate patterns above as
+   their own entries.
+
+Steps 2–4 are deliberately out of scope here — this PR is about *starting to
+capture*, with one real, fully-specified entry to prove the shape.

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -52,25 +52,30 @@ be re-derived, or forgotten. A registry:
 
 ```
 patterns/
-├── registry.json                 # the index: id, category, status, trust-class, one-liner
-├── improvement-loop/             # pattern #1 (this proposal)
+├── registry.json                 # the index: specified patterns + mined candidates + meta-disciplines
+├── improvement-loop/             # specified pattern
 │   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
 │   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
 │   └── scaffold/                 # (future) the templated files stamped into the target app
-└── <future patterns>/
+├── engagement-instrumentation/   # specified pattern — the signal tier that feeds the loop
+│   ├── pattern.md
+│   └── manifest.json
+└── <candidate patterns>/         # mined, catalogued in registry.json, not yet fully specified
 ```
 
-Each pattern is a directory. Two files are the contract:
+Each specified pattern is a directory. Two files are the contract:
 
 - **`pattern.md`** — the human-facing spec. What the pattern is, when to apply it,
-  the mechanism (as a set of generic components), its parameters, the reference
-  implementation it was distilled from, and its trust requirements.
+  the mechanism (as a set of generic components), its parameters, and its trust
+  requirements.
 - **`manifest.json`** — the machine-readable surface a future `apply-pattern`
   script consumes: parameter schema, the files/scaffold it installs, the paths it
   adds to the product's protected pathset, and its trust class.
 
 `registry.json` is a thin index over the directories so a workflow can list and
-filter patterns without opening each manifest.
+filter patterns without opening each manifest. It also carries **candidates**
+(patterns mined but not yet fully specified) and **meta-disciplines** (recurring
+cross-pattern rules — fail-closed, idempotency, injected seams, documented TOCTOU).
 
 ## How a pattern gets applied (proposed `/apply-pattern`)
 
@@ -182,21 +187,57 @@ trust-appropriate behavior, no fork.
 
 ## Candidate patterns (the backlog the registry seeds)
 
-The improvement loop distills into a set of mechanisms
-(`patterns/improvement-loop/pattern.md` catalogs them). Several are strong enough
-to stand alone as their own registry entries CW could apply independently:
+Candidates come from two sources: mechanisms the improvement loop decomposes into,
+and patterns **mined from shipped apps** CW has built.
 
-| Candidate pattern | One-liner | Notes |
+### From the improvement loop
+
+The loop distills into a set of mechanisms
+(`patterns/improvement-loop/pattern.md` catalogs them), several strong enough to
+stand alone:
+
+| Candidate | One-liner | Notes |
 |--|--|--|
-| **improvement-loop** | Autonomous, signal-driven, ratchet-gated fix-forward refinement | Pattern #1, this proposal |
 | **protected-pathset + ratchet** | Monotonic quality high-water mark + fenced goalposts, embedded in the product | CW already runs this on *its own* work; the pattern is embedding it *in the built app* |
 | **decorrelated-judge / shadow-audit** | Referee model family ≠ player model family; blind re-generation to catch shared blind spots | For any product with an LLM-judge or generative success path |
 | **gate-only-holdout** | Train/holdout eval split; holdout withheld from the fixer's context | Anti-overfit for any self-modifying, test-graded product |
 | **signal-ingestion + findings** | Heterogeneous signals → one uniform, pointer-only, idempotent `Finding` shape | The abstraction that makes the loop source-agnostic; carries the trust tag |
 | **business-rules-registry** | Human corrections captured as provenance-bearing, version-controlled rules that outrank inference | The admin-approval trust gate rides on this |
-| **build-test-floor** | Language-agnostic auto-detecting build+test gate | A generic pre-merge check the loop's floor reuses |
 
-Capturing these is future work; the registry structure is built to hold them.
+### Mined from a shipped multi-tenant SaaS app
+
+Mining an existing production app (genericized — no app, domain, or vendor names)
+surfaced a coherent set of reusable shapes. Two observations shaped how they land:
+
+- The **feedback/instrumentation stack** was promoted to its own specified pattern
+  ([`engagement-instrumentation`](../patterns/engagement-instrumentation/pattern.md))
+  because it is precisely the signal supply the improvement loop's *enabling
+  condition* (strong monitoring + feedback) calls for — and one of its
+  sub-patterns, a documented per-metric **trust-boundary "honesty note"**,
+  directly reinforces the [trust model](#trust-model-the-core-generalization):
+  a loop that ingests a signal must know that signal's trust class or it will
+  optimize against a gameable proxy.
+- The **multi-tenant isolation stack** is the *floor* that makes mining per-tenant
+  behavioral data safe — the loop can read across tenants for analysis without
+  leaking between them only atop a fail-closed, server-derived scoping layer.
+
+| Candidate | Category | One-liner |
+|--|--|--|
+| **multi-tenant-isolation** | saas-infra | Server-only tenant resolution → fail-closed tenant-scoped repository → standing cross-tenant isolation proof gate → quarantined cascade erasure. One multi-tenancy blueprint |
+| **provider-neutral-adapter** | multi-provider | Vendor-agnostic seam (neutral DTOs, unexported concrete types = compile-time swappability); behind it: signed-webhook-as-source-of-truth, sign-per-request access tokens, direct browser→CDN upload |
+| **reconciliation-sweep** | process-loop | Periodic bidirectional local↔external drift repair, fail-closed on unknown state, re-confirm before destroy, per-run counts report |
+| **tiered-saas-enforcement** | saas-infra | Single-source tier matrix (unlimited sentinel, restrictive fallback) + stateless quota computed fresh (self-healing, one path for enforce+display) |
+| **immutable-assignment-snapshot** | data-structure | Version-pin assigned composite items so template edits never mutate outstanding assignments; keeps completion analysis drift-free |
+| **elevated-access-session** | saas-infra | Revocable, time-boxed support impersonation with independent TTL, future-skew guard, fail-closed revocation, full audit |
+| **build-test-floor** | gate | Language-agnostic auto-detecting build+test+lint gate with local mirror; optionally zero-cost-until-opt-in |
+
+Plus **meta-disciplines** recurring across the mined patterns — fail-closed on
+unknown input, idempotency + guarded conditional updates, injected interface seams
+for every gate, documented-not-hidden TOCTOU limitations — catalogued in
+`registry.json` as rules rather than installable patterns.
+
+Fully specifying the candidates (a `pattern.md` + `manifest.json` each) is future
+work; the registry structure is built to hold them.
 
 ## Applying a pattern to CW itself
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -108,6 +108,30 @@ Patterns are **project-agnostic** and installed by *value* into the target — t
 same principle as every other CW skill. CW never hardcodes the target's
 warehouse, model, or channel; those are parameters.
 
+## How patterns thread through the existing workflow
+
+Applying a pattern is not a one-shot stamp — it threads through the existing
+build loop. The division of labor: **`/seed` selects, `/architect` binds,
+`/implement` builds, `/close-epic` verifies.** A registry pattern is best thought
+of as a **contract pack** — it ships stable-ID contracts, invariants, integration
+tests, protected paths, and parameters, and the workflow stages consume them
+rather than re-deriving.
+
+| Stage | Role with patterns |
+|--|--|
+| **`/seed`** (or the product-architecture step) | **Selects.** Proposes applicable patterns from the registry given the product's shape ("multi-tenant SaaS with untrusted users" → `multi-tenant-isolation` + `engagement-instrumentation` + `improvement-loop`), records the choice and the per-app trust bindings — the "chosen, not converged" moment, like `/design`. |
+| **`/architect`** | **Binds.** For each selected pattern this epic realizes: folds the pattern's contracts/invariants into `contracts.md` / `invariants.md` **with their stable IDs, pulled from the manifest** (not re-derived); threads its integration tests into `integration-tests.md`; registers its `protected_paths` into `docs/quality/ratchet.json`; and emits `TBD:` markers for any unbound parameter (gated by `check_unresolved.py`) so dependent tickets can't build on a guess. |
+| **`/implement` / `/implement-wave`** | **Builds.** Implements against the pattern-supplied contracts; the `scaffold/` may already be stamped by `/apply-pattern`, and tickets fill in the app-specific parameterization. Workers touching the pattern's protected paths are parked, exactly as with any goalpost. |
+| **`/close-epic`** | **Verifies.** Confirms the pattern's invariants and gates held across the epic (e.g. the cross-tenant isolation proof passes, the ratchet held, the trust gate is wired). |
+
+So the answer to "does `/architect` need to reference the patterns?" is **yes** —
+`/architect` is where a pattern stops being a catalog entry and becomes this
+epic's contracts, gates, and protected paths. Concretely: `multi-tenant-isolation`
+contributes the tenant-scoping invariant + the cross-tenant-proof integration
+test; `engagement-instrumentation` contributes the trusted-denominator +
+monotonic-latch contracts; `improvement-loop` contributes the protected-pathset +
+ratchet-gate + trust-model contracts.
+
 ## Trust model — the core generalization
 
 This is the piece a **trusted-insider** loop can skip, and the reason a registry

--- a/patterns/engagement-instrumentation/manifest.json
+++ b/patterns/engagement-instrumentation/manifest.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/engagement-instrumentation/pattern.md.",
+  "id": "engagement-instrumentation",
+  "version": 1,
+  "title": "Engagement Instrumentation",
+  "category": "monitoring-feedback",
+  "trust_class": "produces-trust-tagged-signal",
+
+  "applies_when": [
+    "product assigns work/content and 'did the user engage with / complete it' is worth answering",
+    "you want deliberate, robust feedback signal (retention/funnel/drop-off), not best-effort telemetry",
+    "designed in from the start — the value is the server-trusted monotonic discipline, not a later patch"
+  ],
+
+  "components": [
+    "client-throttled-emitter: throttle steady ticks, flush on boundary, keepalive on unmount, skip without trusted denominator, no-retry (server is monotonic), preview-never-writes guard",
+    "server-trusted-monotonic-tracker: one row per (assignment, item), lazy create, tenant-scoped, monotonic-max progress, one-way completion latch past threshold, server-trusted denominator (client duration advisory only), upsert (max/set/set-on-insert) with dup-key retry, bounded roll-up query budget",
+    "trust-boundary-honesty-note: per-metric statement of what it proves vs not; robust-against-bugs != robust-against-adversary; enumerate accepted races",
+    "dual-scope-audit-log: append-only tenant-scoped + system-global event trails"
+  ],
+
+  "parameters": {
+    "work_item": {"type": "string", "required": true, "description": "The entity whose engagement is tracked."},
+    "completion_threshold": {"type": "number", "required": true, "description": "Fraction past which the one-way completed latch trips."},
+    "trusted_denominator": {"type": "string", "required": true, "description": "Server-side source of truth for the completion denominator (pinned-at-assignment snapshot or canonical record)."},
+    "throttle_interval": {"type": "string", "required": false, "default": "10s", "description": "Steady-state client report cadence."},
+    "event_source": {"type": "string", "required": true, "description": "Player/content events the client emitter subscribes to."},
+    "signal_trust": {"type": "string", "required": true, "description": "Per-metric trust class annotation; feeds the improvement-loop trust model."}
+  },
+
+  "feeds": {
+    "improvement-loop": "supplies signal_sources of kind 'conversations'/'feedback'/'errors' analog: per-item completion, drop-off, last-activity, plus audit-log events; the per-metric signal_trust is the input to the loop's trust model"
+  },
+
+  "depends_on": {
+    "multi-tenant-isolation": "mining per-tenant behavioral data safely requires a fail-closed, server-derived tenant-scoping data layer"
+  }
+}

--- a/patterns/engagement-instrumentation/pattern.md
+++ b/patterns/engagement-instrumentation/pattern.md
@@ -1,0 +1,112 @@
+# Pattern: Engagement Instrumentation
+
+- **Category:** monitoring-feedback
+- **Trust class:** produces trust-tagged signal (each metric annotated with what it proves)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+The instrumentation tier that captures **how the product is actually doing** —
+how far users get through the work/content assigned to them — in a way that is
+robust against out-of-order reports, replays, concurrent writers, and client
+clock/duration drift. It produces per-item and rolled-up completion/engagement
+signals, each annotated with its trust class.
+
+This is the **companion to the [improvement-loop](../improvement-loop/pattern.md)
+pattern**: strong monitoring and feedback is that loop's one enabling condition,
+and this pattern is how you *build* that signal deliberately rather than hoping it
+exists. Its per-signal trust annotation is exactly what the loop's
+[trust model](../improvement-loop/pattern.md#trust-model) consumes to decide
+whether a signal-derived change may auto-deploy or must be admin-approved.
+
+## When to apply
+
+Apply to any content or task product where "did the user actually engage with /
+complete what they were given" is a question worth answering — which is nearly
+all of them. It is table-stakes for retention/funnel analysis, and the correctness
+subtleties below are subtle enough that most teams get them wrong.
+
+Do **not** bolt it on as an afterthought: the value is in the *server-trusted,
+monotonic* discipline, which has to be designed in, not patched later.
+
+## Mechanism — generic components
+
+Neutral throughout; the "work item", completion threshold, and player/event
+source are [parameters](#parameters).
+
+### Client-side throttled emitter
+
+- Subscribe to the content/player events (progress tick, pause, end, teardown).
+- **Throttle** steady-state progress ticks (e.g. one report per ~10s); **flush
+  immediately** on meaningful boundaries (pause / end / unmount).
+- The unmount flush uses a **keepalive** request so it survives in-app teardown.
+- **Skip reporting while no trusted denominator exists yet** (don't emit progress
+  you can't ground).
+- **No retry** beyond the next natural event — safe *because* the server latch is
+  monotonic, so a lost report only delays, never loses, eventual state.
+- A **"preview never writes"** guard: reporting is disabled entirely unless a real
+  assignment context is present, so admin/preview views never pollute telemetry.
+
+### Server-trusted monotonic tracker
+
+- **One row per (assignment, work-item)**, created lazily on first report,
+  tenant-scoped, never deleted by user action.
+- The client self-reports position + duration, but completion fraction is computed
+  **only from a server-trusted denominator** (a duration/size snapshot pinned at
+  assignment time, or the canonical item record). The **client-reported duration
+  is stored as advisory telemetry only** — never as the denominator.
+- Progress advances with a **monotonic-max** operator so it never regresses;
+  **"completed" is a one-way latch** that trips past a threshold fraction and never
+  unsets.
+- Writes are a single **upsert**: `max` for the monotonic latches, `set` for
+  last-activity, `set-on-insert` for immutable fields. A duplicate-key on
+  concurrent first-insert is caught and retried once.
+- Roll-up summaries use a **bounded query budget per page** (one aggregation + one
+  lookup), never per-item fan-out.
+
+### Trust-boundary honesty note (per signal)
+
+- Alongside each metric's contract, write down **what it can and cannot prove**:
+  it is self-reported; the server hardens it against *accidental* corruption
+  (trusted denominators, monotonic latches, server-side attribution) but the
+  measured party can still inflate their *own* diligence — accepted when the only
+  person they can fool is themselves.
+- Enumerate known races and their **bounded, non-security** impact as accepted
+  limitations rather than hiding them.
+- This makes each signal's **trust class explicit** so nothing downstream — least
+  of all a self-improvement loop — optimizes against a gameable proxy.
+
+### Dual-scope audit log (complementary event source)
+
+- Two append-only logs: a **tenant-scoped** one (actions a tenant should see,
+  flowing through the tenant-isolated repository) and a **system-global** one
+  (provider-less background/operational events).
+- Entries carry actor, action, target, timestamp, optional metadata. A rich,
+  immutable event source for behavioral and operational analysis.
+
+## Parameters
+
+| Parameter | What it is |
+|--|--|
+| `work_item` | the entity whose engagement is tracked |
+| `completion_threshold` | fraction past which the one-way "completed" latch trips |
+| `trusted_denominator` | server-side source of truth for the completion denominator (pinned-at-assignment snapshot or canonical record) |
+| `throttle_interval` | steady-state client report cadence |
+| `event_source` | the player/content events the client emitter subscribes to |
+| `signal_trust` | per-metric trust class annotation (feeds the improvement loop) |
+
+## Relationship to other patterns
+
+- **Feeds `improvement-loop`.** The per-item completion rates, drop-off points,
+  and last-activity timestamps are the funnel/retention signal the loop consumes;
+  the audit logs are a second event source. The per-signal trust annotation is the
+  input to the loop's trust model.
+- **Depends on a tenant-isolation floor.** Mining per-tenant behavioral data is
+  only safe atop server-derived tenant scoping (see the
+  `multi-tenant-isolation` candidate in [`registry.json`](../registry.json)) —
+  the fail-closed data layer is what lets the loop read across tenants without
+  leaking between them.
+- **Reuses CW disciplines.** The trust-boundary note is the product-signal analog
+  of CW's contract discipline; the monotonic latch + fail-closed race handling are
+  the same "ratchet, never slide" stance CW applies to quality, applied here to a
+  metric.

--- a/patterns/improvement-loop/manifest.json
+++ b/patterns/improvement-loop/manifest.json
@@ -1,0 +1,88 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/improvement-loop/pattern.md.",
+  "id": "improvement-loop",
+  "version": 1,
+  "title": "Improvement Lifecycle Loop",
+  "category": "process-loop",
+  "trust_class": "trust-aware",
+
+  "applies_when": [
+    "product has a stream of gradeable outcomes (conversations/requests/transactions)",
+    "product has a deterministic benchmark to ratchet against",
+    "editable surfaces (prompts/config/code) are separable from goalposts (objective/guardrails/gate)"
+  ],
+
+  "parameters": {
+    "signal_sources": {
+      "type": "array",
+      "required": true,
+      "description": "Heterogeneous signal inputs, each normalized to a Finding.",
+      "items": {
+        "kind": {"enum": ["conversations", "feedback", "errors", "backlog"], "required": true},
+        "locator": {"type": "string", "required": true, "description": "How to read the source (connection/collection/path/query)."},
+        "trust": {"enum": ["trusted", "untrusted"], "required": true, "description": "trusted = internal/authenticated-admin origin; untrusted = end-user-supplied content. Drives the human gate. An app's own error logs stay trusted even in a public app."}
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "required": true,
+      "fields": {
+        "strict_cmd": {"type": "string", "required": true, "description": "Command emitting per-case pass/fail for the strict (deterministic) pass-set."},
+        "golden_dir": {"type": "string", "required": true, "description": "Fix-visible benchmark cases."},
+        "holdout_dir": {"type": "string", "required": false, "description": "Gate-only cases withheld from the fixer's context."}
+      }
+    },
+    "floor_cmd": {"type": "string", "required": true, "description": "Language-agnostic build/test floor (e.g. a pre-merge-check script)."},
+    "product_model_family": {"type": "string", "required": true, "description": "Operational model family under test."},
+    "judge_model_family": {"type": "string", "required": true, "description": "Decorrelated judge family; MUST differ from product_model_family."},
+    "protected_paths": {"type": "array", "required": true, "description": "Goalposts the loop must not move; added to the app's ratchet protected pathset.", "items": {"type": "string"}},
+    "human_channel": {"type": "string", "required": true, "description": "Destination for park-and-notify and approval requests."},
+    "admin_authority": {"type": "object", "required": true, "description": "How admin identity is verified for approvals.", "fields": {
+      "kind": {"enum": ["codeowners", "signed-commit", "allowlist"], "required": true},
+      "locator": {"type": "string", "required": false}
+    }},
+    "deploy_cmd": {"type": "string", "required": true, "description": "Fix-forward deploy command (no rollback)."},
+    "schedule": {"type": "string", "required": false, "default": "nightly", "description": "Iteration cadence."}
+  },
+
+  "installs": {
+    "$comment": "Files the pattern stamps into the target repo. scaffold/ is NOT YET BUILT — these are the intended install targets.",
+    "app_skill": ".app/skills/improvement-loop/SKILL.md",
+    "scripts": ".app/skills/improvement-loop/scripts/{ingest_*,recent_errors,synthesize,ratchet,guard_protected_paths,recent_queries}.py",
+    "judge_rubric": ".app/skills/improvement-loop/judge_rubric.md",
+    "state_dir": ".app/skills/improvement-loop/state/",
+    "business_rules": "docs/business-rules.md",
+    "quarantine_dir": "docs/patterns/pending-approval/",
+    "adoption_record": "docs/patterns/adopted.json"
+  },
+
+  "protected_paths_added": [
+    "eval/**",
+    ".app/skills/improvement-loop/scripts/ratchet.py",
+    ".app/skills/improvement-loop/scripts/guard_protected_paths.sh",
+    ".app/skills/improvement-loop/state/**",
+    ".app/skills/improvement-loop/judge_rubric.md",
+    "docs/quality/**"
+  ],
+
+  "trust_model": {
+    "$comment": "The core generalization. See docs/patterns-registry.md#trust-model.",
+    "finding_trust": "each Finding inherits signal_trust from its source",
+    "change_trust": "a proposed change inherits the LOWEST trust of the findings in its cluster",
+    "gates": [
+      {"provenance": "only trusted signals, no protected path", "gate": "autonomous-fix-forward", "blocking": false},
+      {"provenance": "touches a protected path (any provenance)", "gate": "park-and-notify", "blocking": false},
+      {"provenance": "any untrusted signal", "gate": "quarantine-then-admin-approval", "blocking": true}
+    ],
+    "approval": {
+      "command": "patterns approve <id> --admin <identity>",
+      "identity_verified_against": "admin_authority parameter (codeowners/signed-commit/allowlist), never self-asserted",
+      "journaled": "approval and approver appended to the tamper-evident ratchet journal"
+    }
+  },
+
+  "requires_target": {
+    "ratchet": "reuses docs/quality/ratchet.json (scripts/ratchet.py) for the high-water mark, journal, and protected pathset",
+    "unresolved_gate": "unbound parameters become TBD: markers gated by scripts/check_unresolved.py"
+  }
+}

--- a/patterns/improvement-loop/pattern.md
+++ b/patterns/improvement-loop/pattern.md
@@ -1,0 +1,208 @@
+# Pattern: Improvement Lifecycle Loop
+
+- **Category:** process-loop
+- **Trust class:** trust-aware (behavior depends on per-app signal-trust binding)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+A self-improvement loop installed **into the product** that acts as the product's
+**error function**: after CW ships the app, the loop runs on a schedule, consumes
+the app's runtime signals (conversations, user feedback, error logs, real
+requests), diagnoses each into a finding, clusters findings into structural
+issues, fixes them forward across any product surface (prompts, contracts, config,
+code), gates the change on a deterministic ratchet, and — depending on the trust
+of the signals that drove it — either auto-deploys or quarantines for admin
+approval.
+
+It is the **operate/refine** counterpart to CW's **build** loops. CW's existing
+loops take an app from nothing to shipped (`/seed → /architect → /implement-wave
+→ /close-epic`). This pattern is what the app runs *itself*, afterward, to keep
+improving without a human writing every ticket.
+
+## When to apply
+
+Apply when the built product has **all three** of:
+
+1. **A stream of gradeable outcomes** — conversations, requests, or transactions
+   whose quality can be judged (by assertion or by a decorrelated judge).
+2. **A deterministic benchmark** — a golden set the loop can ratchet against, so
+   "fix forward, no rollback" is survivable.
+3. **A safe blast radius** — surfaces the loop may edit (prompts, config, code)
+   are separable from the goalposts it must not (objective, guardrails, the gate
+   itself).
+
+Do **not** apply to a product with no benchmark and no gradeable outcome stream —
+the loop has no error signal and no floor, and autonomy is unsafe.
+
+## Mechanism — generic components
+
+Every component is generic and technology-agnostic. Concrete choices
+(warehouse/datastore, operational vs judge model, notification channel, deploy
+target, ticketing system) are **parameters** — see [Parameters](#parameters).
+
+### Loop shape
+
+- **Inner/outer split** — cheap continuous per-item diagnosis (inner) feeds a
+  periodic batch improvement (outer). Per-item granularity is what makes later
+  clustering possible.
+- **One skill invocation = one iteration**, scheduled via cron/`/loop` (e.g.
+  nightly), **not** CI-triggered. Cloud automation (a scheduler invoking the skill
+  headless) is a deferred deployment shape, not a requirement.
+
+### Signals in (the error-function inputs)
+
+- **Uniform Finding abstraction** — every heterogeneous source normalizes to one
+  `Finding` shape: pointer-only evidence (trace/conversation/execution id, never
+  inlined PII), a stable idempotency key of `(source_id, signals_digest)` that
+  deliberately excludes agent version so the same problem dedupes across builds,
+  and a **`signal_trust` tag**.
+- **Conversation + feedback ingestion** — real transcripts and explicit user
+  corrections. Feedback outranks inference: the user's text becomes both
+  `root_cause` and a `proposed_fix`, with provenance.
+- **Runtime error ingestion** — operational failures (panics, guardrail trips,
+  5xx) grouped by a **normalized signature** (volatile tokens stripped) with a
+  `sufficient|INSUFFICIENT` context flag. Diagnosed *without* the judge (objective
+  evidence).
+- **Real-backlog ingestion** — resolved real requests with known-good answers
+  become benchmark cases extending the same schema; unanswered ones are
+  judge-graded and kept out of the strict ratchet.
+
+### Diagnose (inner loop)
+
+- **Decorrelated, stake-free judge** — when quality is LLM-judged, the judge is a
+  **different model family** from the operational model AND sees only the rubric +
+  transcript (never the fix/diff). Judge output is **advisory forever**; only
+  deterministic cases are *trusted* by the ratchet. `judge_family` is recorded so
+  judge drift is observable.
+- **Shadow / differential re-generation** — for *successful* outputs, blindly
+  re-generate twice with fresh decorrelated agents and semantically diff against
+  production, splitting "generator wrong" from "grounding wrong". Dry-run
+  validated, never executed.
+
+### Improve (outer loop)
+
+- **Deterministic clustering → ranked queue** — group findings on
+  (surface × failure_mode), rank by severity × mass, **pin ratchet regressions
+  first**. Deterministic so priority is un-game-able. Cluster mass is a
+  corroboration threshold: a lone low-confidence finding can't solo-trigger a fix.
+- **Fix forward** across any product surface; **no rollback** (the next
+  iteration's signals catch slips).
+- **Amnesia context** — inject the last N iteration records so the fixer doesn't
+  re-try a fix it already regressed. The gate-only holdout is withheld from this
+  same context.
+- **Observability ratchet** — when an error can't be root-caused from its log
+  (INSUFFICIENT), the fix is to *enrich the log site*, not guess the bug; a stable
+  site tag links old→new signature and a follow-up tracks it until it recurs
+  (root-cause then) or goes quiet. Each iteration reduces next-run ambiguity.
+
+### Gates (deterministic; the loop cannot move these)
+
+- **Build/test floor** — language-agnostic auto-detecting `does it build + pass`.
+- **Deterministic ratchet** — the strict benchmark pass-set is a monotonic
+  high-water mark **derived from the journal of deployed iterations**, not a
+  separately-writable file. A deploy is blocked unless the current pass-set is a
+  superset. Plus a **definition-hash** guard: a case that keeps its id but weakens
+  its assertion does not count as passing. **→ this is CW's [ratchet](../../docs/ratchet.md), used as a hard pre-deploy gate.**
+- **Tamper-evident hash-chained journal** — iteration outcomes form an append-only
+  hash chain; the high-water mark is derived from the verified chain, so lowering
+  the bar by editing state is detectable and fails closed. **→ identical to CW's ratchet journal.**
+- **Gate-only holdout** — a benchmark split withheld from the fixer's context and
+  run only at the gate, so the fixer can't overfit-and-ship.
+- **Protected pathset** — a git-diff fence over the files that *define correct*,
+  *enforce safe*, or *are the gate*. **Fail-closed**: unresolvable base → unsafe;
+  protected touched → park; clean → proceed. **→ this is CW's [protected pathset](../../docs/ratchet.md).**
+
+### Human touchpoint
+
+- **Baseline behavior (trusted signals): park-and-notify, non-blocking.** A
+  protected-path touch or an unverifiable domain-truth question posts one deduped
+  message to a human channel and **parks** the item; the loop never waits — a
+  future iteration consumes the human's out-of-band reply. This is safe only when
+  the signal sources are trusted.
+- **Untrusted signals: quarantine + blocking admin approval.** See
+  [Trust model](#trust-model).
+
+### Governance
+
+- **Authority split (code as black box)** — business rules = human authority;
+  code = agent authority. The loop may re-architect the product but never move its
+  own goalposts (benchmark, guardrails, gate scripts, its own spec/state) — those
+  are the protected pathset.
+- **Self-reducing-friction lane** — the loop may improve *its own procedure*
+  (helpers, skill body) but not its own *guards* (ratchet/guard/state/judge), which
+  stay protected. Guard-adjacent self-edits auto-park.
+
+## Trust model
+
+The core design decision. A baseline loop assumes **trusted signal sources** (the
+people whose feedback and conversations drive it are authenticated insiders), so
+its only human gate is non-blocking park-and-notify. Apps with **untrusted end
+users** turn feedback/conversation signals into a **prompt-injection surface** — a
+malicious user can craft feedback engineered to get the loop to diagnose a "fix"
+that weakens a guardrail or plants a backdoor. So the pattern adds a trust axis.
+Full rationale in [`docs/patterns-registry.md`](../../docs/patterns-registry.md#trust-model-the-core-generalization).
+
+1. **Signal sources are tagged `trusted` or `untrusted`** at apply time. Every
+   `Finding` inherits `signal_trust`; every proposed change inherits the **lowest**
+   trust of the findings in its cluster. (An app's own runtime error logs stay
+   `trusted` — the app describes its own failure, not user words.)
+
+2. **The human gate is trust-conditional:**
+
+   | Change provenance | Gate |
+   |--|--|
+   | Only `trusted` signals, no protected path | Autonomous fix-forward → auto-deploy |
+   | Touches a protected path (any provenance) | Park-and-notify (goalpost review) |
+   | **Any `untrusted` signal** | **Quarantine → blocking admin approval** |
+
+3. **Quarantine (`docs/patterns/pending-approval/<id>/` in the target app):** the
+   proposed diff + full provenance chain (findings, signals, verbatim source text)
+   + trust classification. The change is **inert** — not parked-but-eventual;
+   it cannot deploy.
+
+4. **Release requires admin-authenticated approval** —
+   `patterns approve <id> --admin <identity>`, where admin identity is verified
+   against a real authority (CODEOWNERS / signed approval commit / operator
+   allowlist), never self-asserted. On approval the change **and its approver** are
+   appended to the tamper-evident journal, so you can always prove an
+   untrusted-derived change reached prod only through a named admin.
+
+An internal-only app binds every source `trusted` and gets the frictionless
+autonomous loop. A public app binds its user-feedback source `untrusted` and
+automatically gets the quarantine gate. **Same pattern, no fork.**
+
+## Parameters
+
+Bound per app at apply time (schema in [`manifest.json`](./manifest.json)):
+
+| Parameter | What it is |
+|--|--|
+| `signal_sources[]` | each `{kind, locator, trust}` — conversations / feedback / errors / backlog, with its trust level |
+| `benchmark.strict_cmd` | deterministic per-case pass/fail extractor |
+| `benchmark.golden_dir` / `holdout_dir` | fix-visible vs gate-only eval |
+| `floor_cmd` | build/test floor |
+| `product_model_family` | the operational model (judge must differ) |
+| `judge_model_family` | decorrelated judge family |
+| `protected_paths[]` | goalposts the loop can't move |
+| `human_channel` | park-and-notify + approval destination |
+| `admin_authority` | how admin identity is verified for approvals |
+| `deploy_cmd` | fix-forward deploy |
+| `schedule` | iteration cadence |
+
+## Relationship to existing CW machinery
+
+This pattern is **mostly a repackaging of machinery CW already owns**, pointed at
+the *product* instead of at CW's build loop:
+
+- Ratchet, high-water mark, definition-hash, tamper-evident journal → CW's
+  [`docs/ratchet.md`](../../docs/ratchet.md) / `scripts/ratchet.py`, essentially verbatim.
+- Protected pathset → CW's protected pathset, same concept.
+- Human-parks-goalpost-changes → CW's "workers can't move their own goalposts".
+- Traceability of findings → CW's `@cw-trace` / [`docs/traceability.md`](../../docs/traceability.md) spirit.
+- `TBD:`/`UNRESOLVED:` gating of unbound parameters → `scripts/check_unresolved.py`.
+
+The genuinely **new** parts are: (a) the **operate/refine loop shape** itself
+(CW has no post-ship loop), (b) the **signal abstraction** (uniform Finding over
+heterogeneous sources), and (c) the **trust model** (quarantine + blocking admin
+approval for untrusted-derived changes).

--- a/patterns/improvement-loop/pattern.md
+++ b/patterns/improvement-loop/pattern.md
@@ -22,18 +22,29 @@ improving without a human writing every ticket.
 
 ## When to apply
 
-Apply when the built product has **all three** of:
+The one enabling condition is **strong monitoring and feedback**. Wherever a
+product emits rich signal about how it's actually doing — quality-gradeable
+outcomes, explicit user corrections, structured error telemetry — the loop has
+something real to act on. This is not specific to conversational or analytics
+agents; any system with good observability + feedback is a candidate. Conversely,
+a product with weak monitoring has no error signal, and the loop has nothing to
+drive it — don't bother.
 
-1. **A stream of gradeable outcomes** — conversations, requests, or transactions
-   whose quality can be judged (by assertion or by a decorrelated judge).
-2. **A deterministic benchmark** — a golden set the loop can ratchet against, so
-   "fix forward, no rollback" is survivable.
-3. **A safe blast radius** — surfaces the loop may edit (prompts, config, code)
-   are separable from the goalposts it must not (objective, guardrails, the gate
-   itself).
+Signal strength gets the loop *value*. Two further properties govern *how
+autonomous* it's allowed to be — this is a spectrum, not a yes/no:
 
-Do **not** apply to a product with no benchmark and no gradeable outcome stream —
-the loop has no error signal and no floor, and autonomy is unsafe.
+| Monitoring / feedback | Deterministic gate (benchmark + trust) | Loop runs as |
+|--|--|--|
+| Strong | Strong — golden benchmark to ratchet against, and trusted signals | Fully autonomous fix-forward, auto-deploy |
+| Strong | Weak / none, **or** any untrusted signal | Loop still surfaces, diagnoses, and *proposes* — but **every change is human-gated** (quarantine → approval; no auto-deploy) |
+| Weak | (any) | Not a candidate — no error signal to drive it |
+
+So a **deterministic benchmark** and a **safe blast radius** (editable surfaces
+separable from the goalposts the loop must not move) aren't preconditions for
+running the loop — they're what unlocks the *autonomous* column. Without them, or
+with untrusted signals, the loop is still valuable as a human-gated proposer. The
+[trust model](#trust-model) is the mechanism that places a given change in the
+right row.
 
 ## Mechanism — generic components
 

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}.",
+  "version": 1,
+  "patterns": [
+    {
+      "id": "improvement-loop",
+      "title": "Improvement Lifecycle Loop",
+      "category": "process-loop",
+      "status": "specified",
+      "trust_class": "trust-aware",
+      "summary": "Autonomous, signal-driven, ratchet-gated fix-forward refinement installed into the product. Trusted-signal changes deploy autonomously; untrusted-signal (end-user) changes quarantine for blocking admin approval.",
+      "spec": "patterns/improvement-loop/pattern.md",
+      "manifest": "patterns/improvement-loop/manifest.json"
+    }
+  ],
+  "candidates": [
+    {"id": "protected-pathset-ratchet", "title": "Protected Pathset + Deterministic Ratchet", "category": "gate", "status": "candidate", "summary": "Monotonic quality high-water mark + fenced goalposts, embedded in the built product (CW already runs this on its own work)."},
+    {"id": "decorrelated-judge", "title": "Decorrelated Judge / Shadow Audit", "category": "gate", "status": "candidate", "summary": "Referee model family must differ from the player model family; blind re-generation catches shared blind spots."},
+    {"id": "gate-only-holdout", "title": "Gate-Only Holdout Split", "category": "gate", "status": "candidate", "summary": "Train/holdout eval split; holdout withheld from the fixer's context to prevent overfit-and-ship."},
+    {"id": "signal-ingestion-findings", "title": "Signal Ingestion + Findings Store", "category": "data-structure", "status": "candidate", "summary": "Heterogeneous signals normalized into one uniform, pointer-only, idempotent Finding shape carrying a trust tag."},
+    {"id": "business-rules-registry", "title": "Business-Rules Registry", "category": "human-touchpoint", "status": "candidate", "summary": "Human corrections captured as provenance-bearing, version-controlled rules that outrank inference; the admin-approval trust gate rides on this."},
+    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test gate across a polyglot repo."}
+  ]
+}

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}.",
+  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}. Candidates are mined but not yet fully specified.",
   "version": 1,
   "patterns": [
     {
@@ -11,14 +11,35 @@
       "summary": "Autonomous, signal-driven, ratchet-gated fix-forward refinement installed into the product. Trusted-signal changes deploy autonomously; untrusted-signal (end-user) changes quarantine for blocking admin approval.",
       "spec": "patterns/improvement-loop/pattern.md",
       "manifest": "patterns/improvement-loop/manifest.json"
+    },
+    {
+      "id": "engagement-instrumentation",
+      "title": "Engagement Instrumentation",
+      "category": "monitoring-feedback",
+      "status": "specified",
+      "trust_class": "produces-trust-tagged-signal",
+      "summary": "Server-trusted, tamper-resistant capture of how far users get through assigned work/content, robust to out-of-order/replay/concurrent/clock-drift. The instrumentation tier that feeds the improvement loop; each signal annotated with its trust class.",
+      "feeds": "improvement-loop",
+      "spec": "patterns/engagement-instrumentation/pattern.md",
+      "manifest": "patterns/engagement-instrumentation/manifest.json"
     }
   ],
   "candidates": [
-    {"id": "protected-pathset-ratchet", "title": "Protected Pathset + Deterministic Ratchet", "category": "gate", "status": "candidate", "summary": "Monotonic quality high-water mark + fenced goalposts, embedded in the built product (CW already runs this on its own work)."},
-    {"id": "decorrelated-judge", "title": "Decorrelated Judge / Shadow Audit", "category": "gate", "status": "candidate", "summary": "Referee model family must differ from the player model family; blind re-generation catches shared blind spots."},
-    {"id": "gate-only-holdout", "title": "Gate-Only Holdout Split", "category": "gate", "status": "candidate", "summary": "Train/holdout eval split; holdout withheld from the fixer's context to prevent overfit-and-ship."},
-    {"id": "signal-ingestion-findings", "title": "Signal Ingestion + Findings Store", "category": "data-structure", "status": "candidate", "summary": "Heterogeneous signals normalized into one uniform, pointer-only, idempotent Finding shape carrying a trust tag."},
-    {"id": "business-rules-registry", "title": "Business-Rules Registry", "category": "human-touchpoint", "status": "candidate", "summary": "Human corrections captured as provenance-bearing, version-controlled rules that outrank inference; the admin-approval trust gate rides on this."},
-    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test gate across a polyglot repo."}
-  ]
+    {"id": "multi-tenant-isolation", "title": "Multi-Tenant Isolation Stack", "category": "saas-infra", "status": "candidate", "summary": "Server-only tenant resolution (rejects client hints) -> context-injected, fail-closed tenant-scoped repository (AND-wrapped filters, reject-don't-override, recursive field-scan, unexported handles) -> standing cross-tenant isolation proof as an executable test gate (positive controls + negative matrix + no-foreign-id-in-denial) -> quarantined transactional cascade erasure. Composes into one multi-tenancy blueprint; the floor that makes mining per-tenant data safe.", "reusability": "high"},
+    {"id": "provider-neutral-adapter", "title": "Provider-Neutral Port/Adapter", "category": "multi-provider", "status": "candidate", "summary": "Vendor-agnostic seam for a swappable external service: neutral DTOs only, concrete vendor types unexported (compile-time swappability), vendor states mapped to internal enums with safe defaults. Behind it: signed-webhook ingestion normalized to idempotent internal events (webhook is source of truth, not the client callback), sign-per-request short-lived access tokens, and direct browser->CDN upload via a one-time server-minted ticket.", "reusability": "high"},
+    {"id": "reconciliation-sweep", "title": "Bidirectional Reconciliation Sweep", "category": "process-loop", "status": "candidate", "summary": "Periodic job repairing divergence between local records and an external system in both directions plus a stale-in-flight sweep. Fail-closed on unknown age, re-confirm before destructive action, idempotent guarded updates, per-run counts report. Its run reports and audit stream are operational-health signal.", "reusability": "high"},
+    {"id": "tiered-saas-enforcement", "title": "Tiered-SaaS Limit Enforcement", "category": "saas-infra", "status": "candidate", "summary": "Single-source-of-truth tier matrix (unlimited sentinel, unknown-tier falls back to most-restrictive) enforced via injected check-before-act gate seams; stateless quota computed fresh from source of truth (no stored counters, self-healing on delete) with one shared path for enforce + display and pessimistic in-flight reservation. Limit-hit events are strong upgrade-intent signal.", "reusability": "high"},
+    {"id": "immutable-assignment-snapshot", "title": "Immutable Assignment Snapshot", "category": "data-structure", "status": "candidate", "summary": "Pin the exact version of a composite item at assignment time (draft -> immutable published version -> assignment references a version, not the live template) so later edits never retroactively mutate outstanding assignments. Keeps longitudinal completion analysis clean (no denominator drift).", "reusability": "medium-high"},
+    {"id": "elevated-access-session", "title": "Revocable Elevated-Access Session", "category": "saas-infra", "status": "candidate", "summary": "Time-boxed support impersonation with a short server-enforced TTL independent of the identity token, future-skew guard, per-request self-consistency check, fail-closed revocation lookup, fixed middleware order, and full audit. High value but only for products needing operator act-as.", "reusability": "medium"},
+    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test+lint gate across a polyglot repo, with a local pre-merge script mirroring CI; optionally zero-cost-until-opt-in (manual-dispatch trigger) for cost-sensitive private repos.", "reusability": "medium"}
+  ],
+  "meta_disciplines": {
+    "$comment": "Recurring cross-pattern engineering rules worth stating once, not registry entries themselves.",
+    "rules": [
+      "fail-closed on unknown/ambiguous input (grace windows, revocation lookups, tenant resolution, unknown-tier fallback)",
+      "idempotency + guarded conditional updates for anything touching external state",
+      "injected interface seams for every gate so services stay testable without real infra",
+      "document accepted TOCTOU/limitation classes inline rather than hiding them"
+    ]
+  }
 }


### PR DESCRIPTION
## What

Introduces a **patterns registry** — a curated library of reusable *product* patterns Chief Wiggum can stamp into the apps it builds (distinct from CW's own internals, which are improved directly through Claude Code by the trusted operator).

This PR captures the shape with one fully-specified entry; no workflow wiring yet.

## Contents

- **`docs/patterns-registry.md`** — the design proposal. Registry layout, how a pattern gets applied (`/apply-pattern`), the candidate backlog, and the **trust model**.
- **`patterns/registry.json`** — the index (pattern #1 + candidate backlog).
- **`patterns/improvement-loop/{pattern.md,manifest.json}`** — the improvement lifecycle loop: the operate/refine counterpart to CW's build loops, described generically and parameterized.
- **`CLAUDE.md`** — repo-layout pointer.

## The core generalization: trust model

A baseline autonomous improvement loop is safe only when its signal sources are trusted insiders (its one human touchpoint is non-blocking park-and-notify). Point it at an app with **untrusted end users** and feedback/conversation signals become a prompt-injection surface.

The registry closes this:
- Signal sources are tagged `trusted` / `untrusted`; every finding and proposed change inherits trust.
- **Untrusted-derived changes quarantine and require blocking admin approval** (identity verified against CODEOWNERS / signed commit / allowlist, journaled into the tamper-evident ratchet chain) — they can never silently reach prod.
- Same pattern, trust-appropriate behavior, no fork.

## Reuses existing CW machinery

Ratchet, high-water mark, definition-hash, tamper-evident journal, and protected pathset are pointed at the *product* instead of CW's build loop. The genuinely new parts: the operate/refine loop shape, the uniform signal/Finding abstraction, and the trust model.

## Status

Design proposal — starting to capture patterns. `/apply-pattern`, the `scaffold/`, and `/seed`+`/architect` integration are proposed follow-ups (see Rollout).