### PR TITLE
fix(pre-merge-check): install node deps before running vitest/lint/build

### DIFF
--- a/templates/pre-merge-check.sh
+++ b/templates/pre-merge-check.sh
@@ -82,6 +82,14 @@ scan_dir() {
     if [ -f "$dir/package.json" ]; then
         printf "\n${YELLOW}── %s (Node)${NC}\n" "$label"
 
+        # Install deps first — vitest/eslint/build all need node_modules, which a
+        # clean CI checkout never has. Use `npm install`, NOT `npm ci`: target repos
+        # frequently carry lockfile drift and `npm ci` hard-fails on any drift, which
+        # would turn "deps not installed" into a misleading red check.
+        if [ ! -d "$dir/node_modules" ]; then
+            run_check "$label: install" "cd '$dir' && npm install"
+        fi
+
         # Test: prefer vitest > jest > npm test
         if grep -q '"vitest"' "$dir/package.json" 2>/dev/null; then
             run_check "$label: tests" "cd '$dir' && npx vitest run"


### PR DESCRIPTION
## What

`templates/pre-merge-check.sh` ran the Node layer's `npx vitest run` / `npm run lint` / `npm run build` **without ever running `npm install`**. On a clean CI checkout `node_modules` doesn't exist, so the checks failed in a way that reads as a *test* failure rather than a *missing-deps* failure.

Downstream this exact bug (in dogeared-coach's copy of the script) froze every staging deploy for the Billing epic before it was root-caused and fixed there (dogeared-coach #213). The CW template still had it.

## Fix

Before running any Node check, install deps if `node_modules` is absent:

- Uses **`npm install`, not `npm ci`** — target repos frequently carry lockfile drift, and `npm ci` hard-fails on drift, which would reintroduce the same "CI red for the wrong reason" failure mode. `npm install` was the fix that actually worked downstream.
- Gated on `[ ! -d node_modules ]` so local runs (where deps are already installed) skip the reinstall and stay fast.
- Runs through the existing `run_check` harness, so a failed install is reported like any other check.

## Note

Downstream repos that already carry a **copy** of this script need the same fix applied to their copy — the template change does not retroactively patch clones.

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)