### PR TITLE
fix(worktree-isolation): guard the main checkout is pristine before waves/merges (#96)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -165,12 +165,16 @@ echo "test" | gemini --yolo --output-format text -p "" >/dev/null 2>&1 && echo "
 cd "$TARGET_REPO"
 git checkout "$DEFAULT_BRANCH"
 git pull --ff-only
-git status --porcelain  # must be empty
+# Guard: main must be on the default branch with a clean tree. Catches an isolation
+# LEAK from a previous run — a worker that ran `git checkout` in the main checkout
+# instead of its worktree leaves main on a feature branch, contaminating every base
+# branched off it. Re-run this before each wave's worktree creation and before merging.
+python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
 ```
 
 **If any AI tool fails auth, fix it now.** Do not discover auth failures 20 minutes into a parallel wave. If the user needs to run an interactive login, tell them to run `! codex auth login` or similar.
 
-**If the repo is not clean, STOP.** Uncommitted changes will cause worktree conflicts.
+**If `assert-main-pristine` fails, STOP** — main is on a feature branch or dirty (an isolation leak). Restore it (`git checkout "$DEFAULT_BRANCH"`, inspect/park any stray changes) before launching any wave, or every worktree will branch off a contaminated base.
 
 **Load amnesia context** (if the repo has `docs/quality/ratchet.json`): replay the recent ratchet journal so this session doesn't re-litigate decisions a previous wave already made (a parked ticket, an amended contract, a known-flaky suite):
 
@@ -293,6 +297,9 @@ This is the same principle as `/implement` Step 8 — the orchestrator is the qu
    cd "$TARGET_REPO"
    git checkout "$DEFAULT_BRANCH"
    git pull --ff-only
+   # Re-assert main is pristine before branching the staging base off it (a worker in
+   # this wave may have leaked a checkout into main).
+   python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
    git checkout -b "wave-$wave_number-staging"
    ```
 

--- a/scripts/chief_wiggum/gitops.py
+++ b/scripts/chief_wiggum/gitops.py
@@ -124,6 +124,35 @@ def assert_worktree(
     return wt_root
 
 
+def assert_main_pristine(
+    main_checkout: str | Path,
+    default_branch: str,
+    *,
+    runner: Runner = subprocess.run,
+) -> None:
+    """Assert the MAIN checkout is pristine: on ``default_branch`` with a clean tree.
+
+    The orchestrator-side complement of ``assert_worktree``. It catches the isolation
+    LEAK that ``assert_worktree`` (which each worker runs on itself) cannot see: a worker
+    that ran ``git checkout`` in the main checkout instead of its worktree leaves main on
+    a feature branch, silently contaminating the base of the next worker/wave. Called
+    before creating worktrees and before merging, so a leak fails loudly and early
+    instead of surfacing later as a mystified diff.
+    """
+    branch = current_branch(main_checkout, runner=runner)
+    if branch != default_branch:
+        raise GitSafetyError(
+            f"main checkout is on {branch!r}, not the default branch {default_branch!r} — "
+            f"a worker likely checked out a branch in the main checkout instead of its "
+            f"worktree (isolation leak). Restore: git -C <main> checkout {default_branch}"
+        )
+    if not is_clean(main_checkout, runner=runner):
+        raise GitSafetyError(
+            f"main checkout has uncommitted changes on {default_branch!r} — refusing to "
+            f"branch/merge off a dirty base. Inspect `git -C <main> status` first."
+        )
+
+
 # --- fast-forward promotion -------------------------------------------------
 
 

--- a/scripts/git_safety.py
+++ b/scripts/git_safety.py
@@ -11,6 +11,10 @@ Examples:
     # Abort unless cwd is a worktree distinct from the main checkout
     python3 scripts/git_safety.py assert-worktree --main "$TARGET_REPO"
 
+    # Abort unless the main checkout is on the default branch with a clean tree
+    # (catches a worker that leaked a branch into main — isolation leak)
+    python3 scripts/git_safety.py assert-main-pristine --main "$TARGET_REPO" --default-branch main
+
     # Validate a branch name
     python3 scripts/git_safety.py check-branch feat/my-thing
 
@@ -37,6 +41,14 @@ def main(argv: list[str] | None = None) -> int:
     p_wt.add_argument("--main", required=True, help="Path to the main checkout")
     p_wt.add_argument("--worktree", default=".", help="Worktree path (default: cwd)")
 
+    p_pristine = sub.add_parser(
+        "assert-main-pristine",
+        help="Assert the main checkout is on the default branch with a clean tree "
+        "(catches a worker that leaked a branch into the main checkout)",
+    )
+    p_pristine.add_argument("--main", required=True, help="Path to the main checkout")
+    p_pristine.add_argument("--default-branch", required=True, help="Expected default branch")
+
     p_branch = sub.add_parser("check-branch", help="Validate a branch name")
     p_branch.add_argument("name")
 
@@ -54,6 +66,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "assert-worktree":
             root = gitops.assert_worktree(args.worktree, args.main)
             print(f"OK: worktree {root} is isolated from main")
+        elif args.command == "assert-main-pristine":
+            gitops.assert_main_pristine(args.main, args.default_branch)
+            print(f"OK: main checkout is pristine (on {args.default_branch}, clean tree)")
         elif args.command == "check-branch":
             gitops.assert_branch_name(args.name)
             print(f"OK: {args.name} is a valid branch name")

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -150,3 +150,42 @@ def test_cli_assert_worktree_same_path_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(gitops, "assert_worktree", lambda *a, **k: (_ for _ in ()).throw(gitops.GitSafetyError("main checkout")))
     rc = git_safety.main(["assert-worktree", "--main", str(tmp_path)])
     assert rc == 1
+
+
+# --- main-checkout pristine guard (#96) -------------------------------------
+
+
+def _pristine_runner(*, branch="main", porcelain=""):
+    """Runner that answers `rev-parse` (current branch) and `status` (cleanliness)
+    differently, so assert_main_pristine's two git calls can be driven independently."""
+    def run(args, **kwargs):
+        if "rev-parse" in args:
+            return subprocess.CompletedProcess(args, 0, stdout=branch, stderr="")
+        if "status" in args:
+            return subprocess.CompletedProcess(args, 0, stdout=porcelain, stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+    return run
+
+
+def test_assert_main_pristine_ok_on_clean_default_branch():
+    # No exception when main is on the default branch with a clean tree.
+    gitops.assert_main_pristine(".", "main", runner=_pristine_runner(branch="main", porcelain=""))
+
+
+def test_assert_main_pristine_rejects_feature_branch_in_main():
+    # The #96 failure: a worker left main on a feature branch (isolation leak).
+    with pytest.raises(gitops.GitSafetyError, match="isolation leak"):
+        gitops.assert_main_pristine(".", "main", runner=_pristine_runner(branch="feat/162"))
+
+
+def test_assert_main_pristine_rejects_dirty_tree():
+    with pytest.raises(gitops.GitSafetyError, match="uncommitted"):
+        gitops.assert_main_pristine(
+            ".", "main", runner=_pristine_runner(branch="main", porcelain=" M svc.go\n")
+        )
+
+
+def test_assert_main_pristine_cli_wired():
+    # The subcommand is registered and delegates to gitops (feature-branch main -> exit 1).
+    rc = git_safety.main(["assert-main-pristine", "--main", ".", "--default-branch", "main"])
+    assert rc in (0, 1)  # 0 if this repo is on main+clean, 1 otherwise — never a crash/usage error


### PR DESCRIPTION
## Problem

`assert_worktree` catches a worker operating *in* the main checkout — but each worker runs it on *itself*. Nothing checks the main checkout from the orchestrator's side. So when the #162 worker ran `git checkout` in the main checkout instead of its worktree, it left main on `feat/162`, and every worktree/merge branched off main afterward inherited a **contaminated base** (it poisoned #194's base — recovered by hand mid-session).

## Fix

- `gitops.assert_main_pristine(main, default_branch)` — fails loudly if the main checkout is not on the default branch, or has a dirty tree.
- `git_safety.py assert-main-pristine --main <path> --default-branch <name>` — the CLI surface.
- Wired into `/implement-wave`: pre-flight, and again before each staging-branch creation. A leak now **stops the line early** with a clear "restore with `git checkout <default>`" message, instead of surfacing later as a mystified diff.

## Tests
- OK on a clean default branch; rejects a feature-branch-in-main (the isolation-leak case) and a dirty tree; CLI subcommand wired.
- Full suite green (559 passed), `make lint` + portability clean.

Fixes #96. Complements the worker-side `assert_worktree` — one guards the worker, this guards the base it merges into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)