### PR TITLE
Add regulated-data compliance patterns (template + /seed + /saas-gate)

### DIFF
--- a/.claude/commands/saas-gate.md
+++ b/.claude/commands/saas-gate.md
@@ -4,6 +4,8 @@ Validates common SaaS non-functional requirements (security, tenant isolation, p
 
 The build-side complement to a SaaS baseline: it proves a chief-wiggum-built (or cloned) SaaS app meets production standards before shipping.
 
+For products that hold **regulated or sensitive data** (health, financial, biometric, children's, government-classified, or PII at scale), the runtime checks are necessary but not sufficient — there is also a **design-time compliance posture** to verify (data classification, privacy/cross-border law, retention + legal hold, de-identification, the AI/LLM data-path gate). That posture is captured in `docs/compliance-requirements.md` (filled from `templates/compliance-requirements.md`), and this gate checks it exists and its controls are evidenced. See Step 5.
+
 ## Usage
 ```
 /saas-gate <owner/repo> --base-url <url> [--auth-mode cookie|bearer]
@@ -49,6 +51,19 @@ Options: `--require-https` (require HSTS), `--rate-limit-path` / `--rate-limit-r
 - **Performance**: sample representative endpoints under a realistic load and compare against the target SLOs.
 - **Data integrity**: confirm an audit trail is written and soft-delete is honored (verify in the datastore / via the API).
 
-### Step 5: Report
+### Step 5: The regulated-data compliance dimension (design-time)
 
-Present the per-category pass/fail. Flag every `fail` with the actionable fix. As a `/close-epic` gate, a `fail` blocks the epic close; `warn`/`skipped` are surfaced but don't block.
+Run this dimension **only if the product holds regulated/sensitive data** (otherwise mark the whole dimension `not_applicable`). It is a design-time checklist, not a runtime probe — it verifies the compliance posture is defined and evidenced, drawing its criteria from the product's `docs/compliance-requirements.md`.
+
+- **Requirements doc present** — `docs/compliance-requirements.md` exists and is filled (not the raw template). Absent for a regulated-data product is a `fail`.
+- **Data classification** — a classification is stated and drives handling.
+- **AI/LLM data-path GATE** — if regulated data is sent to any third-party model, the doc records a resolved residency / no-training / no-retention posture (in-region model, signed DPA, reasonable-steps/transfer-impact file). Unresolved is a `fail` — this gate is load-bearing.
+- **Encryption + immutable audit** — customer-managed keys at rest and a tamper-evident audit trail of regulated-data access are evidenced in the running app (extends the Step 4 data-integrity check).
+- **Retention + legal hold** — a retention schedule exists and a `legal_hold` hard-block on deletion is implemented.
+- **De-identification** — analytics/benchmarking run on de-identified data with small-cell suppression; identified data is access-walled.
+- **Individual rights** — access/correction (and erasure where required) workflows exist with the right SLAs.
+- **Unresolved `TBD:` legal items** — surface any `TBD:` in the requirements doc; a `TBD:` blocking a shipped data-touching feature is a `fail` (a guessed lawful basis / retention period must not ship). Reuse `scripts/check_unresolved.py` against the doc.
+
+### Step 6: Report
+
+Present the per-category pass/fail, including the regulated-data compliance dimension (Step 5) where applicable. Flag every `fail` with the actionable fix. As a `/close-epic` gate, a `fail` blocks the epic close; `warn`/`skipped` are surfaced but don't block.

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -67,6 +67,8 @@ Write the findings to `$CW_TMP/domain-context.md` with **citations** (file paths
 
 If the product has no existing data source and no usage history (true greenfield), note that in `domain-context.md` and move on — don't invent ceremony.
 
+**If the product holds regulated or sensitive data** (health, financial, biometric, children's, government-classified, or PII at scale), also research and fill `templates/compliance-requirements.md` into `$CW_TMP/compliance-requirements.md` (copied to `docs/compliance-requirements.md` at Step 7). This is where the compliance posture is grounded before contracts are written — data classification, privacy/cross-border law, retention + legal hold, de-identification, and the **AI/LLM data-path gate** (if regulated data is sent to any third-party model, its residency / no-training / no-retention posture is a GO/NO-GO gate resolved *here*, not deferred — it frequently overturns the default cloud/provider choice). Unconfirmed obligations get `TBD:` markers and gate dependent tickets; `/saas-gate` later verifies the filled doc. This is heavy web/legal research — spin it out to parallel workers by dimension (privacy law, security frameworks, data-path, retention) and keep only the cited findings.
+
 ### Step 3: Interactive architecture brainstorm
 
 Work through the key architecture decisions with the user. Don't assume — ask. Cover:
@@ -133,14 +135,15 @@ When both reviews are back:
 
 ### Step 7: Commit architecture decisions
 
-Copy the finalised architecture decisions to the target repo as `ARCHITECTURE.md`. If Step 2.5 produced domain context, copy it to `docs/domain-context.md` — `/architect` loads it before writing data contracts. Update `CLAUDE.md` if the tech stack has changed from what was previously documented.
+Copy the finalised architecture decisions to the target repo as `ARCHITECTURE.md`. If Step 2.5 produced domain context, copy it to `docs/domain-context.md` — `/architect` loads it before writing data contracts. If Step 2.5 produced a compliance-requirements doc (regulated-data products), copy it to `docs/compliance-requirements.md` — `/architect` folds it into security/privacy contracts and `/saas-gate` verifies it. Update `CLAUDE.md` if the tech stack has changed from what was previously documented.
 
 Commit and push:
 ```bash
 cd "$TARGET_DIR"
 mkdir -p docs
 cp "$CW_TMP/domain-context.md" docs/domain-context.md 2>/dev/null || true
-git add ARCHITECTURE.md CLAUDE.md docs/domain-context.md
+cp "$CW_TMP/compliance-requirements.md" docs/compliance-requirements.md 2>/dev/null || true
+git add ARCHITECTURE.md CLAUDE.md docs/domain-context.md docs/compliance-requirements.md
 git commit -m "Add architecture decisions from seed session"
 git push
 ```

--- a/templates/compliance-requirements.md
+++ b/templates/compliance-requirements.md
@@ -1,0 +1,141 @@
+<!--
+Chief Wiggum — Regulated-Data Compliance Requirements template.
+
+USE THIS when a product holds regulated or sensitive data at rest — health, financial,
+biometric, children's, criminal-record, or government-classified data, or PII at scale.
+Fill it during /seed (or the first /architect pass) and commit it to the target repo as
+`docs/compliance-requirements.md`. It is the design-time complement to /saas-gate's runtime
+checks: /saas-gate proves the controls RUN; this document defines what they must BE.
+
+It is jurisdiction-parameterized — the worked hints below are illustrative (AU shown as an
+example because that is where it was first authored). Replace them with the obligations of the
+product's actual jurisdiction(s) and buyer.
+
+Two load-bearing patterns this template exists to enforce:
+  1. THE LLM/AI DATA-PATH GATE. If regulated data is ever sent to a third-party model (extraction,
+     classification, RAG, generation), the residency / no-training / no-retention posture of that
+     model provider is a GO/NO-GO GATE resolved BEFORE the pipeline is built — not a downstream
+     spike. Cross-border disclosure law (e.g. AU APP 8, EU GDPR Ch. V) usually keeps YOU
+     accountable for the provider's mishandling. Model availability by region is frequently the
+     deciding constraint and often overturns the "obvious" cloud choice.
+  2. LEGAL-SIGNOFF TBDs GATE WORK. Any obligation that can't be confirmed against a primary legal
+     source is written as a `TBD:` and gates the dependent ticket (same mechanism as
+     scripts/check_unresolved.py). Do not hard-code a retention period, a lawful basis, or a
+     classification you inferred — mark it TBD and get a lawyer to sign it off.
+-->
+
+# {PRODUCT} — Compliance & Security Requirements
+
+> **The licence to operate.** {PRODUCT} holds {DATA_CATEGORY} at rest for {BUYER}. Meeting
+> {GOVERNING_STANDARD} is not a phase-2 nicety — a vendor that fails the assessment does not get
+> in the door. These controls are built from the first commit and **gate every data-touching
+> ticket**. Every material claim below is cited; unconfirmed items are `TBD:` and gate dependent
+> work until a lawyer signs them off.
+
+## 1. Data classification
+- Classify the data under the buyer's scheme ({e.g. AU PSPF OFFICIAL:Sensitive; US data
+  categories; EU special-category data}). The classification **drives every control below** —
+  handling, logging, access, encryption, residency.
+- Identify the **governing standard for the specific buyer** — it is often narrower/state-level,
+  not the headline national framework ({e.g. a state regulator → state data-security standard, not
+  the Commonwealth one}). `TBD:` confirm the exact classification + security schedule in the
+  actual contract/RFT.
+
+## 2. Privacy / data-protection law
+- **What law applies, to whom, and where.** Map the obligation set for each jurisdiction the data
+  touches ({national + state/sector regimes}). Note any exemptions AND whether they actually apply
+  to **this** entity — a common trap is assuming a customer's exemption (e.g. an employer's
+  employee-records exemption) flows to a third-party **processor**. It usually does not.
+- **The obligations that bite hardest** (fill per regime): lawful basis / consent for collection;
+  collection notice; use/disclosure limits (incl. "no secondary use to train a model without
+  explicit opt-in"); cross-border disclosure (§4); security proportional to sensitivity (§8);
+  access + correction rights (§9).
+
+## 3. Sector / records law (if any)
+- Sector-specific regimes ({health-records act, financial-records rules, education/children's
+  codes}) often apply **concurrently** with general privacy law and can impose stricter retention,
+  access-response SLAs, and a different regulator. Capture them here. `TBD:` any characterisation
+  that changes the obligation (e.g. "are we legally a health-service provider?").
+
+## 4. Cross-border & the AI/LLM data-path — GATE
+- **State the cross-border rule** ({e.g. AU APP 8: reasonable steps + ongoing accountability;
+  GDPR Ch. V: SCCs/adequacy}). Assume a foreign-HQ'd provider triggers it even when compute is
+  in-region, unless proven otherwise.
+- **Resolve the AI/LLM data-path GATE explicitly:**
+  - [ ] Which provider + region actually processes and stores the data? (Model availability by
+        region is frequently the binding constraint — verify, don't assume the parent cloud has it.)
+  - [ ] Contractual **no-training** on your data (+ explicit opt-in only if ever otherwise).
+  - [ ] **Zero / short retention**, and where any retained data lives.
+  - [ ] Signed DPA; subprocessor register; breach-notification + audit rights.
+  - [ ] Pin an **in-region model identifier** where cross-region routing is possible.
+  - [ ] A written "reasonable-steps" / transfer-impact file, kept even when compute is in-region.
+  - **Verdict:** {compliant route = …} / {fallback = …} / {no compliant route → the AI feature
+    changes}.
+
+## 5. Data-breach obligations
+- The applicable breach-notification scheme(s), the assessment window, who to notify, and the
+  trigger threshold. Sensitive data usually pushes the "serious harm" test toward notification —
+  treat those breaches as high-severity by default. Ship a runbook (§ checklist).
+
+## 6. Retention schedule & legal hold
+- A per-record-type **retention schedule** with the statutory basis for each; default
+  **conservatively** where a period is `TBD:` pending legal sign-off.
+- **Legal hold** — a preservation duty arises once litigation/investigation is reasonably
+  anticipated, and destroying anticipated evidence can be a **criminal offence**. A `legal_hold`
+  flag must **hard-block** retention-expiry deletion, be immutably logged, and be releasable only
+  by an authorised role.
+
+| Record type | Retention | Basis |
+|---|---|---|
+| … | … | … (mark TBD where unconfirmed) |
+
+## 7. De-identification & minimisation
+- The legal bar for de-identification ({e.g. "no reasonable likelihood of re-identification"}) and
+  that **pseudonymisation with a retained key is still personal data**. Beware small-n /
+  spontaneous-recognition risk — **suppress small cells (n<{k})** and aggregate for analytics.
+- Split features: which run on **de-identified/aggregated** data (benchmarking, trends) vs which
+  genuinely **require identity** (per-subject case handling). Minimising held identified data is
+  the single strongest control.
+
+## 8. Security controls (target: {GOVERNING_STANDARD} + {baseline, e.g. Essential Eight ML2})
+- Encryption at rest via **customer-managed keys** (rotation policy; crypto-shred at expiry) +
+  strong TLS in transit.
+- **Immutable/tamper-evident audit** (WORM/object-lock or hash-chain) of every access to and
+  mutation of regulated data; retain to match the record schedule.
+- Enforced **MFA/SSO**, least-privilege RBAC, **tenant isolation** (DB row-level security done
+  right: forced RLS, non-owner app role, per-request tenant context, a zero-rows test),
+  break-glass with mandatory review.
+- Baseline hygiene to the named maturity level (patching, app control, admin hardening, backups),
+  secrets in a manager (never env vars), malware scanning on upload, network segmentation.
+- **Defer** the expensive formal certification/assessment (e.g. IRAP, HITRUST) until a deal
+  requires it — but build to the bar from day 1 and leverage the cloud provider's own assessment.
+
+## 9. Individual-rights mechanics
+- Access + correction (+ any erasure) rights, their **response SLAs**, and whether correction is
+  annotation vs deletion. For **data subjects who are not your users** (e.g. a customer's
+  employees/patients), route requests through the controller with your product as processor.
+
+## 10. AI-specific governance & upcoming reform
+- Automated-decision-making transparency, high-risk-AI rules, and any pending reforms with a
+  commencement date — track what is IN FORCE vs pending. Plus model governance: labelled benchmark
+  corpus, accuracy-by-class, confidence calibration, prompt/model regression tests, model-change
+  approvals, prompt-injection handling.
+
+---
+
+## What {PRODUCT} must build/do — consolidated checklist
+- [ ] Data-classification policy + tagging that drives handling
+- [ ] Consent / lawful-basis engine + collection notices (+ never-train-by-default)
+- [ ] Access & correction workflow with the right SLAs (+ controller-mediated for non-users)
+- [ ] Cross-border / AI-data-path controls (DPA, in-region model, no-training, reasonable-steps file)
+- [ ] Security baseline to {GOVERNING_STANDARD}+{maturity} (CMK, TLS, MFA, RLS, immutable audit)
+- [ ] Retention engine + `legal_hold` hard-block
+- [ ] De-identification pipeline (small-cell suppression) with identified data walled off
+- [ ] Breach-response runbook (assessment window → notification templates)
+- [ ] AI transparency / model-governance obligations
+
+## `TBD:` — legal sign-off required before hard-coding (these gate dependent tickets)
+- {list every inferred classification, lawful basis, retention period, or characterisation here}
+
+## Sources
+- {primary legal + provider sources, with URLs}


### PR DESCRIPTION
## What

Harvests reusable **regulated-data compliance patterns** from the SafeTrail seed session (a new AU psychosocial-compliance SaaS that holds **OFFICIAL:Sensitive** health data) and folds the *jurisdiction-neutral* patterns back into the Chief Wiggum workflow.

## Why

When a product holds regulated/sensitive data (health, financial, biometric, children's, gov-classified, PII at scale), the compliance posture is the licence to operate — and today nothing in `/seed` or `/saas-gate` prompts for it. Two patterns in particular were non-obvious and expensive to (re)derive:

1. **The AI/LLM data-path GATE.** If regulated data is ever sent to a third-party model (extraction/RAG/generation), the provider's **residency / no-training / no-retention** posture is a GO/NO-GO gate that must be resolved *before* building the pipeline. In SafeTrail it overturned the default cloud choice entirely (Claude wasn't available in-region on the first-choice provider). Cross-border law (AU APP 8, GDPR Ch. V) keeps *you* accountable for the provider's mishandling.
2. **Legal-signoff `TBD:`s gate work** — retention periods, lawful bases, and classifications that can't be confirmed against a primary source must not be hard-coded. Reuses the existing `check_unresolved.py` mechanism.

## Changes

- **`templates/compliance-requirements.md`** (new) — fill-in, jurisdiction-parameterized template: data classification, privacy/cross-border law, sector/records law, the AI/LLM data-path gate, breach obligations, retention + criminal-backed legal-hold, de-identification (small-cell suppression), security-to-a-named-standard, individual-rights SLAs, AI governance.
- **`/seed` Step 2.5 + Step 7** — for regulated-data products, research and fill the compliance doc (spun out to parallel workers by dimension), then copy it to `docs/compliance-requirements.md` so `/architect` folds it into contracts.
- **`/saas-gate`** — new **design-time regulated-data compliance dimension** (Step 5) verifying the filled doc and its controls (data-path gate, CMK+immutable audit, retention+legal-hold, de-id, rights, unresolved TBDs), complementing the existing runtime checks.

## Provenance

Worked example that produced these patterns: `plwp/safetrail` (`docs/compliance-requirements.md`, `ARCHITECTURE.md`). Research was pressure-tested across a codex + claude-interactive consultation and four parallel Sonnet deep-research streams (privacy law, gov security frameworks, LLM data-path, retention/de-identification).

## Notes

- Docs/skills-only change; no code paths touched. The `/seed` mirror under `skills/chief-wiggum/references/workflows/seed.md` is a symlink, so it tracks automatically. `/saas-gate` has no portable mirror in that set (pre-existing).