### PR TITLE
patterns: concrete stack-profile layer (micro-SaaS factory) + deployment-release pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ python3 "$CW_HOME/scripts/repo.py" clean acme/app     # remove cache
 skills/              # Harness-portable skills and bundled resources
 scripts/             # Python helpers called by skills
 templates/           # Issue, PR, review, and checklist templates
+patterns/            # Registry of reusable product patterns CW stamps into built apps (see docs/patterns-registry.md)
 models.md            # AI model IDs and library versions (refresh with /update)
 ```
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -1,0 +1,228 @@
+# Patterns Registry — reusable product patterns Chief Wiggum stamps into apps
+
+> **Status: design proposal.** This document defines the patterns registry and
+> captures the first pattern (the improvement lifecycle loop). The registry entry
+> lives at `patterns/improvement-loop/`. Nothing here is wired into a workflow yet
+> — see [Rollout](#rollout).
+
+## What this is (and what it is not)
+
+Chief Wiggum already installs *artifacts* into the apps it builds: `/design`
+stamps `docs/design/`, `/architect` stamps `docs/epics/*/contracts.md`. Those
+are **per-product** artifacts, generated fresh each time.
+
+A **pattern** is one level up: a proven, opinionated, reusable *architecture +
+process* that CW knows how to stamp into **the app it is building** — the same
+way a senior engineer carries a handful of battle-tested shapes ("put a guarded
+query layer here", "gate deploys on a benchmark ratchet") from project to
+project. The registry is the curated library of those shapes.
+
+The distinction that matters:
+
+| | Home | Scope | Trust model |
+|--|--|--|--|
+| **CW workflows** (`/architect`, `/implement`) | the CW checkout | operate *on* a target repo | the operator (developer at the prompt) is trusted |
+| **A registry pattern** | defined in CW, **installed into the target repo** | becomes part of the *product's* own machinery, runs after CW walks away | the product's **end users may be untrusted** — this is the new axis |
+
+The registry is **not** about Chief Wiggum's own internals. CW itself is improved
+**directly, human-in-the-loop, through Claude Code** — the developer at the
+prompt *is* the admin, so every CW change is already admin-gated by construction.
+CW does not need an autonomous self-improvement loop bolted onto it. (The
+improvement-loop pattern is nonetheless *available* to point at CW or a CW
+subsystem later, if a case appears where an autonomous nightly pass earns its
+keep — see [Applying a pattern to CW itself](#applying-a-pattern-to-cw-itself).)
+
+## Why a registry
+
+Right now the valuable, reusable shapes CW could install are trapped inside the
+one-off apps that happen to implement them (a self-improvement loop is one). When
+CW builds the next analytics agent, nothing carries that loop forward — it would
+be re-derived, or forgotten. A registry:
+
+1. **Captures** each shape once, generically, with its parameters made explicit.
+2. **Catalogs** them so `/seed` and `/architect` can *select* patterns as part
+   of designing a product ("this is an agent over a warehouse → apply the
+   guarded-query + improvement-loop patterns").
+3. **Stamps** the pattern's scaffold into the target repo with its parameters
+   bound, then registers its protected paths with the product's ratchet.
+4. **Governs** the trust boundary — the piece a trusted-insider loop can skip but
+   a public-facing app cannot (see [Trust model](#trust-model-the-core-generalization)).
+
+## Registry layout
+
+```
+patterns/
+├── registry.json                 # the index: id, category, status, trust-class, one-liner
+├── improvement-loop/             # pattern #1 (this proposal)
+│   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
+│   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
+│   └── scaffold/                 # (future) the templated files stamped into the target app
+└── <future patterns>/
+```
+
+Each pattern is a directory. Two files are the contract:
+
+- **`pattern.md`** — the human-facing spec. What the pattern is, when to apply it,
+  the mechanism (as a set of generic components), its parameters, the reference
+  implementation it was distilled from, and its trust requirements.
+- **`manifest.json`** — the machine-readable surface a future `apply-pattern`
+  script consumes: parameter schema, the files/scaffold it installs, the paths it
+  adds to the product's protected pathset, and its trust class.
+
+`registry.json` is a thin index over the directories so a workflow can list and
+filter patterns without opening each manifest.
+
+## How a pattern gets applied (proposed `/apply-pattern`)
+
+A pattern is installed into a target repo by a new thin workflow (or a mode of
+`/architect`):
+
+```
+/apply-pattern owner/repo --pattern improvement-loop
+```
+
+Mechanically:
+
+1. **Resolve** the target repo (`scripts/repo.py`, as every workflow does).
+2. **Bind parameters** — read `manifest.json`'s parameter schema and resolve each
+   from the target app's context (its signal sources, its build/test commands,
+   its model family, its protected paths). Unresolved facts become `TBD:`
+   markers, gated exactly like every other CW artifact
+   (`scripts/check_unresolved.py`).
+3. **Stamp** the scaffold into the target repo with parameters bound.
+4. **Register protected paths** — add the pattern's `protected_paths` to the
+   product's `docs/quality/ratchet.json`, so the pattern's own guards/objective
+   become goalposts the app's autonomous machinery cannot move
+   (reuses the existing [ratchet](ratchet.md)).
+5. **Record adoption** — write `docs/patterns/adopted.json` in the target repo
+   with the pattern id, version, bound parameters, and provenance. This is the
+   product's manifest of "which CW patterns am I running, and how were they
+   configured".
+
+Patterns are **project-agnostic** and installed by *value* into the target — the
+same principle as every other CW skill. CW never hardcodes the target's
+warehouse, model, or channel; those are parameters.
+
+## Trust model — the core generalization
+
+This is the piece a **trusted-insider** loop can skip, and the reason a registry
+(rather than a copy-paste) is worth building.
+
+A baseline autonomous improvement loop runs fully autonomous to production. Its
+*one* human touchpoint is **non-blocking park-and-notify**: when a change touches
+the protected pathset, or needs domain truth the agent can't verify, it posts one
+message to a human channel and **parks** the item — it never waits for a reply.
+That is safe **only because its signal sources are trusted insiders**: the people
+whose feedback and conversations drive the loop are authenticated employees.
+
+Generalize the loop to an app with **untrusted end users** and those same signal
+inputs — user feedback text, conversation transcripts — become a **prompt-injection
+surface**. A malicious user can craft feedback engineered to get the loop to
+diagnose a "fix" that weakens a guardrail, rewrites a business rule, or plants a
+backdoor. Park-and-notify is not enough: a parked-but-eventually-auto-applied
+change is still an attacker-influenced change reaching production.
+
+The registry closes this with two additions to the pattern-as-installed:
+
+### 1. Signal sources carry a trust level
+
+Every signal source declared in the pattern's parameters is tagged
+`trusted` or `untrusted`:
+
+- `trusted` — internal/authenticated-admin origin (named insiders,
+  operator-authored benchmark cases, runtime error logs the app emits about
+  itself).
+- `untrusted` — any end-user-supplied content (public feedback, conversation
+  text from unauthenticated or low-privilege users).
+
+Trust flows through the whole chain: every `Finding` inherits `signal_trust`
+from its source, and every proposed change inherits the *lowest* trust of the
+findings in its cluster. (Runtime error logs the app emits about itself stay
+`trusted` even in a public app — the app is describing its own failure, not
+relaying user words.)
+
+### 2. Untrusted-derived changes require blocking admin approval
+
+The human gate becomes **trust-conditional**:
+
+| Change provenance | Gate |
+|--|--|
+| Derived **only** from `trusted` signals, touches no protected path | Autonomous fix-forward (the baseline model): floor + ratchet, auto-deploy |
+| Touches a **protected path** (any provenance) | Park-and-notify (the baseline model) — goalpost changes always human-reviewed |
+| Derived from **any** `untrusted` signal | **Quarantine → blocking admin approval** before it can enter the deployable set |
+
+The third row is the new one. An untrusted-derived change:
+
+1. Is written to a **quarantine** (`docs/patterns/pending-approval/<id>/` in the
+   target repo): the proposed diff + its full provenance chain (which findings,
+   which signals, verbatim source text) + the trust classification.
+2. **Cannot deploy.** It is not a parked-but-eventual change; it is inert until
+   an admin acts.
+3. Is released only by an **admin-authenticated approval** —
+   `patterns approve <id> --admin <identity>` — where admin identity is verified
+   against a real authority (CODEOWNERS / a signed approval commit / an
+   operator allowlist), **not** self-asserted by the loop.
+4. On approval, the change (and *who* approved it) is appended to the existing
+   **tamper-evident hash-chained journal** (the ratchet journal), so approvals
+   are auditable and un-forgeable — you can always prove an untrusted-derived
+   change reached prod *only* through a named admin.
+
+The result: a malicious end-user's feedback can, at worst, produce a **proposal
+in quarantine**. It can never silently become a deployed guardrail change or a
+business rule. Business rules derived from untrusted feedback are likewise marked
+`unverified` until an admin confirms them — a "domain truth needs a human ruling"
+idea, but promoted from a *domain-uncertainty* trigger to a *trust* trigger and
+hardened from park-notify into a blocking gate.
+
+This trust axis is **declared per pattern** in `manifest.json` and **bound per
+app** at apply time: an internal-only tool binds every source `trusted` and gets
+the frictionless autonomous loop; a public app binds its user-feedback source
+`untrusted` and automatically gets the quarantine gate. Same pattern,
+trust-appropriate behavior, no fork.
+
+## Candidate patterns (the backlog the registry seeds)
+
+The improvement loop distills into a set of mechanisms
+(`patterns/improvement-loop/pattern.md` catalogs them). Several are strong enough
+to stand alone as their own registry entries CW could apply independently:
+
+| Candidate pattern | One-liner | Notes |
+|--|--|--|
+| **improvement-loop** | Autonomous, signal-driven, ratchet-gated fix-forward refinement | Pattern #1, this proposal |
+| **protected-pathset + ratchet** | Monotonic quality high-water mark + fenced goalposts, embedded in the product | CW already runs this on *its own* work; the pattern is embedding it *in the built app* |
+| **decorrelated-judge / shadow-audit** | Referee model family ≠ player model family; blind re-generation to catch shared blind spots | For any product with an LLM-judge or generative success path |
+| **gate-only-holdout** | Train/holdout eval split; holdout withheld from the fixer's context | Anti-overfit for any self-modifying, test-graded product |
+| **signal-ingestion + findings** | Heterogeneous signals → one uniform, pointer-only, idempotent `Finding` shape | The abstraction that makes the loop source-agnostic; carries the trust tag |
+| **business-rules-registry** | Human corrections captured as provenance-bearing, version-controlled rules that outrank inference | The admin-approval trust gate rides on this |
+| **build-test-floor** | Language-agnostic auto-detecting build+test gate | A generic pre-merge check the loop's floor reuses |
+
+Capturing these is future work; the registry structure is built to hold them.
+
+## Applying a pattern to CW itself
+
+Because CW is also just a repo, the improvement-loop pattern *can* target it.
+That is **not the default** and not needed for normal CW development (you improve
+CW directly through Claude Code, and you are the trusted admin). But if a bounded,
+well-benchmarked CW subsystem emerges where an autonomous nightly pass earns its
+keep — say, a suite whose failures are mechanical and gradeable — the pattern is
+available to point at it. If that ever happens, every CW signal source is
+`trusted` (there are no untrusted end users at the CW prompt), so it runs in the
+frictionless autonomous mode with no quarantine gate.
+
+## Rollout
+
+Proposed, smallest-first:
+
+1. **This PR** — the registry structure + pattern #1 captured as a spec
+   (`pattern.md` + `manifest.json`) + this design doc. No workflow wiring yet.
+2. **`/apply-pattern` skill** — the thin installer described above, plus the
+   `scaffold/` for pattern #1 (the generic loop skill + scripts, with the
+   trust/quarantine gate added).
+3. **`/seed` + `/architect` integration** — pattern *selection* becomes part of
+   product design: the architecture stage proposes applicable patterns and
+   records the choice, the way `/design` records a chosen design direction.
+4. **Fill the backlog** — capture the standalone candidate patterns above as
+   their own entries.
+
+Steps 2–4 are deliberately out of scope here — this PR is about *starting to
+capture*, with one real, fully-specified entry to prove the shape.

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -52,7 +52,7 @@ be re-derived, or forgotten. A registry:
 
 ```
 patterns/
-├── registry.json                 # the index: specified patterns + mined candidates + meta-disciplines
+├── registry.json                 # the index: specified patterns + mined candidates + meta-disciplines + stacks pointer
 ├── improvement-loop/             # specified pattern
 │   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
 │   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
@@ -60,7 +60,14 @@ patterns/
 ├── engagement-instrumentation/   # specified pattern — the signal tier that feeds the loop
 │   ├── pattern.md
 │   └── manifest.json
-└── <candidate patterns>/         # mined, catalogued in registry.json, not yet fully specified
+├── <candidate patterns>/         # mined, catalogued in registry.json, not yet fully specified
+└── stacks/                       # CONCRETE layer: vendor-bound profiles (the factory) — see #stack-profiles
+    ├── registry.json             # index of stack profiles + the cost-tier ladder
+    └── gcp-serverless-saas/
+        ├── stack.md              # the house stack: topology, cost tiers, graduation triggers, provenance
+        ├── manifest.json         # machine-readable: vendors, tiers, bindings, cost model, skills
+        ├── bindings/             # pattern × this-stack → concrete recipe (one .md per bound pattern)
+        └── skills/               # runnable stand-up playbooks ("the skills to use them")
 ```
 
 Each specified pattern is a directory. Two files are the contract:
@@ -350,6 +357,70 @@ Supporting monetization candidates in `registry.json`:
 
 Fully specifying the remaining candidates (a `pattern.md` + `manifest.json` each)
 is future work; the registry structure is built to hold them.
+
+## Stack profiles — the concrete layer (the factory)
+
+Everything above is deliberately **vendor-neutral**: `provider-neutral-adapter` is
+the seam, `tiered-subscription` names no billing vendor. That abstraction is
+correct — but a catalog of seams is not yet a **factory**. To actually *stamp a
+working product* you need an opinionated, real-vendor **default** for each seam,
+wired the way that has already shipped, with the runnable steps to stand it up and a
+cost model so you know the zero-cost PoC footprint and where money starts.
+
+A **stack profile** (`patterns/stacks/<id>/`) is that default. It **binds** the
+abstract patterns to a concrete infrastructure stack, ships the **skills** to stand
+each piece up, and carries a **cost model**. The abstract pattern stays neutral (you
+can swap Cloud Run for Fly, Stripe for Paddle); the profile is the bound default the
+factory reaches for first.
+
+```
+  ABSTRACT (patterns/<id>)         CONCRETE (patterns/stacks/<id>)
+  vendor-neutral seam         ×    named vendor + wiring    →   runnable recipe + cost
+```
+
+Each profile is four things:
+
+- **`stack.md`** — the house stack: vendor table, the **cost-tier ladder**, the
+  **graduation triggers** between tiers, provenance (which shipped apps it was mined
+  from), and honest known-gaps.
+- **`manifest.json`** — machine-readable: `vendors`, `cost_tiers`,
+  `graduation_triggers`, `bindings` (pattern → recipe → source app), `skills`.
+- **`bindings/*.md`** — one per bound pattern: the concrete realization *on this
+  stack*, including the non-obvious glue and the gotchas mined from real code.
+- **`skills/*.md`** — runnable stand-up playbooks with real commands (the *"skills
+  to use them"*).
+
+### The cost axis is first-class
+
+A micro/mini-SaaS factory lives or dies on **zero-cost PoC deployments and
+predictable cost scaling**, so every profile declares a **tier ladder**: the lowest
+tier is a genuine ~$0 footprint (scale-to-zero compute, free-tier datastore, no
+vendor), and each higher tier adds one seam with its cost and a **graduation
+trigger** (the concrete signal that says "now add this"). The single most important
+number a profile surfaces is the **first real fixed-cost jump** and the **only
+uncapped variable cost** — so a builder knows exactly what they're signing up for.
+
+### First profile: `gcp-serverless-saas`
+
+The house stack behind every CW-built app so far — **Firebase Hosting + Cloud Run
+(Go) + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless
+WIF deploys** — presented as a **T0 → T1 → T2 cost ladder** ($0 static/DIY →
+$0–5 thin-serverless → $60–140 full-production). It was mined from three shipped
+apps (`plwp.net`, `booking-forms`, `dogeared-coach`) and binds
+`tiered-subscription`, `engagement-instrumentation`, `multi-tenant-isolation`
+(two variants), `provider-neutral-adapter`, `transactional-email-and-dunning`
+(dunning half flagged aspirational — honestly unbuilt in the mined apps), and
+`deployment-release`. See [`patterns/stacks/gcp-serverless-saas/stack.md`](../patterns/stacks/gcp-serverless-saas/stack.md).
+
+### How a stack profile threads through the workflow
+
+A profile extends, not replaces, the [pattern threading](#how-patterns-thread-through-the-existing-workflow):
+`/seed` selects the patterns *and* a stack profile for the product's cost tier;
+`/architect` binds the profile's concrete contracts (still with the abstract
+patterns' stable IDs); `/apply-pattern --stack` stamps the profile's scaffold and
+runs the stand-up skills; the cost tier chosen becomes an explicit product decision
+(like a chosen design direction). Every vendor stays swappable because the binding
+sits *below* the abstract pattern's neutral seam.
 
 ## Applying a pattern to CW itself
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -52,25 +52,30 @@ be re-derived, or forgotten. A registry:
 
 ```
 patterns/
-├── registry.json                 # the index: id, category, status, trust-class, one-liner
-├── improvement-loop/             # pattern #1 (this proposal)
+├── registry.json                 # the index: specified patterns + mined candidates + meta-disciplines
+├── improvement-loop/             # specified pattern
 │   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
 │   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
 │   └── scaffold/                 # (future) the templated files stamped into the target app
-└── <future patterns>/
+├── engagement-instrumentation/   # specified pattern — the signal tier that feeds the loop
+│   ├── pattern.md
+│   └── manifest.json
+└── <candidate patterns>/         # mined, catalogued in registry.json, not yet fully specified
 ```
 
-Each pattern is a directory. Two files are the contract:
+Each specified pattern is a directory. Two files are the contract:
 
 - **`pattern.md`** — the human-facing spec. What the pattern is, when to apply it,
-  the mechanism (as a set of generic components), its parameters, the reference
-  implementation it was distilled from, and its trust requirements.
+  the mechanism (as a set of generic components), its parameters, and its trust
+  requirements.
 - **`manifest.json`** — the machine-readable surface a future `apply-pattern`
   script consumes: parameter schema, the files/scaffold it installs, the paths it
   adds to the product's protected pathset, and its trust class.
 
 `registry.json` is a thin index over the directories so a workflow can list and
-filter patterns without opening each manifest.
+filter patterns without opening each manifest. It also carries **candidates**
+(patterns mined but not yet fully specified) and **meta-disciplines** (recurring
+cross-pattern rules — fail-closed, idempotency, injected seams, documented TOCTOU).
 
 ## How a pattern gets applied (proposed `/apply-pattern`)
 
@@ -182,21 +187,57 @@ trust-appropriate behavior, no fork.
 
 ## Candidate patterns (the backlog the registry seeds)
 
-The improvement loop distills into a set of mechanisms
-(`patterns/improvement-loop/pattern.md` catalogs them). Several are strong enough
-to stand alone as their own registry entries CW could apply independently:
+Candidates come from two sources: mechanisms the improvement loop decomposes into,
+and patterns **mined from shipped apps** CW has built.
 
-| Candidate pattern | One-liner | Notes |
+### From the improvement loop
+
+The loop distills into a set of mechanisms
+(`patterns/improvement-loop/pattern.md` catalogs them), several strong enough to
+stand alone:
+
+| Candidate | One-liner | Notes |
 |--|--|--|
-| **improvement-loop** | Autonomous, signal-driven, ratchet-gated fix-forward refinement | Pattern #1, this proposal |
 | **protected-pathset + ratchet** | Monotonic quality high-water mark + fenced goalposts, embedded in the product | CW already runs this on *its own* work; the pattern is embedding it *in the built app* |
 | **decorrelated-judge / shadow-audit** | Referee model family ≠ player model family; blind re-generation to catch shared blind spots | For any product with an LLM-judge or generative success path |
 | **gate-only-holdout** | Train/holdout eval split; holdout withheld from the fixer's context | Anti-overfit for any self-modifying, test-graded product |
 | **signal-ingestion + findings** | Heterogeneous signals → one uniform, pointer-only, idempotent `Finding` shape | The abstraction that makes the loop source-agnostic; carries the trust tag |
 | **business-rules-registry** | Human corrections captured as provenance-bearing, version-controlled rules that outrank inference | The admin-approval trust gate rides on this |
-| **build-test-floor** | Language-agnostic auto-detecting build+test gate | A generic pre-merge check the loop's floor reuses |
 
-Capturing these is future work; the registry structure is built to hold them.
+### Mined from a shipped multi-tenant SaaS app
+
+Mining an existing production app (genericized — no app, domain, or vendor names)
+surfaced a coherent set of reusable shapes. Two observations shaped how they land:
+
+- The **feedback/instrumentation stack** was promoted to its own specified pattern
+  ([`engagement-instrumentation`](../patterns/engagement-instrumentation/pattern.md))
+  because it is precisely the signal supply the improvement loop's *enabling
+  condition* (strong monitoring + feedback) calls for — and one of its
+  sub-patterns, a documented per-metric **trust-boundary "honesty note"**,
+  directly reinforces the [trust model](#trust-model-the-core-generalization):
+  a loop that ingests a signal must know that signal's trust class or it will
+  optimize against a gameable proxy.
+- The **multi-tenant isolation stack** is the *floor* that makes mining per-tenant
+  behavioral data safe — the loop can read across tenants for analysis without
+  leaking between them only atop a fail-closed, server-derived scoping layer.
+
+| Candidate | Category | One-liner |
+|--|--|--|
+| **multi-tenant-isolation** | saas-infra | Server-only tenant resolution → fail-closed tenant-scoped repository → standing cross-tenant isolation proof gate → quarantined cascade erasure. One multi-tenancy blueprint |
+| **provider-neutral-adapter** | multi-provider | Vendor-agnostic seam (neutral DTOs, unexported concrete types = compile-time swappability); behind it: signed-webhook-as-source-of-truth, sign-per-request access tokens, direct browser→CDN upload |
+| **reconciliation-sweep** | process-loop | Periodic bidirectional local↔external drift repair, fail-closed on unknown state, re-confirm before destroy, per-run counts report |
+| **tiered-saas-enforcement** | saas-infra | Single-source tier matrix (unlimited sentinel, restrictive fallback) + stateless quota computed fresh (self-healing, one path for enforce+display) |
+| **immutable-assignment-snapshot** | data-structure | Version-pin assigned composite items so template edits never mutate outstanding assignments; keeps completion analysis drift-free |
+| **elevated-access-session** | saas-infra | Revocable, time-boxed support impersonation with independent TTL, future-skew guard, fail-closed revocation, full audit |
+| **build-test-floor** | gate | Language-agnostic auto-detecting build+test+lint gate with local mirror; optionally zero-cost-until-opt-in |
+
+Plus **meta-disciplines** recurring across the mined patterns — fail-closed on
+unknown input, idempotency + guarded conditional updates, injected interface seams
+for every gate, documented-not-hidden TOCTOU limitations — catalogued in
+`registry.json` as rules rather than installable patterns.
+
+Fully specifying the candidates (a `pattern.md` + `manifest.json` each) is future
+work; the registry structure is built to hold them.
 
 ## Applying a pattern to CW itself
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -108,6 +108,30 @@ Patterns are **project-agnostic** and installed by *value* into the target — t
 same principle as every other CW skill. CW never hardcodes the target's
 warehouse, model, or channel; those are parameters.
 
+## How patterns thread through the existing workflow
+
+Applying a pattern is not a one-shot stamp — it threads through the existing
+build loop. The division of labor: **`/seed` selects, `/architect` binds,
+`/implement` builds, `/close-epic` verifies.** A registry pattern is best thought
+of as a **contract pack** — it ships stable-ID contracts, invariants, integration
+tests, protected paths, and parameters, and the workflow stages consume them
+rather than re-deriving.
+
+| Stage | Role with patterns |
+|--|--|
+| **`/seed`** (or the product-architecture step) | **Selects.** Proposes applicable patterns from the registry given the product's shape ("multi-tenant SaaS with untrusted users" → `multi-tenant-isolation` + `engagement-instrumentation` + `improvement-loop`), records the choice and the per-app trust bindings — the "chosen, not converged" moment, like `/design`. |
+| **`/architect`** | **Binds.** For each selected pattern this epic realizes: folds the pattern's contracts/invariants into `contracts.md` / `invariants.md` **with their stable IDs, pulled from the manifest** (not re-derived); threads its integration tests into `integration-tests.md`; registers its `protected_paths` into `docs/quality/ratchet.json`; and emits `TBD:` markers for any unbound parameter (gated by `check_unresolved.py`) so dependent tickets can't build on a guess. |
+| **`/implement` / `/implement-wave`** | **Builds.** Implements against the pattern-supplied contracts; the `scaffold/` may already be stamped by `/apply-pattern`, and tickets fill in the app-specific parameterization. Workers touching the pattern's protected paths are parked, exactly as with any goalpost. |
+| **`/close-epic`** | **Verifies.** Confirms the pattern's invariants and gates held across the epic (e.g. the cross-tenant isolation proof passes, the ratchet held, the trust gate is wired). |
+
+So the answer to "does `/architect` need to reference the patterns?" is **yes** —
+`/architect` is where a pattern stops being a catalog entry and becomes this
+epic's contracts, gates, and protected paths. Concretely: `multi-tenant-isolation`
+contributes the tenant-scoping invariant + the cross-tenant-proof integration
+test; `engagement-instrumentation` contributes the trusted-denominator +
+monotonic-latch contracts; `improvement-loop` contributes the protected-pathset +
+ratchet-gate + trust-model contracts.
+
 ## Trust model — the core generalization
 
 This is the piece a **trusted-insider** loop can skip, and the reason a registry

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -66,11 +66,15 @@ patterns/
 Each specified pattern is a directory. Two files are the contract:
 
 - **`pattern.md`** — the human-facing spec. What the pattern is, when to apply it,
-  the mechanism (as a set of generic components), its parameters, and its trust
-  requirements.
+  the mechanism (as a set of generic components), its parameters, its
+  **success metrics**, and its trust requirements.
 - **`manifest.json`** — the machine-readable surface a future `apply-pattern`
   script consumes: parameter schema, the files/scaffold it installs, the paths it
-  adds to the product's protected pathset, and its trust class.
+  adds to the product's protected pathset, its **`success_metrics`**, and its
+  trust class.
+
+Declaring **success metrics is mandatory**, not decorative — see
+[Success metrics make patterns improvable](#success-metrics-make-patterns-improvable).
 
 `registry.json` is a thin index over the directories so a workflow can list and
 filter patterns without opening each manifest. It also carries **candidates**
@@ -131,6 +135,59 @@ contributes the tenant-scoping invariant + the cross-tenant-proof integration
 test; `engagement-instrumentation` contributes the trusted-denominator +
 monotonic-latch contracts; `improvement-loop` contributes the protected-pathset +
 ratchet-gate + trust-model contracts.
+
+## Success metrics make patterns improvable
+
+Every pattern **must declare its own success metrics** (`success_metrics` in the
+manifest, a table in `pattern.md`). This is the hinge that turns a pattern from a
+static scaffold into a **self-improving unit**, and it's what makes the whole
+registry more than a snippet library:
+
+> **A pattern's metric is its objective.** The metric defines "is this working";
+> the [monitoring group](#monitoring--signal-is-a-pattern-group) captures it as
+> trust-tagged signal; the [improvement loop](../patterns/improvement-loop/pattern.md)
+> optimizes the pattern toward it; the ratchet holds it monotonic so it only ever
+> improves. Without a declared metric, the loop has nothing to optimize and the
+> pattern can only ever be as good as the day it was stamped.
+
+Each metric carries a **goal direction** (`up` / `down` / `context`), so a
+downstream loop knows which way is better without a human re-explaining it every
+iteration. Examples already specified:
+
+- `frictionless-onboarding` → `activation_rate ↑`, `time_to_first_value ↓`,
+  `free_to_paid_conversion ↑`.
+- `tiered-subscription` → `mrr ↑`, `dunning_recovery_rate ↑`, `revenue_leak ↓`.
+- `engagement-instrumentation` → `signal_coverage ↑`, `latch_integrity ↑` (a
+  monitoring pattern's metrics are about the *quality of the instrument*).
+- `improvement-loop` → `highwater_trend ↑`, `escaped_defect_rate ↓`.
+
+Because monetization and conversion metrics are optimized from **end-user
+behavioral signal** and touch **pricing/paywall goalposts**, loop-proposed changes
+against them are exactly what the [trust model](#trust-model-the-core-generalization)
+routes to **blocking admin approval** — the pattern iterates continuously, but a
+human signs off on changes to how the product makes money.
+
+## Monitoring & signal is a pattern group
+
+Patterns fall into groups, and **monitoring / signal** is a first-class one — the
+substrate the rest depend on, because *every* pattern's success metrics have to be
+captured by *something*. It's the supply side of the "declare a metric" contract
+above.
+
+| Group | Members (specified + candidate) |
+|--|--|
+| **monitoring & signal** | `engagement-instrumentation` (flagship); candidates: dual-scope `audit-log`, error-signature ingestion + `signal-ingestion + findings` (from the loop), funnel/activation capture |
+| **process loops** | `improvement-loop`, `reconciliation-sweep`, `transactional-email-and-dunning`, `referral-invite-loop` |
+| **monetization / growth** | `tiered-subscription`, `frictionless-onboarding`, `feature-entitlements`, `self-serve-billing-portal` |
+| **saas-infra** | `multi-tenant-isolation`, `provider-neutral-adapter`, `elevated-access-session` |
+| **gates** | `build-test-floor`, `protected-pathset + ratchet`, `decorrelated-judge`, `gate-only-holdout` |
+
+The three groups compose into one loop: **monitoring** captures each pattern's
+declared metric → the **improvement loop** (a process loop) optimizes toward it →
+**gates** keep it from sliding back → and the **monetization/saas-infra** patterns
+are the surfaces being improved. Grouping also guides `/seed`'s selection: pick the
+saas-infra floor, the monetization surface you're monetizing, and always the
+monitoring group underneath so the rest are measurable.
 
 ## Trust model — the core generalization
 
@@ -250,18 +307,49 @@ surfaced a coherent set of reusable shapes. Two observations shaped how they lan
 | **multi-tenant-isolation** | saas-infra | Server-only tenant resolution → fail-closed tenant-scoped repository → standing cross-tenant isolation proof gate → quarantined cascade erasure. One multi-tenancy blueprint |
 | **provider-neutral-adapter** | multi-provider | Vendor-agnostic seam (neutral DTOs, unexported concrete types = compile-time swappability); behind it: signed-webhook-as-source-of-truth, sign-per-request access tokens, direct browser→CDN upload |
 | **reconciliation-sweep** | process-loop | Periodic bidirectional local↔external drift repair, fail-closed on unknown state, re-confirm before destroy, per-run counts report |
-| **tiered-saas-enforcement** | saas-infra | Single-source tier matrix (unlimited sentinel, restrictive fallback) + stateless quota computed fresh (self-healing, one path for enforce+display) |
 | **immutable-assignment-snapshot** | data-structure | Version-pin assigned composite items so template edits never mutate outstanding assignments; keeps completion analysis drift-free |
 | **elevated-access-session** | saas-infra | Revocable, time-boxed support impersonation with independent TTL, future-skew guard, fail-closed revocation, full audit |
 | **build-test-floor** | gate | Language-agnostic auto-detecting build+test+lint gate with local mirror; optionally zero-cost-until-opt-in |
 
 Plus **meta-disciplines** recurring across the mined patterns — fail-closed on
 unknown input, idempotency + guarded conditional updates, injected interface seams
-for every gate, documented-not-hidden TOCTOU limitations — catalogued in
+for every gate, documented-not-hidden TOCTOU limitations, external state
+authoritative via signed webhooks not client redirects — catalogued in
 `registry.json` as rules rather than installable patterns.
 
-Fully specifying the candidates (a `pattern.md` + `manifest.json` each) is future
-work; the registry structure is built to hold them.
+### Mini-SaaS growth & monetization
+
+The reusable building blocks every product-led SaaS re-implements. Two were
+promoted to **specified** patterns (they carry the clearest "re-used *and improved
+on*" story — the loop optimizes them over time, admin-gated because they touch how
+the product asks for money):
+
+- [`tiered-subscription`](../patterns/tiered-subscription/pattern.md) — subscribe →
+  enforce → lifecycle, with billing webhooks as source of truth and **non-destructive**
+  degradation on downgrade/lapse. Absorbs the mined `tiered-saas-enforcement`.
+- [`frictionless-onboarding`](../patterns/frictionless-onboarding/pattern.md) —
+  value-first free tier, contextual upgrade prompts at limit-hit friction points,
+  optional reverse trial. Consumes `tiered-subscription` + `engagement-instrumentation`.
+
+The **through-line** the loop makes real: a limit-hit `409` from tiered-subscription
+is the upgrade trigger for onboarding; the resulting conversion funnel is captured
+by engagement-instrumentation as trust-tagged signal; the improvement loop optimizes
+prompt copy / thresholds / trial length against that funnel — but every such change
+is **admin-gated**, because it's driven by end-user behavior (an injection surface)
+and touches pricing/paywall (a goalpost). Continuously improved, human always signs
+off on the ask for money.
+
+Supporting monetization candidates in `registry.json`:
+
+| Candidate | Category | One-liner |
+|--|--|--|
+| **transactional-email-and-dunning** | process-loop | Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge, re-engagement, failed-payment dunning with bounded retries + send-once keys. Recovery outcomes are retention signal |
+| **referral-invite-loop** | process-loop | Invite → signed single-use expiring token → attribution → two-sided reward. Reuses the signed-token discipline; a self-serve growth loop |
+| **feature-entitlements** | saas-infra | One resolver: capability flags from tier + per-account overrides + grandfathering, queried identically by backend gates and frontend UI |
+| **self-serve-billing-portal** | saas-infra | User-managed plan / payment / seats; provider-hosted portal session + a webhook-authoritative local mirror. Kills the #1 support-ticket class |
+
+Fully specifying the remaining candidates (a `pattern.md` + `manifest.json` each)
+is future work; the registry structure is built to hold them.
 
 ## Applying a pattern to CW itself
 

--- a/patterns/deployment-release/manifest.json
+++ b/patterns/deployment-release/manifest.json
@@ -1,0 +1,64 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/deployment-release/pattern.md. Mined from two shipped GCP apps (keyless WIF + promote-identical-image + staging-auto/prod-gate + bundle-guard).",
+  "id": "deployment-release",
+  "version": 1,
+  "title": "Deployment & Release",
+  "category": "gate",
+  "trust_class": "deploy-pipeline-and-promotion-authority-are-protected-path",
+
+  "applies_when": [
+    "product is deployed to a hosted environment on a cadence (essentially every SaaS)",
+    "you need a provable 'what we tested is what we shipped' guarantee",
+    "CI must reach the cloud without long-lived stored credentials"
+  ],
+
+  "components": [
+    "keyless-federated-ci-identity: CI mints a short-lived OIDC token scoped to the exact repo; no long-lived cloud keys at rest",
+    "environment-split-with-promotion-gate: merge->staging auto-deploy after floor; production is manual human-gated promotion (protected env / required reviewers)",
+    "promote-identical-artifact: prod ships the byte-identical staged build (pull/retag/push, no rebuild); per-env rebuild is documented exception behind the fence",
+    "config-leak-fence: mechanical assertion that the artifact carries no lower-env config/secrets; fail-closed",
+    "least-privilege-deploy-identity: deployer can roll releases but cannot mutate infra or read secret values; infra changes are a separate human-run privileged path",
+    "floor-gated: no deploy without build/test/lint floor passing, mirrored locally",
+    "post-deploy-smoke: assert liveness + core-dependency health before the deploy is considered live",
+    "secret-containers-out-of-band-values: IaC creates secret containers + grants runtime read; values added out-of-band, never in state or repo"
+  ],
+
+  "parameters": {
+    "ci_provider": {"type": "string", "required": true, "description": "CI system minting the OIDC identity."},
+    "cloud": {"type": "string", "required": true, "description": "Target cloud."},
+    "federated_identity": {"type": "object", "required": true, "description": "Keyless workload-identity binding scoped to the source repo."},
+    "environments": {"type": "array", "required": true, "description": "Ordered env list; each with its deploy trigger and gate."},
+    "promote_strategy": {"enum": ["identical-artifact", "rebuild-guarded"], "required": false, "default": "identical-artifact", "description": "How prod gets its artifact."},
+    "floor_cmd": {"type": "string", "required": true, "description": "Build/test/lint floor, mirrored locally."},
+    "build_guard_cmd": {"type": "string", "required": false, "description": "Config-leak fence assertion."},
+    "smoke_cmd": {"type": "string", "required": true, "description": "Post-deploy liveness + dependency-health check."},
+    "deployer_permissions": {"type": "object", "required": true, "description": "Least-privilege set: roll-release yes; mutate-infra / read-secrets no."},
+    "prod_promotion_authority": {"type": "string", "required": true, "description": "How a human is required to approve prod (protected env / required reviewers / signed promotion)."}
+  },
+
+  "success_metrics": {
+    "$comment": "DORA-flavored delivery health. Pipeline definition is protected-path, so changes to how deploys happen are always human-reviewed.",
+    "metrics": [
+      {"id": "deploy_frequency", "goal": "up", "desc": "releases reaching prod per unit time"},
+      {"id": "lead_time_to_prod", "goal": "down", "desc": "merged-commit -> live-in-prod latency"},
+      {"id": "change_failure_rate", "goal": "down", "desc": "% of prod deploys causing an incident / rollback"},
+      {"id": "staging_prod_drift", "goal": "down", "desc": "build/config divergence between staging and prod (target 0; asserted by identical-artifact + fence)"},
+      {"id": "hotfix_rate", "goal": "down", "desc": "out-of-band emergency deploys (proxy for gate escapes)"}
+    ]
+  },
+
+  "protected_paths": [
+    "the CI/CD workflow definitions",
+    "the promotion gate + required-reviewer config",
+    "the federated-identity bindings",
+    "the config-leak fence script"
+  ],
+
+  "depends_on": {
+    "build-test-floor": "the floor is the pre-condition gate enforced before any deploy"
+  },
+
+  "feeds": {
+    "improvement-loop": "deploy frequency / change-failure / smoke outcomes are operational signal; the loop's deploy_cmd is realized here; pipeline defs are protected-path so loop changes to them are human-gated"
+  }
+}

--- a/patterns/deployment-release/pattern.md
+++ b/patterns/deployment-release/pattern.md
@@ -1,0 +1,124 @@
+# Pattern: Deployment & Release
+
+- **Category:** gate (delivery)
+- **Trust class:** the deploy pipeline and prod-promotion authority are protected-path (goalpost-grade)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+The **build → stage → promote** machinery that gets a change from a merged commit
+to production **safely and provably**: keyless CI identity, an environment split
+with a human-gated production promotion, promotion of the **byte-identical
+artifact** that passed staging (so "tested" and "shipped" are the same bits), a
+mechanical config-leak fence, a least-privilege deploy identity that can roll
+releases but not mutate infrastructure, and post-deploy smoke verification.
+
+It is the delivery counterpart to `build-test-floor`
+(candidate): the floor answers *"does this build and pass?"*; this pattern answers
+*"how does a passing build reach production without drift, leaked config, or an
+over-privileged robot?"*. Most teams re-derive this per product and get one of the
+subtle parts wrong (rebuilding for prod → staging/prod drift; long-lived CI keys →
+credential blast radius; a deployer that can also read secrets → lateral movement).
+
+## When to apply
+
+Any product shipped to a hosted environment on a cadence — i.e. essentially every
+SaaS. The value compounds with the number of deploys and the sensitivity of the
+target; a weekend project deploying by hand can skip it, a product taking money
+cannot.
+
+## Mechanism — generic components
+
+Neutral throughout; the CI system, cloud, and identity provider are
+[parameters](#parameters).
+
+- **Keyless federated CI identity.** CI authenticates to the cloud with a
+  **short-lived token minted from the CI provider's OIDC**, scoped to the *exact*
+  source repository — **no long-lived stored cloud keys**. A leaked CI log or fork
+  PR cannot exfiltrate a credential that does not exist at rest.
+- **Environment split with a promotion gate.** At least `staging` and `production`.
+  Merge to the main branch **auto-deploys to staging** (after the floor passes);
+  production is a **manual, human-gated promotion** (protected environment /
+  required reviewers), never an automatic consequence of a merge. The prod trigger
+  is explicit (`workflow_dispatch` / tag / signed promotion), so "we merged" and
+  "we shipped" are decoupled decisions.
+- **Promote the identical artifact — by digest.** Production ships the
+  **byte-identical build** that passed staging, referenced by its **immutable content
+  digest** (not a mutable tag, which can be repointed after validation); pull the
+  staged image, retag, push, deploy the digest — **do not rebuild**. A
+  rebuild can pick up a different dependency, a different base image, or different
+  build-time config, silently breaking the "what we tested is what we shipped"
+  guarantee. Where a per-environment rebuild is unavoidable (e.g. a frontend bundle
+  that inlines the environment's public config), it is the **documented exception**
+  and it runs behind the config-leak fence below.
+- **Config-leak fence (build guard).** Before an artifact can ship, a mechanical
+  check asserts it contains **no lower-environment config or secrets** (staging
+  URLs, demo keys, test-mode flags). Fail-closed: a match blocks the release. This
+  is what makes a per-environment rebuild safe when it can't be avoided.
+- **Least-privilege deploy identity.** The deployer identity can **roll a release**
+  (deploy an image, publish hosting) but **cannot mutate infrastructure or read
+  secret values**. Infra changes (new secrets, IAM, service topology) are a
+  **separate, privileged, human-run path** (e.g. `terraform apply` from an operator
+  workspace), so a compromised or misbehaving deploy job has a bounded blast radius.
+- **Floor-gated.** No deploy without the `build-test-floor` (candidate) gate
+  passing first — build + test + lint, mirrored locally by a pre-merge script so
+  the gate is reproducible off-CI.
+- **Post-deploy smoke verification.** After each roll, assert a **liveness + core-
+  dependency health signal** (e.g. a `/healthz` that checks the datastore) before
+  the deploy is considered live; a failed smoke fails the release.
+- **Secret containers, out-of-band values.** Infra provisioning creates the secret
+  *containers* and grants the runtime identity read access to exactly those; the
+  **values are added out-of-band** and never live in the IaC state or the repo.
+
+## Parameters
+
+| Parameter | What it is |
+|--|--|
+| `ci_provider` | the CI system minting the OIDC identity |
+| `cloud` + `federated_identity` | target cloud and the keyless workload-identity binding (scoped to the repo) |
+| `environments[]` | ordered env list (`staging`, `production`, …), each with its deploy trigger + gate |
+| `promote_strategy` | `identical-artifact` (default) or `rebuild-guarded` (per-env rebuild behind the fence) |
+| `floor_cmd` | build/test/lint floor, mirrored locally |
+| `build_guard_cmd` | the config-leak fence assertion |
+| `smoke_cmd` | post-deploy liveness + dependency-health check |
+| `deployer_permissions` | least-privilege set: roll-release yes, mutate-infra / read-secrets no |
+| `prod_promotion_authority` | how a human is required to approve prod (protected env / required reviewers / signed promotion) |
+
+## Success metrics
+
+Delivery health (DORA-flavored); the loop can tune cadence/gating toward these,
+but the **pipeline definition itself is protected-path**, so changes to *how*
+deploys happen are always human-reviewed:
+
+| Metric | Goal | What it measures |
+|--|--|--|
+| `deploy_frequency` | ↑ | releases reaching prod per unit time |
+| `lead_time_to_prod` | ↓ | merged-commit → live-in-prod latency |
+| `change_failure_rate` | ↓ | % of prod deploys causing an incident / rollback |
+| `staging_prod_drift` | ↓ | build/config divergence between staging and prod (target 0; asserted by identical-artifact + the fence) |
+| `hotfix_rate` | ↓ | out-of-band emergency deploys (a proxy for gate escapes) |
+
+## Trust model
+
+The **deploy pipeline definition** (workflow files, promotion gate, the identity
+bindings, the build guard) and **who is allowed to promote to production** are
+**goalpost-grade**: a wrong change here is a direct route to shipping unreviewed or
+malicious code. They belong in the [improvement-loop](../improvement-loop/pattern.md#trust-model)
+**protected pathset** — the loop may *propose* pipeline improvements, but every
+such change routes through **park-and-notify** (trusted signal) or the
+**blocking admin-approval quarantine** (any untrusted signal). Production-promotion
+authority is verified against a real authority (protected environment / CODEOWNERS
+/ signed promotion), **never self-asserted** by an automated actor.
+
+## Relationship to other patterns
+
+- **Sits above `build-test-floor`** (candidate) — the floor
+  is the pre-condition gate this pattern enforces before any deploy.
+- **Emits the deploy signal `improvement-loop` needs** — deploy frequency, change-
+  failure, and smoke outcomes are exactly the operational signal a post-ship loop
+  consumes; the loop's own `deploy_cmd` parameter is realized by this pattern.
+- **Its smoke + health surface is a [monitoring](../../docs/patterns-registry.md#monitoring--signal-is-a-pattern-group)
+  signal source** — `/healthz` and post-deploy verification feed the same
+  observability substrate the other patterns' metrics ride on.
+- **Provider-neutral by construction** — cloud, CI, and identity provider are
+  parameters, so the same pattern binds to any keyless-OIDC-capable stack.

--- a/patterns/engagement-instrumentation/manifest.json
+++ b/patterns/engagement-instrumentation/manifest.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/engagement-instrumentation/pattern.md.",
+  "id": "engagement-instrumentation",
+  "version": 1,
+  "title": "Engagement Instrumentation",
+  "category": "monitoring-feedback",
+  "trust_class": "produces-trust-tagged-signal",
+
+  "applies_when": [
+    "product assigns work/content and 'did the user engage with / complete it' is worth answering",
+    "you want deliberate, robust feedback signal (retention/funnel/drop-off), not best-effort telemetry",
+    "designed in from the start — the value is the server-trusted monotonic discipline, not a later patch"
+  ],
+
+  "components": [
+    "client-throttled-emitter: throttle steady ticks, flush on boundary, keepalive on unmount, skip without trusted denominator, no-retry (server is monotonic), preview-never-writes guard",
+    "server-trusted-monotonic-tracker: one row per (assignment, item), lazy create, tenant-scoped, monotonic-max progress, one-way completion latch past threshold, server-trusted denominator (client duration advisory only), upsert (max/set/set-on-insert) with dup-key retry, bounded roll-up query budget",
+    "trust-boundary-honesty-note: per-metric statement of what it proves vs not; robust-against-bugs != robust-against-adversary; enumerate accepted races",
+    "dual-scope-audit-log: append-only tenant-scoped + system-global event trails"
+  ],
+
+  "parameters": {
+    "work_item": {"type": "string", "required": true, "description": "The entity whose engagement is tracked."},
+    "completion_threshold": {"type": "number", "required": true, "description": "Fraction past which the one-way completed latch trips."},
+    "trusted_denominator": {"type": "string", "required": true, "description": "Server-side source of truth for the completion denominator (pinned-at-assignment snapshot or canonical record)."},
+    "throttle_interval": {"type": "string", "required": false, "default": "10s", "description": "Steady-state client report cadence."},
+    "event_source": {"type": "string", "required": true, "description": "Player/content events the client emitter subscribes to."},
+    "signal_trust": {"type": "string", "required": true, "description": "Per-metric trust class annotation; feeds the improvement-loop trust model."}
+  },
+
+  "feeds": {
+    "improvement-loop": "supplies signal_sources of kind 'conversations'/'feedback'/'errors' analog: per-item completion, drop-off, last-activity, plus audit-log events; the per-metric signal_trust is the input to the loop's trust model"
+  },
+
+  "depends_on": {
+    "multi-tenant-isolation": "mining per-tenant behavioral data safely requires a fail-closed, server-derived tenant-scoping data layer"
+  }
+}

--- a/patterns/engagement-instrumentation/manifest.json
+++ b/patterns/engagement-instrumentation/manifest.json
@@ -32,6 +32,15 @@
     "improvement-loop": "supplies signal_sources of kind 'conversations'/'feedback'/'errors' analog: per-item completion, drop-off, last-activity, plus audit-log events; the per-metric signal_trust is the input to the loop's trust model"
   },
 
+  "success_metrics": {
+    "$comment": "This pattern IS a monitoring pattern, so its metrics are about signal quality/coverage — the health of the instrument the loop depends on.",
+    "metrics": [
+      {"id": "signal_coverage", "goal": "up", "desc": "% of assigned work-items with tracked engagement"},
+      {"id": "latch_integrity", "goal": "up", "desc": "monotonic-latch never-regressed invariant holds (violations -> 0)"},
+      {"id": "funnel_resolvability", "goal": "up", "desc": "drop-off computable per funnel step (denominator trusted, no gaps)"}
+    ]
+  },
+
   "depends_on": {
     "multi-tenant-isolation": "mining per-tenant behavioral data safely requires a fail-closed, server-derived tenant-scoping data layer"
   }

--- a/patterns/engagement-instrumentation/pattern.md
+++ b/patterns/engagement-instrumentation/pattern.md
@@ -1,0 +1,112 @@
+# Pattern: Engagement Instrumentation
+
+- **Category:** monitoring-feedback
+- **Trust class:** produces trust-tagged signal (each metric annotated with what it proves)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+The instrumentation tier that captures **how the product is actually doing** —
+how far users get through the work/content assigned to them — in a way that is
+robust against out-of-order reports, replays, concurrent writers, and client
+clock/duration drift. It produces per-item and rolled-up completion/engagement
+signals, each annotated with its trust class.
+
+This is the **companion to the [improvement-loop](../improvement-loop/pattern.md)
+pattern**: strong monitoring and feedback is that loop's one enabling condition,
+and this pattern is how you *build* that signal deliberately rather than hoping it
+exists. Its per-signal trust annotation is exactly what the loop's
+[trust model](../improvement-loop/pattern.md#trust-model) consumes to decide
+whether a signal-derived change may auto-deploy or must be admin-approved.
+
+## When to apply
+
+Apply to any content or task product where "did the user actually engage with /
+complete what they were given" is a question worth answering — which is nearly
+all of them. It is table-stakes for retention/funnel analysis, and the correctness
+subtleties below are subtle enough that most teams get them wrong.
+
+Do **not** bolt it on as an afterthought: the value is in the *server-trusted,
+monotonic* discipline, which has to be designed in, not patched later.
+
+## Mechanism — generic components
+
+Neutral throughout; the "work item", completion threshold, and player/event
+source are [parameters](#parameters).
+
+### Client-side throttled emitter
+
+- Subscribe to the content/player events (progress tick, pause, end, teardown).
+- **Throttle** steady-state progress ticks (e.g. one report per ~10s); **flush
+  immediately** on meaningful boundaries (pause / end / unmount).
+- The unmount flush uses a **keepalive** request so it survives in-app teardown.
+- **Skip reporting while no trusted denominator exists yet** (don't emit progress
+  you can't ground).
+- **No retry** beyond the next natural event — safe *because* the server latch is
+  monotonic, so a lost report only delays, never loses, eventual state.
+- A **"preview never writes"** guard: reporting is disabled entirely unless a real
+  assignment context is present, so admin/preview views never pollute telemetry.
+
+### Server-trusted monotonic tracker
+
+- **One row per (assignment, work-item)**, created lazily on first report,
+  tenant-scoped, never deleted by user action.
+- The client self-reports position + duration, but completion fraction is computed
+  **only from a server-trusted denominator** (a duration/size snapshot pinned at
+  assignment time, or the canonical item record). The **client-reported duration
+  is stored as advisory telemetry only** — never as the denominator.
+- Progress advances with a **monotonic-max** operator so it never regresses;
+  **"completed" is a one-way latch** that trips past a threshold fraction and never
+  unsets.
+- Writes are a single **upsert**: `max` for the monotonic latches, `set` for
+  last-activity, `set-on-insert` for immutable fields. A duplicate-key on
+  concurrent first-insert is caught and retried once.
+- Roll-up summaries use a **bounded query budget per page** (one aggregation + one
+  lookup), never per-item fan-out.
+
+### Trust-boundary honesty note (per signal)
+
+- Alongside each metric's contract, write down **what it can and cannot prove**:
+  it is self-reported; the server hardens it against *accidental* corruption
+  (trusted denominators, monotonic latches, server-side attribution) but the
+  measured party can still inflate their *own* diligence — accepted when the only
+  person they can fool is themselves.
+- Enumerate known races and their **bounded, non-security** impact as accepted
+  limitations rather than hiding them.
+- This makes each signal's **trust class explicit** so nothing downstream — least
+  of all a self-improvement loop — optimizes against a gameable proxy.
+
+### Dual-scope audit log (complementary event source)
+
+- Two append-only logs: a **tenant-scoped** one (actions a tenant should see,
+  flowing through the tenant-isolated repository) and a **system-global** one
+  (provider-less background/operational events).
+- Entries carry actor, action, target, timestamp, optional metadata. A rich,
+  immutable event source for behavioral and operational analysis.
+
+## Parameters
+
+| Parameter | What it is |
+|--|--|
+| `work_item` | the entity whose engagement is tracked |
+| `completion_threshold` | fraction past which the one-way "completed" latch trips |
+| `trusted_denominator` | server-side source of truth for the completion denominator (pinned-at-assignment snapshot or canonical record) |
+| `throttle_interval` | steady-state client report cadence |
+| `event_source` | the player/content events the client emitter subscribes to |
+| `signal_trust` | per-metric trust class annotation (feeds the improvement loop) |
+
+## Relationship to other patterns
+
+- **Feeds `improvement-loop`.** The per-item completion rates, drop-off points,
+  and last-activity timestamps are the funnel/retention signal the loop consumes;
+  the audit logs are a second event source. The per-signal trust annotation is the
+  input to the loop's trust model.
+- **Depends on a tenant-isolation floor.** Mining per-tenant behavioral data is
+  only safe atop server-derived tenant scoping (see the
+  `multi-tenant-isolation` candidate in [`registry.json`](../registry.json)) —
+  the fail-closed data layer is what lets the loop read across tenants without
+  leaking between them.
+- **Reuses CW disciplines.** The trust-boundary note is the product-signal analog
+  of CW's contract discipline; the monotonic latch + fail-closed race handling are
+  the same "ratchet, never slide" stance CW applies to quality, applied here to a
+  metric.

--- a/patterns/engagement-instrumentation/pattern.md
+++ b/patterns/engagement-instrumentation/pattern.md
@@ -95,6 +95,17 @@ source are [parameters](#parameters).
 | `event_source` | the player/content events the client emitter subscribes to |
 | `signal_trust` | per-metric trust class annotation (feeds the improvement loop) |
 
+## Success metrics
+
+This pattern *is* a monitoring pattern, so its own metrics are about the health of
+the instrument — the signal quality every other pattern's metrics depend on:
+
+| Metric | Goal | What it measures |
+|--|--|--|
+| `signal_coverage` | ↑ | % of assigned work-items with tracked engagement |
+| `latch_integrity` | ↑ | the monotonic-latch never-regressed invariant holds (violations → 0) |
+| `funnel_resolvability` | ↑ | drop-off computable per funnel step (trusted denominator, no gaps) |
+
 ## Relationship to other patterns
 
 - **Feeds `improvement-loop`.** The per-item completion rates, drop-off points,

--- a/patterns/frictionless-onboarding/manifest.json
+++ b/patterns/frictionless-onboarding/manifest.json
@@ -1,0 +1,51 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/frictionless-onboarding/pattern.md.",
+  "id": "frictionless-onboarding",
+  "version": 1,
+  "title": "Frictionless Onboarding (free -> upgrade)",
+  "category": "monetization",
+  "trust_class": "conversion-changes-are-end-user-signal-driven",
+
+  "applies_when": [
+    "product-led-growth SaaS with a free or trial tier converting to paid",
+    "self-serve upgrade, no sales touch",
+    "NOT for sales-led / enterprise-only products with human onboarding"
+  ],
+
+  "components": [
+    "value-first-free-tier: no credit card, free tier delivers a real complete unit of value, TTFV is the north-star",
+    "activation-instrumentation: define the aha activation event, instrument signup->activation->habit->upgrade funnel (trust-tagged) via engagement-instrumentation",
+    "progressive-disclosure: minimum up front, defer friction, collect more only when a feature needs it",
+    "just-in-time-upgrade-prompts: triggered by friction signals (limit-hit 409, locked-capability tap, approaching quota), not time-based nags; one-click self-serve",
+    "reverse-trial(optional): time-boxed premium with server-enforced independent TTL, then fall back to free",
+    "recovery-loops: activation nudges + failed-payment dunning via transactional-email-and-dunning"
+  ],
+
+  "parameters": {
+    "activation_event": {"type": "string", "required": true, "description": "The instrumented aha moment (funnel success step)."},
+    "free_tier_value_unit": {"type": "string", "required": true, "description": "The complete unit of value the free tier delivers."},
+    "upgrade_triggers": {"type": "array", "required": true, "description": "Friction signals that surface a contextual upgrade prompt."},
+    "reverse_trial_length": {"type": "string", "required": false, "description": "Optional time-boxed premium window; omit to disable."},
+    "nudge_cadence": {"type": "string", "required": false, "description": "Activation/re-engagement email schedule."}
+  },
+
+  "success_metrics": {
+    "$comment": "Conversion funnel; the loop's optimization target for this pattern, admin-gated (proposals touch pricing/paywall + are end-user-signal-driven).",
+    "metrics": [
+      {"id": "activation_rate", "goal": "up", "desc": "% of signups reaching the aha activation event"},
+      {"id": "time_to_first_value", "goal": "down", "desc": "TTFV: signup -> first real value"},
+      {"id": "free_to_paid_conversion", "goal": "up", "desc": "% of free users upgrading to paid"},
+      {"id": "prompt_conversion", "goal": "up", "desc": "contextual upgrade-prompt -> upgrade rate"},
+      {"id": "reverse_trial_conversion", "goal": "up", "desc": "% converting after the reverse-trial window (if enabled)"}
+    ]
+  },
+
+  "depends_on": {
+    "tiered-subscription": "limit-hit gate is the upgrade trigger; one-click upgrade drops into its lifecycle",
+    "engagement-instrumentation": "the activation/conversion funnel is captured as trust-tagged engagement signal"
+  },
+
+  "feeds": {
+    "improvement-loop": "conversion funnel is the optimization target; but proposals touch paywall/pricing (goalpost) and are end-user-signal-driven (untrusted), so they route to BLOCKING admin approval, never silent auto-deploy"
+  }
+}

--- a/patterns/frictionless-onboarding/pattern.md
+++ b/patterns/frictionless-onboarding/pattern.md
@@ -1,0 +1,90 @@
+# Pattern: Frictionless Onboarding (free → upgrade)
+
+- **Category:** monetization (growth process-loop)
+- **Trust class:** conversion changes are end-user-signal-driven → admin-gated in the loop
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+Minimize **time-to-value** on a free tier, then convert to paid at natural
+friction points — self-serve, no sales touch. The design goal is that a new user
+reaches a real, complete unit of value *before* being asked for money, and the
+upgrade ask arrives *at the moment the user feels the ceiling*, not as a blanket
+nag.
+
+This is the mini-SaaS pattern **most improved by the [improvement
+loop](../improvement-loop/pattern.md)**: activation and conversion rates are its
+optimization target. It only works if the funnel is instrumented — so it composes
+directly with [`engagement-instrumentation`](../engagement-instrumentation/pattern.md).
+
+## When to apply
+
+Any product-led-growth SaaS with a free (or trial) tier converting to paid. Not
+for sales-led / enterprise-only products where onboarding is a human process.
+
+## Mechanism — generic components
+
+- **Value-first free tier.** No credit card to start. The free tier delivers a
+  **real, complete unit of value**, not a crippled demo. Time-to-first-value
+  (TTFV) is the north-star metric — everything below serves shrinking it.
+- **Activation instrumentation.** Define the **"aha" activation event** (the first
+  moment of real value) and instrument the funnel `signup → activation → habit →
+  upgrade` via `engagement-instrumentation`, each step **trust-tagged**. You cannot
+  improve a funnel you can't see.
+- **Progressive disclosure.** Ask for the minimum up front; defer account/config
+  friction; collect more only when a feature actually needs it. Every required
+  field before activation is a drop-off risk.
+- **Just-in-time contextual upgrade prompts.** The upgrade ask is triggered by
+  **friction signals** — a limit-hit (`409` from the `tiered-subscription`
+  enforcement seam), a tap on a locked capability, approaching a quota — **not**
+  time-based nags. The prompt is shown *in context* and the upgrade path is
+  one-click self-serve into the `tiered-subscription` flow.
+- **Reverse trial (optional).** Start new users in a **time-boxed premium**
+  experience, then fall back to free — converting on loss-aversion once they've
+  felt the ceiling from above. The elevated entitlement is time-boxed with a
+  server-enforced TTL (same "independent TTL, fail-closed expiry" discipline as
+  the `elevated-access-session` candidate), so the trial can't be extended
+  client-side.
+- **Recovery loops.** If a user signs up but doesn't activate, a nudge sequence
+  fires; failed upgrade payments enter dunning. Both run through
+  `transactional-email-and-dunning` (candidate) — idempotent, provider-neutral.
+
+## Parameters
+
+| Parameter | What it is |
+|--|--|
+| `activation_event` | the instrumented "aha" moment (the funnel's success step) |
+| `free_tier_value_unit` | the complete unit of value the free tier delivers |
+| `upgrade_triggers` | the friction signals that surface a contextual prompt |
+| `reverse_trial_length` | optional time-boxed premium window (omit to disable) |
+| `nudge_cadence` | activation/re-engagement email schedule |
+
+## Success metrics
+
+The conversion funnel — this pattern's whole reason to exist, and the loop's
+optimization target for it (admin-gated):
+
+| Metric | Goal | What it measures |
+|--|--|--|
+| `activation_rate` | ↑ | % of signups reaching the aha activation event |
+| `time_to_first_value` | ↓ | TTFV: signup → first real value |
+| `free_to_paid_conversion` | ↑ | % of free users upgrading to paid |
+| `prompt_conversion` | ↑ | contextual upgrade-prompt → upgrade rate |
+| `reverse_trial_conversion` | ↑ | % converting after the reverse-trial window (if enabled) |
+
+## Relationship to other patterns
+
+- **Consumes `tiered-subscription`** — the limit-hit gate is the primary upgrade
+  trigger; the one-click upgrade drops into its lifecycle.
+- **Composes with `engagement-instrumentation`** — the activation/conversion funnel
+  *is* engagement signal, captured with the same server-trusted, trust-tagged
+  discipline.
+- **The through-line to `improvement-loop`.** This pattern is where "re-used **and
+  improved on**" is most literal: the loop can propose changes to prompt copy,
+  trigger thresholds, nudge timing, and reverse-trial length, scored against the
+  conversion funnel. But because those proposals are **driven by end-user
+  behavioral signal** (an injection/gaming surface) and touch **paywall/pricing
+  entitlements** (goalpost-grade), they are exactly the changes the loop's
+  [trust model](../improvement-loop/pattern.md#trust-model) routes to **blocking
+  admin approval** — never silent auto-deploy. The pattern is continuously
+  optimized, but a human always signs off on how the product asks for money.

--- a/patterns/improvement-loop/manifest.json
+++ b/patterns/improvement-loop/manifest.json
@@ -1,0 +1,88 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/improvement-loop/pattern.md.",
+  "id": "improvement-loop",
+  "version": 1,
+  "title": "Improvement Lifecycle Loop",
+  "category": "process-loop",
+  "trust_class": "trust-aware",
+
+  "applies_when": [
+    "product has a stream of gradeable outcomes (conversations/requests/transactions)",
+    "product has a deterministic benchmark to ratchet against",
+    "editable surfaces (prompts/config/code) are separable from goalposts (objective/guardrails/gate)"
+  ],
+
+  "parameters": {
+    "signal_sources": {
+      "type": "array",
+      "required": true,
+      "description": "Heterogeneous signal inputs, each normalized to a Finding.",
+      "items": {
+        "kind": {"enum": ["conversations", "feedback", "errors", "backlog"], "required": true},
+        "locator": {"type": "string", "required": true, "description": "How to read the source (connection/collection/path/query)."},
+        "trust": {"enum": ["trusted", "untrusted"], "required": true, "description": "trusted = internal/authenticated-admin origin; untrusted = end-user-supplied content. Drives the human gate. An app's own error logs stay trusted even in a public app."}
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "required": true,
+      "fields": {
+        "strict_cmd": {"type": "string", "required": true, "description": "Command emitting per-case pass/fail for the strict (deterministic) pass-set."},
+        "golden_dir": {"type": "string", "required": true, "description": "Fix-visible benchmark cases."},
+        "holdout_dir": {"type": "string", "required": false, "description": "Gate-only cases withheld from the fixer's context."}
+      }
+    },
+    "floor_cmd": {"type": "string", "required": true, "description": "Language-agnostic build/test floor (e.g. a pre-merge-check script)."},
+    "product_model_family": {"type": "string", "required": true, "description": "Operational model family under test."},
+    "judge_model_family": {"type": "string", "required": true, "description": "Decorrelated judge family; MUST differ from product_model_family."},
+    "protected_paths": {"type": "array", "required": true, "description": "Goalposts the loop must not move; added to the app's ratchet protected pathset.", "items": {"type": "string"}},
+    "human_channel": {"type": "string", "required": true, "description": "Destination for park-and-notify and approval requests."},
+    "admin_authority": {"type": "object", "required": true, "description": "How admin identity is verified for approvals.", "fields": {
+      "kind": {"enum": ["codeowners", "signed-commit", "allowlist"], "required": true},
+      "locator": {"type": "string", "required": false}
+    }},
+    "deploy_cmd": {"type": "string", "required": true, "description": "Fix-forward deploy command (no rollback)."},
+    "schedule": {"type": "string", "required": false, "default": "nightly", "description": "Iteration cadence."}
+  },
+
+  "installs": {
+    "$comment": "Files the pattern stamps into the target repo. scaffold/ is NOT YET BUILT — these are the intended install targets.",
+    "app_skill": ".app/skills/improvement-loop/SKILL.md",
+    "scripts": ".app/skills/improvement-loop/scripts/{ingest_*,recent_errors,synthesize,ratchet,guard_protected_paths,recent_queries}.py",
+    "judge_rubric": ".app/skills/improvement-loop/judge_rubric.md",
+    "state_dir": ".app/skills/improvement-loop/state/",
+    "business_rules": "docs/business-rules.md",
+    "quarantine_dir": "docs/patterns/pending-approval/",
+    "adoption_record": "docs/patterns/adopted.json"
+  },
+
+  "protected_paths_added": [
+    "eval/**",
+    ".app/skills/improvement-loop/scripts/ratchet.py",
+    ".app/skills/improvement-loop/scripts/guard_protected_paths.sh",
+    ".app/skills/improvement-loop/state/**",
+    ".app/skills/improvement-loop/judge_rubric.md",
+    "docs/quality/**"
+  ],
+
+  "trust_model": {
+    "$comment": "The core generalization. See docs/patterns-registry.md#trust-model.",
+    "finding_trust": "each Finding inherits signal_trust from its source",
+    "change_trust": "a proposed change inherits the LOWEST trust of the findings in its cluster",
+    "gates": [
+      {"provenance": "only trusted signals, no protected path", "gate": "autonomous-fix-forward", "blocking": false},
+      {"provenance": "touches a protected path (any provenance)", "gate": "park-and-notify", "blocking": false},
+      {"provenance": "any untrusted signal", "gate": "quarantine-then-admin-approval", "blocking": true}
+    ],
+    "approval": {
+      "command": "patterns approve <id> --admin <identity>",
+      "identity_verified_against": "admin_authority parameter (codeowners/signed-commit/allowlist), never self-asserted",
+      "journaled": "approval and approver appended to the tamper-evident ratchet journal"
+    }
+  },
+
+  "requires_target": {
+    "ratchet": "reuses docs/quality/ratchet.json (scripts/ratchet.py) for the high-water mark, journal, and protected pathset",
+    "unresolved_gate": "unbound parameters become TBD: markers gated by scripts/check_unresolved.py"
+  }
+}

--- a/patterns/improvement-loop/manifest.json
+++ b/patterns/improvement-loop/manifest.json
@@ -81,6 +81,16 @@
     }
   },
 
+  "success_metrics": {
+    "$comment": "What 'this pattern is working' means, and what the loop optimizes toward. Captured by the monitoring group; ratcheted so they only move up.",
+    "metrics": [
+      {"id": "highwater_trend", "goal": "up", "desc": "strict benchmark pass-set high-water mark; the ratchet enforces never-down"},
+      {"id": "finding_close_rate", "goal": "up", "desc": "% of diagnosed finding-clusters resolved vs still-open after N iterations"},
+      {"id": "escaped_defect_rate", "goal": "down", "desc": "high-water cases that regressed live post-deploy (target 0; detected by replay)"},
+      {"id": "autonomy_ratio", "goal": "context", "desc": "% changes auto-deployed vs parked/quarantined; measures remaining human load"}
+    ]
+  },
+
   "requires_target": {
     "ratchet": "reuses docs/quality/ratchet.json (scripts/ratchet.py) for the high-water mark, journal, and protected pathset",
     "unresolved_gate": "unbound parameters become TBD: markers gated by scripts/check_unresolved.py"

--- a/patterns/improvement-loop/pattern.md
+++ b/patterns/improvement-loop/pattern.md
@@ -1,0 +1,208 @@
+# Pattern: Improvement Lifecycle Loop
+
+- **Category:** process-loop
+- **Trust class:** trust-aware (behavior depends on per-app signal-trust binding)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+A self-improvement loop installed **into the product** that acts as the product's
+**error function**: after CW ships the app, the loop runs on a schedule, consumes
+the app's runtime signals (conversations, user feedback, error logs, real
+requests), diagnoses each into a finding, clusters findings into structural
+issues, fixes them forward across any product surface (prompts, contracts, config,
+code), gates the change on a deterministic ratchet, and — depending on the trust
+of the signals that drove it — either auto-deploys or quarantines for admin
+approval.
+
+It is the **operate/refine** counterpart to CW's **build** loops. CW's existing
+loops take an app from nothing to shipped (`/seed → /architect → /implement-wave
+→ /close-epic`). This pattern is what the app runs *itself*, afterward, to keep
+improving without a human writing every ticket.
+
+## When to apply
+
+Apply when the built product has **all three** of:
+
+1. **A stream of gradeable outcomes** — conversations, requests, or transactions
+   whose quality can be judged (by assertion or by a decorrelated judge).
+2. **A deterministic benchmark** — a golden set the loop can ratchet against, so
+   "fix forward, no rollback" is survivable.
+3. **A safe blast radius** — surfaces the loop may edit (prompts, config, code)
+   are separable from the goalposts it must not (objective, guardrails, the gate
+   itself).
+
+Do **not** apply to a product with no benchmark and no gradeable outcome stream —
+the loop has no error signal and no floor, and autonomy is unsafe.
+
+## Mechanism — generic components
+
+Every component is generic and technology-agnostic. Concrete choices
+(warehouse/datastore, operational vs judge model, notification channel, deploy
+target, ticketing system) are **parameters** — see [Parameters](#parameters).
+
+### Loop shape
+
+- **Inner/outer split** — cheap continuous per-item diagnosis (inner) feeds a
+  periodic batch improvement (outer). Per-item granularity is what makes later
+  clustering possible.
+- **One skill invocation = one iteration**, scheduled via cron/`/loop` (e.g.
+  nightly), **not** CI-triggered. Cloud automation (a scheduler invoking the skill
+  headless) is a deferred deployment shape, not a requirement.
+
+### Signals in (the error-function inputs)
+
+- **Uniform Finding abstraction** — every heterogeneous source normalizes to one
+  `Finding` shape: pointer-only evidence (trace/conversation/execution id, never
+  inlined PII), a stable idempotency key of `(source_id, signals_digest)` that
+  deliberately excludes agent version so the same problem dedupes across builds,
+  and a **`signal_trust` tag**.
+- **Conversation + feedback ingestion** — real transcripts and explicit user
+  corrections. Feedback outranks inference: the user's text becomes both
+  `root_cause` and a `proposed_fix`, with provenance.
+- **Runtime error ingestion** — operational failures (panics, guardrail trips,
+  5xx) grouped by a **normalized signature** (volatile tokens stripped) with a
+  `sufficient|INSUFFICIENT` context flag. Diagnosed *without* the judge (objective
+  evidence).
+- **Real-backlog ingestion** — resolved real requests with known-good answers
+  become benchmark cases extending the same schema; unanswered ones are
+  judge-graded and kept out of the strict ratchet.
+
+### Diagnose (inner loop)
+
+- **Decorrelated, stake-free judge** — when quality is LLM-judged, the judge is a
+  **different model family** from the operational model AND sees only the rubric +
+  transcript (never the fix/diff). Judge output is **advisory forever**; only
+  deterministic cases are *trusted* by the ratchet. `judge_family` is recorded so
+  judge drift is observable.
+- **Shadow / differential re-generation** — for *successful* outputs, blindly
+  re-generate twice with fresh decorrelated agents and semantically diff against
+  production, splitting "generator wrong" from "grounding wrong". Dry-run
+  validated, never executed.
+
+### Improve (outer loop)
+
+- **Deterministic clustering → ranked queue** — group findings on
+  (surface × failure_mode), rank by severity × mass, **pin ratchet regressions
+  first**. Deterministic so priority is un-game-able. Cluster mass is a
+  corroboration threshold: a lone low-confidence finding can't solo-trigger a fix.
+- **Fix forward** across any product surface; **no rollback** (the next
+  iteration's signals catch slips).
+- **Amnesia context** — inject the last N iteration records so the fixer doesn't
+  re-try a fix it already regressed. The gate-only holdout is withheld from this
+  same context.
+- **Observability ratchet** — when an error can't be root-caused from its log
+  (INSUFFICIENT), the fix is to *enrich the log site*, not guess the bug; a stable
+  site tag links old→new signature and a follow-up tracks it until it recurs
+  (root-cause then) or goes quiet. Each iteration reduces next-run ambiguity.
+
+### Gates (deterministic; the loop cannot move these)
+
+- **Build/test floor** — language-agnostic auto-detecting `does it build + pass`.
+- **Deterministic ratchet** — the strict benchmark pass-set is a monotonic
+  high-water mark **derived from the journal of deployed iterations**, not a
+  separately-writable file. A deploy is blocked unless the current pass-set is a
+  superset. Plus a **definition-hash** guard: a case that keeps its id but weakens
+  its assertion does not count as passing. **→ this is CW's [ratchet](../../docs/ratchet.md), used as a hard pre-deploy gate.**
+- **Tamper-evident hash-chained journal** — iteration outcomes form an append-only
+  hash chain; the high-water mark is derived from the verified chain, so lowering
+  the bar by editing state is detectable and fails closed. **→ identical to CW's ratchet journal.**
+- **Gate-only holdout** — a benchmark split withheld from the fixer's context and
+  run only at the gate, so the fixer can't overfit-and-ship.
+- **Protected pathset** — a git-diff fence over the files that *define correct*,
+  *enforce safe*, or *are the gate*. **Fail-closed**: unresolvable base → unsafe;
+  protected touched → park; clean → proceed. **→ this is CW's [protected pathset](../../docs/ratchet.md).**
+
+### Human touchpoint
+
+- **Baseline behavior (trusted signals): park-and-notify, non-blocking.** A
+  protected-path touch or an unverifiable domain-truth question posts one deduped
+  message to a human channel and **parks** the item; the loop never waits — a
+  future iteration consumes the human's out-of-band reply. This is safe only when
+  the signal sources are trusted.
+- **Untrusted signals: quarantine + blocking admin approval.** See
+  [Trust model](#trust-model).
+
+### Governance
+
+- **Authority split (code as black box)** — business rules = human authority;
+  code = agent authority. The loop may re-architect the product but never move its
+  own goalposts (benchmark, guardrails, gate scripts, its own spec/state) — those
+  are the protected pathset.
+- **Self-reducing-friction lane** — the loop may improve *its own procedure*
+  (helpers, skill body) but not its own *guards* (ratchet/guard/state/judge), which
+  stay protected. Guard-adjacent self-edits auto-park.
+
+## Trust model
+
+The core design decision. A baseline loop assumes **trusted signal sources** (the
+people whose feedback and conversations drive it are authenticated insiders), so
+its only human gate is non-blocking park-and-notify. Apps with **untrusted end
+users** turn feedback/conversation signals into a **prompt-injection surface** — a
+malicious user can craft feedback engineered to get the loop to diagnose a "fix"
+that weakens a guardrail or plants a backdoor. So the pattern adds a trust axis.
+Full rationale in [`docs/patterns-registry.md`](../../docs/patterns-registry.md#trust-model-the-core-generalization).
+
+1. **Signal sources are tagged `trusted` or `untrusted`** at apply time. Every
+   `Finding` inherits `signal_trust`; every proposed change inherits the **lowest**
+   trust of the findings in its cluster. (An app's own runtime error logs stay
+   `trusted` — the app describes its own failure, not user words.)
+
+2. **The human gate is trust-conditional:**
+
+   | Change provenance | Gate |
+   |--|--|
+   | Only `trusted` signals, no protected path | Autonomous fix-forward → auto-deploy |
+   | Touches a protected path (any provenance) | Park-and-notify (goalpost review) |
+   | **Any `untrusted` signal** | **Quarantine → blocking admin approval** |
+
+3. **Quarantine (`docs/patterns/pending-approval/<id>/` in the target app):** the
+   proposed diff + full provenance chain (findings, signals, verbatim source text)
+   + trust classification. The change is **inert** — not parked-but-eventual;
+   it cannot deploy.
+
+4. **Release requires admin-authenticated approval** —
+   `patterns approve <id> --admin <identity>`, where admin identity is verified
+   against a real authority (CODEOWNERS / signed approval commit / operator
+   allowlist), never self-asserted. On approval the change **and its approver** are
+   appended to the tamper-evident journal, so you can always prove an
+   untrusted-derived change reached prod only through a named admin.
+
+An internal-only app binds every source `trusted` and gets the frictionless
+autonomous loop. A public app binds its user-feedback source `untrusted` and
+automatically gets the quarantine gate. **Same pattern, no fork.**
+
+## Parameters
+
+Bound per app at apply time (schema in [`manifest.json`](./manifest.json)):
+
+| Parameter | What it is |
+|--|--|
+| `signal_sources[]` | each `{kind, locator, trust}` — conversations / feedback / errors / backlog, with its trust level |
+| `benchmark.strict_cmd` | deterministic per-case pass/fail extractor |
+| `benchmark.golden_dir` / `holdout_dir` | fix-visible vs gate-only eval |
+| `floor_cmd` | build/test floor |
+| `product_model_family` | the operational model (judge must differ) |
+| `judge_model_family` | decorrelated judge family |
+| `protected_paths[]` | goalposts the loop can't move |
+| `human_channel` | park-and-notify + approval destination |
+| `admin_authority` | how admin identity is verified for approvals |
+| `deploy_cmd` | fix-forward deploy |
+| `schedule` | iteration cadence |
+
+## Relationship to existing CW machinery
+
+This pattern is **mostly a repackaging of machinery CW already owns**, pointed at
+the *product* instead of at CW's build loop:
+
+- Ratchet, high-water mark, definition-hash, tamper-evident journal → CW's
+  [`docs/ratchet.md`](../../docs/ratchet.md) / `scripts/ratchet.py`, essentially verbatim.
+- Protected pathset → CW's protected pathset, same concept.
+- Human-parks-goalpost-changes → CW's "workers can't move their own goalposts".
+- Traceability of findings → CW's `@cw-trace` / [`docs/traceability.md`](../../docs/traceability.md) spirit.
+- `TBD:`/`UNRESOLVED:` gating of unbound parameters → `scripts/check_unresolved.py`.
+
+The genuinely **new** parts are: (a) the **operate/refine loop shape** itself
+(CW has no post-ship loop), (b) the **signal abstraction** (uniform Finding over
+heterogeneous sources), and (c) the **trust model** (quarantine + blocking admin
+approval for untrusted-derived changes).

--- a/patterns/improvement-loop/pattern.md
+++ b/patterns/improvement-loop/pattern.md
@@ -22,18 +22,29 @@ improving without a human writing every ticket.
 
 ## When to apply
 
-Apply when the built product has **all three** of:
+The one enabling condition is **strong monitoring and feedback**. Wherever a
+product emits rich signal about how it's actually doing — quality-gradeable
+outcomes, explicit user corrections, structured error telemetry — the loop has
+something real to act on. This is not specific to conversational or analytics
+agents; any system with good observability + feedback is a candidate. Conversely,
+a product with weak monitoring has no error signal, and the loop has nothing to
+drive it — don't bother.
 
-1. **A stream of gradeable outcomes** — conversations, requests, or transactions
-   whose quality can be judged (by assertion or by a decorrelated judge).
-2. **A deterministic benchmark** — a golden set the loop can ratchet against, so
-   "fix forward, no rollback" is survivable.
-3. **A safe blast radius** — surfaces the loop may edit (prompts, config, code)
-   are separable from the goalposts it must not (objective, guardrails, the gate
-   itself).
+Signal strength gets the loop *value*. Two further properties govern *how
+autonomous* it's allowed to be — this is a spectrum, not a yes/no:
 
-Do **not** apply to a product with no benchmark and no gradeable outcome stream —
-the loop has no error signal and no floor, and autonomy is unsafe.
+| Monitoring / feedback | Deterministic gate (benchmark + trust) | Loop runs as |
+|--|--|--|
+| Strong | Strong — golden benchmark to ratchet against, and trusted signals | Fully autonomous fix-forward, auto-deploy |
+| Strong | Weak / none, **or** any untrusted signal | Loop still surfaces, diagnoses, and *proposes* — but **every change is human-gated** (quarantine → approval; no auto-deploy) |
+| Weak | (any) | Not a candidate — no error signal to drive it |
+
+So a **deterministic benchmark** and a **safe blast radius** (editable surfaces
+separable from the goalposts the loop must not move) aren't preconditions for
+running the loop — they're what unlocks the *autonomous* column. Without them, or
+with untrusted signals, the loop is still valuable as a human-gated proposer. The
+[trust model](#trust-model) is the mechanism that places a given change in the
+right row.
 
 ## Mechanism — generic components
 

--- a/patterns/improvement-loop/pattern.md
+++ b/patterns/improvement-loop/pattern.md
@@ -201,6 +201,18 @@ Bound per app at apply time (schema in [`manifest.json`](./manifest.json)):
 | `deploy_cmd` | fix-forward deploy |
 | `schedule` | iteration cadence |
 
+## Success metrics
+
+Every pattern declares the metrics that define "it's working" — they are what the
+loop optimizes toward and what the ratchet holds monotonic. The loop's own:
+
+| Metric | Goal | What it measures |
+|--|--|--|
+| `highwater_trend` | ↑ | strict benchmark pass-set high-water mark (ratchet enforces never-down) |
+| `finding_close_rate` | ↑ | % of diagnosed finding-clusters resolved vs still-open after N iterations |
+| `escaped_defect_rate` | ↓ | high-water cases that regressed live post-deploy (target 0; caught by replay) |
+| `autonomy_ratio` | context | % changes auto-deployed vs parked/quarantined — the remaining human load |
+
 ## Relationship to existing CW machinery
 
 This pattern is **mostly a repackaging of machinery CW already owns**, pointed at

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}. Candidates are mined but not yet fully specified.",
+  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}. Candidates are mined/known but not yet fully specified.",
   "version": 1,
   "patterns": [
     {
@@ -22,13 +22,39 @@
       "feeds": "improvement-loop",
       "spec": "patterns/engagement-instrumentation/pattern.md",
       "manifest": "patterns/engagement-instrumentation/manifest.json"
+    },
+    {
+      "id": "tiered-subscription",
+      "title": "Tiered Subscription",
+      "category": "saas-infra",
+      "status": "specified",
+      "trust_class": "entitlement-changes-are-protected-path",
+      "summary": "Subscribe -> enforce -> lifecycle machinery for a plan-tiered SaaS: single-source tier matrix, injected gate seams, stateless quota, billing-webhook as source of truth, and non-destructive graceful degradation on downgrade/lapse. Absorbs the former tiered-saas-enforcement candidate.",
+      "feeds": "frictionless-onboarding, improvement-loop",
+      "spec": "patterns/tiered-subscription/pattern.md",
+      "manifest": "patterns/tiered-subscription/manifest.json"
+    },
+    {
+      "id": "frictionless-onboarding",
+      "title": "Frictionless Onboarding (free -> upgrade)",
+      "category": "monetization",
+      "status": "specified",
+      "trust_class": "conversion-changes-are-end-user-signal-driven",
+      "summary": "Minimize time-to-value on a free tier, convert at contextual friction points (limit-hit prompts, optional reverse trial), self-serve. The mini-SaaS pattern most improved by the loop -- and, since its proposals touch pricing/paywall driven by end-user behavior, always admin-gated.",
+      "depends_on": "tiered-subscription, engagement-instrumentation",
+      "feeds": "improvement-loop",
+      "spec": "patterns/frictionless-onboarding/pattern.md",
+      "manifest": "patterns/frictionless-onboarding/manifest.json"
     }
   ],
   "candidates": [
     {"id": "multi-tenant-isolation", "title": "Multi-Tenant Isolation Stack", "category": "saas-infra", "status": "candidate", "summary": "Server-only tenant resolution (rejects client hints) -> context-injected, fail-closed tenant-scoped repository (AND-wrapped filters, reject-don't-override, recursive field-scan, unexported handles) -> standing cross-tenant isolation proof as an executable test gate (positive controls + negative matrix + no-foreign-id-in-denial) -> quarantined transactional cascade erasure. Composes into one multi-tenancy blueprint; the floor that makes mining per-tenant data safe.", "reusability": "high"},
     {"id": "provider-neutral-adapter", "title": "Provider-Neutral Port/Adapter", "category": "multi-provider", "status": "candidate", "summary": "Vendor-agnostic seam for a swappable external service: neutral DTOs only, concrete vendor types unexported (compile-time swappability), vendor states mapped to internal enums with safe defaults. Behind it: signed-webhook ingestion normalized to idempotent internal events (webhook is source of truth, not the client callback), sign-per-request short-lived access tokens, and direct browser->CDN upload via a one-time server-minted ticket.", "reusability": "high"},
     {"id": "reconciliation-sweep", "title": "Bidirectional Reconciliation Sweep", "category": "process-loop", "status": "candidate", "summary": "Periodic job repairing divergence between local records and an external system in both directions plus a stale-in-flight sweep. Fail-closed on unknown age, re-confirm before destructive action, idempotent guarded updates, per-run counts report. Its run reports and audit stream are operational-health signal.", "reusability": "high"},
-    {"id": "tiered-saas-enforcement", "title": "Tiered-SaaS Limit Enforcement", "category": "saas-infra", "status": "candidate", "summary": "Single-source-of-truth tier matrix (unlimited sentinel, unknown-tier falls back to most-restrictive) enforced via injected check-before-act gate seams; stateless quota computed fresh from source of truth (no stored counters, self-healing on delete) with one shared path for enforce + display and pessimistic in-flight reservation. Limit-hit events are strong upgrade-intent signal.", "reusability": "high"},
+    {"id": "transactional-email-and-dunning", "title": "Transactional Email & Dunning Lifecycle", "category": "process-loop", "status": "candidate", "summary": "Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge (fires if a signed-up user hasn't hit the activation event), re-engagement, and a failed-payment dunning sequence with bounded retries before degrade. Send-once keys prevent duplicate sends across retries. Recovery outcomes are conversion/retention signal.", "reusability": "high"},
+    {"id": "referral-invite-loop", "title": "Referral / Invite Growth Loop", "category": "process-loop", "status": "candidate", "summary": "Invite -> signed invite token (server-trusted, single-use, expiring) -> attribution on accept -> reward both sides. Reuses the signed-token discipline; attribution is trust-tagged signal. A self-serve growth loop the improvement loop can optimize (reward size/copy) under admin gating.", "reusability": "medium-high"},
+    {"id": "feature-entitlements", "title": "Feature Entitlements Read-Model", "category": "saas-infra", "status": "candidate", "summary": "A single entitlement resolver deriving capability flags from tier + per-account overrides + grandfathering, consumed identically by backend gates and the frontend (one source of 'what can this account do'). Distinct from the tier matrix: it layers overrides and is the read model onboarding + UI both query.", "reusability": "medium-high"},
+    {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"},
     {"id": "immutable-assignment-snapshot", "title": "Immutable Assignment Snapshot", "category": "data-structure", "status": "candidate", "summary": "Pin the exact version of a composite item at assignment time (draft -> immutable published version -> assignment references a version, not the live template) so later edits never retroactively mutate outstanding assignments. Keeps longitudinal completion analysis clean (no denominator drift).", "reusability": "medium-high"},
     {"id": "elevated-access-session", "title": "Revocable Elevated-Access Session", "category": "saas-infra", "status": "candidate", "summary": "Time-boxed support impersonation with a short server-enforced TTL independent of the identity token, future-skew guard, per-request self-consistency check, fail-closed revocation lookup, fixed middleware order, and full audit. High value but only for products needing operator act-as.", "reusability": "medium"},
     {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test+lint gate across a polyglot repo, with a local pre-merge script mirroring CI; optionally zero-cost-until-opt-in (manual-dispatch trigger) for cost-sensitive private repos.", "reusability": "medium"}
@@ -37,9 +63,10 @@
     "$comment": "Recurring cross-pattern engineering rules worth stating once, not registry entries themselves.",
     "rules": [
       "fail-closed on unknown/ambiguous input (grace windows, revocation lookups, tenant resolution, unknown-tier fallback)",
-      "idempotency + guarded conditional updates for anything touching external state",
+      "idempotency + guarded conditional updates for anything touching external state (incl. send-once keys for messaging)",
       "injected interface seams for every gate so services stay testable without real infra",
-      "document accepted TOCTOU/limitation classes inline rather than hiding them"
+      "document accepted TOCTOU/limitation classes inline rather than hiding them",
+      "external state changes are authoritative via signed webhooks, never the client redirect"
     ]
   }
 }

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}.",
+  "version": 1,
+  "patterns": [
+    {
+      "id": "improvement-loop",
+      "title": "Improvement Lifecycle Loop",
+      "category": "process-loop",
+      "status": "specified",
+      "trust_class": "trust-aware",
+      "summary": "Autonomous, signal-driven, ratchet-gated fix-forward refinement installed into the product. Trusted-signal changes deploy autonomously; untrusted-signal (end-user) changes quarantine for blocking admin approval.",
+      "spec": "patterns/improvement-loop/pattern.md",
+      "manifest": "patterns/improvement-loop/manifest.json"
+    }
+  ],
+  "candidates": [
+    {"id": "protected-pathset-ratchet", "title": "Protected Pathset + Deterministic Ratchet", "category": "gate", "status": "candidate", "summary": "Monotonic quality high-water mark + fenced goalposts, embedded in the built product (CW already runs this on its own work)."},
+    {"id": "decorrelated-judge", "title": "Decorrelated Judge / Shadow Audit", "category": "gate", "status": "candidate", "summary": "Referee model family must differ from the player model family; blind re-generation catches shared blind spots."},
+    {"id": "gate-only-holdout", "title": "Gate-Only Holdout Split", "category": "gate", "status": "candidate", "summary": "Train/holdout eval split; holdout withheld from the fixer's context to prevent overfit-and-ship."},
+    {"id": "signal-ingestion-findings", "title": "Signal Ingestion + Findings Store", "category": "data-structure", "status": "candidate", "summary": "Heterogeneous signals normalized into one uniform, pointer-only, idempotent Finding shape carrying a trust tag."},
+    {"id": "business-rules-registry", "title": "Business-Rules Registry", "category": "human-touchpoint", "status": "candidate", "summary": "Human corrections captured as provenance-bearing, version-controlled rules that outrank inference; the admin-approval trust gate rides on this."},
+    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test gate across a polyglot repo."}
+  ]
+}

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}.",
+  "$comment": "Index of reusable product patterns Chief Wiggum can stamp into the apps it builds. See docs/patterns-registry.md. Each entry points at patterns/<id>/{pattern.md,manifest.json}. Candidates are mined but not yet fully specified.",
   "version": 1,
   "patterns": [
     {
@@ -11,14 +11,35 @@
       "summary": "Autonomous, signal-driven, ratchet-gated fix-forward refinement installed into the product. Trusted-signal changes deploy autonomously; untrusted-signal (end-user) changes quarantine for blocking admin approval.",
       "spec": "patterns/improvement-loop/pattern.md",
       "manifest": "patterns/improvement-loop/manifest.json"
+    },
+    {
+      "id": "engagement-instrumentation",
+      "title": "Engagement Instrumentation",
+      "category": "monitoring-feedback",
+      "status": "specified",
+      "trust_class": "produces-trust-tagged-signal",
+      "summary": "Server-trusted, tamper-resistant capture of how far users get through assigned work/content, robust to out-of-order/replay/concurrent/clock-drift. The instrumentation tier that feeds the improvement loop; each signal annotated with its trust class.",
+      "feeds": "improvement-loop",
+      "spec": "patterns/engagement-instrumentation/pattern.md",
+      "manifest": "patterns/engagement-instrumentation/manifest.json"
     }
   ],
   "candidates": [
-    {"id": "protected-pathset-ratchet", "title": "Protected Pathset + Deterministic Ratchet", "category": "gate", "status": "candidate", "summary": "Monotonic quality high-water mark + fenced goalposts, embedded in the built product (CW already runs this on its own work)."},
-    {"id": "decorrelated-judge", "title": "Decorrelated Judge / Shadow Audit", "category": "gate", "status": "candidate", "summary": "Referee model family must differ from the player model family; blind re-generation catches shared blind spots."},
-    {"id": "gate-only-holdout", "title": "Gate-Only Holdout Split", "category": "gate", "status": "candidate", "summary": "Train/holdout eval split; holdout withheld from the fixer's context to prevent overfit-and-ship."},
-    {"id": "signal-ingestion-findings", "title": "Signal Ingestion + Findings Store", "category": "data-structure", "status": "candidate", "summary": "Heterogeneous signals normalized into one uniform, pointer-only, idempotent Finding shape carrying a trust tag."},
-    {"id": "business-rules-registry", "title": "Business-Rules Registry", "category": "human-touchpoint", "status": "candidate", "summary": "Human corrections captured as provenance-bearing, version-controlled rules that outrank inference; the admin-approval trust gate rides on this."},
-    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test gate across a polyglot repo."}
-  ]
+    {"id": "multi-tenant-isolation", "title": "Multi-Tenant Isolation Stack", "category": "saas-infra", "status": "candidate", "summary": "Server-only tenant resolution (rejects client hints) -> context-injected, fail-closed tenant-scoped repository (AND-wrapped filters, reject-don't-override, recursive field-scan, unexported handles) -> standing cross-tenant isolation proof as an executable test gate (positive controls + negative matrix + no-foreign-id-in-denial) -> quarantined transactional cascade erasure. Composes into one multi-tenancy blueprint; the floor that makes mining per-tenant data safe.", "reusability": "high"},
+    {"id": "provider-neutral-adapter", "title": "Provider-Neutral Port/Adapter", "category": "multi-provider", "status": "candidate", "summary": "Vendor-agnostic seam for a swappable external service: neutral DTOs only, concrete vendor types unexported (compile-time swappability), vendor states mapped to internal enums with safe defaults. Behind it: signed-webhook ingestion normalized to idempotent internal events (webhook is source of truth, not the client callback), sign-per-request short-lived access tokens, and direct browser->CDN upload via a one-time server-minted ticket.", "reusability": "high"},
+    {"id": "reconciliation-sweep", "title": "Bidirectional Reconciliation Sweep", "category": "process-loop", "status": "candidate", "summary": "Periodic job repairing divergence between local records and an external system in both directions plus a stale-in-flight sweep. Fail-closed on unknown age, re-confirm before destructive action, idempotent guarded updates, per-run counts report. Its run reports and audit stream are operational-health signal.", "reusability": "high"},
+    {"id": "tiered-saas-enforcement", "title": "Tiered-SaaS Limit Enforcement", "category": "saas-infra", "status": "candidate", "summary": "Single-source-of-truth tier matrix (unlimited sentinel, unknown-tier falls back to most-restrictive) enforced via injected check-before-act gate seams; stateless quota computed fresh from source of truth (no stored counters, self-healing on delete) with one shared path for enforce + display and pessimistic in-flight reservation. Limit-hit events are strong upgrade-intent signal.", "reusability": "high"},
+    {"id": "immutable-assignment-snapshot", "title": "Immutable Assignment Snapshot", "category": "data-structure", "status": "candidate", "summary": "Pin the exact version of a composite item at assignment time (draft -> immutable published version -> assignment references a version, not the live template) so later edits never retroactively mutate outstanding assignments. Keeps longitudinal completion analysis clean (no denominator drift).", "reusability": "medium-high"},
+    {"id": "elevated-access-session", "title": "Revocable Elevated-Access Session", "category": "saas-infra", "status": "candidate", "summary": "Time-boxed support impersonation with a short server-enforced TTL independent of the identity token, future-skew guard, per-request self-consistency check, fail-closed revocation lookup, fixed middleware order, and full audit. High value but only for products needing operator act-as.", "reusability": "medium"},
+    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test+lint gate across a polyglot repo, with a local pre-merge script mirroring CI; optionally zero-cost-until-opt-in (manual-dispatch trigger) for cost-sensitive private repos.", "reusability": "medium"}
+  ],
+  "meta_disciplines": {
+    "$comment": "Recurring cross-pattern engineering rules worth stating once, not registry entries themselves.",
+    "rules": [
+      "fail-closed on unknown/ambiguous input (grace windows, revocation lookups, tenant resolution, unknown-tier fallback)",
+      "idempotency + guarded conditional updates for anything touching external state",
+      "injected interface seams for every gate so services stay testable without real infra",
+      "document accepted TOCTOU/limitation classes inline rather than hiding them"
+    ]
+  }
 }

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -45,8 +45,26 @@
       "feeds": "improvement-loop",
       "spec": "patterns/frictionless-onboarding/pattern.md",
       "manifest": "patterns/frictionless-onboarding/manifest.json"
+    },
+    {
+      "id": "deployment-release",
+      "title": "Deployment & Release",
+      "category": "gate",
+      "status": "specified",
+      "trust_class": "deploy-pipeline-and-promotion-authority-are-protected-path",
+      "summary": "build -> stage -> promote machinery that gets a change to prod safely and provably: keyless federated CI identity, environment split with a human-gated prod promotion, promotion of the byte-identical staged artifact, a config-leak fence, a least-privilege deploy identity that can roll releases but not mutate infra/read secrets, and post-deploy smoke verification. Mined from two shipped GCP apps.",
+      "feeds": "improvement-loop",
+      "spec": "patterns/deployment-release/pattern.md",
+      "manifest": "patterns/deployment-release/manifest.json"
     }
   ],
+  "stacks": {
+    "$comment": "Concrete stack profiles bind these vendor-neutral patterns to a real infrastructure stack + runnable stand-up skills + a cost model. This is the layer that turns the catalog into a micro/mini-SaaS factory. Index: patterns/stacks/registry.json. See docs/patterns-registry.md#stack-profiles.",
+    "index": "patterns/stacks/registry.json",
+    "profiles": [
+      {"id": "gcp-serverless-saas", "summary": "Firebase Hosting + Cloud Run + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless WIF, as a T0->T1->T2 cost ladder ($0 PoC -> paid prod).", "provenance": ["plwp.net", "booking-forms", "dogeared-coach"]}
+    ]
+  },
   "candidates": [
     {"id": "multi-tenant-isolation", "title": "Multi-Tenant Isolation Stack", "category": "saas-infra", "status": "candidate", "summary": "Server-only tenant resolution (rejects client hints) -> context-injected, fail-closed tenant-scoped repository (AND-wrapped filters, reject-don't-override, recursive field-scan, unexported handles) -> standing cross-tenant isolation proof as an executable test gate (positive controls + negative matrix + no-foreign-id-in-denial) -> quarantined transactional cascade erasure. Composes into one multi-tenancy blueprint; the floor that makes mining per-tenant data safe.", "reusability": "high"},
     {"id": "provider-neutral-adapter", "title": "Provider-Neutral Port/Adapter", "category": "multi-provider", "status": "candidate", "summary": "Vendor-agnostic seam for a swappable external service: neutral DTOs only, concrete vendor types unexported (compile-time swappability), vendor states mapped to internal enums with safe defaults. Behind it: signed-webhook ingestion normalized to idempotent internal events (webhook is source of truth, not the client callback), sign-per-request short-lived access tokens, and direct browser->CDN upload via a one-time server-minted ticket.", "reusability": "high"},

--- a/patterns/stacks/gcp-serverless-saas/bindings/deployment-release.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/deployment-release.md
@@ -1,0 +1,87 @@
+# Binding: `deployment-release` → keyless WIF on GCP + GitHub Actions
+
+- **Realizes:** [`deployment-release`](../../../deployment-release) (vendor-neutral spec)
+- **Tier:** T1+ · **Vendor:** GitHub Actions + GCP Workload Identity Federation · **Source:** `booking-forms`, `dogeared-coach`
+
+The concrete pipeline for the abstract build → stage → promote pattern. This is the
+most consistent shape across the mined apps and the reference for the whole stack.
+
+## Keyless identity (no stored cloud keys)
+
+- **Workload Identity Federation** binds **GitHub's OIDC** to a single
+  `github-deployer` service account, locked by
+  `attribute.repository == '<owner>/<repo>'` (`google-github-actions/auth@v2`). No
+  long-lived JSON SA keys exist anywhere — a leaked log or fork PR has nothing to
+  steal.
+- All WIF/CI infra is gated behind an `enable_cicd` flag, applied once from an
+  operator workspace (infra is a human-run path, not something CI can grant itself).
+
+## Environment split
+
+- **Staging = fully automatic on push to the main branch**, after the floor:
+  `pre-merge-check.sh` (Go build/test/lint + Node lint/vitest/build) gates → build &
+  push the backend image to **Artifact Registry tagged with the short SHA** →
+  `gcloud run deploy` (an **image-only roll**, *not* a full `terraform apply`) →
+  `firebase deploy` for the frontend → **smoke-test `/healthz`** (asserts
+  `"db":"ok"`).
+- **Production = manual `workflow_dispatch`**, gated by a GitHub **`production`
+  environment with required reviewers**. It **copies the byte-identical staging
+  image** to the prod registry (docker pull → tag → push, **no rebuild**), rolls
+  prod Cloud Run, and **rebuilds only the frontend** with prod Vite env.
+
+## The two safety fences
+
+1. **Promote the identical *backend* image — by digest.** Prod runs the exact bits
+   staging validated; the backend is never rebuilt. Promote by **immutable digest**,
+   not the mutable short-SHA tag (a tag can be repointed after validation), and
+   record the digest as deploy provenance. The **frontend is explicitly *not*
+   byte-identical** — it's rebuilt with prod env — so the honest guarantee is
+   **"backend digest-identical, frontend rebuild-guarded"**, not "the whole release
+   is identical".
+2. **Bundle guard.** A step greps the built frontend JS and fails if staging/demo
+   config leaked into the prod bundle. Treat this as a **denylist backstop, not a
+   complete fence** — a grep catches the known-bad strings it's given and misses
+   novel leaks. The stronger form is an **env allowlist + an artifact manifest +
+   a source-map/secret scan**; keep the grep as the cheap first line.
+
+## Least-privilege deployer
+
+The `github-deployer` SA can **roll images and deploy hosting** but **deliberately
+lacks secret-accessor and serviceusage permissions** — so it cannot call Secret
+Manager directly or mutate infra; infra stays a separate human `terraform apply`.
+**Caveat that matters:** a deployer that can `run deploy` can still ship an image
+that executes **as the runtime SA** and reads whatever *that* SA can — so the
+deployer's true privilege ceiling is the runtime SA's. Bound it from both sides:
+keep the **runtime SA's secret grants minimal and per-service**, and gate **which
+image** prod accepts (digest-allowlisted promote-only path), not just who may
+deploy. (`ci.yml` is `workflow_dispatch`-only on private repos to save Actions
+minutes.)
+
+## Migrations
+
+No migration tool — the stack's datastores are **additive-schema** (Firestore
+schemaless; Mongo indexes created in code). Schema changes are forward-compatible by
+convention. **This is under-powered for T2** and is a known sharp edge: an index
+build, a backfill, or an incompatible data-shape change can break prod
+*independently of a green code smoke-test*. Minimum discipline when you outgrow
+"additive-only": follow **expand → migrate → contract** (add the new shape, backfill
++ dual-read, then remove the old) and add an **index-readiness check** to the smoke
+step so a deploy waits on its indexes.
+
+## Trust & protected paths
+
+Per the [`deployment-release` trust model](../../../deployment-release/pattern.md#trust-model),
+register the **workflow files, the `production` environment/reviewer config, the WIF
+bindings, and the bundle-guard script** as **protected paths**. A loop may propose
+pipeline improvements, but every change here is human-gated — this is the path to
+prod, the highest-value goalpost in the product.
+
+## Cost
+
+The pipeline is **free** — GitHub Actions free minutes, Artifact Registry (0.5 GB
+free), Cloud Build (120 build-min/day free) for source deploys. The only real lever
+is keeping `ci.yml` manual-dispatch on private repos to conserve Actions minutes.
+
+## Stand it up
+
+See [`skills/deploy-gcp-wif.md`](../skills/deploy-gcp-wif.md).

--- a/patterns/stacks/gcp-serverless-saas/bindings/engagement-instrumentation.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/engagement-instrumentation.md
@@ -1,0 +1,96 @@
+# Binding: `engagement-instrumentation` → DIY Firestore analytics
+
+- **Realizes:** [`engagement-instrumentation`](../../../engagement-instrumentation) (vendor-neutral spec)
+- **Tier:** T0+ · **Vendor:** Firestore REST (no SDK, no vendor) · **Source:** `plwp.net`
+
+The **zero-cost** end of the instrumentation seam: capture how far users get
+through content with no analytics vendor, no Cloud Function, no server — a
+cookieless beacon straight to Firestore, read offline by a CLI. This is the T0
+building block that makes *every* other pattern's success metrics measurable for
+$0.
+
+## Write path (client → Firestore, direct)
+
+A tiny IIFE exposes `track(event, detail)` that does a raw `fetch()` **POST to the
+Firestore REST API** —
+`https://firestore.googleapis.com/v1/projects/<project>/databases/(default)/documents/<collection>`
+— with `keepalive: true` (survives page unload) and a hand-built Firestore REST
+`fields` payload. Guards that matter:
+
+- **Origin guard** — skip the write unless `location.hostname` matches the
+  production domain, so local dev never pollutes the data.
+- **Never break the page** — wrapped in `try/catch` + `.catch(()=>{})`; analytics
+  failure is silent by construction.
+- **No PII, cookieless** — capture `event`, `detail`, `path`, `referrer`, `ua`,
+  `lang`, `tz` (rough geo), `screen`, `ts`. No user id, no cookie, no stored IP.
+
+Instrument both navigation (`pageview`, `panel`) and in-content engagement
+(`game_start`, `game_over`) — i.e. the "how far did they get" signal the pattern is
+about.
+
+## Security: public-write, server-only-read (the whole trick)
+
+One collection, **append-only**, enforced by security rules:
+
+```
+match /hits/{id} {
+  allow create: if request.resource.data.keys().hasOnly([...whitelist...])
+                && <each field type/size validated>
+                && request.resource.data.ts is timestamp;
+  allow read, update, delete: if false;
+}
+match /{document=**} { allow read, write: if false; }   // deny-all catch-all
+```
+
+The public can **append well-formed beacons** but can never read or tamper. Reads
+happen server-side only.
+
+**Be honest about what this is not.** The endpoint is **unauthenticated and
+abuseable**: the origin guard is **client-side only** (it's just an `if` in JS an
+attacker skips by POSTing straight to the Firestore REST URL), and `ts` is
+**client-supplied** so it's untrusted for ordering/geo. A hostile actor can
+**poison your metrics** (inflate events), **exhaust the ~20k/day free write quota**,
+and — **if billing is enabled — run up billable writes**. The append-only `hasOnly`
+schema bounds the *shape* of abuse (small, typed, whitelisted fields only), not its
+*volume*. Mitigate per how much the numbers matter: **validate every field**
+(`hasAll` + a type/size check on each, not just some), put a **project budget
+alert** + a **hard write quota** on the database, and when it graduates past "vanity
+metrics" move the write behind **App Check** or a **rate-limited Cloud Run endpoint**
+with a **server-set timestamp**.
+
+## Read / aggregate / display
+
+A stdlib-only CLI (`stats.py`): authenticate with `gcloud auth print-access-token`,
+POST a Firestore `runQuery` (`structuredQuery` over the collection, filtered
+`ts >= now - N days`), aggregate in-memory with `collections.Counter` (pageviews/day
+ASCII chart, event counts, referrers, timezones, UA-derived browser/device), with a
+**bot filter** (`bot`/`crawl`/`headless`/`lighthouse` UA markers). Dashboard = the
+terminal; no stored aggregates, no scheduled rollups.
+
+## Trust (this is the important bit for the loop)
+
+These writes are **public and unauthenticated → `untrusted` signal**. Per the
+[improvement-loop trust model](../../../improvement-loop/pattern.md#trust-model),
+any finding a loop derives from this data inherits `untrusted`, so a change it
+proposes routes to **quarantine → blocking admin approval**. The append-only
+`hasOnly` schema also *bounds* the injection surface — an attacker can only write
+whitelisted, size-capped fields, not arbitrary payloads. Bind this source
+`untrusted` at apply time.
+
+## Cost
+
+Genuinely **~$0**: 1 write per event sits well under the Firestore free tier
+(~20k writes/day); reads happen only when the owner runs the CLI. No always-on
+server, no vendor SaaS. This is the cost floor of the whole stack.
+
+## Graduating up
+
+When you outgrow it: keep the append-only + trust-tag discipline, move the write
+behind a Cloud Run endpoint (so you can enrich server-side: real geo from IP, a
+trusted server timestamp, rate limiting), and add scheduled rollups. The *shape*
+(append-only, server-derived trust fields, one-path aggregation) is what carries
+forward — see the vendor-neutral spec.
+
+## Stand it up
+
+See [`skills/firestore-diy-analytics-setup.md`](../skills/firestore-diy-analytics-setup.md).

--- a/patterns/stacks/gcp-serverless-saas/bindings/multi-tenant-isolation.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/multi-tenant-isolation.md
@@ -1,0 +1,86 @@
+# Binding: `multi-tenant-isolation` → two variants on GCP Serverless SaaS
+
+- **Realizes:** [`multi-tenant-isolation`](../../registry.json) (candidate; vendor-neutral)
+- **Tier:** T1 (variant A) / T2 (variant B) · **Source:** `booking-forms`, `dogeared-coach`
+
+Two genuinely different concrete realizations mined from two shipped apps. They are
+**not** better/worse — they sit at different points on the cost/isolation curve.
+Pick by whether tenants share a running process.
+
+## Variant A — build-time isolation (T1, cheapest) · `booking-forms`
+
+**One deployment artifact per tenant.** Tenants never share a running frontend.
+
+- **Frontend resolution:** the shipped app substring-matches the host to a tenant,
+  with a **`NEXT_PUBLIC_SITE_ID` baked at build time** as the fallback. Because CI
+  fans out a **separate static build + separate Firebase Hosting site per tenant**,
+  isolation is a *deploy artifact* boundary, not runtime routing — so a
+  mis-resolution here is a UX bug, not (at this tier) a data leak.
+  **⚠ Do not carry substring host-matching into any tier where the host decides data
+  access.** Substring matching is a classic **tenant-confusion** bug —
+  `foo.attacker.com` and `notfoo.example` both contain `foo`. The correct form is an
+  **exact, normalized (lower-case / punycode) hostname allowlist that fails closed**
+  on no match. At T1 lean on the baked `SITE_ID` as the source of truth and treat
+  the host only as a hint.
+- **Backend resolution:** tenant is a **path segment** (`/api/bookings/{tenant}`),
+  and every handler runs `isValidSlug` (lowercase/digit/hyphen, ≤100 chars,
+  path-traversal-safe) **and** checks membership in a hardcoded allowlist map —
+  unknown tenant → **404**.
+- **Per-tenant scoping** is by **separate secrets** (`ADMIN_TOKEN_<TENANT>`),
+  **separate config docs** (Firestore `pricing_configs/{tenant}`), and **separate
+  builds** — not a database tenant column.
+- **Admin auth:** per-tenant **static bearer token**, constant-time compared
+  (`crypto/subtle.ConstantTimeCompare`), delivered via a `?token=` magic-link that's
+  stripped from the URL into `sessionStorage`.
+  **⚠ Understand the trade-off:** a static bearer token **in a URL leaks** via
+  browser history, server/proxy logs, screenshots, and referrers, and `sessionStorage`
+  is **readable by any XSS** on the page. This is acceptable only as a **T1
+  low-value-admin** shortcut with a **short-lived, rotatable** token. The hardened
+  form: make the link a **one-time, expiring redeem token** that the server exchanges
+  for an **HttpOnly, SameSite** session cookie (so the durable credential is never in
+  the URL or JS-readable), with rotation + an audit trail. Move to real auth (Variant
+  B / Firebase Auth) before this admin controls anything valuable.
+
+**Trade-off:** dead simple, near-$0, no shared-process leak surface at all — but
+doesn't scale past a handful of known tenants (every tenant is a build + a secret +
+a hosting site) and has no self-serve tenant creation.
+
+## Variant B — runtime server-derived scoping (T2, scalable) · `dogeared-coach`
+
+**Tenants share a running process; isolation is enforced in every query.**
+
+- **Server-derived tenant identity only.** Tenant is resolved from the
+  **authenticated session**, a **custom-domain/host mapping**, a **path**, or a
+  **signed invite token** — and a client-supplied **`X-Tenant-*` header is *never*
+  trusted** as identity (both architecture-review AIs flagged raw-header trust as a
+  cross-tenant escalation; ADR-3 / INV-006).
+- **Forced tenant-scoped repository layer.** Handlers **cannot touch raw
+  collections** — they go through a repo layer that injects `tenant_id` into every
+  read/write. This is the fail-closed core: you can't *forget* to scope a query.
+- **Schema-level enforcement.** Compound unique indexes **include `tenant_id`**;
+  identity is global (`user_identity` = Firebase UID) with **per-tenant membership**
+  records (one dog owner using two vets = one identity, two client records).
+- **Standing isolation proof.** Integration tests **attempt cross-tenant access and
+  must fail** — the cross-tenant proof is an executable gate (register it as a
+  protected path so the loop can't weaken it).
+
+**Trade-off:** self-serve tenant creation, one deploy, scales to many tenants — at
+the cost of a real shared-process leak surface that the scoped-repo + proof-tests
+exist to close.
+
+## Choosing
+
+| If… | Use |
+|--|--|
+| few known tenants, static frontend, no self-serve signup | **Variant A** (build-time) |
+| many/self-serve tenants, shared backend, per-user accounts | **Variant B** (runtime scoped repo) |
+
+Both are **fail-closed on unknown tenant** (404 / reject), both resolve tenancy
+**server-side**, both keep tenant config out of client-trusted inputs — that
+invariant is the pattern; the mechanism differs by tier.
+
+## Cost
+
+Variant A adds ~$0 (more builds, same free tiers). Variant B adds the cost of the
+shared backend running (T2 Cloud Run) but **one** backend for all tenants — cheaper
+per-tenant at scale.

--- a/patterns/stacks/gcp-serverless-saas/bindings/provider-neutral-adapter.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/provider-neutral-adapter.md
@@ -1,0 +1,61 @@
+# Binding: `provider-neutral-adapter` → Go interface + webhooks (Cloudflare Stream exemplar)
+
+- **Realizes:** [`provider-neutral-adapter`](../../registry.json) (candidate; vendor-neutral)
+- **Tier:** T2 · **Vendor:** Cloudflare Stream (exemplar) · **Source:** `dogeared-coach`
+
+The concrete shape of "put a swappable vendor behind a seam". Mined from the video
+integration, but the *same shape* is how this stack wraps Stripe, GCS, and any
+external service — so it's the meta-binding the others lean on.
+
+## The seam
+
+The vendor lives entirely behind a **Go interface** (`video/` package:
+`cloudflare.go`, `jwt.go`, `webhook.go`, `service.go`). The rules that make it
+genuinely swappable:
+
+- **Neutral DTOs only** cross the seam; the **concrete vendor types are unexported**
+  → the compiler enforces that nothing outside the package depends on the vendor.
+- **Vendor states are mapped to internal enums** with safe defaults (an unknown
+  vendor status maps to a conservative internal state, never a permissive one).
+- Only a **neutral id** (`video_id`) is stored — never a vendor URL or signed asset.
+
+## Three reusable mechanisms behind the seam
+
+1. **Direct browser → CDN upload.** The server mints a **one-time upload URL**; the
+   browser uploads **straight to the vendor**, never proxying bytes through Cloud
+   Run (which would blow the request timeout and egress budget). Cloud Run only
+   brokers the ticket.
+2. **Per-request signed access, nothing stored.** Playback and thumbnail access are
+   **short-lived signed JWTs minted per request** (time-bound), signed with a key in
+   Secret Manager. Only the `video_id` is persisted; a leaked DB row grants nothing.
+3. **Webhook as source of truth, idempotent.** The vendor's **signed webhook**
+   (`*_WEBHOOK_SECRET`) reconciles upload/processing status, so the app's record
+   matches reality even if the browser dies mid-upload — this is what prevents
+   **billing-ghost orphans** (assets you pay to store but the app forgot about).
+
+## The same shape, other vendors on this stack
+
+- **Stripe** sits behind the same discipline (config module, webhook-as-truth) —
+  see [`tiered-subscription.md`](tiered-subscription.md).
+- **GCS thumbnails**: a private bucket (uniform bucket-level access) served via
+  **V4 signed URLs** signed by the Cloud Run service account (`signBlob` IAM) — the
+  storage equivalent of per-request signed access.
+
+## Trust & meta-disciplines
+
+This binding is where several registry
+[meta-disciplines](../../../../docs/patterns-registry.md) become concrete:
+*external state is authoritative via signed webhooks, not the client redirect*;
+*idempotency + guarded updates for anything touching external state*; *injected
+interface seams for every gate*. The webhook is a **trusted, self-describing
+signal** (the vendor reporting its own state, signature-verified) — so it stays
+`trusted` even in a public app. Register the vendor config + webhook handler as
+**protected paths**.
+
+## Cost
+
+The seam is free; the vendor is the cost. For Cloudflare Stream the only
+usage-driven cost is **storage ($5/1,000 min stored/mo) + delivery ($1/1,000 min
+delivered/mo)** — **delivery is the one uncapped variable cost in the whole stack**,
+so bind it to per-plan caps (e.g. storage-minutes + client count per tier) and set a
+soft alert. Encoding/ingest is free.

--- a/patterns/stacks/gcp-serverless-saas/bindings/tiered-subscription.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/tiered-subscription.md
@@ -1,0 +1,90 @@
+# Binding: `tiered-subscription` → Stripe on GCP Serverless SaaS
+
+- **Realizes:** [`tiered-subscription`](../../../tiered-subscription) (vendor-neutral spec)
+- **Tier:** T2 · **Vendor:** Stripe (`stripe-go/v82`) · **Source:** `dogeared-coach`
+
+The concrete Stripe wiring for the abstract subscribe → enforce → lifecycle
+pattern. The abstract spec says "billing webhook is the source of truth"; this is
+*how*, with the sharp edges that actually bit.
+
+## Surface
+
+- **Hosted Checkout Sessions** (subscription mode) for upgrades to paid plans; one
+  Stripe **Price** per paid tier (`STRIPE_PRICE_<TIER>`). Checkout in a
+  `billing_checkout` service; plan/price config in a `config/stripe` module.
+- **Customer Portal** for self-serve plan/payment management (realizes the
+  `self-serve-billing-portal` candidate — portal session minted server-side).
+- **Stripe Tax** for jurisdiction tax + invoices (optional).
+
+## The non-obvious glue (get these wrong and you leak revenue or corrupt state)
+
+1. **Webhook is the *single entitlement writer*; checkout never writes entitlement.**
+   `POST /api/v1/webhooks/stripe` is registered **outside** auth/tenant middleware.
+   The handler does **fetch-on-webhook reconcile**: the event is only a *trigger* —
+   it re-fetches the live subscription from Stripe and projects entitlement from
+   *that*, never from the event payload or the post-checkout redirect (which can die
+   mid-flow). One writer = no split-brain between "checkout says paid" and "webhook
+   says paid".
+2. **Verify against a rotation *list* of secrets.** `ConstructWebhookEvent` checks
+   the signature against **`STRIPE_WEBHOOK_SECRETS` (comma-separated)**, not a single
+   secret — so you can rotate the signing secret with zero downtime (accept old+new
+   during the overlap).
+3. **`livemode` guard.** Assert `event.livemode == config.Livemode()` and **400 on
+   mismatch**, so a test-mode event can never mutate live subscription state (and
+   vice-versa).
+4. **Idempotent dedupe.** A claim→processed state machine keyed on `stripe_event_id`
+   — Stripe retries deliveries; each event applies at most once.
+5. **At-most-one customer per account.** The invariant you actually need is
+   **one account → one Stripe customer**, so the durable guard is a **unique
+   constraint / CAS on `(provider, account_id)`**, plus `account_id` written into the
+   Stripe customer **metadata** for reverse mapping. The Stripe **idempotency key**
+   (`provider:{account_id}:customer`) stops a *retry* from duplicating but is not a
+   permanent data invariant; a unique index on `stripe_customer_id` only prevents the
+   *reverse* (one customer → many accounts) — necessary but **not sufficient**. On
+   CAS failure, delete the orphan customer you just minted. Spell out the constraint
+   per datastore (Mongo partial unique index vs a Firestore transaction on a
+   deterministic doc id).
+6. **Test/live safety at boot.** `STRIPE_MODE` defaults to `test`; only exact
+   `"live"` enables live. `ValidateStripeConfig` at startup asserts the key segment
+   (`_test_` / `_live_`) matches the mode **and** every paid plan has a price, else
+   `log.Fatalf`. Fail-fast beats a silently-misconfigured prod.
+7. **Degrade, don't crash, when unconfigured.** If Stripe env is absent the client
+   is nil, billing routes return **503**, and the server still boots — so a T1
+   deploy without billing is a valid state.
+
+## Enforcement + limits
+
+Plan caps live in one `plan.LimitsFor(tier)` function (the abstract spec's "tier
+matrix as single source of truth"); a limit-hit returns a **`409`**, which is the
+friction signal [`frictionless-onboarding`](../../../frictionless-onboarding)
+consumes for a contextual upgrade prompt. Unknown/empty tier → most-restrictive
+fallback (free), never a silent grant.
+
+## Trust & protected paths
+
+Entitlement, price, and paywall definitions are **goalpost-grade** — register
+`config/stripe`, `plan.go`, and the webhook handler as **protected paths**.
+
+**Signature ≠ full trust.** A verified signature proves the event *came from Stripe*
+(transport origin) — it does **not** make every field trustworthy. The **signed
+vendor state** (subscription status, price id, current-period-end — which is exactly
+why you re-fetch it) is `trusted`; but **customer-controlled fields carried in the
+event** (customer `email`, `metadata`, `cancellation_reason`, and — under Connect —
+the connected-account context) are **`untrusted`** and must be validated, never used
+to decide entitlement or routed to the loop as trusted signal. Concretely: verify
+the event's **account/context matches the account you expect**, use
+**endpoint-specific signing secrets**, keep Stripe's default timestamp tolerance
+(replay window), and optionally IP-allowlist Stripe's ranges alongside the signature.
+With that split, loop changes *driven by verified billing state* are park-and-notify;
+anything derived from a customer-controlled field is `untrusted` → quarantine — and
+changes to the *pricing/matrix* files are always human-gated regardless of provenance.
+
+## Cost
+
+Stripe has **no monthly fee** — pure per-transaction (~2.9%+ + fixed; AU domestic
+≈ 1.7% + A$0.30). It is a linear variable cost from transaction #1, never a cliff.
+Customer Portal and webhooks are free.
+
+## Stand it up
+
+See [`skills/stripe-subscriptions-setup.md`](../skills/stripe-subscriptions-setup.md).

--- a/patterns/stacks/gcp-serverless-saas/bindings/transactional-email.md
+++ b/patterns/stacks/gcp-serverless-saas/bindings/transactional-email.md
@@ -1,0 +1,61 @@
+# Binding: `transactional-email-and-dunning` → Resend on GCP Serverless SaaS
+
+- **Realizes:** [`transactional-email-and-dunning`](../../registry.json) (candidate; vendor-neutral)
+- **Tier:** T1+ · **Vendor:** Resend · **Source:** `booking-forms`, `dogeared-coach`
+- **Honesty flag:** the **transactional half is shipped**; the **dunning half is
+  aspirational** — no mined app built a failed-payment sequence (Stripe sends the
+  billing emails). This binding describes what shipped and marks the gap.
+
+## Transactional email (shipped)
+
+- **Client:** Resend, either **raw HTTPS** (`POST https://api.resend.com/emails`,
+  no SDK — dgrd) or the **`resend-go` SDK** (booking-forms). API key from
+  `RESEND_API_KEY` in Secret Manager.
+- **Emails that shipped:** single-use **invite** links (7-day expiry token) for
+  onboarding providers/clients (dgrd); **booking notification + customer
+  confirmation** sent synchronously in the request handler (booking-forms).
+- **Templating:** hand-rolled Go `fmt.Sprintf` HTML — **no template engine**. Per-
+  tenant branding (banners, hours, from-address) from a config map.
+- **Injection hygiene (important):** `html.EscapeString` on all interpolated values
+  **plus CRLF/header sanitization**, because names/fields can be *provider-* or
+  *user-controlled* — an unescaped name is an HTML-injection and header-injection
+  vector. Anti-autoreply headers (`Auto-Submitted`, `X-Auto-Response-Suppress`) to
+  stop bounce loops.
+- **From address:** `RESEND_FROM` (e.g. `no-reply-<tenant>@bookings.<domain>`).
+- **Dev fallback:** a `logSender` that **logs the accept URL instead of sending**,
+  so local/CI never hits Resend and you can still click the link.
+
+## Dunning (aspirational — the intended shape)
+
+Not yet built in any mined app; specified here so the factory knows the target
+rather than inventing wiring. When added, follow the vendor-neutral spec:
+
+- **Idempotent, send-once keys** — a `(account, email_kind, period)` key so retries
+  and concurrent workers never double-send.
+- **Failed-payment sequence** — driven off the Stripe `past_due` webhook (the
+  `tiered-subscription` binding already surfaces it): a bounded retry/notify
+  cadence within the `dunning_grace_window` before graceful degrade.
+- **Lifecycle nudges** — welcome, activation nudge (fires if a signed-up user hasn't
+  hit the activation event), re-engagement. These need a **scheduler**, which this
+  stack does not yet provision (see the stack's known gaps) — the natural pairing is
+  a Cloud Scheduler → PSK-gated Cloud Run endpoint.
+
+## Trust
+
+Recovery/nudge outcomes are **retention/conversion signal** for the loop. The email
+*content templates* that touch conversion (upgrade nudges, dunning copy) are
+adjacent to pricing/paywall, so treat copy changes proposed from **end-user signal**
+as admin-gated, consistent with the monetization patterns.
+
+## Cost
+
+Resend free tier is **3,000 emails/mo (100/day)** — at ~2 emails per event this is
+typically the **first free-tier ceiling** a T1 app hits (~50 events/day). Above it,
+~$20/mo flat for 50k. Synchronous send at T1 means email latency is in the request
+path (watch the handler timeout); move to async once you provision a queue.
+
+## Stand it up
+
+Resend setup is a subset of [`secret-manager-setup.md`](../skills/secret-manager-setup.md)
+(store `RESEND_API_KEY`) + verifying a sending domain (SPF/DKIM) in the Resend
+dashboard; no dedicated skill until the dunning scheduler lands.

--- a/patterns/stacks/gcp-serverless-saas/manifest.json
+++ b/patterns/stacks/gcp-serverless-saas/manifest.json
@@ -1,0 +1,75 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern --stack installer. Human spec: patterns/stacks/gcp-serverless-saas/stack.md. A stack profile binds vendor-neutral patterns (../../<id>) to concrete vendors, ships stand-up skills, and carries a cost model. Mined from plwp.net (T0), booking-forms (T1), dogeared-coach (T2).",
+  "id": "gcp-serverless-saas",
+  "version": 1,
+  "title": "GCP Serverless SaaS (the house stack)",
+  "status": "specified",
+  "provenance": {"T0": "plwp.net", "T1": "booking-forms", "T2": "dogeared-coach"},
+
+  "vendors": {
+    "hosting": {"vendor": "Firebase Hosting", "role": "static frontend, multi-site", "swappable_for": ["Vercel", "Netlify", "Cloudflare Pages"]},
+    "backend": {"vendor": "Cloud Run", "role": "Go API, scale-to-zero", "region": "us-central1", "swappable_for": ["Fly.io", "Render"]},
+    "database": {"vendor": "Firestore | MongoDB Atlas", "role": "Firestore T0/T1, Atlas T2", "swappable_for": ["Postgres/Supabase"]},
+    "auth": {"vendor": "Firebase Auth / Identity Platform", "role": "server-verified ID tokens + RBAC", "swappable_for": ["Clerk", "Auth0"]},
+    "payments": {"vendor": "Stripe", "role": "Checkout+Portal subscriptions | Connect marketplace", "swappable_for": ["Paddle", "Lemon Squeezy"]},
+    "email": {"vendor": "Resend", "role": "transactional email", "swappable_for": ["Postmark", "SES"]},
+    "media": {"vendor": "provider-neutral (Cloudflare Stream exemplar)", "role": "direct-to-CDN upload + signed playback", "swappable_for": ["Mux", "GCS+CDN"]},
+    "secrets": {"vendor": "GCP Secret Manager", "role": "containers via IaC, values out-of-band"},
+    "deploy_identity": {"vendor": "Workload Identity Federation (GitHub OIDC)", "role": "keyless, repo-scoped, least-privilege deployer"},
+    "observability": {"vendor": "Cloud Logging + append-only audit collections", "role": "structured stdout + /healthz; no paid APM by default"},
+    "iac": {"vendor": "Terraform", "role": "services + secret containers + IAM + WIF"}
+  },
+
+  "cost_tiers": [
+    {
+      "id": "T0", "name": "Static + DIY", "monthly": "~$0", "exemplar": "plwp.net",
+      "active_seams": ["hosting", "database(firestore, analytics-only)"],
+      "use_for": "landing pages, marketing, tiny tools, demand validation",
+      "free_tier_limits": ["Firestore ~20k writes/day", "Hosting 10GB storage + 360MB/day egress"]
+    },
+    {
+      "id": "T1", "name": "Thin serverless", "monthly": "~$0-5", "exemplar": "booking-forms",
+      "active_seams": ["hosting", "backend(scale-to-zero)", "database(firestore)", "email", "payments(connect)", "secrets", "deploy_identity"],
+      "use_for": "transactional micro-SaaS, per-tenant config, marketplace/deposits",
+      "first_ceiling": "Resend 3k mail/mo (100/day) free tier",
+      "cost_caps": ["Cloud Run max-instances cap (throughput ceiling doubles as cost cap)"]
+    },
+    {
+      "id": "T2", "name": "Full production", "monthly": "~$60-140", "exemplar": "dogeared-coach",
+      "active_seams": ["hosting", "backend(min-instances=1)", "database(atlas)", "auth", "payments(checkout+portal+webhooks)", "email", "media", "secrets", "deploy_identity", "observability"],
+      "use_for": "subscription SaaS with accounts, media, compliance",
+      "biggest_fixed_jump": "prod Cloud Run min-instances=1 (~$45-65/mo illustrative; depends on region/CPU/memory/billing-mode, not an invariant)",
+      "largest_uncapped_meter": "media delivery (bound with per-plan caps + soft alert); NOT the only metered line -- Firestore, Cloud Run egress, Hosting transfer, Logging, Artifact Registry, Resend, Stripe fees all scale with use. Put a project budget alert on everything.",
+      "db_graduation_is_a_migration": "Firestore->Atlas changes query/index/txn/backup semantics; needs dual-write/backfill/cutover, not a config flip"
+    }
+  ],
+
+  "graduation_triggers": [
+    {"from": "T0", "to": "T1", "trigger": "need server logic / write-side validation / secrets", "add": "Cloud Run"},
+    {"from": "T1", "to": "T2", "trigger": "Firestore query model doesn't fit (joins, cross-entity txns, aggregations)", "add": "MongoDB Atlas"},
+    {"from": "T1", "to": "T2", "trigger": "real user accounts + role-based access", "add": "Firebase Auth + RBAC"},
+    {"from": "T1", "to": "T2", "trigger": "cold starts hurt auth/media UX", "add": "prod min-instances=1 (biggest fixed jump)"}
+  ],
+
+  "bindings": {
+    "tiered-subscription": {"tier": "T2", "recipe": "bindings/tiered-subscription.md", "vendor": "Stripe Checkout+Portal", "source": "dogeared-coach"},
+    "engagement-instrumentation": {"tier": "T0+", "recipe": "bindings/engagement-instrumentation.md", "vendor": "DIY Firestore beacon", "source": "plwp.net"},
+    "multi-tenant-isolation": {"tier": "T1/T2", "recipe": "bindings/multi-tenant-isolation.md", "vendor": "server-derived scoping (2 variants)", "source": "booking-forms, dogeared-coach"},
+    "provider-neutral-adapter": {"tier": "T2", "recipe": "bindings/provider-neutral-adapter.md", "vendor": "Go interface + Cloudflare Stream", "source": "dogeared-coach"},
+    "transactional-email-and-dunning": {"tier": "T1+", "recipe": "bindings/transactional-email.md", "vendor": "Resend", "source": "booking-forms, dogeared-coach", "note": "dunning half aspirational (unbuilt in mined apps)"},
+    "deployment-release": {"tier": "T1+", "recipe": "bindings/deployment-release.md", "vendor": "keyless WIF + promote-identical", "source": "booking-forms, dogeared-coach"}
+  },
+
+  "skills": [
+    {"id": "deploy-gcp-wif", "path": "skills/deploy-gcp-wif.md", "stands_up": "keyless WIF deploy pipeline (staging-auto / prod-promote-identical)"},
+    {"id": "stripe-subscriptions-setup", "path": "skills/stripe-subscriptions-setup.md", "stands_up": "Stripe Checkout + Portal + webhook (fetch-on-webhook reconcile)"},
+    {"id": "firestore-diy-analytics-setup", "path": "skills/firestore-diy-analytics-setup.md", "stands_up": "zero-cost DIY Firestore analytics beacon + CLI"},
+    {"id": "secret-manager-setup", "path": "skills/secret-manager-setup.md", "stands_up": "Secret Manager containers + least-privilege runtime access"}
+  ],
+
+  "known_gaps": [
+    "dunning unbuilt in every mined app (Stripe sends billing emails); dunning binding half is aspirational",
+    "no standing job/queue infra; reconciliation is a PSK-gated pull endpoint poked by an external scheduler",
+    "observability is structured logs + audit collections only; no APM/error tracker wired"
+  ]
+}

--- a/patterns/stacks/gcp-serverless-saas/skills/deploy-gcp-wif.md
+++ b/patterns/stacks/gcp-serverless-saas/skills/deploy-gcp-wif.md
@@ -1,0 +1,132 @@
+# Skill: Stand up a keyless WIF deploy pipeline (GCP + GitHub Actions)
+
+Realizes [`deployment-release`](../bindings/deployment-release.md) on this stack.
+Outcome: pushes to `main` auto-deploy to **staging**; production is a manual,
+reviewer-gated promotion of the **byte-identical** staging image. **No long-lived
+cloud keys.**
+
+> Parameters to bind first: `PROJECT_STAGING`, `PROJECT_PROD`, `REPO` (`owner/repo`),
+> `REGION` (`us-central1`), `SERVICE` (Cloud Run service name), `AR_REPO`
+> (Artifact Registry repo).
+
+## 1. Workload Identity Federation (once, from an operator shell)
+
+```bash
+# Pool + GitHub OIDC provider
+gcloud iam workload-identity-pools create github-pool \
+  --project="$PROJECT_STAGING" --location=global --display-name="GitHub pool"
+
+gcloud iam workload-identity-pools providers create-oidc github-provider \
+  --project="$PROJECT_STAGING" --location=global \
+  --workload-identity-pool=github-pool \
+  --display-name="GitHub OIDC" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.job_workflow_ref" \
+  --attribute-condition="assertion.repository=='${REPO}'"   # <-- repo lock is the FLOOR, not enough on its own (see below)
+
+# Deployer SA (least privilege: roll releases, NOT read secrets / mutate infra)
+gcloud iam service-accounts create github-deployer --project="$PROJECT_STAGING"
+SA="github-deployer@${PROJECT_STAGING}.iam.gserviceaccount.com"
+for role in roles/run.developer roles/artifactregistry.writer roles/firebasehosting.admin; do
+  gcloud projects add-iam-policy-binding "$PROJECT_STAGING" --member="serviceAccount:$SA" --role="$role"
+done
+# Deliberately DO NOT grant roles/secretmanager.secretAccessor or serviceusage.* to the deployer.
+
+# Let the GitHub identity impersonate the deployer SA — but scope the binding TIGHTER
+# than repo-only (see the hardening note): here, only pushes to the main ref.
+POOL=$(gcloud iam workload-identity-pools describe github-pool --project="$PROJECT_STAGING" --location=global --format="value(name)")
+gcloud iam service-accounts add-iam-policy-binding "$SA" --project="$PROJECT_STAGING" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository/${REPO}"
+```
+
+Put the provider resource name and `$SA` into GitHub repo secrets
+`GCP_WIF_PROVIDER` / `GCP_WIF_SERVICE_ACCOUNT`.
+
+> **⚠ Repo-only WIF is the floor, not the ceiling.** `assertion.repository=='${REPO}'`
+> lets **any workflow, on any branch, in that repo** mint the deployer token. An
+> attacker who can land a workflow file (or a malicious PR that runs a workflow with
+> `id-token: write`) can satisfy the condition and deploy — **the GitHub
+> `environment: production` reviewer gate lives in the workflow YAML and can be
+> bypassed by not using it.** Harden prod separately:
+>
+> - **Split staging and prod** into two WIF providers + two deployer SAs in two
+>   projects. The prod provider/SA binding must additionally require a
+>   **protected-branch ref** and/or the **`job_workflow_ref`** of a *reusable,
+>   protected* promote workflow — e.g. bind the prod SA's `workloadIdentityUser` to
+>   `attribute.workflow_ref/<owner>/<repo>/.github/workflows/promote-prod.yml@refs/heads/main`.
+> - Enforce prod approval in **branch/tag protection + the GitHub environment**, not
+>   only in the YAML, so a rewritten workflow can't skip it.
+
+## 2. Local floor mirror (`scripts/pre-merge-check.sh`)
+
+Same commands CI runs, so the gate is reproducible off-CI: `go build ./... && go
+test ./... && go vet ./...` + `npm ci && npm run lint && npm run test && npm run
+build`. CI calls this exact script.
+
+## 3. Staging workflow (`.github/workflows/deploy-staging.yml`)
+
+Trigger `on: push: branches: [main]`. Steps:
+`permissions: { id-token: write, contents: read }` → `google-github-actions/auth@v2`
+(with the two WIF secrets, **no key file**) → run `pre-merge-check.sh` →
+`gcloud builds submit`/`docker build` + push to `${REGION}-docker.pkg.dev/${PROJECT_STAGING}/${AR_REPO}/${SERVICE}:${GITHUB_SHA::7}` →
+`gcloud run deploy $SERVICE --image <that> --region $REGION` →
+`npm run build -- --mode staging && firebase deploy --only hosting:<staging-site>` →
+`curl -fsS https://<staging>/healthz | grep '"db":"ok"'`.
+
+## 4. Production promote (`.github/workflows/promote-prod.yml`)
+
+Trigger `on: workflow_dispatch`. Add `environment: production` (configure **required
+reviewers** on that environment in repo settings — this is the human gate, and it
+must be backed by branch/tag protection per the WIF note, not just this line).
+Steps: auth via WIF → **promote the identical image by DIGEST** (not by the mutable
+SHA tag — a tag can be repointed; a digest can't):
+
+```bash
+# resolve the staged image to its immutable digest, then promote THAT
+DIGEST=$(gcloud artifacts docker images describe \
+  "${REGION}-docker.pkg.dev/${PROJECT_STAGING}/${AR_REPO}/${SERVICE}:${SHA}" \
+  --format='value(image_summary.digest)')
+SRC="${REGION}-docker.pkg.dev/${PROJECT_STAGING}/${AR_REPO}/${SERVICE}@${DIGEST}"
+DST="${REGION}-docker.pkg.dev/${PROJECT_PROD}/${AR_REPO}/${SERVICE}@${DIGEST}"
+docker pull "$SRC"; docker tag "$SRC" "${DST%@*}:${SHA}"; docker push "${DST%@*}:${SHA}"
+# deploy by the digest you verified, and record it as provenance
+gcloud run deploy "$SERVICE" --image "${DST%@*}@${DIGEST}" --project "$PROJECT_PROD" --region "$REGION" --min-instances=1
+```
+
+Enable **immutable tags** on the Artifact Registry repo so a tag can never be
+silently repointed after it's been validated.
+
+→ rebuild frontend with prod env → **bundle guard**:
+
+```bash
+# fail if any staging/demo config leaked into the prod bundle
+if grep -rE "(dogeared-stag|firebaseapp.com/__/staging|demo-)" dist/assets/*.js; then
+  echo "::error::staging config leaked into prod bundle"; exit 1
+fi
+```
+
+→ `firebase deploy --only hosting:<prod-site>` → smoke `/healthz`.
+
+## Verify
+
+- Push a trivial change to `main` → staging deploys, `/healthz` green.
+- Run the prod workflow → it waits for a reviewer, then ships the same digest.
+- Confirm the deployer SA **cannot** read a secret (`gcloud secrets versions
+  access` as that SA fails) — least privilege holds.
+
+## Gotchas
+
+- Forgetting the `attribute-condition` repo lock = any repo can mint your token.
+- **Repo-only lock is not enough for prod** — see the WIF hardening note; scope prod
+  to a protected branch + the promote workflow's `job_workflow_ref`.
+- Rebuilding for prod instead of promoting the image = silent staging/prod drift.
+- Promoting by mutable **tag** instead of **digest** = a repointed tag can slip
+  unvalidated bits into prod. Promote by digest; enable immutable tags.
+- Granting the deployer `secretAccessor` "to make it work" = you just widened the
+  blast radius to every secret. Keep it out — **but know that even without it, a
+  deployer that can `run deploy` can ship an image that runs *as the runtime SA* and
+  reads every secret the runtime SA can.** The deployer's real privilege ceiling is
+  "whatever the runtime SA can do", so (a) keep the runtime SA's secret grants
+  minimal and per-service, and (b) gate *what image* prod will accept (digest
+  allowlist / the promote-only path above), not just *who* can call deploy.

--- a/patterns/stacks/gcp-serverless-saas/skills/firestore-diy-analytics-setup.md
+++ b/patterns/stacks/gcp-serverless-saas/skills/firestore-diy-analytics-setup.md
@@ -1,0 +1,128 @@
+# Skill: Stand up zero-cost DIY Firestore analytics
+
+Realizes [`engagement-instrumentation`](../bindings/engagement-instrumentation.md)
+at T0. Outcome: a cookieless beacon writing straight to Firestore, read offline by a
+CLI. **No SDK, no Cloud Function, no vendor, ~$0.**
+
+> Bind first: `PROJECT`, `COLLECTION` (e.g. `hits`), `PROD_HOST` (origin guard),
+> the field whitelist.
+
+## 1. Firestore + append-only rules (the security core)
+
+Create a Firestore database, then deploy rules that allow **public append of
+well-formed docs only** — no read, no update, no delete:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /hits/{id} {
+      allow create: if
+        request.resource.data.keys().hasOnly(['event','detail','path','referrer','ua','lang','tz','screen','ts'])
+        && request.resource.data.keys().hasAll(['event','ts'])
+        // validate EVERY field's type + size (not just some) — an unvalidated field is an abuse vector
+        && request.resource.data.event    is string && request.resource.data.event.size()    < 64
+        && request.resource.data.detail   is string && request.resource.data.detail.size()   < 256
+        && request.resource.data.path     is string && request.resource.data.path.size()     < 512
+        && request.resource.data.referrer is string && request.resource.data.referrer.size() < 512
+        && request.resource.data.ua       is string && request.resource.data.ua.size()       < 512
+        && request.resource.data.lang     is string && request.resource.data.lang.size()     < 32
+        && request.resource.data.tz       is string && request.resource.data.tz.size()       < 64
+        && request.resource.data.screen   is string && request.resource.data.screen.size()   < 16
+        && request.resource.data.ts       is timestamp;   // NB: client-supplied, untrusted for ordering
+      allow read, update, delete: if false;
+    }
+    match /{document=**} { allow read, write: if false; }   // deny-all catch-all
+  }
+}
+```
+
+```bash
+firebase deploy --only firestore:rules
+```
+
+The `hasOnly`/`hasAll` key set + a per-field type/size check **bound the injection
+surface** — a public writer can only ever append small, typed, whitelisted fields.
+They do **not** bound *volume*.
+
+> **⚠ This endpoint is unauthenticated and abuseable.** The origin guard in the
+> beacon (below) is **client-side only** — an attacker POSTs straight to the
+> Firestore REST URL and skips it. They can inflate your metrics and burn the
+> ~20k/day free write quota (or your money if billing is on). Put a **project budget
+> alert** + a **hard database write quota** in place, treat `ts` as untrusted, and
+> when the numbers start to matter front the write with **App Check** or a
+> **rate-limited Cloud Run endpoint that sets a server timestamp**. This T0 recipe
+> is for vanity / product-signal metrics — not billing-grade or adversarial counting.
+
+## 2. The beacon (inline, no build)
+
+```html
+<script>
+(function(){
+  var P="PROJECT", C="COLLECTION";
+  window.track=function(event,detail){
+    if(!/(^|\.)PROD_HOST$/.test(location.hostname)) return;      // anti-noise only — client-side, NOT security
+    try{
+      fetch("https://firestore.googleapis.com/v1/projects/"+P+"/databases/(default)/documents/"+C,{
+        method:"POST", keepalive:true, headers:{"Content-Type":"application/json"},
+        body:JSON.stringify({fields:{
+          event:{stringValue:event||"pageview"}, detail:{stringValue:detail||""},
+          path:{stringValue:location.pathname}, referrer:{stringValue:document.referrer},
+          ua:{stringValue:navigator.userAgent}, lang:{stringValue:navigator.language},
+          tz:{stringValue:Intl.DateTimeFormat().resolvedOptions().timeZone},
+          screen:{stringValue:screen.width+"x"+screen.height},
+          ts:{timestampValue:new Date().toISOString()}
+        }})
+      }).catch(function(){});                                    // never break the page
+    }catch(e){}
+  };
+  track("pageview");
+})();
+</script>
+```
+
+Call `track('panel','pricing')`, `track('game_start')`, etc. at engagement points.
+
+## 3. Read it (offline CLI, `stats.py`)
+
+Stdlib only — auth with a gcloud token, `runQuery` filtered to the last N days,
+aggregate with `collections.Counter`:
+
+```python
+# python3 stats.py --days 7   (needs: gcloud auth login)
+import json,subprocess,urllib.request,collections,sys
+PROJECT="PROJECT"; days=7
+tok=subprocess.check_output(["gcloud","auth","print-access-token"]).decode().strip()
+q={"structuredQuery":{"from":[{"collectionId":"hits"}],
+   "where":{"fieldFilter":{"field":{"fieldPath":"ts"},"op":"GREATER_THAN",
+     "value":{"timestampValue":__import__("datetime").datetime.utcnow().isoformat()+"Z"}}}}}
+# (swap the filter value for now-minus-N-days in real use)
+req=urllib.request.Request(
+  f"https://firestore.googleapis.com/v1/projects/{PROJECT}/databases/(default)/documents:runQuery",
+  data=json.dumps(q).encode(), headers={"Authorization":f"Bearer {tok}","Content-Type":"application/json"})
+rows=[r["document"]["fields"] for r in json.load(urllib.request.urlopen(req)) if "document" in r]
+c=collections.Counter(f["event"]["stringValue"] for f in rows)
+print(c.most_common())
+```
+
+Add a **bot filter** (drop UAs matching `bot|crawl|headless|lighthouse`) and a
+per-day pageview bar chart as needed.
+
+## 4. Bind the trust tag
+
+When wiring this into an improvement loop, declare this source **`untrusted`**
+(public, unauthenticated). Findings derived from it inherit `untrusted` → quarantine
+→ blocking admin approval. See the binding's trust section.
+
+## Verify
+
+- Load the prod page → a `hits` doc appears. Load from `localhost` → **no** doc
+  (origin guard).
+- Try to `read` the collection from a browser console → **denied** (rules hold).
+- Try to append a doc with an extra field → **denied** (`hasOnly` holds).
+- `python3 stats.py --days 7` prints counts.
+
+## Cost
+
+Free: ~1 write/event under the ~20k/day Firestore free tier; reads only when you run
+the CLI. No server, no vendor.

--- a/patterns/stacks/gcp-serverless-saas/skills/secret-manager-setup.md
+++ b/patterns/stacks/gcp-serverless-saas/skills/secret-manager-setup.md
@@ -1,0 +1,78 @@
+# Skill: Secret Manager containers + least-privilege runtime access
+
+The secrets discipline every T1+ binding on this stack depends on. Outcome: IaC
+creates secret **containers** and grants the **runtime** SA read on exactly those;
+**values are added out-of-band** and never touch tfstate, `.tfvars`, env files, or
+the repo. Mirrors [chief-wiggum's own rule](../../../../CLAUDE.md): secrets never
+become environment variables in your tooling either.
+
+> Bind first: `PROJECT`, the runtime service account `RUNTIME_SA`, and the logical
+> secret → env-var map (e.g. `resend-api-key → RESEND_API_KEY`).
+
+## 1. Create containers via IaC (Terraform), env-suffixed
+
+```hcl
+variable "secret_ids" { default = ["resend-api-key", "mongodb-atlas-uri", "stripe-secret-key", "stripe-webhook-secrets"] }
+
+resource "google_secret_manager_secret" "s" {
+  for_each  = toset(var.secret_ids)
+  secret_id = "${each.value}-${var.env}"     # e.g. resend-api-key-prod
+  replication { auto {} }
+}
+
+# Grant ONLY the runtime SA read on ONLY these secrets (least privilege)
+resource "google_secret_manager_secret_iam_member" "runtime_read" {
+  for_each  = google_secret_manager_secret.s
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.runtime_sa}"
+}
+```
+
+Terraform creates **containers only**. It never sees a secret value.
+
+## 2. Add values out-of-band (operator shell, not CI)
+
+```bash
+printf %s "$THE_ACTUAL_KEY" | gcloud secrets versions add resend-api-key-prod \
+  --project="$PROJECT" --data-file=-
+```
+
+Rotate by adding a new version; consumers reading `latest` pick it up on next boot.
+For rotation-list secrets (`stripe-webhook-secrets`) store a comma-separated value
+and let the app accept any entry.
+
+## 3. Inject into Cloud Run at runtime (not build time)
+
+```bash
+gcloud run deploy "$SERVICE" --project="$PROJECT" --region="$REGION" \
+  --set-secrets="RESEND_API_KEY=resend-api-key-${ENV}:latest,\
+STRIPE_SECRET_KEY=stripe-secret-key-${ENV}:latest,\
+STRIPE_WEBHOOK_SECRETS=stripe-webhook-secrets-${ENV}:latest"
+```
+
+Cloud Run mounts the value as an env var **in the running container only** — it is
+not in the image, the build logs, or the deploy config.
+
+## 4. Keep the deployer out
+
+The **deploy** SA (`github-deployer`) must **not** have `secretAccessor` — only the
+**runtime** SA does. This is the split that bounds blast radius: a compromised deploy
+job can roll an image but cannot read a single secret. Verify:
+
+```bash
+gcloud secrets versions access latest --secret=resend-api-key-prod \
+  --impersonate-service-account="$DEPLOYER_SA"   # must FAIL
+```
+
+## Non-secret config
+
+Public/non-secret config (API URLs, `NEXT_PUBLIC_*`, feature flags) goes in
+`--env-vars-file=.env.yaml` or build env — **not** Secret Manager. Only true secrets
+get a container.
+
+## Verify
+
+- `terraform plan` shows secret **containers**, zero secret **values**.
+- The running service reads the key; the repo and tfstate contain none.
+- The deployer SA access check above **fails**; the runtime SA succeeds.

--- a/patterns/stacks/gcp-serverless-saas/skills/stripe-subscriptions-setup.md
+++ b/patterns/stacks/gcp-serverless-saas/skills/stripe-subscriptions-setup.md
@@ -1,0 +1,87 @@
+# Skill: Stand up Stripe subscriptions (Checkout + Portal + webhook)
+
+Realizes [`tiered-subscription`](../bindings/tiered-subscription.md) on this stack.
+Outcome: users upgrade via hosted Checkout, self-serve via the Customer Portal, and
+**the webhook is the single entitlement writer** via fetch-on-webhook reconcile.
+
+> Bind first: the tier list + one Stripe **Price** per paid tier; `STRIPE_MODE`
+> (`test`|`live`); the datastore for the entitlement projection.
+
+## 1. Products & prices (test mode first)
+
+```bash
+stripe products create --name "Coach"
+stripe prices create --product <prod_id> --unit-amount 2900 --currency aud \
+  --recurring[interval]=month
+# repeat per paid tier; store price ids as STRIPE_PRICE_<TIER>
+```
+
+## 2. Secrets (never in env/repo — see secret-manager-setup)
+
+Store `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRETS` (comma-separated to allow
+rotation) in Secret Manager; grant the **runtime** SA `secretAccessor` (the
+**deployer** SA must not have it).
+
+## 3. Checkout (server mints the session)
+
+Create a Checkout Session in `subscription` mode with the tier's price, a
+`client_reference_id` = your account id, `success_url`/`cancel_url`. **Do not** write
+entitlement on the success redirect — it can die mid-flow.
+
+## 4. Customer Portal
+
+Enable the Portal in the Stripe dashboard; mint a portal session server-side
+(`stripe.billingPortal.sessions.create`) so users manage plan/payment without
+support. (Realizes the `self-serve-billing-portal` candidate.)
+
+## 5. Webhook — the single entitlement writer
+
+Register `POST /api/v1/webhooks/stripe` **outside** auth/tenant middleware. In the
+handler:
+
+```
+1. Read the RAW body; verify signature with ConstructWebhookEvent against EACH
+   secret in STRIPE_WEBHOOK_SECRETS (rotation list) — accept if any matches.
+2. Guard: if event.livemode != config.Livemode() -> 400 (test can't touch live).
+3. Idempotency: claim stripe_event_id (claim->processed); if already processed, 200.
+4. FETCH-ON-WEBHOOK: ignore the payload's snapshot; re-fetch the live subscription
+   from Stripe and project entitlement from THAT. This handler is the ONLY writer
+   of entitlement. Trust the re-fetched VENDOR state; treat customer-controlled
+   fields (email, metadata, cancellation_reason, Connect account context) as
+   UNTRUSTED — validate the account/context matches the account you expect.
+5. At-most-one customer: durable unique constraint / CAS on (provider, account_id)
+   (+ account_id in Stripe customer metadata); the idempotency key only dedupes
+   retries. On CAS loss, delete the orphan customer.
+```
+
+Register the webhook endpoint + subscribe to
+`checkout.session.completed`, `customer.subscription.*`, `invoice.payment_failed`:
+
+```bash
+stripe listen --forward-to localhost:8080/api/v1/webhooks/stripe   # local dev
+# prod: add the endpoint in the dashboard; copy its signing secret into the rotation list
+```
+
+## 6. Boot-time validation (fail fast)
+
+On startup assert: key segment (`_test_`/`_live_`) matches `STRIPE_MODE`; every paid
+tier has a price; if Stripe env absent → billing routes return **503** but the
+server still boots (valid T1 state).
+
+## Verify
+
+- `stripe trigger checkout.session.completed` → entitlement appears **only** after
+  the webhook, never from the redirect.
+- Fire a **test-mode** event at a **live**-configured handler → **400** (livemode
+  guard holds).
+- Replay the same event twice → applied once (idempotency holds).
+- Rotate: add a second secret to the list, flip Stripe's signing secret, confirm no
+  missed events, then drop the old one.
+
+## Gotchas
+
+- Writing entitlement in the success_url handler = split-brain when the redirect
+  dies. Webhook-only.
+- Single webhook secret = downtime on rotation. Use the list.
+- Trusting the event payload's subscription snapshot = stale on out-of-order
+  delivery. Re-fetch.

--- a/patterns/stacks/gcp-serverless-saas/stack.md
+++ b/patterns/stacks/gcp-serverless-saas/stack.md
@@ -1,0 +1,175 @@
+# Stack Profile: GCP Serverless SaaS (the house stack)
+
+- **Status:** specified (bindings + skills below; `scaffold/` not yet built)
+- **Provenance:** mined from three shipped apps — `plwp.net` (T0), `booking-forms`
+  (T1), `dogeared-coach` (T2). The vendor choices are consistent across all three;
+  this profile is that consistency written down.
+
+## What a stack profile is (and why it's separate from a pattern)
+
+The [patterns registry](../../../docs/patterns-registry.md) is deliberately
+**vendor-neutral** — `provider-neutral-adapter` (candidate)
+is the whole seam, and a pattern like [`tiered-subscription`](../../tiered-subscription)
+names *no* vendor. That abstraction is correct, but a catalog of seams is not a
+factory: to actually *stamp a working product* you need an **opinionated, real-
+vendor default** for each seam, wired the way that has already shipped.
+
+A **stack profile** is that default. It **binds** the abstract patterns to a
+concrete infrastructure stack, ships the **runnable skills** to stand each piece
+up, and carries a **cost model** so you know the zero-cost PoC footprint and where
+money starts. The abstract pattern stays neutral (swap Cloud Run for Fly, Stripe
+for Paddle); the profile is the bound default the factory reaches for first.
+
+```
+  ABSTRACT (patterns/)            CONCRETE (this profile)
+  vendor-neutral seam        ×    named vendor + wiring    →   runnable recipe + cost
+  ─────────────────────           ─────────────────────        ───────────────────────
+  tiered-subscription        ×    Stripe Checkout+Portal   →   bindings/tiered-subscription.md
+  engagement-instrumentation ×    DIY Firestore beacon     →   bindings/engagement-instrumentation.md
+  multi-tenant-isolation     ×    server-derived scoping   →   bindings/multi-tenant-isolation.md
+  provider-neutral-adapter   ×    Go interface + webhooks  →   bindings/provider-neutral-adapter.md
+  transactional-email        ×    Resend + token links     →   bindings/transactional-email.md
+  deployment-release         ×    keyless WIF + promote    →   bindings/deployment-release.md
+```
+
+## The house stack
+
+| Seam | Vendor | Notes |
+|--|--|--|
+| **Static hosting / frontend** | **Firebase Hosting** | multi-site (one site per env/tenant); SPA rewrite; immutable-hashed assets, `no-cache` HTML |
+| **Backend / API** | **Cloud Run** (Go) | region `us-central1`; scale-to-zero by default; public ingress, app does its own auth |
+| **Database** | **Firestore** (T0/T1) → **MongoDB Atlas** (T2) | Firestore for config/append-only/simple; Atlas when the query model needs joins/txns/aggregations |
+| **Auth** | **Firebase Auth / Identity Platform** | email/password + passwordless magic-link; verified server-side via Admin SDK; RBAC (e.g. Casbin) on top |
+| **Payments** | **Stripe** | Checkout + Customer Portal for **subscriptions**; **Connect** for per-tenant marketplace/deposits |
+| **Transactional email** | **Resend** | raw HTTPS or SDK; hand-rolled sanitized HTML; single-use token links |
+| **Media / large files** | provider-neutral (**Cloudflare Stream** exemplar) | behind a Go interface: direct-to-CDN upload, per-request signed playback, webhook reconcile |
+| **Secrets** | **GCP Secret Manager** | IaC creates containers + grants runtime read; values added out-of-band |
+| **Deploy identity** | **Workload Identity Federation** (GitHub OIDC) | keyless, repo-scoped; least-privilege deployer (roll releases, not mutate infra) |
+| **Observability** | **Cloud Logging** (structured stdout) + append-only audit collections | no paid APM by default; `/healthz` smoke; DIY Firestore analytics for product signal |
+| **IaC** | **Terraform** | provisions services, secret containers, IAM, WIF; infra changes are a human-run privileged path |
+
+Backend language is **Go** (Gin at T2, stdlib `net/http` at T1); frontend is a
+**Vite/React SPA** (T2) or **Next.js static export** (T1), TypeScript throughout.
+
+## Cost tiers — the ladder from $0 to production
+
+The same stack, subsetted into three coherent tiers. You start at the lowest tier
+that does the job and **graduate one seam at a time** — most seams add cleanly
+(add Cloud Run, add Auth, flip `min-instances`). **One seam is not a knob but a
+migration: Firestore → Atlas** changes query semantics, indexes, transactions,
+backups, and local tooling — it needs a dual-write/backfill/cutover plan, not a
+config flip. Design the T1 data access behind a repository interface *from the
+start* so that migration is contained.
+
+### T0 — Static + DIY (~$0/mo) · exemplar `plwp.net`
+
+- **Firebase Hosting** serving a static site directly (no build step), manual
+  `firebase deploy`.
+- **DIY Firestore analytics**: a cookieless beacon POSTs directly to the Firestore
+  **REST API**; writes locked **append-only** by security rules (`hasOnly` key
+  whitelist, `read/update/delete: if false`); read offline by a stdlib CLI. No SDK,
+  no Cloud Function, no analytics vendor. See
+  [`bindings/engagement-instrumentation.md`](bindings/engagement-instrumentation.md).
+- **No auth, no CI, no server.**
+- **Cost:** genuinely ~$0 — Firestore free tier (~20k writes/day), Hosting free
+  tier (10 GB storage, 360 MB/day egress), heavy libs from third-party CDNs. The
+  cost lever is *no always-on server, no vendor*.
+- **Use for:** landing pages, marketing sites, tiny tools, demand validation.
+
+### T1 — Thin serverless (~$0–5/mo) · exemplar `booking-forms`
+
+- **+ Cloud Run** (Go, stdlib `net/http`), `min-instances=0` (scale-to-zero),
+  `max-instances` capped for cost — the cap doubles as a throughput ceiling.
+- **+ Firestore** for per-tenant config: **layered defaults ← Firestore override**,
+  merged behind a **60-second TTL cache**, with a **parity audit** (what the form
+  presented vs what the server recomputed) logged as structured JSON.
+- **+ Resend** for transactional email (sent synchronously in the request handler
+  at this tier).
+- **+ Stripe** — at this tier typically **Connect** (per-tenant connected accounts,
+  pay-per-booking deposits) rather than subscriptions.
+- **+ per-tenant static bearer token** for `/admin` (constant-time compare, magic-
+  link `?token=` → `sessionStorage`), instead of a full identity provider.
+- **+ keyless WIF deploy**, staging auto on push, prod manual.
+- **Cost:** ~$0–5/mo — everything scale-to-zero or free-tier. **First ceiling hit
+  is usually Resend** (3k mail/mo, 100/day free).
+- **Use for:** real transactional micro-SaaS, per-tenant config, marketplace/deposit
+  collection.
+
+### T2 — Full production (~$60–140/mo) · exemplar `dogeared-coach`
+
+- **+ Cloud Run prod `min-instances=1`** to kill cold-start latency on auth/media —
+  typically **the biggest fixed-cost jump**. *~$45–65/mo is an illustrative figure*
+  (1 always-allocated instance, ~1 vCPU / 512Mi–1Gi, `us-central1`, instance-based
+  billing); the real number depends on region, CPU/memory, concurrency, and whether
+  you use request-based vs instance-based billing — treat it as an example, not a
+  stack invariant.
+- **+ MongoDB Atlas** (Flex ~$8–30/mo → M10 ~$57/mo at hundreds of tenants) when
+  the query model outgrows Firestore. **This is a data migration** (see the tier-
+  ladder note), not a drop-in — budget for a dual-read/backfill/cutover.
+- **+ Firebase Auth + RBAC** (Casbin) for real user accounts and roles.
+- **+ Stripe Checkout + Customer Portal + webhooks** for subscriptions: the webhook
+  is the **single entitlement writer** via **fetch-on-webhook reconcile**, verified
+  against a **rotation list** of signing secrets with a **`livemode` guard**. See
+  [`bindings/tiered-subscription.md`](bindings/tiered-subscription.md).
+- **+ provider-neutral media** (Cloudflare Stream exemplar): direct-to-CDN upload,
+  per-request signed playback JWTs (only the media id is stored), webhook reconcile
+  for billing-ghosts.
+- **+ promote-identical-image** deploys with a **bundle-guard** config-leak fence;
+  **cross-tenant isolation proof tests** that must fail on leak.
+- **Cost:** ~$60–140/mo. **Media delivery is usually the largest uncapped product
+  meter** — bound it with per-plan caps + a soft alert. It is *not* the only
+  usage-metered line, though: Firestore reads/writes/storage, Cloud Run
+  requests/CPU/**egress**, Firebase Hosting transfer, Cloud Logging ingestion,
+  Artifact Registry storage, Resend overages, and Stripe per-txn fees all scale with
+  use. Put a **budget alert** on the project and cap/alert each meter. Break-even ≈ a
+  handful of paying customers.
+- **Use for:** subscription SaaS with accounts, media, and compliance needs.
+
+### Graduation triggers (the cost-scaling knobs)
+
+| From → To | Trigger | Add |
+|--|--|--|
+| T0 → T1 | need server logic / write-side validation / secrets | Cloud Run |
+| T1 → T2 (db) | Firestore query model doesn't fit (joins, cross-entity txns, aggregations) | MongoDB Atlas |
+| T1 → T2 (auth) | real user accounts + role-based access | Firebase Auth + RBAC |
+| T1 → T2 (latency) | cold starts hurt auth/media UX | prod `min-instances=1` ← **biggest fixed jump** |
+| usage | Resend > 3k mail/mo | ~$20 flat |
+| usage | Stripe | linear per-txn from #1 (no free tier); Connect adds per-account fees |
+| usage | media delivery | the **largest uncapped meter** (but not the only one — see cost note) — bound with plan caps + a soft alert |
+
+## Pattern bindings (concrete recipes)
+
+Each file below is the concrete realization of one vendor-neutral pattern **on this
+stack** — the wiring, the non-obvious glue, the gotchas mined from the real apps.
+
+| Binding | Realizes | Tier | Source |
+|--|--|--|--|
+| [`tiered-subscription.md`](bindings/tiered-subscription.md) | `tiered-subscription` | T2 | dgrd |
+| [`engagement-instrumentation.md`](bindings/engagement-instrumentation.md) | `engagement-instrumentation` | T0+ | plwp.net |
+| [`multi-tenant-isolation.md`](bindings/multi-tenant-isolation.md) | `multi-tenant-isolation` (two variants) | T1/T2 | booking-forms, dgrd |
+| [`provider-neutral-adapter.md`](bindings/provider-neutral-adapter.md) | `provider-neutral-adapter` | T2 | dgrd (Cloudflare) |
+| [`transactional-email.md`](bindings/transactional-email.md) | `transactional-email-and-dunning` | T1+ | booking-forms, dgrd |
+| [`deployment-release.md`](bindings/deployment-release.md) | `deployment-release` | T1+ | booking-forms, dgrd |
+
+## Stand-up skills (runnable playbooks)
+
+The "skills to use them" — step-by-step stand-up procedures for the vendor pieces:
+
+| Skill | Stands up |
+|--|--|
+| [`deploy-gcp-wif.md`](skills/deploy-gcp-wif.md) | keyless WIF deploy pipeline (staging-auto / prod-promote-identical) |
+| [`stripe-subscriptions-setup.md`](skills/stripe-subscriptions-setup.md) | Stripe Checkout + Portal + webhook (fetch-on-webhook reconcile) |
+| [`firestore-diy-analytics-setup.md`](skills/firestore-diy-analytics-setup.md) | the zero-cost DIY Firestore analytics beacon + CLI |
+| [`secret-manager-setup.md`](skills/secret-manager-setup.md) | Secret Manager containers + least-privilege runtime access |
+
+## Known gaps (honest, mined-from-real)
+
+- **Dunning is unbuilt** in every mined app — Stripe sends billing emails; no
+  in-app failed-payment sequence exists yet. The
+  [`transactional-email.md`](bindings/transactional-email.md) binding marks the
+  dunning half **aspirational** rather than inventing a recipe that never shipped.
+- **No standing job/queue infra** — reconciliation is a PSK-gated pull endpoint
+  poked by an external scheduler; no Cloud Scheduler/Tasks resource is provisioned.
+  A `reconciliation-sweep` binding is a natural next addition.
+- **Observability is thin** — structured logs + audit collections only; no APM/error
+  tracker wired. Fine at these tiers; name it when a product needs SLOs.

--- a/patterns/stacks/registry.json
+++ b/patterns/stacks/registry.json
@@ -1,0 +1,60 @@
+{
+  "$comment": "Index of CONCRETE stack profiles: opinionated, real-vendor bindings of the vendor-neutral patterns in ../registry.json to a specific infrastructure stack, with a cost model and runnable stand-up skills. A stack profile is what turns the pattern catalog into a micro/mini-SaaS factory: the abstract pattern is the seam, the profile is the bound default. See docs/patterns-registry.md#stack-profiles. Each profile is patterns/stacks/<id>/{stack.md,manifest.json,bindings/*.md,skills/*.md}.",
+  "version": 1,
+  "stacks": [
+    {
+      "id": "gcp-serverless-saas",
+      "title": "GCP Serverless SaaS (the house stack)",
+      "status": "specified",
+      "summary": "Firebase Hosting + Cloud Run (Go) + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless WIF deploys. A single stack presented as a three-tier cost ladder (T0 static/DIY -> T1 thin-serverless -> T2 full-production) so the same blueprint scales from a zero-cost PoC to paid production without re-platforming.",
+      "spec": "patterns/stacks/gcp-serverless-saas/stack.md",
+      "manifest": "patterns/stacks/gcp-serverless-saas/manifest.json",
+      "provenance": ["plwp.net (T0)", "booking-forms (T1)", "dogeared-coach (T2)"],
+      "binds": [
+        "tiered-subscription",
+        "engagement-instrumentation",
+        "multi-tenant-isolation",
+        "provider-neutral-adapter",
+        "transactional-email-and-dunning",
+        "deployment-release",
+        "build-test-floor"
+      ]
+    }
+  ],
+  "cost_tiers": {
+    "$comment": "The cost ladder is a first-class artifact of the factory. Each tier is a coherent subset of the house stack with a monthly footprint and a graduation trigger to the next tier. Full detail per stack in its stack.md.",
+    "tiers": [
+      {
+        "id": "T0",
+        "name": "Static + DIY",
+        "monthly": "~$0",
+        "includes": ["Firebase Hosting (static, no build)", "DIY Firestore analytics (REST beacon + CLI reads)", "no auth", "manual deploy"],
+        "use_for": "landing pages, marketing sites, tiny tools, validating demand",
+        "exemplar": "plwp.net"
+      },
+      {
+        "id": "T1",
+        "name": "Thin serverless",
+        "monthly": "~$0-5",
+        "includes": ["+ Cloud Run (scale-to-zero, max-instances capped)", "+ Firestore (layered config + TTL cache)", "+ Resend (transactional email)", "+ Stripe (Connect or Checkout)", "+ per-tenant bearer admin", "+ keyless WIF deploy, prod-manual"],
+        "use_for": "real transactional micro-SaaS, per-tenant config, pay-per-use / marketplace",
+        "exemplar": "booking-forms"
+      },
+      {
+        "id": "T2",
+        "name": "Full production",
+        "monthly": "~$60-140",
+        "includes": ["+ Cloud Run prod min-instances=1", "+ MongoDB Atlas", "+ Firebase Auth + RBAC", "+ Stripe Checkout+Portal+webhooks", "+ provider-neutral media (e.g. Cloudflare Stream)", "+ promote-identical-image + bundle-guard", "+ cross-tenant isolation proof tests"],
+        "use_for": "subscription SaaS with real accounts, media, and compliance needs",
+        "exemplar": "dogeared-coach"
+      }
+    ],
+    "graduation_triggers": [
+      "T0->T1: need server-side logic / write-side validation / secrets -> add Cloud Run",
+      "T1->T2 (db): Firestore query model doesn't fit (joins, cross-entity transactions, aggregations) -> MongoDB Atlas",
+      "T1->T2 (auth): real user accounts + role-based access -> Firebase Auth + RBAC",
+      "T1->T2 (latency): cold starts hurt auth/playback UX -> prod min-instances=1 (the single biggest fixed-cost jump, ~$45-65/mo)",
+      "usage cliffs: Resend >3k mail/mo -> ~$20; Stripe fees linear from txn #1; media delivery is the only uncapped variable cost (bound it with plan caps)"
+    ]
+  }
+}

--- a/patterns/tiered-subscription/manifest.json
+++ b/patterns/tiered-subscription/manifest.json
@@ -1,0 +1,53 @@
+{
+  "$comment": "Machine-readable surface for a future /apply-pattern installer. Human spec: patterns/tiered-subscription/pattern.md. Absorbs the former tiered-saas-enforcement candidate.",
+  "id": "tiered-subscription",
+  "version": 1,
+  "title": "Tiered Subscription",
+  "category": "saas-infra",
+  "trust_class": "entitlement-changes-are-protected-path",
+
+  "applies_when": [
+    "product has more than one paid tier, or free + paid",
+    "you need self-serve plan changes and enforcement at every mutating action",
+    "lapse/downgrade must degrade gracefully without deleting customer data"
+  ],
+
+  "components": [
+    "tier-matrix-single-source-of-truth: per-tier caps/flags, -1 unlimited sentinel, unknown-tier -> most-restrictive fallback",
+    "injected-gate-seams: Allow/Check interfaces into services + webhook handlers, check-before-act, documented bounded TOCTOU",
+    "stateless-quota: recompute usage fresh from source of truth, one path for enforce + display, pessimistic in-flight reservation",
+    "billing-webhook-source-of-truth: signed idempotent provider webhooks drive subscription state, never the client redirect",
+    "lifecycle: subscribe / upgrade(immediate,proration-by-provider) / downgrade(at-period-end) / cancel(retain-till-period-end) / reactivate; entitlement recomputed per transition",
+    "graceful-degradation: past_due -> dunning grace window; cancel/expire -> free-tier or read-only, never hard-delete; over-cap downgrade -> block-new keep-existing"
+  ],
+
+  "parameters": {
+    "tiers": {"type": "array", "required": true, "description": "Tier ids in ascending order."},
+    "matrix": {"type": "object", "required": true, "description": "Per-tier capability/limit matrix; -1 = unlimited."},
+    "billing_provider": {"type": "string", "required": true, "description": "Billing vendor, behind provider-neutral-adapter."},
+    "unknown_tier_fallback": {"type": "string", "required": false, "default": "free", "description": "Most-restrictive tier used for unknown/empty tier."},
+    "dunning_grace_window": {"type": "string", "required": false, "default": "14d", "description": "How long past_due retains access before degrade."},
+    "downgrade_policy": {"enum": ["block-new", "read-only"], "required": false, "default": "block-new", "description": "Over-cap downgrade behavior; never destructive."},
+    "lapse_policy": {"enum": ["free-tier", "read-only"], "required": false, "default": "free-tier", "description": "On cancel/expire; never delete data."}
+  },
+
+  "success_metrics": {
+    "$comment": "Monetization health; the loop optimizes packaging/thresholds toward these, admin-gated (entitlement/pricing are protected-path).",
+    "metrics": [
+      {"id": "mrr", "goal": "up", "desc": "monthly recurring revenue / ARPU"},
+      {"id": "upgrade_rate", "goal": "up", "desc": "% of accounts moving to a higher tier"},
+      {"id": "voluntary_churn_rate", "goal": "down", "desc": "% cancelling per period"},
+      {"id": "dunning_recovery_rate", "goal": "up", "desc": "% of past_due accounts recovered before degrade (involuntary churn saved)"},
+      {"id": "revenue_leak", "goal": "down", "desc": "unpaid-access or wrong-tier-grant incidents (target 0; asserted by the enforcement gate)"}
+    ]
+  },
+
+  "depends_on": {
+    "provider-neutral-adapter": "billing vendor + its signed webhooks sit behind the neutral seam"
+  },
+
+  "feeds": {
+    "frictionless-onboarding": "limit-hit 409 from the enforcement seam is the upgrade-prompt trigger",
+    "improvement-loop": "limit-hit / upgrade / downgrade / dunning events are monetization signal; entitlement+pricing defs are protected-path, so loop-proposed changes are admin-gated"
+  }
+}

--- a/patterns/tiered-subscription/pattern.md
+++ b/patterns/tiered-subscription/pattern.md
@@ -1,0 +1,96 @@
+# Pattern: Tiered Subscription
+
+- **Category:** saas-infra (monetization)
+- **Trust class:** entitlement changes are protected-path (goalpost-grade)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+
+## What it is
+
+The full **subscribe → enforce → lifecycle** machinery for a plan-tiered SaaS:
+a single source-of-truth tier matrix, self-serve plan changes, billing-provider
+webhooks as the authoritative subscription state, capability/quota enforcement at
+every mutating action, and **graceful degradation** when a subscription lapses or
+downgrades. Absorbs the earlier `tiered-saas-enforcement` candidate and adds the
+lifecycle + degradation half.
+
+## When to apply
+
+Any product with more than one paid tier (or free + paid). The subtle parts —
+authoritative state from webhooks not client redirects, never-destructive
+downgrade enforcement, restrictive fallback for unknown tiers — are where most
+implementations leak revenue or delete customer data, so it's worth stamping as
+one coherent shape.
+
+## Mechanism — generic components
+
+Neutral throughout; tiers, provider, and policies are [parameters](#parameters).
+
+- **Tier matrix as single source of truth.** One structure holds every tier's
+  capabilities and limits (counts, per-item caps, quotas, capability flags). A
+  `-1` **unlimited sentinel**; an **unknown/empty tier falls back to the most
+  restrictive tier**, never silently granting a higher one.
+- **Enforcement via injected gate seams.** `Allow…` / `Check…` methods exposed as
+  injected interfaces into services *and* webhook handlers, so enforcement is
+  testable without real infra. Check-before-act at each mutating action; the
+  bounded check-before-act TOCTOU is documented and accepted, not papered over.
+- **Stateless quota.** Usage is recomputed fresh from the source of truth on every
+  check (no stored counters that drift), the **same computation path backs both
+  the enforcement gate and the user-facing usage display**, and in-flight items
+  are reserved pessimistically to close the sequential-overcommit gap.
+- **Billing webhook is the source of truth.** Subscription state
+  (`active` / `trialing` / `past_due` / `canceled`) is driven by **signed,
+  idempotent provider webhooks**, never by the browser's post-checkout redirect
+  (which can die mid-flow). Reuses the webhook-ingestion shape from
+  `provider-neutral-adapter` (raw-body verify → replay window → normalize →
+  idempotent apply).
+- **Lifecycle transitions.** Subscribe / upgrade (effective immediately, proration
+  delegated to the provider) / downgrade (effective at period end) / cancel
+  (retain access until period end) / reactivate. Entitlement is **recomputed on
+  each transition**, never hand-mutated.
+- **Graceful, non-destructive degradation.** `past_due` → a **dunning grace
+  window**: keep access, notify (see `transactional-email-and-dunning` candidate).
+  `canceled` / expired → fall back to the **free tier or read-only**, and **never
+  hard-delete data** — grandfather it and offer export. A downgrade that leaves the
+  account over the new caps **blocks new creation but keeps existing items** — no
+  destructive enforcement, ever.
+- **Provider-neutral.** The billing provider sits behind
+  `provider-neutral-adapter`, so it is swappable.
+
+## Parameters
+
+| Parameter | What it is |
+|--|--|
+| `tiers` + `matrix` | the capability/limit matrix per tier (`-1` = unlimited) |
+| `billing_provider` | the provider (behind the neutral adapter) |
+| `unknown_tier_fallback` | most-restrictive tier used for unknown/empty (default: free) |
+| `dunning_grace_window` | how long `past_due` retains access before degrade |
+| `downgrade_policy` | `block-new` (keep existing over-cap items) or `read-only` |
+| `lapse_policy` | on cancel/expire: `free-tier` or `read-only`; never delete |
+
+## Success metrics
+
+Monetization health — the loop optimizes packaging/thresholds toward these
+(admin-gated, since entitlement/pricing are protected-path):
+
+| Metric | Goal | What it measures |
+|--|--|--|
+| `mrr` | ↑ | monthly recurring revenue / ARPU |
+| `upgrade_rate` | ↑ | % of accounts moving to a higher tier |
+| `voluntary_churn_rate` | ↓ | % cancelling per period |
+| `dunning_recovery_rate` | ↑ | % of `past_due` accounts recovered before degrade |
+| `revenue_leak` | ↓ | unpaid-access / wrong-tier-grant incidents (target 0; asserted by the gate) |
+
+## Relationship to other patterns
+
+- **Behind `provider-neutral-adapter`** for the billing vendor + its webhooks.
+- **Consumed by `frictionless-onboarding`** — its limit-hit gate (a `409` from the
+  enforcement seam) is the friction signal that triggers a contextual upgrade
+  prompt.
+- **Emits monetization signal for `improvement-loop`.** Limit-hit events,
+  upgrade/downgrade transitions, and dunning outcomes are exactly the signal the
+  loop can optimize (packaging, thresholds, prompt timing). Because entitlement /
+  pricing / paywall definitions are **goalpost-grade** (a wrong change is a direct
+  revenue or trust bug) they belong in the **protected pathset** — the loop may
+  *propose* changes to them, but they route through park-and-notify or, when the
+  proposal is driven by end-user behavioral signal, the **blocking admin-approval**
+  quarantine (see the [improvement-loop trust model](../improvement-loop/pattern.md#trust-model)).


### PR DESCRIPTION
## What & why

Turns the **vendor-neutral** pattern catalog into a **micro/mini-SaaS factory** by adding a concrete binding layer, mined from three shipped apps — `plwp.net` (T0), `booking-forms` (T1), `dogeared-coach` (T2). The abstract patterns stay neutral (`provider-neutral-adapter` is still the seam); a **stack profile** is the opinionated real-vendor *default* the factory reaches for first — with runnable stand-up skills and a **cost model**.

```
ABSTRACT (patterns/<id>)        CONCRETE (patterns/stacks/<id>)
vendor-neutral seam        ×    named vendor + wiring    →   runnable recipe + cost
```

## New

- **`patterns/deployment-release/`** — a new *abstract* pattern (the registry's biggest gap; deployment/release had no home): keyless federated CI identity, env split with a **human-gated prod promotion**, **promote-identical-artifact by digest**, config-leak fence, least-privilege deployer, floor-gated + post-deploy smoke. Trust class: pipeline + promotion authority are protected-path.
- **`patterns/stacks/`** — the concrete layer: `registry.json` (index + **T0→T1→T2 cost-tier ladder** with graduation triggers) and the flagship **`gcp-serverless-saas`** profile (Firebase Hosting + Cloud Run + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless WIF; ~$0 PoC → ~$60–140 prod).
  - **6 pattern bindings** (concrete recipe + gotchas each): tiered-subscription, engagement-instrumentation, multi-tenant-isolation (two variants), provider-neutral-adapter, transactional-email (dunning flagged aspirational), deployment-release.
  - **4 stand-up skills** with real commands: `deploy-gcp-wif`, `stripe-subscriptions-setup`, `firestore-diy-analytics-setup`, `secret-manager-setup`.
- **`docs/patterns-registry.md`** — documents the stack-profile layer + the first-class cost axis.

## The cost axis (a factory requirement)

Every profile declares a tier ladder: a genuine **~$0 PoC** floor (scale-to-zero compute, free-tier datastore, no vendor), each higher tier adding one seam with its cost and a **graduation trigger**. Surfaces the two numbers that matter: the **first fixed-cost jump** (prod `min-instances=1`) and the **largest uncapped meter** (media delivery).

## Quality gate — codex red/blue review

Ran a red-team/blue-team review with codex; **13 findings folded back in**, e.g.: repo-only WIF is insufficient for prod (scope to protected branch + `job_workflow_ref`); a deployer's true privilege ceiling is the runtime SA (malicious-image path); promote by **digest** not mutable tag; DIY analytics origin guard is anti-noise **not security** (unauthenticated/abuseable → add budget/quota/App Check); substring host-matching is tenant-confusion; static bearer-in-URL leaks (→ one-time redeem → HttpOnly cookie); at-most-one-customer needs a `(provider, account_id)` constraint; a signed webhook proves *origin* not per-field trust; and corrected cost overclaims (min-instances figure is illustrative; media isn't the *only* uncapped meter; Firestore→Atlas is a **migration**, not a knob).

## Validation

- All registry JSON parses.
- All relative markdown cross-links resolve (checked).
- No code touched; this is a docs/spec + registry change. Rollout of `/apply-pattern --stack` wiring is deliberately out of scope (future work, per the design doc).