### PR TITLE
docs(worker-contracts): fold anti-stall guidance into the contract (#94)

### DIFF
--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -91,6 +91,14 @@ scope / isolation / stop) is what another harness implements.
   **last commit on the feature branch**. Anything uncommitted is presumed lost.
   Squashing, if wanted, happens at merge time — never buy tidy history at the
   cost of an unrecoverable interruption.
+- **Stay alive under the stream-watchdog**: a harness that kills a worker after N
+  seconds of *no output* (Claude Code's ~600s stream-watchdog) reads a long silent
+  operation as a hang. Emit a progress line before and after each long step (AI
+  consult, full test run, build) so the watchdog sees liveness, and **background** a
+  long blocking call rather than waiting on it silently. The provider-consult path
+  already heartbeats to stderr (`consult_ai.py`, #95); mirror that for any other
+  multi-minute step. Combined with incremental commits, a worker that *is* killed is
+  both rarer and recoverable.
 - **Stop condition**: tests green, lint clean, acceptance verified; or a blocking
   error reported after the retry budget is exhausted.
 


### PR DESCRIPTION
## What

Adds a "stay alive under the stream-watchdog" clause to the implementation-worker contract: emit progress lines around long steps (AI consult, full test run, build) so the watchdog sees liveness, and background long blocking calls instead of waiting silently.

## Why

The ~600s stream-watchdog kills a worker after ~10 min of **no output**, so a long silent step reads as a hang and the worker dies mid-work — a recurring stall in large waves.

The watchdog itself is a **Claude Code harness constraint**, not a CW script, so CW can't "fix" it directly — CW's lever is worker discipline. This completes the CW-side mitigations alongside the already-shipped heartbeat (`consult_ai.py`, #95) and incremental commits (#97): together they make stalls rarer *and* any kill recoverable.

## Note

This **refs** rather than fixes #94 — the watchdog behavior is outside CW's control. Recommend keeping #94 open as a harness-tracking item, or closing it as "mitigated CW-side" (heartbeat + incremental commits + this contract clause). Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)