### PR TITLE
fix(consult_ai): hard process-group timeout so a hung provider can't stall a worker (#95)

### DIFF
--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import argparse
 import os
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 
 # Allow importing keychain from the same directory
@@ -44,8 +47,84 @@ TOOL_TIMEOUTS: dict[str, int] = {
 }
 TIMEOUT = 600  # fallback
 
+# Interval (seconds) between liveness heartbeats emitted to stderr while a provider CLI
+# runs. A silent multi-minute consult is indistinguishable from a hang to a worker's
+# stream-watchdog; a periodic line proves the consult is alive and progressing.
+HEARTBEAT_INTERVAL = 30
+
 # Default model for Vertex AI path (override with --model)
 DEFAULT_VERTEX_MODEL = "gemini-3.1-pro-preview"
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    """SIGTERM then SIGKILL the child's whole process group, so the provider CLI **and
+    any subprocesses it spawned** die — not just the direct child. This is the crux of
+    the hang fix: a surviving grandchild that inherited the stdout pipe keeps
+    communicate() blocked forever otherwise."""
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        return
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+        try:
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            continue  # escalate to SIGKILL
+
+
+def _run_capture(
+    cmd: list[str], *, input_text: str | None, timeout: int, cwd: str | None, tool: str,
+    check: bool = True,
+) -> str:
+    """Run a provider CLI, capturing stdout, with a HARD timeout that actually fires.
+
+    ``subprocess.run(timeout=...)`` kills only the direct child; if the CLI spawned
+    grandchildren holding the stdout pipe open, the follow-up ``communicate()`` blocks
+    reading that pipe until they exit — so the "timeout" never returns and the calling
+    worker hangs (the root cause of consult-driven stalls, #95). Here the CLI runs in
+    its OWN session/process group (``start_new_session``) and a timeout kills the whole
+    group, guaranteeing control returns within ``timeout``. A daemon thread emits a
+    stderr heartbeat so a long-but-live consult is not mistaken for a hang.
+
+    Raises ``subprocess.TimeoutExpired`` / ``subprocess.CalledProcessError`` to preserve
+    the previous ``subprocess.run(check=True, timeout=...)`` contract.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, cwd=cwd, start_new_session=True,
+    )
+    stop = threading.Event()
+
+    def _heartbeat() -> None:
+        start = time.monotonic()
+        while not stop.wait(HEARTBEAT_INTERVAL):
+            elapsed = int(time.monotonic() - start)
+            print(f"[consult:{tool}] still running ({elapsed}s / {timeout}s budget)",
+                  file=sys.stderr, flush=True)
+
+    hb = threading.Thread(target=_heartbeat, daemon=True)
+    hb.start()
+    try:
+        out, err = proc.communicate(input_text, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        try:
+            proc.communicate(timeout=10)  # drain now-closed pipes; group is dead
+        except Exception:
+            pass
+        raise
+    finally:
+        stop.set()
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, output=out, stderr=err)
+    return out
 
 
 def consult_codex(prompt: str, model: str | None = None, cwd: str | None = None) -> str:
@@ -64,12 +143,10 @@ def consult_codex(prompt: str, model: str | None = None, cwd: str | None = None)
     if model:
         cmd.extend(["--model", model])
     cmd.append("-")  # read prompt from stdin
-    result = subprocess.run(
-        cmd, input=prompt, capture_output=True, text=True, check=True,
-        timeout=TOOL_TIMEOUTS.get("codex", TIMEOUT),
-        cwd=cwd,
+    return _run_capture(
+        cmd, input_text=prompt, timeout=TOOL_TIMEOUTS.get("codex", TIMEOUT),
+        cwd=cwd, tool="codex",
     )
-    return result.stdout
 
 
 def consult_gemini(prompt: str, model: str | None = None, cwd: str | None = None) -> str:
@@ -82,12 +159,10 @@ def consult_gemini(prompt: str, model: str | None = None, cwd: str | None = None
     cmd = ["gemini", "--yolo", "--output-format", "text", "-p", ""]
     if model:
         cmd.extend(["-m", model])
-    result = subprocess.run(
-        cmd, input=prompt, capture_output=True, text=True, check=True,
-        timeout=TOOL_TIMEOUTS.get("gemini", TIMEOUT),
-        cwd=cwd,
+    return _run_capture(
+        cmd, input_text=prompt, timeout=TOOL_TIMEOUTS.get("gemini", TIMEOUT),
+        cwd=cwd, tool="gemini",
     )
-    return result.stdout
 
 
 def consult_gemini_vertex(prompt: str, model: str | None = None, cwd: str | None = None) -> str:
@@ -117,12 +192,10 @@ def consult_claude(prompt: str, model: str | None = None, cwd: str | None = None
     cmd = ["claude", "-p", "--output-format", "text"]
     if model:
         cmd.extend(["--model", model])
-    result = subprocess.run(
-        cmd, input=prompt, capture_output=True, text=True,
-        check=True, timeout=TOOL_TIMEOUTS.get("claude", TIMEOUT),
-        cwd=cwd,
+    return _run_capture(
+        cmd, input_text=prompt, timeout=TOOL_TIMEOUTS.get("claude", TIMEOUT),
+        cwd=cwd, tool="claude",
     )
-    return result.stdout
 
 
 def consult_claude_interactive(prompt: str, model: str | None = None, cwd: str | None = None) -> str:
@@ -145,20 +218,17 @@ def consult_claude_interactive(prompt: str, model: str | None = None, cwd: str |
         ]
         if cwd:
             cmd.extend(["--cwd", cwd])
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=TOOL_TIMEOUTS["claude-interactive"],
+        stdout = _run_capture(
+            cmd, input_text=None, timeout=TOOL_TIMEOUTS["claude-interactive"],
+            cwd=None, tool="claude-interactive",
         )
-        for line in result.stdout.splitlines():
+        for line in stdout.splitlines():
             if line.startswith("RESULT="):
                 result_path = Path(line.removeprefix("RESULT="))
                 if result_path.exists():
                     return result_path.read_text()
                 raise RuntimeError(f"claude-interactive result path does not exist: {result_path}")
-        raise RuntimeError(f"claude-interactive completed without RESULT line: {result.stdout}")
+        raise RuntimeError(f"claude-interactive completed without RESULT line: {stdout}")
     finally:
         prompt_file.unlink(missing_ok=True)
 

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -182,11 +182,13 @@ def test_claude_interactive_uses_delegate_submit_without_precreating_task(tmp_pa
     result_file.write_text("delegate response")
     calls = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run_capture(cmd, **kwargs):
         calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout=f"RESULT={result_file}\n", stderr="")
+        return f"RESULT={result_file}\n"
 
-    monkeypatch.setattr(consult_ai.subprocess, "run", fake_run)
+    # consult_* now route through _run_capture (process-group-aware runner, #95),
+    # not subprocess.run — mock at that seam.
+    monkeypatch.setattr(consult_ai, "_run_capture", fake_run_capture)
 
     output = consult_ai.consult_claude_interactive("prompt", cwd=str(tmp_path))
 
@@ -195,3 +197,41 @@ def test_claude_interactive_uses_delegate_submit_without_precreating_task(tmp_pa
     assert "submit" in cmd
     assert "--prompt-file" in cmd
     assert "--task-id" not in cmd
+
+
+# --- _run_capture: hard-timeout process-group runner (#95) -------------------
+
+import time as _time  # noqa: E402
+
+
+def test_run_capture_returns_stdout():
+    assert consult_ai._run_capture(
+        ["sh", "-c", "printf hello"], input_text=None, timeout=10, cwd=None, tool="t"
+    ) == "hello"
+
+
+def test_run_capture_passes_stdin():
+    assert consult_ai._run_capture(
+        ["cat"], input_text="piped-in", timeout=10, cwd=None, tool="t"
+    ) == "piped-in"
+
+
+def test_run_capture_raises_calledprocesserror_on_nonzero():
+    with pytest.raises(subprocess.CalledProcessError):
+        consult_ai._run_capture(
+            ["sh", "-c", "exit 3"], input_text=None, timeout=10, cwd=None, tool="t"
+        )
+
+
+def test_run_capture_timeout_does_not_hang_on_surviving_grandchild():
+    # A grandchild inherits the stdout pipe and outlives the timeout. subprocess.run
+    # would block in communicate() draining that pipe for the grandchild's full 30s;
+    # _run_capture must kill the whole process group and return promptly.
+    start = _time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        consult_ai._run_capture(
+            ["sh", "-c", "sleep 30 & sleep 30"],
+            input_text=None, timeout=2, cwd=None, tool="t",
+        )
+    elapsed = _time.monotonic() - start
+    assert elapsed < 15, f"timeout did not return promptly ({elapsed:.1f}s) — pipe hang not fixed"


### PR DESCRIPTION
## Problem

`/implement` workers stalled repeatedly and got killed at the 600s stream-watchdog mid-work. Root cause: `consult_ai.py` called `subprocess.run(timeout=...)`, which kills only the **direct child** on timeout. When a provider CLI (codex/gemini/claude) spawned grandchildren that inherited the stdout pipe, the follow-up `communicate()` blocks reading that pipe until the grandchildren exit — so the "timeout" never effectively returns, and the worker waiting on the consult hangs.

## Fix

Route every provider call through a new `_run_capture`:
- Launches the CLI in its **own session / process group** (`start_new_session=True`).
- On timeout, `SIGTERM`→`SIGKILL`s the **whole group** (`os.killpg`), so the CLI *and everything it spawned* die — control returns within the budget instead of hanging.
- A daemon thread emits a **stderr heartbeat** every 30s, so a long-but-live consult is distinguishable from a hang.
- Preserves the previous `TimeoutExpired` / `CalledProcessError` contract, so `main()`'s handlers are unchanged.

Applied to codex, gemini, claude, and claude-interactive.

## Tests
- `_run_capture` returns stdout, passes stdin, raises `CalledProcessError` on nonzero exit.
- **Regression guard**: a command whose grandchild holds the stdout pipe past the timeout now returns in <15s (not the grandchild's full 30s) — proving the pipe-drain hang is fixed.
- Existing claude-interactive test re-pointed to the new `_run_capture` seam.
- Full repo suite green (555 passed), `make lint` clean.

Fixes #95. Complements #94 (watchdog) and #97 (incremental commits) — together they make consult-driven interruptions both rarer and recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)