### PR TITLE
Add VIC Gov RFT scout: periodic Victorian tender opportunity monitor

### DIFF
--- a/tools/vic-rft-scout/.gitignore
+++ b/tools/vic-rft-scout/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+state/
+digests/*
+!digests/.gitkeep
+__pycache__/
+*.pyc
+rows.json

--- a/tools/vic-rft-scout/README.md
+++ b/tools/vic-rft-scout/README.md
@@ -1,0 +1,149 @@
+# VIC Gov RFT scout
+
+A periodic scout for **Victorian Government tender opportunities**. It scrapes
+[tenders.vic.gov.au](https://www.tenders.vic.gov.au), filters listings to your
+interest profile, remembers what it has already seen, and writes a Markdown
+digest that highlights **new** opportunities — including *advance notices* that
+haven't opened yet (weeks of lead time to prepare a bid).
+
+There is no RSS feed or public API for this portal, and it sits behind
+Cloudflare, so the scout drives a real browser to clear the challenge. Two fetch
+backends are provided (see **Fetching** below).
+
+## Design
+
+The tool splits into a **deterministic core** (parse → filter → diff → digest —
+pure functions, fully unit-tested against real captured listings) and a **fetch
+layer** (the fragile, Cloudflare-facing part). The core can be driven from a
+JSON array (`--from-json`) with no browser at all, which is how the tests and
+the claude-in-chrome runner feed it.
+
+## What it watches
+
+| Preset | Meaning | Why it matters |
+|---|---|---|
+| `open` | Currently open tenders (RFT / EOI / RFI / RFQ) | You can bid now |
+| `future` | Advance Tender Notices | Not open yet — best early signal, most lead time |
+
+Listings are matched to a profile of **software / digital / web + data / AI /
+analytics + psychosocial / wellbeing / compliance** (edit `config.json`). A
+listing matches if any of its UNSPSC codes starts with a configured prefix, or
+its title/buyer contains a configured keyword.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[launchd timer<br/>daily 08:00] --> B[scout.py]
+    B --> C{Playwright + Chrome}
+    C -->|clears Cloudflare| D[Scrape 'open' + 'future'<br/>all pages, paced]
+    D --> E[Parse rows:<br/>ref · title · buyer · UNSPSC · closing]
+    E --> F[Filter by UNSPSC prefix<br/>+ title/buyer keywords]
+    F --> G{Diff vs state/seen.json}
+    G -->|new ids| H[Mark 🆕]
+    G --> I[Build digest]
+    H --> I
+    I --> J[digests/YYYY-MM-DD.md<br/>+ digests/latest.md]
+    I --> K[macOS notification<br/>if new matches]
+    G --> L[Update seen.json]
+```
+
+## Setup
+
+```bash
+cd tools/vic-rft-scout
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+# Uses your installed Chrome (browser_channel: "chrome"). If you'd rather use
+# Playwright's bundled Chromium, run:  playwright install chromium
+```
+
+## Run
+
+```bash
+. .venv/bin/activate
+python scout.py                       # scrape (Playwright), filter, write digest, notify
+python scout.py --dry-run             # don't update the seen-cache (everything reads as new)
+python scout.py --no-notify           # skip the macOS notification
+python scout.py --date 2026-07-09     # override the run date (testing)
+python scout.py --from-json rows.json # skip scraping; use pre-fetched rows (runner / offline)
+```
+
+## Fetching (Cloudflare)
+
+The portal is behind Cloudflare's managed challenge, which is **rate-based**.
+Two backends:
+
+1. **Playwright (default)** — `python scout.py`. Self-contained, no Claude
+   needed. Clears the challenge from a real Chrome, paces requests, and retries
+   with backoff. At a gentle once-a-day cadence this is usually fine, but a
+   fresh headless browser can still get challenged; a persistently blocked page
+   is logged and skipped (partial digest, not a crash).
+2. **claude-in-chrome runner (most reliable)** — drives *your* Chrome, which
+   already holds a warm Cloudflare clearance, so it isn't bot-challenged. See
+   `runner_prompt.md`; it fetches all pages, writes `rows.json`, and calls
+   `scout.py --from-json rows.json`. Use this if the Playwright path gets blocked
+   in your environment.
+
+## Tests
+
+The core logic is covered by `test_scout.py` (no network — uses
+`fixtures/sample_listings.json`, real listings captured from the portal,
+including the "Victoria → ict" false-positive traps):
+
+```bash
+. .venv/bin/activate && python -m unittest -v
+```
+
+Output:
+- `digests/YYYY-MM-DD.md` — that day's digest
+- `digests/latest.md` — always the most recent
+- `state/seen.json` — first-seen date per tender id (drives the 🆕 flag)
+
+`state/` and `digests/` are git-ignored — they're your local running state.
+
+## Schedule it (launchd, macOS)
+
+The scout runs locally and needs Chrome, so it's scheduled with **launchd** in
+your user session (not a cloud cron — Cloudflare needs a real browser).
+
+```bash
+# 1. Edit the plist: set the absolute path to this folder and your python.
+#    (placeholders __SCOUT_DIR__ are marked inside the file)
+# 2. Install it:
+cp com.plwp.vic-rft-scout.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.plwp.vic-rft-scout.plist
+# Runs daily at 08:00. To run it once now:
+launchctl start com.plwp.vic-rft-scout
+# Logs: /tmp/vic-rft-scout.{out,err}.log
+# To stop scheduling:
+launchctl unload ~/Library/LaunchAgents/com.plwp.vic-rft-scout.plist
+```
+
+> **Note:** launchd fires the job when the Mac is awake; if it's asleep at
+> 08:00, the run happens shortly after wake. If the Mac is off, that day is
+> skipped (the seen-cache means the next run still surfaces anything new).
+
+## Tuning the profile
+
+Edit `config.json`:
+- `unspsc_prefixes` — 8-digit UNSPSC code prefixes (e.g. `"43"` = all IT/telecom,
+  `"8413"` = employee-assistance/HR wellbeing).
+- `keywords` — grouped title/buyer substrings; the group name shows up in the
+  digest's "Why" column.
+- `presets` — `["open"]` for bidding-now only, or add `"future"` for lead-time.
+- `request_delay_seconds` / `retry_backoff_seconds` / `max_retries` — Cloudflare
+  is rate-based; raise the delay if you see persistent blocks.
+
+## Limitations
+
+- **Cloudflare is rate-based.** The Playwright backend paces requests and retries
+  with backoff; a persistent block on a page is logged and that page is skipped
+  (partial digest rather than a crash). If it blocks consistently, use the
+  claude-in-chrome runner.
+- **Listing-level only.** It reads the search results, not each tender's full
+  document set. The digest links straight to the tender page for the detail.
+- **No dollar values.** The portal's listing rows don't include contract value.
+- **Read-only.** The scout never registers, bids, submits, or downloads — it
+  only reads public listings.

--- a/tools/vic-rft-scout/com.plwp.vic-rft-scout.plist
+++ b/tools/vic-rft-scout/com.plwp.vic-rft-scout.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd agent for the VIC RFT scout. Runs run.sh daily at 08:00 in your
+  user session (so it can drive a real browser past Cloudflare).
+
+  Install:
+    1. Replace __SCOUT_DIR__ below with the absolute path to this folder, e.g.
+       /Users/you/repos/chief-wiggum/tools/vic-rft-scout
+    2. cp com.plwp.vic-rft-scout.plist ~/Library/LaunchAgents/
+       launchctl load ~/Library/LaunchAgents/com.plwp.vic-rft-scout.plist
+    3. Run once now:  launchctl start com.plwp.vic-rft-scout
+  Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.plwp.vic-rft-scout.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.plwp.vic-rft-scout</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__SCOUT_DIR__/run.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SCOUT_DIR__</string>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/vic-rft-scout.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/vic-rft-scout.err.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/tools/vic-rft-scout/config.json
+++ b/tools/vic-rft-scout/config.json
@@ -1,0 +1,32 @@
+{
+  "presets": ["open", "future"],
+  "max_pages": 5,
+  "headless": true,
+  "browser_channel": "chrome",
+  "request_delay_seconds": 3,
+  "retry_backoff_seconds": 8,
+  "max_retries": 3,
+
+  "_comment": "A listing matches if ANY of its UNSPSC codes starts with a prefix below, OR its title/buyer contains a keyword (whole-word match). Profile: software/digital/web + data/AI/analytics + psychosocial/wellbeing/compliance. 43=IT/telecom/software/data, 8413=employee-assistance/HR wellbeing.",
+
+  "unspsc_prefixes": ["43", "8413"],
+
+  "keywords": {
+    "software": [
+      "software", "system", "platform", "web", "website", "cms",
+      "content management", "application", "digital", "portal", "api",
+      "saas", "cloud", "integration", "automation", "database", "ict"
+    ],
+    "data/ai": [
+      "analytics", "dashboard", "reporting", "visualisation",
+      "visualization", "forecasting", "model", "machine learning",
+      "artificial intelligence", "ai", "insights"
+    ],
+    "wellbeing/compliance": [
+      "wellbeing", "well-being", "psychosocial", "employee assistance",
+      "eap", "mental health", "occupational health", "workplace safety",
+      "worksafe", "governance", "compliance", "grc", "learning hub",
+      "learning management"
+    ]
+  }
+}

--- a/tools/vic-rft-scout/fixtures/sample_listings.json
+++ b/tools/vic-rft-scout/fixtures/sample_listings.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "326699", "rfx": "REQ-33834", "preset": "open",
+    "title": "Electronic Speed Limit Signs - Network Management System Upgrade",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Department of Transport and Planning",
+    "unspsc": ["43000000 - Information Technology Broadcasting and Telecommunications"],
+    "opened": "Thu, 09 July 2026 2:15 pm", "closing": "Thu, 06 August 2026 2:00 pm"
+  },
+  {
+    "id": "900001", "rfx": "EOI-PINP", "preset": "open",
+    "title": "Website Redevelopment",
+    "tender_type": "Expression of Interest", "status": "Open",
+    "buyer": "Phillip Island Nature Park Board of Management Inc",
+    "unspsc": ["43232200 - Content management software", "43232107 - Web page creation and editing software"],
+    "opened": "Mon, 29 June 2026 2:00 pm", "closing": "Tue, 21 July 2026 2:00 pm"
+  },
+  {
+    "id": "900002", "rfx": "N1000271", "preset": "open",
+    "title": "Student Demand Forecasting Model & Visualisation Tool(s)",
+    "tender_type": "Request for Quotation", "status": "Open",
+    "buyer": "Department of Education",
+    "unspsc": ["86000000 - Education and Training Services"],
+    "opened": "Tue, 23 June 2026 2:15 pm", "closing": "Mon, 20 July 2026 2:00 pm"
+  },
+  {
+    "id": "324729", "rfx": "25-26-122", "preset": "open",
+    "title": "The Departments of Government Services, Treasury and Finance and Premier and Cabinet Employee Assistance Program (EAP) Provider",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Department of Government Services",
+    "unspsc": ["84131609 - Employee assistance programs", "80110000 - Human resources services", "80000000 - Management and Business Professionals and Administrative Services"],
+    "opened": "Wed, 24 June 2026 12:00 pm", "closing": "Fri, 31 July 2026 11:55 pm"
+  },
+  {
+    "id": "326219", "rfx": "N1000253", "preset": "open",
+    "title": "Wellbeing Support Program for early childhood staff in the community services sector",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Department of Education",
+    "unspsc": ["86000000 - Education and Training Services"],
+    "opened": "Tue, 07 July 2026 12:10 pm", "closing": "Fri, 31 July 2026 2:00 pm"
+  },
+  {
+    "id": "323293", "rfx": "2025018", "preset": "future",
+    "title": "Governance, Risk & Compliance Software",
+    "tender_type": "Advanced Tender Notice", "status": "Advance",
+    "buyer": "Westernport Water",
+    "unspsc": ["43232305 - Data base reporting software", "43230000 - Software"],
+    "opened": "Fri, 05 June 2026 12:00 pm", "closing": "Mon, 31 August 2026 2:00 pm"
+  },
+  {
+    "id": "900003", "rfx": "RITM0044432", "preset": "open",
+    "title": "Silverfort Licencing and Support",
+    "tender_type": "Request for Quotation", "status": "Open",
+    "buyer": "Department of Parliamentary Services, Parliament of Victoria - IT Operations",
+    "unspsc": ["43233200 - Security and protection software"],
+    "opened": "Wed, 01 July 2026 5:00 pm", "closing": "Fri, 10 July 2026 1:00 pm"
+  },
+  {
+    "id": "326018", "rfx": "C5379-2026", "preset": "open",
+    "title": "Ladders and Walkways Compliance Program 2026",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Southern Rural Water",
+    "unspsc": ["83101500 - Water and sewer utilities"],
+    "opened": "Fri, 03 July 2026 3:10 pm", "closing": "Fri, 14 August 2026 5:00 pm"
+  },
+
+  {
+    "id": "323445", "rfx": "BBVNPRP26", "preset": "open",
+    "title": "Newhaven Pier Restoration Project",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Victorian Fisheries Authority",
+    "unspsc": ["72141200 - Marine construction services"],
+    "opened": "Fri, 05 June 2026 12:00 pm", "closing": "Wed, 29 July 2026 5:00 pm"
+  },
+  {
+    "id": "325220", "rfx": "2026-009", "preset": "open",
+    "title": "Cleaning Services",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Triple Zero Victoria",
+    "unspsc": ["76110000 - Cleaning and janitorial services", "47000000 - Cleaning Equipment and Supplies"],
+    "opened": "Thu, 02 July 2026 11:00 am", "closing": "Thu, 06 August 2026 2:00 pm"
+  },
+  {
+    "id": "900004", "rfx": "DOT44674", "preset": "open",
+    "title": "Installation of Traffic Signals and associated works on Grubb Road at Smithton Grove, Ocean Grove",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "Department of Transport and Planning",
+    "unspsc": ["46161504 - Traffic signals"],
+    "opened": "Tue, 30 June 2026 10:45 am", "closing": "Wed, 19 August 2026 3:30 pm"
+  },
+  {
+    "id": "900005", "rfx": "EGH-Willaura-2026", "preset": "open",
+    "title": "Willaura Redevelopment",
+    "tender_type": "Request for Tender", "status": "Open",
+    "buyer": "East Grampians Health Services",
+    "unspsc": ["72000000 - Building and Facility Construction and Maintenance Services"],
+    "opened": "Mon, 15 June 2026 2:00 pm", "closing": "Thu, 13 August 2026 2:00 pm"
+  },
+  {
+    "id": "315961", "rfx": "ATN 2841", "preset": "future",
+    "title": "Supply of Multi-Purpose Chairs (MPCs)",
+    "tender_type": "Advanced Tender Notice", "status": "Advance",
+    "buyer": "Ambulance Victoria",
+    "unspsc": ["42170000 - Mobile medical services products"],
+    "opened": "Sat, 21 March 2026 8:40 am", "closing": "Thu, 31 December 2026 2:00 pm"
+  }
+]

--- a/tools/vic-rft-scout/requirements.txt
+++ b/tools/vic-rft-scout/requirements.txt
@@ -1,0 +1,1 @@
+playwright>=1.44

--- a/tools/vic-rft-scout/run.sh
+++ b/tools/vic-rft-scout/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Daily runner for the VIC RFT scout (invoked by launchd).
+# Default path: Playwright fetch (no Claude needed). If Cloudflare blocks the
+# Playwright fetch in your environment, switch to the claude-in-chrome runner
+# (see runner_prompt.md) by commenting the python line and using the claude one.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# --- Default: self-contained Playwright fetch -------------------------------
+python scout.py
+
+# --- Reliable alternative: drive your real Chrome via claude-in-chrome -------
+# Requires the Claude Code CLI + the Claude-in-Chrome extension connected.
+# claude -p "$(cat runner_prompt.md)" --dangerously-skip-permissions

--- a/tools/vic-rft-scout/runner_prompt.md
+++ b/tools/vic-rft-scout/runner_prompt.md
@@ -1,0 +1,45 @@
+# VIC RFT scout — claude-in-chrome runner
+
+This is the **reliable fetch path**: it drives your real Chrome (which already
+holds a warm Cloudflare clearance) via the Claude-in-Chrome extension, so it
+doesn't get bot-challenged the way a fresh headless browser can.
+
+Feed this file to a Claude Code session (e.g. `claude -p "$(cat runner_prompt.md)"`).
+
+---
+
+You are fetching Victorian Government tender listings so the local scout can
+build a digest. Do exactly this, then stop:
+
+1. Using the Claude-in-Chrome tools, open a tab and load each of these URLs in
+   turn, waiting for results to render (the page title becomes "Current Tenders"
+   or "Advance Tender Notice", not "Attention Required"). Pace ~3s between loads.
+   - Open tenders, all pages:
+     `https://www.tenders.vic.gov.au/tender/search?preset=open&page=1` … keep
+     incrementing `page` until a page shows no `tender/view` links (currently ~3 pages).
+   - Advance notices, all pages:
+     `https://www.tenders.vic.gov.au/tender/search?preset=future&page=1` … same,
+     until empty (currently ~3 pages).
+
+2. For every result row on every page, extract these fields (use `javascript_tool`
+   to read the table rows; each row has an `<a href=".../tender/view?id=NNNNN">`):
+   - `id`   — the digits from the view link's `id=`
+   - `rfx`  — the RFx number (first line of the row's first cell)
+   - `status`, `tender_type` — from the first cell ("Open"/"Advance Notice";
+     one of Request for Tender / Expression of Interest / Request for Information /
+     Request for Quotation / Advanced Tender Notice)
+   - `title` — the link text
+   - `buyer` — the text after "Issued by:"
+   - `unspsc` — a list of "CODE - label" strings (drop the trailing "- NN%")
+   - `opened`, `closing` — the date strings
+   - `preset` — "open" for the open pages, "future" for the advance-notice pages
+
+3. Write the combined array of row objects to `rows.json` in this folder.
+
+4. Run: `python scout.py --from-json rows.json`
+   (activate `.venv` first). That filters to the interest profile, diffs against
+   the seen-cache, writes `digests/<today>.md` + `digests/latest.md`, and fires a
+   macOS notification if there are new matches.
+
+5. Report the digest's headline counts and any 🆕 items. Do not bid, register,
+   submit, or download anything — this is read-only reconnaissance.

--- a/tools/vic-rft-scout/scout.py
+++ b/tools/vic-rft-scout/scout.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""VIC Gov RFT scout.
+
+Periodically scrapes the Victorian Government tenders portal
+(tenders.vic.gov.au), filters listings to a configured interest profile
+(UNSPSC codes + title/buyer keywords), diffs against a seen-cache so only NEW
+opportunities are surfaced, and writes a Markdown digest.
+
+The portal sits behind Cloudflare, so a plain HTTP GET returns HTTP 403. This
+uses Playwright (a real Chromium/Chrome) to clear the JS challenge. There is no
+RSS feed or public API. Two "presets" are scanned:
+
+    open   - currently open tenders (RFT / EOI / RFI / RFQ)
+    future - Advance Tender Notices (not yet open; weeks of lead time)
+
+Run manually:  python scout.py
+Scheduled:     via launchd (see com.plwp.vic-rft-scout.plist)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    sys.exit(
+        "Playwright is not installed. Set up the venv first:\n"
+        "  python3 -m venv .venv && . .venv/bin/activate\n"
+        "  pip install -r requirements.txt && playwright install chromium"
+    )
+
+BASE = "https://www.tenders.vic.gov.au"
+SEARCH = BASE + "/tender/search?preset={preset}&page={page}"
+VIEW = BASE + "/tender/view?id={id}"
+
+HERE = Path(__file__).resolve().parent
+CONFIG_PATH = HERE / "config.json"
+STATE_PATH = HERE / "state" / "seen.json"
+DIGEST_DIR = HERE / "digests"
+
+
+@dataclass
+class Tender:
+    id: str
+    rfx: str
+    title: str
+    tender_type: str
+    status: str
+    buyer: str
+    unspsc: list[str] = field(default_factory=list)  # ["43230000 - Software", ...]
+    opened: str = ""
+    closing: str = ""
+    closing_iso: str = ""  # sortable YYYY-MM-DD, best-effort
+    preset: str = ""
+
+    @property
+    def url(self) -> str:
+        return VIEW.format(id=self.id)
+
+    @property
+    def unspsc_codes(self) -> list[str]:
+        return [re.match(r"\s*(\d+)", u).group(1) for u in self.unspsc if re.match(r"\s*(\d+)", u)]
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+def load_config() -> dict:
+    return json.loads(CONFIG_PATH.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Scrape
+# --------------------------------------------------------------------------- #
+def _launch(pw, cfg: dict):
+    """Launch Chrome (preferred) or bundled Chromium; both clear Cloudflare."""
+    headless = cfg.get("headless", True)
+    channel = cfg.get("browser_channel", "chrome")
+    if channel:
+        try:
+            return pw.chromium.launch(channel=channel, headless=headless)
+        except Exception as exc:  # channel not installed -> fall back
+            print(f"[scout] channel={channel!r} unavailable ({exc}); using bundled chromium", file=sys.stderr)
+    return pw.chromium.launch(headless=headless)
+
+
+TENDER_TYPES = (
+    "Request for Tender", "Expression of Interest", "Request for Information",
+    "Request for Quotation", "Advanced Tender Notice",
+)
+
+
+def _cloudflared(page) -> bool:
+    t = (page.title() or "").lower()
+    return "just a moment" in t or "attention required" in t
+
+
+def goto_cleared(page, url: str, cfg: dict) -> bool:
+    """Navigate and wait out Cloudflare's JS challenge. Reload-retry on block.
+
+    The block is rate-based, so callers should also pace requests. Returns True
+    once tender links are present, False if still blocked after all retries.
+    """
+    retries = cfg.get("max_retries", 3)
+    for attempt in range(retries + 1):
+        page.goto(url, wait_until="domcontentloaded", timeout=45000)
+        for _ in range(25):  # up to ~25s for the challenge to resolve
+            if not _cloudflared(page) and page.query_selector('a[href*="tender/view"]'):
+                return True
+            page.wait_for_timeout(1000)
+        if attempt < retries:
+            # Back off, then reload — Cloudflare usually passes on a later try.
+            time.sleep(cfg.get("retry_backoff_seconds", 8) * (attempt + 1))
+    return False
+
+
+def _parse_row0(cell_text: str) -> tuple[str, str, str]:
+    """cell[0] is 'RFx\\nStatus\\nType'."""
+    lines = [ln.strip() for ln in cell_text.splitlines() if ln.strip()]
+    rfx = lines[0] if lines else ""
+    status = lines[1] if len(lines) > 1 else ""
+    ttype = ""
+    joined = " ".join(lines)
+    for known in TENDER_TYPES:
+        if known in joined:
+            ttype = known
+            break
+    return rfx, status, ttype
+
+
+def _parse_details(cell_text: str) -> tuple[str, list[str]]:
+    """cell[1] is 'Title\\nIssued by: Buyer\\nUNSPSC...: code - label - NN%'."""
+    buyer = ""
+    m = re.search(r"Issued by:\s*(.+?)(?:\n|$)", cell_text)
+    if m:
+        buyer = re.sub(r"\s+", " ", m.group(1)).strip()
+    unspsc: list[str] = []
+    for code, label in re.findall(r"(\d{8})\s*-\s*(.+)", cell_text):
+        label = re.sub(r"\s*-\s*\d+%\s*$", "", label).strip()  # drop trailing weighting
+        unspsc.append(f"{code} - {label}")
+    return buyer, unspsc
+
+
+_MONTHS = {m: i for i, m in enumerate(
+    ["january", "february", "march", "april", "may", "june", "july",
+     "august", "september", "october", "november", "december"], start=1)}
+
+
+def _parse_date_cell(cell_text: str) -> tuple[str, str, str]:
+    """cell[2] is 'Opened\\n<date>\\nClosing\\n<date>'. Returns (opened, closing, closing_iso)."""
+    opened = closing = closing_iso = ""
+    m = re.search(r"Opened\s*(.+?)(?:\s*Closing|$)", cell_text, re.S)
+    if m:
+        opened = re.sub(r"\s+", " ", m.group(1)).strip()
+    m = re.search(r"Closing\s*(.+?)$", cell_text, re.S)
+    if m:
+        closing = re.sub(r"\s+", " ", m.group(1)).strip()
+        dm = re.search(r"(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})", closing)
+        if dm and dm.group(2).lower() in _MONTHS:
+            closing_iso = f"{dm.group(3)}-{_MONTHS[dm.group(2).lower()]:02d}-{int(dm.group(1)):02d}"
+    return opened, closing, closing_iso
+
+
+def scrape_preset(page, preset: str, cfg: dict) -> list[Tender]:
+    tenders: list[Tender] = []
+    max_pages = cfg.get("max_pages", 5)
+    delay = cfg.get("request_delay_seconds", 3)
+    for pageno in range(1, max_pages + 1):
+        if not goto_cleared(page, SEARCH.format(preset=preset, page=pageno), cfg):
+            print(f"[scout] {preset} p{pageno}: Cloudflare block persisted", file=sys.stderr)
+            break
+        rows = page.query_selector_all("table tr")
+        found_on_page = 0
+        for row in rows:
+            link = row.query_selector('a[href*="tender/view"]')
+            if not link:
+                continue
+            m = re.search(r"id=(\d+)", link.get_attribute("href") or "")
+            if not m:
+                continue
+            cells = row.query_selector_all("td")
+            if len(cells) < 3:
+                continue
+            rfx, status, ttype = _parse_row0(cells[0].inner_text())
+            buyer, unspsc = _parse_details(cells[1].inner_text())
+            opened, closing, closing_iso = _parse_date_cell(cells[2].inner_text())
+            tenders.append(Tender(
+                id=m.group(1), rfx=rfx, title=link.inner_text().strip(),
+                tender_type=ttype, status=status, buyer=buyer, unspsc=unspsc,
+                opened=opened, closing=closing, closing_iso=closing_iso, preset=preset,
+            ))
+            found_on_page += 1
+        print(f"[scout] {preset} p{pageno}: {found_on_page} listings", file=sys.stderr)
+        if found_on_page == 0:
+            break
+        time.sleep(delay)  # pace requests to stay under Cloudflare's rate heuristic
+    return tenders
+
+
+def tenders_from_records(records: list[dict]) -> list[Tender]:
+    """Build Tenders from a list of plain dicts (the --from-json / runner path).
+
+    Recomputes closing_iso when absent so callers only need the raw fields.
+    """
+    out: list[Tender] = []
+    fields = Tender.__dataclass_fields__
+    for r in records:
+        data = {k: r[k] for k in fields if k in r}
+        t = Tender(**data)
+        if not t.closing_iso and t.closing:
+            _, _, t.closing_iso = _parse_date_cell(f"Closing {t.closing}")
+        out.append(t)
+    return out
+
+
+def scrape(cfg: dict) -> list[Tender]:
+    all_tenders: dict[str, Tender] = {}
+    with sync_playwright() as pw:
+        browser = _launch(pw, cfg)
+        context = browser.new_context(
+            user_agent=("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"),
+            viewport={"width": 1280, "height": 900}, locale="en-AU",
+        )
+        page = context.new_page()
+        for preset in cfg.get("presets", ["open", "future"]):
+            for t in scrape_preset(page, preset, cfg):
+                all_tenders.setdefault(t.id, t)  # first preset wins (open > future)
+        browser.close()
+    return list(all_tenders.values())
+
+
+# --------------------------------------------------------------------------- #
+# Filter
+# --------------------------------------------------------------------------- #
+def match_reasons(t: Tender, cfg: dict) -> list[str]:
+    reasons: list[str] = []
+    prefixes = cfg.get("unspsc_prefixes", [])
+    for code in t.unspsc_codes:
+        for pref in prefixes:
+            if code.startswith(pref):
+                reasons.append(f"UNSPSC {code}")
+                break
+    haystack = f"{t.title} {t.buyer}".lower()
+    for label, words in cfg.get("keywords", {}).items():
+        hits = [w for w in words if _word_match(w.lower().strip(), haystack)]
+        if hits:
+            reasons.append(f"{label}: {', '.join(sorted(set(hits)))}")
+    return reasons
+
+
+def _word_match(kw: str, haystack: str) -> bool:
+    """Whole-word (boundary) match, so 'ict' does not fire on 'Victoria'."""
+    return re.search(r"(?<![a-z0-9])" + re.escape(kw) + r"(?![a-z0-9])", haystack) is not None
+
+
+# --------------------------------------------------------------------------- #
+# State
+# --------------------------------------------------------------------------- #
+def load_state() -> dict:
+    if STATE_PATH.exists():
+        return json.loads(STATE_PATH.read_text())
+    return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+# --------------------------------------------------------------------------- #
+# Digest
+# --------------------------------------------------------------------------- #
+def _row(t: Tender, reasons: list[str], is_new: bool) -> str:
+    tag = " 🆕" if is_new else ""
+    closes = t.closing or "—"
+    return (f"| {closes} | [{t.rfx}]({t.url}) | {t.title}{tag} | {t.buyer} | "
+            f"{t.tender_type or t.status} | {'; '.join(reasons)} |")
+
+
+def build_digest(matched: list[tuple[Tender, list[str]]], new_ids: set[str], today: str) -> str:
+    open_rows = [(t, r) for t, r in matched if t.preset == "open"]
+    future_rows = [(t, r) for t, r in matched if t.preset == "future"]
+
+    def section(title, rows):
+        if not rows:
+            return f"### {title}\n\n_None matched._\n"
+        header = ("| Closes | Ref | Title | Buyer | Type | Why |\n"
+                  "|---|---|---|---|---|---|\n")
+        body = "\n".join(_row(t, r, t.id in new_ids) for t, r in rows)
+        return f"### {title}  ({len(rows)})\n\n{header}{body}\n"
+
+    n_new = len([1 for t, _ in matched if t.id in new_ids])
+    lines = [
+        f"# VIC Gov RFT scout — {today}",
+        "",
+        f"**{len(matched)} matched** ({len(open_rows)} open, {len(future_rows)} advance notices) · "
+        f"**{n_new} new since last run** 🆕",
+        "",
+        "Source: [tenders.vic.gov.au](https://www.tenders.vic.gov.au/tender/search?preset=open) · "
+        "filtered to your interest profile (see `config.json`).",
+        "",
+        section("🎯 Open now", open_rows),
+        "",
+        section("🔭 Advance notices (not yet open — lead time)", future_rows),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def notify_macos(n_new: int, digest_path: Path) -> None:
+    if n_new <= 0:
+        return
+    try:
+        subprocess.run(
+            ["osascript", "-e",
+             f'display notification "{n_new} new matching VIC tender(s)" '
+             f'with title "VIC RFT scout" subtitle "{digest_path.name}"'],
+            check=False, capture_output=True, timeout=10,
+        )
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    ap = argparse.ArgumentParser(description="VIC Gov RFT scout")
+    ap.add_argument("--no-notify", action="store_true", help="skip macOS notification")
+    ap.add_argument("--dry-run", action="store_true", help="do not update seen-cache")
+    ap.add_argument("--date", help="override run date (YYYY-MM-DD), for testing")
+    ap.add_argument("--from-json", metavar="FILE",
+                    help="load listings from a JSON array instead of scraping "
+                         "(the claude-in-chrome runner / offline-test path)")
+    args = ap.parse_args()
+
+    cfg = load_config()
+    today = args.date or dt.date.today().isoformat()
+
+    if args.from_json:
+        records = json.loads(Path(args.from_json).read_text())
+        tenders = tenders_from_records(records)
+        print(f"[scout] loaded {len(tenders)} listings from {args.from_json}", file=sys.stderr)
+    else:
+        print(f"[scout] scraping {cfg.get('presets')} ...", file=sys.stderr)
+        tenders = scrape(cfg)
+        print(f"[scout] scraped {len(tenders)} listings", file=sys.stderr)
+    if not tenders:
+        print("[scout] no listings — Cloudflare block, empty input, or site change?", file=sys.stderr)
+        return 1
+
+    matched = []
+    for t in tenders:
+        reasons = match_reasons(t, cfg)
+        if reasons:
+            matched.append((t, reasons))
+    # Sort: open before future, then by soonest closing date.
+    matched.sort(key=lambda tr: (tr[0].preset != "open", tr[0].closing_iso or "9999"))
+
+    state = load_state()
+    new_ids = {t.id for t, _ in matched if t.id not in state}
+    print(f"[scout] {len(matched)} matched, {len(new_ids)} new", file=sys.stderr)
+
+    digest = build_digest(matched, new_ids, today)
+    DIGEST_DIR.mkdir(parents=True, exist_ok=True)
+    digest_path = DIGEST_DIR / f"{today}.md"
+    digest_path.write_text(digest)
+    (DIGEST_DIR / "latest.md").write_text(digest)
+    print(f"[scout] wrote {digest_path}", file=sys.stderr)
+
+    if not args.dry_run:
+        for t, _ in matched:
+            state.setdefault(t.id, {"first_seen": today, "title": t.title, "closing": t.closing})
+        save_state(state)
+
+    if not args.no_notify:
+        notify_macos(len(new_ids), digest_path)
+
+    # Echo digest to stdout so a launchd log / terminal shows it.
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vic-rft-scout/test_scout.py
+++ b/tools/vic-rft-scout/test_scout.py
@@ -1,0 +1,108 @@
+"""Deterministic tests for the scout core (parse / match / diff / digest).
+
+No network — uses fixtures/sample_listings.json (real listing data captured
+from tenders.vic.gov.au). Run:  python -m unittest -v
+"""
+import json
+import unittest
+from pathlib import Path
+
+import scout
+
+HERE = Path(__file__).resolve().parent
+CFG = scout.load_config()
+RECORDS = json.loads((HERE / "fixtures" / "sample_listings.json").read_text())
+TENDERS = {t.rfx: t for t in scout.tenders_from_records(RECORDS)}
+
+
+class WordMatch(unittest.TestCase):
+    def test_ict_not_in_victoria(self):
+        # The bug that shipped in v1: 'ict' fired on 'Victoria'.
+        self.assertFalse(scout._word_match("ict", "victorian fisheries authority"))
+        self.assertFalse(scout._word_match("ict", "triple zero victoria"))
+
+    def test_ict_matches_standalone(self):
+        self.assertTrue(scout._word_match("ict", "vicroads ict procurement"))
+
+    def test_ai_boundaries(self):
+        self.assertTrue(scout._word_match("ai", "ai model for demand"))
+        self.assertFalse(scout._word_match("ai", "contains detail and maintenance"))
+
+    def test_web_not_website(self):
+        self.assertTrue(scout._word_match("web", "new web portal"))
+        self.assertFalse(scout._word_match("web", "corporate website refresh"))
+
+
+class Parsing(unittest.TestCase):
+    def test_row0(self):
+        rfx, status, ttype = scout._parse_row0("REQ-33834\nOpen\nRequest for Tender")
+        self.assertEqual(rfx, "REQ-33834")
+        self.assertEqual(status, "Open")
+        self.assertEqual(ttype, "Request for Tender")
+
+    def test_details(self):
+        buyer, unspsc = scout._parse_details(
+            "Governance, Risk & Compliance Software\n"
+            "Issued by: Westernport Water\n"
+            "UNSPSC 1: 43232305 - Data base reporting software - 50%\n"
+            "UNSPSC 2: 43230000 - Software - 50%")
+        self.assertEqual(buyer, "Westernport Water")
+        self.assertEqual(unspsc, ["43232305 - Data base reporting software", "43230000 - Software"])
+
+    def test_date_cell(self):
+        opened, closing, iso = scout._parse_date_cell(
+            "Opened\nFri, 05 June 2026 12:00 pm\nClosing\nMon, 31 August 2026 2:00 pm")
+        self.assertEqual(closing, "Mon, 31 August 2026 2:00 pm")
+        self.assertEqual(iso, "2026-08-31")
+
+    def test_records_get_iso(self):
+        self.assertEqual(TENDERS["2025018"].closing_iso, "2026-08-31")
+
+
+class Matching(unittest.TestCase):
+    def _match(self, rfx):
+        return scout.match_reasons(TENDERS[rfx], CFG)
+
+    def test_expected_matches(self):
+        for rfx in ["REQ-33834", "EOI-PINP", "N1000271", "25-26-122",
+                    "N1000253", "2025018", "RITM0044432", "C5379-2026"]:
+            self.assertTrue(self._match(rfx), f"{rfx} should match")
+
+    def test_expected_non_matches(self):
+        # The 'Victoria' traps + unrelated construction/health must NOT match.
+        for rfx in ["BBVNPRP26", "2026-009", "DOT44674", "EGH-Willaura-2026", "ATN 2841"]:
+            self.assertFalse(self._match(rfx), f"{rfx} should NOT match (got {self._match(rfx)})")
+
+    def test_match_reasons_are_specific(self):
+        self.assertIn("UNSPSC 84131609", self._match("25-26-122"))
+        r = self._match("2025018")
+        self.assertTrue(any("UNSPSC 43" in x for x in r))
+        self.assertTrue(any("software" in x for x in r))
+
+
+class DiffAndDigest(unittest.TestCase):
+    def setUp(self):
+        self.matched = [(t, scout.match_reasons(t, CFG))
+                        for t in TENDERS.values() if scout.match_reasons(t, CFG)]
+
+    def test_new_ids_diff(self):
+        seen = {"326699": {}, "324729": {}}  # two already seen
+        new_ids = {t.id for t, _ in self.matched if t.id not in seen}
+        self.assertNotIn("326699", new_ids)
+        self.assertIn("323293", new_ids)  # GRC advance notice is new
+
+    def test_digest_structure(self):
+        new_ids = {t.id for t, _ in self.matched}
+        digest = scout.build_digest(self.matched, new_ids, "2026-07-09")
+        self.assertIn("# VIC Gov RFT scout — 2026-07-09", digest)
+        self.assertIn("Governance, Risk & Compliance Software", digest)  # future section
+        self.assertIn("view?id=323293", digest)                          # direct link
+        self.assertNotIn("Newhaven Pier", digest)                        # filtered out
+        self.assertIn("🆕", digest)                                       # new-flag rendered
+        # open section header present with a count
+        self.assertIn("🎯 Open now", digest)
+        self.assertIn("🔭 Advance notices", digest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

A local, scheduled **scout for Victorian Government tender opportunities**. It scrapes [tenders.vic.gov.au](https://www.tenders.vic.gov.au), filters listings to an interest profile, remembers what it has seen, and writes a Markdown digest highlighting **new** opportunities — including *advance notices* not yet open (weeks of bid lead-time).

Lives under `tools/vic-rft-scout/` — self-contained, unrelated to the core orchestration layer, so it can be relocated to its own repo later if preferred.

## Why it's built this way

The portal has **no RSS feed or public API**, and sits behind a **rate-based Cloudflare** challenge — so fetching needs a real browser. The design isolates the fragile part:

- **Deterministic core** (`scout.py`): parse → filter (UNSPSC prefixes + whole-word keyword match) → diff vs `state/seen.json` → build digest. Pure, fully unit-tested, feedable via `--from-json` with no browser.
- **Fetch layer**, two backends:
  1. **Playwright (default)** — self-contained, clears Cloudflare from a real Chrome, paces + retries; a persistently-blocked page is logged and skipped (partial digest, not a crash).
  2. **claude-in-chrome runner** (`runner_prompt.md`) — drives your warm Chrome, most reliable; fetches all pages → `rows.json` → `scout.py --from-json`.

Watches both `preset=open` (bid now) and `preset=future` (advance notices — best early signal).

## Profile (config.json)

Software/digital/web + data/AI/analytics + psychosocial/wellbeing/compliance. UNSPSC prefixes `43` (IT/telecom/software/data) + `8413` (EAP/wellbeing), plus grouped title/buyer keywords. Whole-word matching fixes a real bug where `ict` matched every "V**ict**oria".

## Scheduling

`com.plwp.vic-rft-scout.plist` — a launchd agent runs `run.sh` daily at 08:00 in the user session (local, not cloud — Cloudflare needs a real browser).

## Tests

`python -m unittest -v` → **13 passing**, no network. Uses `fixtures/sample_listings.json` (real listings captured from the portal), covering the parse, the filter (incl. the "Victoria → ict" traps), the seen-diff, and the digest structure. Sample digest verified end-to-end via `--from-json`.

## Notes / caveats

- The Playwright backend's Cloudflare clearance is rate-sensitive; validated that it *can* clear headless, but the reliable path for unattended runs is the claude-in-chrome runner. Documented honestly in the README.
- Listing-level only (no per-tender document fetch, no dollar values — the portal's rows don't carry them).
- **Read-only**: never registers, bids, submits, or downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)