### PR TITLE
docs(worker-contracts): mandate incremental commits for resilience (#97)

### DIFF
--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -83,6 +83,14 @@ scope / isolation / stop) is what another harness implements.
   checkout; never `gh pr create`/`merge` (the orchestrator owns shipping).
 - **Isolation**: required — operate in a dedicated git worktree and assert it is
   not the main checkout with `scripts/git_safety.py assert-worktree`.
+- **Commit incrementally**: commit after each meaningful unit (failing tests
+  written → commit; implementation green → commit; review fixes applied →
+  commit) — not one squashed commit at the end. The rationale is resilience,
+  not history hygiene: a worker can be killed mid-run (stream-watchdog timeout,
+  crash, cancellation), and the orchestrator recovers its progress from the
+  **last commit on the feature branch**. Anything uncommitted is presumed lost.
+  Squashing, if wanted, happens at merge time — never buy tidy history at the
+  cost of an unrecoverable interruption.
 - **Stop condition**: tests green, lint clean, acceptance verified; or a blocking
   error reported after the retry budget is exhausted.
 


### PR DESCRIPTION
## What

The implementation-worker contract now requires **incremental commits** — commit after each meaningful unit (tests → impl → review fixes), not one squashed commit at the end.

## Why

A worker killed mid-run (stream-watchdog timeout — see #94 — crash, or cancellation) loses everything it hasn't committed. In a recent multi-epic session ~6+ workers were killed and their partial work had to be hand-recovered from worktrees, or was lost. The orchestrator recovers a killed worker from its **last commit on the feature branch**, so anything uncommitted is presumed lost.

This is the cheap insurance that composes with #94 (fix the watchdog / make workers resumable): even with a perfect watchdog, commit-often makes any interruption recoverable.

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)