### PR TITLE
feat(code-metrics): literature-grounded code-quality analysis skill

### DIFF
--- a/.claude/commands/code-metrics.md
+++ b/.claude/commands/code-metrics.md
@@ -1,0 +1,100 @@
+# Code Metrics — Literature-Grounded Code-Quality Analysis
+
+Runs a battery of code-quality metric engines over a repo and produces a consolidated, **cited** report: churn/attribution, cyclomatic + cognitive complexity, maintainability index, history trend, code survival (2-week churn), production duplication, and process metrics (change coupling, entropy, ownership/bus-factor, fix ratio).
+
+Every metric is reported **with its caveat**. The load-bearing truth from the literature is that most product metrics are *size in disguise* — the signals that are **not** just SLOC (relative churn, duplication, code survival) are the trustworthy ones. This skill grades output the way the research says to, not by vibes.
+
+## When to use
+
+- Auditing what an AI/agentic pipeline actually produced (the primary use case)
+- Comparing a repo's churn/duplication against the GitClear pre-AI vs AI-assisted baselines
+- Periodic health check of a codebase's complexity/test-discipline trend over time
+- Prioritising refactoring targets (churn × complexity hotspots)
+
+## Usage
+
+```
+/code-metrics [owner/repo]
+/code-metrics --repo <path>
+/code-metrics                       # defaults to the current git repo
+```
+
+Flags (passed through to `scripts/quality_metrics.py`):
+
+- `--repo <path>`: analyse a direct local path instead of `owner/repo`
+- `--out <dir>`: output directory (defaults to a session temp dir)
+- `--top <N>`: number of churn hotspots to keep (default 25)
+- `--trend-n <N>`: history sample points for the trend engine (default 10)
+- `--skip-trend`: skip history-sampling trend (fastest; avoids worktree churn)
+- `--skip-survival`: skip git-of-theseus code-survival analysis
+- `--skip-duplication`: skip jscpd duplication analysis
+- `--venv <venv>` / `--gobin <dir>`: point complexity engines at a specific toolchain
+
+## Autonomy
+
+**Run to completion without pausing.** This is an analysis skill — no human-in-the-loop checkpoints. Present the final report and let the user decide what to act on. Optional engines (survival, duplication) self-skip when their external tool is absent; report the skip honestly rather than pretending the number is zero.
+
+---
+
+## Workflow
+
+### Step 1: Resolve paths
+
+```bash
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+```
+
+If given `owner/repo`, resolve it (clones/pulls into the cache); otherwise the orchestrator defaults to the current repo or uses `--repo`:
+
+```bash
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")   # only for owner/repo
+```
+
+### Step 2: Run the metric battery
+
+```bash
+python3 "$CW_HOME/scripts/quality_metrics.py" "$owner_repo" --out "$CW_TMP/metrics"
+# or, for a local path:
+python3 "$CW_HOME/scripts/quality_metrics.py" --repo "$TARGET_REPO" --out "$CW_TMP/metrics"
+```
+
+The orchestrator runs each engine, writes per-engine JSON (`churn.json`, `complexity.json`, `trend.json`, `survival.json`, `process.json`, `duplication.json`), builds `combined.json`, renders PNG charts, and writes `report.md`. It prints the `report.md` path on stdout.
+
+Always-run engines (pure Python + git + lizard): **churn, complexity, trend, process**. Optional engines run only when their tool is present: **survival** (git-of-theseus), **duplication** (jscpd/node). A missing tool yields `{"skipped": ...}` in that engine's JSON — the run never crashes.
+
+For a fast pass on a large repo, add `--skip-trend --skip-survival --skip-duplication`.
+
+### Step 3: Read the generated report
+
+Read `$CW_TMP/metrics/report.md`. Cross-reference against `combined.json` for the flattened summary. Note which engines were skipped and why (tool absent vs `--skip-*`).
+
+### Step 4: Present a concise findings summary
+
+Summarise for the user, leading with the trustworthy signals and stating caveats plainly:
+
+- **Scale & discipline**: LOC, test:code ratio, conventional-commit / ticket-ref / PR-merge %.
+- **Churn (strongest signal)**: rework ratio (del:add), churn per commit, top hotspots. This is where AI-generated code degrades most clearly — but only *relative/normalised* churn is predictive.
+- **Complexity**: mean/max cyclomatic, % functions CCN>10, % long methods, cognitive max — **always read alongside SLOC** (CC is ~0.7–0.9 collinear with size at file level). MI is directional only.
+- **Process metrics**: change entropy, bus-factor (with the agentic-repo caveat), commit-size distribution, fix-commit %.
+- **AI-slop signals vs GitClear**: 14-day survival and production duplication against the pre-AI (96.9% / 8.3%) and AI-assisted (94.3% / 12.3%) bands — noting GitClear is a **vendor** series (direction credible, multiples framing-dependent).
+
+Attach or reference the rendered charts (`trends.png`, `ai_slop_signals.png`) if present. Be explicit about what was skipped. Do not over-interpret a single high metric; the honest verdict is a weighted read across signals, weighted toward the non-size-confounded ones.
+
+---
+
+## Metrics & literature
+
+Full citations and thresholds live in `docs/quality-metrics.md`. Summary of each metric, its source, and its caveat:
+
+- **Cyclomatic complexity** (McCabe 1976; NIST SP 500-235): >10 moderate / >15 high / >20 very high. **Caveat:** ~0.7–0.9 collinear with SLOC at file level (Jay 2009; Herraiz & Hassan 2010) — a "high CC" file may just be big; softer at method level. Report CC *alongside* size.
+- **Cognitive complexity** (Campbell/SonarSource 2018; Muñoz Barón 2020): proxies comprehension **effort/time** (r≈0.54), **not correctness** (r≈−0.13, not significant). **Caveat:** no validated threshold; essentially no evidence above ~15.
+- **Maintainability Index** (Oman & Hagemeister 1992; van Deursen 2014): radon 0–100, <65 flagged. **Caveat:** coefficients fit once on a tiny 1980s HP dataset, never recalibrated — **directional only**, never an authoritative score.
+- **Code churn** (Nagappan & Ball 2005): **the strongest, best-replicated defect/AI-slop signal** (relative churn R²≈0.8). **Caveat:** *relative/normalised* churn predicts; absolute churn is weak.
+- **Hotspots = churn × complexity** (Tornhill; Tornhill & Borg 2022): the right *prioritisation* lens. **Caveat:** the 15×/124× impact multiples are **vendor-derived** (CodeScene), not independently replicated.
+- **Code survival / 2-week churn** (GitClear 2024–2025; DORA 2024): 14-day survival vs GitClear pre-AI 96.9% / AI 94.3% (5.7% churn). **Caveat:** GitClear is a **vendor** series — direction corroborated by DORA, exact figures framing-dependent.
+- **Production duplication** (GitClear): % duplicated tokens vs pre-AI 8.3% / AI 12.3% bands, tests excluded. **Caveat:** vendor bands; jscpd token % is not identical to GitClear's block metric — compare direction, not decimals.
+- **Process metrics** (Rahman & Devanbu 2013; Hassan 2009; Bird et al. 2011): change coupling, change entropy (HCM), ownership/bus-factor, commit size, fix ratio. **Process metrics outperform product metrics** for defect prediction and are more stable across releases. **Caveat:** bus-factor/ownership assume human authorship — in an agentic repo the author collapses to one operator identity, so read bus-factor as a signal about the attribution model, not team resilience.
+
+**The load-bearing caveat:** most of these metrics are size in disguise. If a repo differs from a baseline mainly in SLOC, much of the CC/MI/Halstead delta follows mechanically. The findings that are **not** just size — relative churn, duplication/copy-paste ratios, and survival — are the trustworthy process signals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A collection of portable workflow contracts, scripts, and Claude Code slash-comm
 - **Epic level**: `/plan-epic` → `/architect` → (implement tickets) → `/close-epic` — defines contracts, invariants, and integration tests before implementation, validates cross-cutting quality after.
 - **Ticket level**: `/implement` — TDD, multi-AI consultation, structured review, static analysis, and independent verification per ticket.
 - **Wave level**: `/implement-wave` — parallel implementation of an entire epic in dependency-ordered waves. Each wave runs multiple `/implement` loops concurrently in isolated worktrees, merges to main, then starts the next wave.
-- **Supporting**: `/setup`, `/transcribe`, `/seed`, `/create-issue`, `/ship`, `/update`, `/stitch-audit`, `/tutorial-video`.
+- **Supporting**: `/setup`, `/transcribe`, `/seed`, `/create-issue`, `/ship`, `/update`, `/stitch-audit`, `/code-metrics`, `/tutorial-video`.
 
 ## Key Principles
 
@@ -218,6 +218,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 
 /ship                           # Create PR with mermaid diagrams (standalone)
 /stitch-audit owner/repo --trace keyword   # Cross-layer data flow audit
+/code-metrics owner/repo                    # Literature-grounded code-quality metrics (churn/complexity/survival/duplication)
 /tutorial-video owner/repo --feature "..."  # Narrated click-through tutorial video
 /saas-gate owner/repo --base-url <url>     # SaaS non-functional-requirements gate (security/isolation/perf/observability)
 /update                         # Refresh model IDs and library versions

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See `AGENTS.md` and `docs/harnesses.md` for the portable core and adapter model.
 | `/create-issue` | Create well-structured GitHub issues |
 | `/ship` | PR creation with mermaid architecture diagrams |
 | `/stitch-audit` | Cross-layer data flow analysis |
+| `/code-metrics` | Literature-grounded code-quality metrics: churn, complexity, code survival, duplication, process signals |
 | `/tutorial-video` | Narrated click-through tutorial video: script → recording → TTS narration → .mp4 + .srt |
 | `/update` | Refresh AI model IDs and library versions |
 

--- a/docs/quality-metrics.md
+++ b/docs/quality-metrics.md
@@ -1,0 +1,210 @@
+# Code-Quality Metrics: what we compute, what it means, and the honest caveats
+
+The `/code-metrics` skill (`scripts/quality_metrics.py` + the `scripts/quality/`
+package) computes a battery of code-quality metrics over a repo and emits a cited
+report. This doc is the reference: for each metric, **what it measures**, the
+**thresholds** we use, the **evidence strength**, and the **caveat** that keeps
+the number honest.
+
+**The load-bearing caveat for the whole analysis:** most product metrics are
+**size in disguise**. If a repo differs from a baseline mainly in SLOC, much of
+the cyclomatic / MI / Halstead delta follows mechanically. The findings that are
+*not* just size — **relative churn, duplication/copy-paste ratios, and code
+survival** — are the trustworthy process signals. Always report size as a
+covariate.
+
+**Evidence-strength convention:** `[REPLICATED]` confirmed across independent
+datasets; `[SINGLE STUDY]` one strong study, not yet replicated; `[VENDOR]`
+self-published by a party with commercial interest — direction may be
+informative, treat multiples skeptically.
+
+---
+
+## 1. Cyclomatic complexity (McCabe)
+
+**Measures** the number of linearly independent paths through a function's
+control-flow graph (decision points + 1). Computed by `lizard` across
+Python/Go/TS/JS. We report the distribution: mean, max, p90/p95, and % of
+functions over 10 / 15 / 20, plus function length (% > 60 lines).
+
+**Thresholds** — McCabe's own (1976) >10 = split candidate; NIST SP 500-235
+(1996) endorsed 10 with a 15 caveat. The 1–10 / 11–20 / 21–50 / >50
+"simple/moderate/high/untestable" bands are an SEI C4 *characterization*, not an
+empirical result.
+
+**Caveat** `[REPLICATED]` — cyclomatic is **~0.7–0.9 collinear with SLOC** at
+file/module level (Jay et al. 2009, >1.2M files; Herraiz & Hassan 2010, Spearman
+≈0.72; Shepperd 1988). A "high CC" file may just be a big file. It is *softer* at
+method level, so CC is not fully redundant there — but never present it as
+independent of size. It also does not generalize as a cross-project defect
+predictor (Nagappan, Ball & Zeller 2006).
+
+> McCabe (1976), *IEEE TSE* SE-2(4). · NIST SP 500-235 (Watson & McCabe 1996).
+> Jay et al. (2009). · Herraiz & Hassan (2010), *Making Software*. · Shepperd (1988).
+
+## 2. Cognitive complexity (Campbell / SonarSource)
+
+**Measures** understandability, not testability: ignores the method-entry +1,
+counts `switch`+cases as one, and adds a **nesting penalty**. Computed by
+`gocognit` (Go) and `complexipy` (Python); TS has no maintained CLI (n/a).
+
+**Validation** `[SINGLE meta-study]` — Muñoz Barón, Wyrich & Wagner (ESEM 2020,
+Best Paper) pooled 10 datasets: cognitive complexity correlates with
+comprehension **time** (r≈**+0.54**) and perceived difficulty (r≈−0.29), but
+**not** with correctness of understanding (r≈−0.13, CI crosses 0) and **not**
+with physiological load.
+
+**Caveat** — it is a proxy for comprehension **effort/time, not correctness**.
+There is **no validated threshold** and essentially no evidence about behavior
+above ~15 (only 2 of 10 datasets had snippets that high). Do not over-interpret
+high values.
+
+> Campbell (2018), SonarSource white paper + TechDebt'18. · Muñoz Barón et al. (2020),
+> *ESEM*, DOI 10.1145/3382494.3410636.
+
+## 3. Maintainability Index (Oman & Hagemeister)
+
+**Measures** a three-metric polynomial `MI = 171 − 5.2·ln(V) − 0.23·G −
+16.2·ln(LOC)`. Computed by `radon` (Python only), 0–100 scale, <65 flagged.
+
+**Caveat** `[strong critique]` — **report directionally only, never as an
+authoritative score.** Coefficients were fit **once** on a tiny ~35-year-old HP
+C/Pascal dataset and **never recalibrated** (van Deursen 2014). Thresholds are
+self-described "rules of thumb." Sjøberg et al. (2013) found plain file size
+predicts real maintenance effort at least as well. Even radon's own docs call it
+"very experimental." Show MI's raw inputs (LOC, CC, Halstead V) beside it.
+
+> van Deursen (2014), "Think Twice Before Using the Maintainability Index." ·
+> Sjøberg et al. (2013), *IEEE TSE* 39(8), DOI 10.1109/TSE.2012.89.
+
+## 4. Code churn
+
+**Measures** volume/rate of lines added/deleted over history (from `git log`
+diffs). We report absolute added/deleted, net, del:add **rework ratio**, and
+per-month churn. Hotspots rank files by total churn.
+
+**Evidence** `[REPLICATED]` — **the strongest, best-replicated defect signal we
+compute.** Nagappan & Ball (2005), Windows Server 2003, 2,465 binaries: absolute
+churn is a poor predictor (R²≈0.05) but **relative churn is highly predictive**
+of defect density (R²≈0.81–0.84). Sits under the replicated result that
+process/change metrics beat static product metrics (Rahman & Devanbu 2013).
+
+**Caveat** — **normalize churn** (per LOC / per file / per commit); absolute
+churn is weak. This is also the single metric where AI-generated code shows the
+clearest degradation (GitClear: 2-week churn 3.1%→5.7%).
+
+> Nagappan & Ball (2005), *ICSE*. · Hassan (2009), *ICSE*. · Moser et al. (2008).
+
+## 5. Hotspots (churn × complexity)
+
+**Measures** files high in *both* change frequency and complexity — the
+highest-priority refactoring targets. Complexity only matters where code
+actually changes.
+
+**Caveat** `[SINGLE, vendor-adjacent]` — the framework (Tornhill, *Your Code as a
+Crime Scene*) is a practitioner heuristic; the "15× more defects / 124% more
+time" impact multiples come from Tornhill & Borg (TechDebt 2022) using
+CodeScene's proprietary "Code Health" score — **vendor-derived, not
+independently replicated.** Use hotspots to *rank* targets; cite the multiples as
+vendor-adjacent.
+
+> Tornhill, *Your Code as a Crime Scene* (2015/2024). · Tornhill & Borg (2022),
+> arXiv:2203.04374.
+
+## 6. Code survival / 2-week churn
+
+**Measures** the inverse of churn: of the lines a commit added, what fraction are
+still alive after age Δt? Computed from `git-of-theseus` line-survival output,
+line-weighted, reported at 14/30/60 days with a half-life estimate.
+
+**Baselines** `[VENDOR]` — GitClear longitudinal series: **pre-AI 2020 ~96.9%**
+of lines survive 2 weeks; **AI-assisted 2024 ~94.3%** (5.7% churn). The
+convergent AI-code thesis: assistants optimize for *producing plausible new
+lines fast* rather than *integrating/refactoring* — "written to be added, not
+reused."
+
+**Caveat** — GitClear is a **vendor** (sells git analytics; full PDFs gated). The
+*direction* is corroborated by the best independent bridge, **DORA 2024**
+(delivery stability ↓~7.2% per 25% AI adoption). Exact multiples are
+framing-dependent; editions use different base years and are not stackable.
+
+> GitClear (2024 "Coding on Copilot", 2025 "AI Copilot Code Quality"). ·
+> DORA / *Accelerate State of DevOps 2024*.
+
+## 7. Production duplication (copy/paste)
+
+**Measures** % of duplicated tokens across **production** code only (tests,
+`node_modules`, docs, vendor, build output excluded) via `jscpd`. Reported
+against GitClear bands.
+
+**Baselines** `[VENDOR]` — GitClear: copy/paste **8.3% (pre-AI) → 12.3% (AI)**;
+duplicated blocks "increased eightfold" / "4× growth in code clones" (different
+metrics — don't conflate).
+
+**Caveat** — jscpd's token % is **not identical** to GitClear's block metric;
+compare *direction*, not decimals. Tests are excluded so the figure reflects
+shipped code.
+
+## 8. Process / history metrics
+
+Rahman & Devanbu (2013), 85 repos: **process metrics significantly outperform
+code metrics**, which are "unstable" across releases `[REPLICATED]`. From
+`git log`:
+
+- **Change (temporal) coupling** — files that change together (co-changes ≥4,
+  with confidence). Cross-directory coupling is a design-smell signal (Tornhill).
+- **Change entropy (HCM)** — Shannon entropy of how modifications scatter across
+  files, normalized 0–1. Better fault predictor than prior-faults/-modifications
+  (Hassan 2009). *(Do not cite fabricated accuracy percentages — the paper's
+  claim is relative, not a specific %.)*
+- **Ownership / bus-factor** — top-owner share and minor-contributor counts
+  predicted defects *independent of size and churn* (Bird et al. 2011,
+  "Don't Touch My Code!"). We report distinct authors, authors-for-50%-of-churn,
+  and top-author share.
+- **Commit size** — median/p90 churn and file count; % large commits (>400 LOC).
+- **Fix ratio** — % of commits whose subject matches `fix|bugfix|hotfix`, plus
+  fix-touched hotspots. An SZZ-lite defect proxy (Śliwerski et al. 2005; noisy).
+
+**Caveat for agentic repos** — bus-factor and ownership metrics **assume human
+authorship**. When one operator drives an AI pipeline, the git author collapses
+to a single identity, so a bus-factor of 1 reflects the **attribution model**,
+not team fragility. Also mind `git blame` attribution noise (last toucher ≠
+original author) — mitigate with `-M`/`-C` and `.git-blame-ignore-revs`.
+
+> Rahman & Devanbu (2013), *ICSE*. · Hassan (2009). · Bird et al. (2011),
+> ESEC/FSE. · Śliwerski, Zimmermann & Zeller (2005), *MSR* (SZZ).
+
+---
+
+## Interpreting the numbers
+
+1. **Always report CC alongside SLOC** — a "high CC" file may just be big.
+2. **Use CC thresholds as bands, not verdicts** — >10 is an attention point, the
+   higher SEI bands are characterizations, not validated defect thresholds.
+3. **Cognitive complexity = effort, not correctness** — no validated threshold.
+4. **Relative churn is the strongest signal** — normalize it; absolute churn is weak.
+5. **Treat MI as directional only** — never an authoritative score.
+6. **Hotspots prioritise; the impact multiples are vendor-derived.**
+7. **Distinguish vendor from peer-reviewed** — GitClear (churn/duplication) is a
+   vendor; DORA 2024 is the semi-independent corroboration; the peer-reviewed
+   AI-code studies (Pearce 2022 security ~40%, Nguyen & Nadi 2022 correctness
+   27–57%) test 2021-era Copilot.
+8. **Control for size and survivorship** — mine history, not HEAD, to avoid
+   undercounting reverted/churned code. Correlation ≠ causation; the pipeline is
+   one of many confounders (team experience, file age, ownership).
+9. **The load-bearing caveat:** most of these metrics are size in disguise — the
+   non-size signals (relative churn, duplication, survival) are the trustworthy ones.
+
+### Evidence-strength summary
+
+| Finding | Strength |
+|---|---|
+| CC ≈ SLOC (adds little at file level) | `[REPLICATED]` Shepperd '88, Jay '09, Herraiz/Hassan '10 |
+| Cognitive complexity ↔ comprehension time (not correctness) | `[SINGLE meta-study]` Muñoz Barón '20 |
+| Relative churn strongly predicts defect density | `[REPLICATED]` Nagappan/Ball '05; Rahman/Devanbu '13 |
+| Process metrics > static code metrics | `[REPLICATED]` Moser '08, Rahman/Devanbu '13 |
+| Hotspot impact multipliers (15×/124×) | `[SINGLE, vendor]` Tornhill/Borg '22 |
+| MI coefficients unvalidated; size predicts effort as well | `[strong critique]` van Deursen '14; Sjøberg '13 |
+| AI code → rising churn/duplication, declining reuse | `[VENDOR longitudinal]` GitClear '24–'26 |
+| AI adoption → delivery-stability decline | `[large-N semi-independent survey]` DORA '24 |
+| Size & ownership confound metric attribution | `[REPLICATED]` El Emam '01; Bird et al. '11 |

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -98,6 +98,14 @@ WORKFLOW_REQUIREMENTS = {
         "pkgs": {"langchain-google-vertexai", "google-cloud-aiplatform"},
         "secrets": {"GOOGLE_CLOUD_PROJECT"},
     },
+    "quality-metrics": {
+        # Core path needs only lizard + radon + matplotlib + git.
+        # Everything else is optional enrichment (survival, duplication,
+        # cognitive complexity, cross-language complexity).
+        "cmds": set(),  # scc/gocyclo/gocognit/jscpd are OPTIONAL — checked as such
+        "pkgs": {"lizard", "radon", "matplotlib"},
+        "secrets": set(),
+    },
     "go-lsp": {
         "cmds": {"gopls", "go"},
         "pkgs": set(),
@@ -189,6 +197,7 @@ WORKFLOW_PROFILES = {
     "transcribe": ["transcription"],
     "tutorial-video": ["tutorial-video"],
     "stitch-audit": ["core", "gemini"],
+    "code-metrics": ["core", "quality-metrics"],
     "saas-gate": ["core"],
     "update": ["core"],
     "keep-going": ["core"],
@@ -347,6 +356,19 @@ def main():
         "langchain_anthropic",
         is_required("pkgs", "langchain-anthropic", workflows),
     )
+
+    print("\n--- Python Packages (quality-metrics — for /code-metrics) ---")
+    check_python_pkg("lizard", "lizard", is_required("pkgs", "lizard", workflows))
+    check_python_pkg("radon", "radon", is_required("pkgs", "radon", workflows))
+    check_python_pkg("matplotlib", "matplotlib", is_required("pkgs", "matplotlib", workflows))
+    # Optional enrichment — never required; skips gracefully at runtime if absent.
+    check_python_pkg("complexipy", "complexipy", False)
+    check_python_pkg("git-of-theseus", "git_of_theseus", False)
+    check_python_pkg("wily (optional)", "wily", False)
+    check_cmd("scc", "scc", "--version", False)
+    check_cmd("gocyclo", "gocyclo", "-h", False)
+    check_cmd("gocognit", "gocognit", "-h", False)
+    check_cmd("jscpd", "jscpd", "--version", False)
 
     print("\n--- Python Packages (Vertex AI — optional) ---")
     check_python_pkg(

--- a/scripts/quality/__init__.py
+++ b/scripts/quality/__init__.py
@@ -1,0 +1,18 @@
+"""Literature-grounded code-quality metric engines for the /code-metrics skill.
+
+Each module exposes a pure ``analyze(...)`` function returning a JSON-serialisable
+dict. External-tool wrappers degrade gracefully: when a tool is absent they return
+``{"skipped": "<tool> not found"}`` rather than raising, so a partial run never
+crashes the orchestrator.
+
+Engines:
+  - churn:       git-history churn / attribution / hotspots (pure git)
+  - complexity:  cyclomatic (lizard), cognitive (gocognit/complexipy), MI (radon)
+  - trend:       complexity/scale sampled across history (git worktree + lizard)
+  - survival:    code survival / 2-week churn (git-of-theseus)
+  - process:     change coupling, entropy, ownership/bus-factor, commit size, fixes
+  - duplication: production copy/paste ratio (jscpd)
+  - report:      consolidate engine JSON + render charts + emit markdown
+"""
+
+from __future__ import annotations

--- a/scripts/quality/churn.py
+++ b/scripts/quality/churn.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""churn.py — language-agnostic git-history churn metrics for a repo.
+
+Pure ``git log`` analysis (no checkout, non-destructive). Returns a dict:
+  - scale: commits, date range, active days
+  - churn: total added/deleted, net, churn-over-time (per month)
+  - hotspots: top files by (added+deleted), with churn/commit and a churn score
+  - attribution: conventional-commit %, type/scope histograms, PR-merge %,
+    ticket-ref %, author histogram
+  - cadence: commits per active day, mean/median inter-commit gap (days)
+
+Literature: relative churn is the strongest replicated defect/AI-slop signal
+(Nagappan & Ball 2005). Absolute churn is a poor predictor — always normalise.
+
+As a module:
+    from quality.churn import analyze
+    result = analyze("/path/to/repo", top_n=25, no_merges=True)
+
+As a CLI:
+    python3 -m quality.churn /path/to/repo [--top 25] [--no-merges]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+from collections import Counter, defaultdict
+from datetime import datetime
+
+# Files that are generated / vendored / binary — excluded from churn hotspots
+EXCLUDE_RE = re.compile(
+    r"(^|/)(node_modules|dist|build|out|\.next|vendor|\.venv|venv|__pycache__|"
+    r"coverage|\.git)/|"
+    r"(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|go\.sum|poetry\.lock|"
+    r"Cargo\.lock|\.min\.(js|css)$)|"
+    r"\.(png|jpg|jpeg|gif|svg|ico|pdf|woff2?|ttf|mp4|webm|zip|gz)$",
+    re.IGNORECASE,
+)
+CONVENTIONAL_RE = re.compile(
+    r"^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|arch|harden|revert)"
+    r"(\(([^)]+)\))?(!)?:",
+    re.IGNORECASE,
+)
+TICKET_RE = re.compile(r"#\d+")
+MERGE_RE = re.compile(r"Merge pull request|\(#\d+\)$")
+
+SENT = "@@@COMMIT@@@"
+
+
+def _git_log(repo: str, no_merges: bool) -> str:
+    scope = "--no-merges" if no_merges else "--all"
+    # No check=True: a repo with no commits exits 128; we treat that as empty.
+    return subprocess.run(
+        [
+            "git", "-C", repo, "log", scope,
+            f"--format={SENT}%H\t%an\t%ae\t%ad\t%s",
+            "--numstat", "--date=short",
+        ],
+        capture_output=True, text=True,
+    ).stdout
+
+
+def analyze(repo: str, top_n: int = 25, no_merges: bool = True) -> dict:
+    """Compute git-history churn metrics for ``repo``. Never raises on empty repos."""
+    log = _git_log(repo, no_merges)
+
+    commits: list[dict] = []
+    cur: dict | None = None
+    file_churn: dict[str, dict] = defaultdict(lambda: {"add": 0, "del": 0, "commits": 0})
+    for line in log.splitlines():
+        if line.startswith(SENT):
+            h, an, ae, ad, s = line[len(SENT):].split("\t", 4)
+            cur = {
+                "hash": h, "author": an, "email": ae, "date": ad, "subject": s,
+                "add": 0, "del": 0, "files": 0,
+            }
+            commits.append(cur)
+        elif line.strip() and cur is not None:
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            a, d, path = parts
+            add = 0 if a == "-" else int(a)
+            dele = 0 if d == "-" else int(d)
+            cur["add"] += add
+            cur["del"] += dele
+            cur["files"] += 1
+            if not EXCLUDE_RE.search(path):
+                fc = file_churn[path]
+                fc["add"] += add
+                fc["del"] += dele
+                fc["commits"] += 1
+
+    if not commits:
+        return {"repo": repo.rstrip("/").split("/")[-1], "error": "no commits"}
+
+    dates = sorted(c["date"] for c in commits)
+
+    per_month: dict[str, dict] = defaultdict(lambda: {"commits": 0, "add": 0, "del": 0})
+    for c in commits:
+        m = c["date"][:7]
+        per_month[m]["commits"] += 1
+        per_month[m]["add"] += c["add"]
+        per_month[m]["del"] += c["del"]
+
+    ts: list[datetime] = []
+    for c in commits:
+        try:
+            ts.append(datetime.strptime(c["date"], "%Y-%m-%d"))
+        except ValueError:
+            pass
+    ts.sort()
+    gaps_days = [(ts[i] - ts[i - 1]).days for i in range(1, len(ts))]
+
+    conv = sum(1 for c in commits if CONVENTIONAL_RE.match(c["subject"]))
+    ticket = sum(1 for c in commits if TICKET_RE.search(c["subject"]))
+    merges = sum(1 for c in commits if MERGE_RE.search(c["subject"]))
+    type_hist: Counter = Counter()
+    scope_hist: Counter = Counter()
+    for c in commits:
+        m = CONVENTIONAL_RE.match(c["subject"])
+        if m:
+            type_hist[m.group(1).lower()] += 1
+            if m.group(3):
+                scope_hist[m.group(3).lower()] += 1
+    authors = Counter(c["author"] for c in commits)
+
+    hotspots = sorted(
+        (
+            {
+                "file": f, "churn": v["add"] + v["del"], "add": v["add"],
+                "del": v["del"], "commits": v["commits"],
+            }
+            for f, v in file_churn.items()
+        ),
+        key=lambda x: x["churn"], reverse=True,
+    )[:top_n]
+
+    total_add = sum(c["add"] for c in commits)
+    total_del = sum(c["del"] for c in commits)
+
+    return {
+        "repo": repo.rstrip("/").split("/")[-1],
+        "scale": {
+            "commits": len(commits),
+            "first": dates[0], "last": dates[-1],
+            "active_days": len(set(dates)),
+            "span_days": (ts[-1] - ts[0]).days if len(ts) > 1 else 0,
+        },
+        "churn": {
+            "added": total_add, "deleted": total_del,
+            "net": total_add - total_del,
+            "churn_ratio_del_add": round(total_del / total_add, 3) if total_add else 0,
+            "per_month": dict(sorted(per_month.items())),
+        },
+        "cadence": {
+            "commits_per_active_day": round(len(commits) / len(set(dates)), 2),
+            "median_gap_days": statistics.median(gaps_days) if gaps_days else 0,
+            "mean_gap_days": round(statistics.mean(gaps_days), 2) if gaps_days else 0,
+        },
+        "attribution": {
+            "n": len(commits),
+            "conventional_pct": round(100 * conv / len(commits), 1),
+            "ticket_ref_pct": round(100 * ticket / len(commits), 1),
+            "pr_merge_pct": round(100 * merges / len(commits), 1),
+            "type_histogram": dict(type_hist.most_common()),
+            "scope_histogram": dict(scope_hist.most_common(20)),
+            "author_histogram": dict(authors.most_common()),
+        },
+        "hotspots": hotspots,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="git-history churn metrics")
+    parser.add_argument("repo", help="path to the git repository")
+    parser.add_argument("--top", type=int, default=25, help="number of hotspots")
+    parser.add_argument(
+        "--no-merges", action="store_true",
+        help="analyze non-merge commits only (default analyses all)",
+    )
+    args = parser.parse_args()
+    print(json.dumps(analyze(args.repo, top_n=args.top, no_merges=args.no_merges), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality/complexity.py
+++ b/scripts/quality/complexity.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""complexity.py — current-state code-quality metric battery for one repo.
+
+Literature-anchored product metrics, computed uniformly across languages:
+  - Cyclomatic complexity (McCabe 1976): distribution, %>10/15/20, max, mean —
+    via lizard (Py/Go/TS/JS in one parser). Report ALONGSIDE SLOC: CC is
+    ~0.7-0.9 collinear with size at file level (Jay 2009), so a "high CC" file
+    may just be a big file.
+  - Function length (long-method smell): mean NLOC, %>60 lines.
+  - Cognitive complexity (Campbell/SonarSource 2018): Go via gocognit, Python
+    via complexipy. A proxy for comprehension EFFORT, not correctness
+    (Munoz Baron 2020); no validated threshold. (No maintained TS CLI -> n/a.)
+  - Maintainability Index (Oman-Hagemeister; disputed — van Deursen 2014):
+    Python via radon, reported DIRECTIONALLY only.
+  - Scale + test ratio: tracked source LOC, test/non-test split.
+
+Only git-TRACKED source files are measured; docs/, vendor/, generated, and
+contract-DSL files are excluded so metrics reflect product code.
+
+Tools are auto-discovered (venv/bin then PATH). Any missing tool degrades to a
+``None`` sub-metric with a note — the battery never crashes.
+
+As a module:
+    from quality.complexity import analyze
+    result = analyze("/path/to/repo", venv=None, gobin=None)
+
+As a CLI:
+    python3 -m quality.complexity <repo> [--venv <venv>] [--gobin <gobin>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+
+EXT_LANG = {
+    ".py": "python", ".go": "go", ".ts": "typescript", ".tsx": "typescript",
+    ".js": "javascript", ".jsx": "javascript",
+}
+TEST_RE = re.compile(
+    r"(^|/)(tests?|__tests__|e2e)/|(_test\.go$)|"
+    r"(\.(test|spec)\.[tj]sx?$)|(^|/)test_[^/]+\.py$|_test\.py$",
+    re.IGNORECASE,
+)
+# non-product source: docs/DSL, infra models, migrations autogen, node stuff
+EXCLUDE_RE = re.compile(
+    r"(^|/)(docs|node_modules|dist|build|out|\.next|vendor|\.venv|venv|"
+    r"__pycache__|coverage|migrations|\.git)/|"
+    r"(^|/)models/.*\.(go|py)$",  # contract-DSL guard files under */models/
+    re.IGNORECASE,
+)
+
+
+def run(*args, **kw):
+    return subprocess.run(args, capture_output=True, text=True, **kw)
+
+
+def _tool(name: str, venv: str | None = None, gobin: str | None = None) -> str | None:
+    """Resolve a tool: prefer <venv>/bin, then <gobin>, then the running
+    interpreter's own bin dir, then PATH. Returns None if absent."""
+    if venv:
+        cand = os.path.join(venv, "bin", name)
+        if os.path.exists(cand):
+            return cand
+    if gobin:
+        cand = os.path.join(gobin, name)
+        if os.path.exists(cand):
+            return cand
+    # If invoked via <somevenv>/bin/python, sibling tools live next to it.
+    sibling = os.path.join(os.path.dirname(sys.executable), name)
+    if os.path.exists(sibling):
+        return sibling
+    return shutil.which(name)
+
+
+def tracked_files(repo: str) -> list[str]:
+    out = run("git", "-C", repo, "ls-files").stdout.splitlines()
+    return [f for f in out if not EXCLUDE_RE.search(f)]
+
+
+def bucket(repo: str) -> dict:
+    """Return {lang: {'src': [abs], 'test': [abs]}}."""
+    b: dict = defaultdict(lambda: {"src": [], "test": []})
+    for rel in tracked_files(repo):
+        ext = os.path.splitext(rel)[1].lower()
+        lang = EXT_LANG.get(ext)
+        if not lang:
+            continue
+        absf = os.path.join(repo, rel)
+        if not os.path.exists(absf):
+            continue
+        (b[lang]["test"] if TEST_RE.search(rel) else b[lang]["src"]).append(absf)
+    return b
+
+
+def lizard_ccn(files: list[str], lizard_bin: str | None) -> list[dict]:
+    """Per-function CCN + length via lizard --csv. Returns list of dicts."""
+    if not files or not lizard_bin:
+        return []
+    rows: list[dict] = []
+    for i in range(0, len(files), 400):  # chunk to avoid arg limits
+        chunk = files[i:i + 400]
+        r = run(lizard_bin, "--csv", *chunk)
+        for line in csv.reader(io.StringIO(r.stdout)):
+            # lizard csv: nloc,ccn,token,param,length,location,file,func,longname,start,end
+            if len(line) < 5:
+                continue
+            try:
+                rows.append({"nloc": int(line[0]), "ccn": int(line[1]), "length": int(line[4])})
+            except ValueError:
+                continue
+    return rows
+
+
+def dist(rows: list[dict]) -> dict | None:
+    if not rows:
+        return None
+    ccn = sorted(r["ccn"] for r in rows)
+    lens = [r["length"] for r in rows]
+    n = len(ccn)
+    return {
+        "functions": n,
+        "ccn_mean": round(sum(ccn) / n, 2),
+        "ccn_max": ccn[-1],
+        "ccn_p90": ccn[int(0.9 * (n - 1))],
+        "ccn_p95": ccn[int(0.95 * (n - 1))],
+        "pct_ccn_gt10": round(100 * sum(c > 10 for c in ccn) / n, 1),
+        "pct_ccn_gt15": round(100 * sum(c > 15 for c in ccn) / n, 1),
+        "pct_ccn_gt20": round(100 * sum(c > 20 for c in ccn) / n, 1),
+        "len_mean": round(sum(lens) / n, 1),
+        "pct_len_gt60": round(100 * sum(length > 60 for length in lens) / n, 1),
+    }
+
+
+def radon_mi(files: list[str], radon_bin: str | None) -> dict | None:
+    if not files or not radon_bin:
+        return None
+    r = run(radon_bin, "mi", "-j", *files)
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+    mis = [v["mi"] for v in data.values() if isinstance(v, dict) and "mi" in v]
+    if not mis:
+        return None
+    mis.sort()
+    return {
+        "files": len(mis), "mi_mean": round(sum(mis) / len(mis), 1),
+        "mi_min": round(mis[0], 1),
+        "pct_mi_lt65": round(100 * sum(m < 65 for m in mis) / len(mis), 1),
+        "pct_mi_lt20": round(100 * sum(m < 20 for m in mis) / len(mis), 1),
+    }
+
+
+def gocognit_dist(files: list[str], gocognit_bin: str | None) -> dict | None:
+    if not files or not gocognit_bin:
+        return None
+    vals: list[int] = []
+    for i in range(0, len(files), 200):
+        r = run(gocognit_bin, "-json", *files[i:i + 200])
+        try:
+            for item in json.loads(r.stdout or "[]"):
+                vals.append(item["Complexity"])
+        except (json.JSONDecodeError, KeyError, TypeError):
+            continue
+    if not vals:
+        return None
+    vals.sort()
+    n = len(vals)
+    return {
+        "functions": n, "cognitive_mean": round(sum(vals) / n, 2),
+        "cognitive_max": vals[-1], "cognitive_p95": vals[int(0.95 * (n - 1))],
+        "pct_gt15": round(100 * sum(v > 15 for v in vals) / n, 1),
+    }
+
+
+def complexipy_dist(files: list[str], complexipy_bin: str | None) -> dict | None:
+    if not files or not complexipy_bin:
+        return None
+    vals: list[int] = []
+    for i in range(0, len(files), 200):
+        with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tf:
+            outp = tf.name
+        run(complexipy_bin, "-q", "--output-format", "json", "--output", outp, *files[i:i + 200])
+        try:
+            with open(outp) as fh:
+                for item in json.load(fh):
+                    vals.append(item["complexity"])
+        except (json.JSONDecodeError, KeyError, TypeError, OSError):
+            pass
+        finally:
+            try:
+                os.unlink(outp)
+            except OSError:
+                pass
+    if not vals:
+        return None
+    vals.sort()
+    n = len(vals)
+    return {
+        "functions": n, "cognitive_mean": round(sum(vals) / n, 2),
+        "cognitive_max": vals[-1], "cognitive_p95": vals[int(0.95 * (n - 1))],
+        "pct_gt15": round(100 * sum(v > 15 for v in vals) / n, 1),
+    }
+
+
+def loc_counts(files: list[str]) -> int:
+    tot = 0
+    for f in files:
+        try:
+            with open(f, "rb") as fh:
+                tot += sum(1 for _ in fh)
+        except OSError:
+            pass
+    return tot
+
+
+def analyze(repo: str, venv: str | None = None, gobin: str | None = None) -> dict:
+    """Compute the complexity/scale battery. Missing tools degrade gracefully."""
+    lizard_bin = _tool("lizard", venv, gobin)
+    radon_bin = _tool("radon", venv, gobin)
+    gocognit_bin = _tool("gocognit", venv, gobin)
+    complexipy_bin = _tool("complexipy", venv, gobin)
+
+    if not lizard_bin:
+        return {
+            "repo": repo.rstrip("/").split("/")[-1],
+            "skipped": "lizard not found",
+            "note": "cyclomatic complexity requires lizard (pip install lizard)",
+        }
+
+    b = bucket(repo)
+    langs: dict = {}
+    src_loc_total = test_loc_total = 0
+    for lang, sets in b.items():
+        src_loc = loc_counts(sets["src"])
+        test_loc = loc_counts(sets["test"])
+        src_loc_total += src_loc
+        test_loc_total += test_loc
+        entry = {
+            "src_files": len(sets["src"]), "test_files": len(sets["test"]),
+            "src_loc": src_loc, "test_loc": test_loc,
+            "cyclomatic_src": dist(lizard_ccn(sets["src"], lizard_bin)),
+        }
+        if lang == "python":
+            entry["maintainability_index"] = radon_mi(sets["src"], radon_bin)
+            entry["cognitive_src"] = complexipy_dist(sets["src"], complexipy_bin)
+        elif lang == "go":
+            entry["cognitive_src"] = gocognit_dist(sets["src"], gocognit_bin)
+        langs[lang] = entry
+
+    return {
+        "repo": repo.rstrip("/").split("/")[-1],
+        "src_loc_total": src_loc_total,
+        "test_loc_total": test_loc_total,
+        "test_ratio": round(test_loc_total / src_loc_total, 2) if src_loc_total else 0,
+        "languages": langs,
+        "tools": {
+            "lizard": bool(lizard_bin), "radon": bool(radon_bin),
+            "gocognit": bool(gocognit_bin), "complexipy": bool(complexipy_bin),
+        },
+        "notes": {
+            "ccn_threshold": "McCabe: >10 moderate risk, >15 high, >20 very high; "
+                             "CC is ~0.7-0.9 collinear with SLOC (Jay 2009) — read with size.",
+            "mi_caveat": "Maintainability Index disputed (van Deursen 2014, Sjoberg 2013); "
+                         "Python only, radon 0-100 scale, <65 flagged. Directional only.",
+            "cognitive": "Campbell/SonarSource cognitive complexity; Go=gocognit, "
+                         "Python=complexipy; TS has no maintained CLI (n/a). "
+                         "Proxy for effort not correctness (Munoz Baron 2020).",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="code-quality complexity battery")
+    parser.add_argument("repo", help="path to the git repository")
+    parser.add_argument("--venv", default=None, help="virtualenv with lizard/radon/complexipy")
+    parser.add_argument("--gobin", default=None, help="dir containing gocognit")
+    args = parser.parse_args()
+    result = analyze(args.repo, venv=args.venv, gobin=args.gobin)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/duplication.py
+++ b/scripts/quality/duplication.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""duplication.py — production copy/paste ratio via jscpd.
+
+Literature signal (GitClear [VENDOR]): duplicated/copy-pasted code is one of the
+"AI-slop" signals the field converged on — code "written to be added, not
+refactored/reused." GitClear baselines: pre-AI 2020 ~8.3% duplicated blocks,
+AI-assisted 2024 ~12.3%. We measure PRODUCTION code only (tests, node_modules,
+docs, vendor, build output excluded) so the figure is comparable to those bands.
+
+Runs the ``jscpd`` CLI (npm i -g jscpd, or ``npx jscpd``) and parses its
+``jscpd-report.json`` ``statistics.total``. Requires node + jscpd; if either is
+absent, ``analyze`` returns ``{"skipped": ...}`` rather than raising.
+
+As a module:
+    from quality.duplication import analyze
+    result = analyze("/path/to/repo", workdir="/tmp/dup")
+
+As a CLI:
+    python3 -m quality.duplication <repo> --workdir <dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# Production-only: exclude tests, generated, vendored, docs, node output.
+IGNORE = ",".join([
+    "**/node_modules/**", "**/dist/**", "**/build/**", "**/out/**", "**/.next/**",
+    "**/vendor/**", "**/.venv/**", "**/venv/**", "**/__pycache__/**",
+    "**/coverage/**", "**/docs/**", "**/migrations/**",
+    "**/*_test.go", "**/*.test.*", "**/*.spec.*",
+    "**/test_*.py", "**/*_test.py", "**/tests/**", "**/__tests__/**", "**/e2e/**",
+])
+FORMATS = "python,go,typescript,tsx,javascript,jsx"
+
+
+def _round(v: float | None, ndigits: int = 2) -> float | None:
+    return round(v, ndigits) if isinstance(v, (int, float)) else v
+
+
+def _jscpd_cmd() -> list[str] | None:
+    """Resolve how to invoke jscpd: direct binary, else npx. None if node absent."""
+    direct = shutil.which("jscpd")
+    if direct:
+        return [direct]
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, "--yes", "jscpd"]
+    return None
+
+
+def analyze(repo: str, workdir: str, name: str | None = None) -> dict:
+    """Run jscpd over production code and return the duplication statistics."""
+    name = name or repo.rstrip("/").split("/")[-1]
+    cmd = _jscpd_cmd()
+    if not cmd:
+        return {
+            "repo": name,
+            "skipped": "jscpd/node not found",
+            "note": "duplication requires node + jscpd (npm i -g jscpd)",
+        }
+    os.makedirs(workdir, exist_ok=True)
+    proc = subprocess.run(
+        [
+            *cmd, repo,
+            "--reporters", "json",
+            "--output", workdir,
+            "--ignore", IGNORE,
+            "--format", FORMATS,
+            "--mode", "strict",
+            "--silent",
+        ],
+        capture_output=True, text=True,
+    )
+    report = os.path.join(workdir, "jscpd-report.json")
+    if not os.path.exists(report):
+        return {
+            "repo": name,
+            "skipped": "jscpd produced no report",
+            "note": (proc.stderr or proc.stdout or "").strip()[:400],
+        }
+    try:
+        with open(report) as fh:
+            stats = json.load(fh)["statistics"]["total"]
+    except (json.JSONDecodeError, KeyError, OSError) as exc:
+        return {"repo": name, "skipped": f"unreadable jscpd report: {exc}"}
+
+    return {
+        "repo": name,
+        "lines": stats.get("lines"),
+        "tokens": stats.get("tokens"),
+        "sources": stats.get("sources"),
+        "clones": stats.get("clones"),
+        "duplicated_lines": stats.get("duplicatedLines"),
+        "duplicated_tokens": stats.get("duplicatedTokens"),
+        "duplication_pct_lines": _round(stats.get("percentage")),
+        "duplication_pct_tokens": _round(stats.get("percentageTokens")),
+        "baselines": {
+            "gitclear_pre_ai_2020": 8.3,
+            "gitclear_ai_2024": 12.3,
+            "note": "GitClear [VENDOR] copy/paste baselines (% duplicated blocks); "
+                    "direction is credible, exact multiples are framing-dependent.",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="production code duplication (jscpd)")
+    parser.add_argument("repo", help="path to the git repository")
+    parser.add_argument("--workdir", required=True, help="scratch dir for jscpd output")
+    parser.add_argument("--name", default=None, help="display name for the repo")
+    args = parser.parse_args()
+    print(json.dumps(analyze(args.repo, args.workdir, name=args.name), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/process.py
+++ b/scripts/quality/process.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""process.py — process/history metrics (the literature's strongest signals).
+
+Rahman & Devanbu (2013): process metrics outperform static product metrics for
+defect prediction, and are more stable across releases. Computed from ``git log``:
+  - Change (temporal) coupling  — Tornhill: files that change together.
+  - Change entropy (HCM)        — Hassan 2009: Shannon entropy of change spread.
+  - Ownership / bus-factor      — Bird et al. 2011: top-owner share, minor authors.
+  - Commit-size distribution    — large commits = risk / weaker review.
+  - Fix ratio + fix-hotspots    — SZZ-lite defect proxy.
+
+Caveat for agentic repos: bus-factor / ownership metrics assume human authorship;
+when one operator drives an AI pipeline the "author" collapses to one identity, so
+read bus-factor as a signal about the ATTRIBUTION model, not team resilience.
+
+As a module:
+    from quality.process import analyze
+    result = analyze("/path/to/repo")
+
+As a CLI:
+    python3 -m quality.process <repo>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from itertools import combinations
+
+CODE = (".py", ".go", ".ts", ".tsx", ".js", ".jsx")
+EXCLUDE = re.compile(
+    r"(^|/)(node_modules|dist|build|out|\.next|vendor|\.venv|"
+    r"venv|__pycache__|coverage|docs|\.git)/|"
+    r"(package-lock\.json|go\.sum|yarn\.lock)$",
+    re.I,
+)
+FIX = re.compile(r"^(fix|bugfix|hotfix)(\(|:|\b)", re.I)
+
+SENT = "@@@"
+
+
+def is_code(p: str) -> bool:
+    return p.endswith(CODE) and not EXCLUDE.search(p)
+
+
+def analyze(repo: str) -> dict:
+    """Compute process/history metrics for ``repo``. Never raises on empty repos."""
+    log = subprocess.run(
+        ["git", "-C", repo, "log", "--no-merges", f"--format={SENT}%H\t%an\t%s", "--numstat"],
+        capture_output=True, text=True,
+    ).stdout
+
+    commits: list[dict] = []
+    cur: dict | None = None
+    for line in log.splitlines():
+        if line.startswith(SENT):
+            h, an, s = line[len(SENT):].split("\t", 2)
+            cur = {"author": an, "subject": s, "files": []}
+            commits.append(cur)
+        elif line.strip() and cur is not None:
+            parts = line.split("\t")
+            if len(parts) == 3 and is_code(parts[2]):
+                add = 0 if parts[0] == "-" else int(parts[0])
+                dele = 0 if parts[1] == "-" else int(parts[1])
+                cur["files"].append((parts[2], add + dele))
+
+    if not commits:
+        return {"repo": repo.rstrip("/").split("/")[-1], "commits_analyzed": 0}
+
+    # ---- change coupling ----
+    pair_co: Counter = Counter()
+    file_commits: Counter = Counter()
+    for c in commits:
+        fs = [f for f, _ in c["files"]]
+        for f in set(fs):
+            file_commits[f] += 1
+        for a, b in combinations(sorted(set(fs)), 2):
+            pair_co[(a, b)] += 1
+    coupling: list[dict] = []
+    for (a, b), co in pair_co.items():
+        if co < 4:
+            continue
+        conf = co / min(file_commits[a], file_commits[b])
+        cross_dir = a.rsplit("/", 1)[0] != b.rsplit("/", 1)[0]
+        coupling.append({
+            "a": a, "b": b, "co_changes": co,
+            "confidence": round(conf, 2), "cross_dir": cross_dir,
+        })
+    coupling.sort(key=lambda x: (x["confidence"], x["co_changes"]), reverse=True)
+
+    # ---- change entropy (Hassan HCM), normalized 0..1 ----
+    total = sum(file_commits.values())
+    n = len(file_commits)
+    if total and n > 1:
+        H = -sum((v / total) * math.log2(v / total) for v in file_commits.values())
+        entropy = round(H / math.log2(n), 3)
+    else:
+        entropy = 0.0
+
+    # ---- ownership / bus-factor (Bird et al.) ----
+    author_lines: Counter = Counter()
+    file_authors: dict = defaultdict(Counter)
+    for c in commits:
+        for f, ch in c["files"]:
+            author_lines[c["author"]] += ch
+            file_authors[f][c["author"]] += 1
+    tot_lines = sum(author_lines.values()) or 1
+    ranked = author_lines.most_common()
+    acc, bus = 0, 0
+    for _, v in ranked:
+        acc += v
+        bus += 1
+        if acc >= 0.5 * tot_lines:
+            break
+    top_owner_shares: list[float] = []
+    minor_heavy = 0  # files with >1 author AND >=1 minor contributor (<5% of commits)
+    for _f, ac in file_authors.items():
+        tc = sum(ac.values())
+        top = ac.most_common(1)[0][1]
+        top_owner_shares.append(top / tc)
+        if len(ac) > 1 and any(v / tc < 0.05 for v in ac.values()):
+            minor_heavy += 1
+    avg_top_owner = round(sum(top_owner_shares) / len(top_owner_shares), 2) if top_owner_shares else 1.0
+
+    # ---- commit size ----
+    sizes = sorted(sum(ch for _, ch in c["files"]) for c in commits if c["files"])
+    fcounts = sorted(len(c["files"]) for c in commits if c["files"])
+
+    def pct(a: list[int], p: float) -> int:
+        return a[min(len(a) - 1, int(p * len(a)))] if a else 0
+
+    big = sum(1 for s in sizes if s > 400)
+
+    # ---- fix ratio + fix hotspots ----
+    fix_commits = [c for c in commits if FIX.match(c["subject"])]
+    fix_touch: Counter = Counter()
+    for c in fix_commits:
+        for f, _ in c["files"]:
+            fix_touch[f] += 1
+
+    return {
+        "repo": repo.rstrip("/").split("/")[-1],
+        "commits_analyzed": len(commits),
+        "change_entropy_normalized": entropy,
+        "ownership": {
+            "distinct_authors": len(author_lines),
+            "bus_factor_50pct": bus,
+            "top_author_share": round(ranked[0][1] / tot_lines, 2) if ranked else 0,
+            "avg_file_top_owner_share": avg_top_owner,
+            "files_with_minor_contributors": minor_heavy,
+        },
+        "commit_size": {
+            "median_churn": pct(sizes, 0.5), "p90_churn": pct(sizes, 0.9),
+            "median_files": pct(fcounts, 0.5), "p90_files": pct(fcounts, 0.9),
+            "pct_large_commits_gt400": round(100 * big / len(sizes), 1) if sizes else 0,
+        },
+        "defect_proxy": {
+            "fix_commit_pct": round(100 * len(fix_commits) / len(commits), 1) if commits else 0,
+            "top_fix_hotspots": [
+                {"file": f, "fix_touches": v} for f, v in fix_touch.most_common(5)
+            ],
+        },
+        "change_coupling_top": coupling[:8],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="process/history metrics")
+    parser.add_argument("repo", help="path to the git repository")
+    args = parser.parse_args()
+    print(json.dumps(analyze(args.repo), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/report.py
+++ b/scripts/quality/report.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""report.py — consolidate engine JSON into a combined readout, charts, markdown.
+
+Takes the per-engine dicts produced by the churn/complexity/trend/survival/
+process/duplication engines and:
+  - builds a flat ``combined.json`` summary (weighted-aggregate complexity across
+    languages, churn/attribution signals, process signals),
+  - renders PNG charts (trend + AI-slop signal bars) if matplotlib is present,
+  - emits a literature-grounded markdown report with honest caveats.
+
+matplotlib is optional: if absent, charts are skipped and the markdown notes it.
+
+As a module:
+    from quality import report
+    combined = report.build_combined(engines)
+    charts = report.render_charts(engines, out_dir)      # [] if matplotlib absent
+    md = report.render_markdown(engines, combined, charts)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+
+def _weighted_complexity(battery: dict) -> dict:
+    """Aggregate cyclomatic/cognitive across languages, weighted by function count."""
+    tot_fn = 0
+    ccn_sum = 0.0
+    ccn_max = 0
+    gt10_fn = 0.0
+    len60_fn = 0.0
+    cog_max = 0
+    for _lang, e in (battery.get("languages") or {}).items():
+        cc = e.get("cyclomatic_src")
+        if cc and cc.get("functions"):
+            f = cc["functions"]
+            tot_fn += f
+            ccn_sum += cc["ccn_mean"] * f
+            ccn_max = max(ccn_max, cc["ccn_max"])
+            gt10_fn += cc["pct_ccn_gt10"] / 100 * f
+            len60_fn += cc["pct_len_gt60"] / 100 * f
+        cg = e.get("cognitive_src")
+        if cg and cg.get("cognitive_max"):
+            cog_max = max(cog_max, cg["cognitive_max"])
+    return {
+        "functions": tot_fn,
+        "ccn_mean": round(ccn_sum / tot_fn, 2) if tot_fn else None,
+        "ccn_max": ccn_max,
+        "pct_ccn_gt10": round(100 * gt10_fn / tot_fn, 1) if tot_fn else None,
+        "pct_len_gt60": round(100 * len60_fn / tot_fn, 1) if tot_fn else None,
+        "cog_max": cog_max,
+    }
+
+
+def build_combined(engines: dict) -> dict:
+    """Flatten the engine outputs into a single summary row + raw pass-through."""
+    churn = engines.get("churn") or {}
+    battery = engines.get("complexity") or {}
+    process = engines.get("process") or {}
+    survival = engines.get("survival") or {}
+    duplication = engines.get("duplication") or {}
+    trend = engines.get("trend") or {}
+
+    comp = _weighted_complexity(battery)
+    scale = churn.get("scale") or {}
+    ch = churn.get("churn") or {}
+    attr = churn.get("attribution") or {}
+    commits = scale.get("commits") or 0
+    added = ch.get("added") or 0
+    deleted = ch.get("deleted") or 0
+
+    summary = {
+        "repo": churn.get("repo") or battery.get("repo"),
+        "first": scale.get("first"), "last": scale.get("last"),
+        "span_days": scale.get("span_days"),
+        "commits": commits,
+        "src_loc": battery.get("src_loc_total"),
+        "test_loc": battery.get("test_loc_total"),
+        "test_ratio": battery.get("test_ratio"),
+        **comp,
+        "added": added, "deleted": deleted,
+        "churn_per_commit": round((added + deleted) / commits) if commits else 0,
+        "rework_ratio": round(deleted / added, 3) if added else 0,  # del:add
+        "conv_pct": attr.get("conventional_pct"),
+        "ticket_pct": attr.get("ticket_ref_pct"),
+        "pr_pct": attr.get("pr_merge_pct"),
+        "change_entropy": process.get("change_entropy_normalized"),
+        "bus_factor_50pct": (process.get("ownership") or {}).get("bus_factor_50pct"),
+        "fix_commit_pct": (process.get("defect_proxy") or {}).get("fix_commit_pct"),
+        "trend_points": trend.get("points"),
+    }
+    surv_14 = None
+    if not survival.get("skipped"):
+        surv_14 = ((survival.get("survival_by_age_days") or {}).get(14)
+                   or (survival.get("survival_by_age_days") or {}).get("14") or {})
+        summary["survival_14d_pct"] = surv_14.get("survival_pct")
+        summary["half_life_days"] = survival.get("half_life_days")
+    if not duplication.get("skipped"):
+        summary["duplication_pct_tokens"] = duplication.get("duplication_pct_tokens")
+
+    return {"summary": summary, "engines": engines}
+
+
+def render_charts(engines: dict, out_dir: str) -> list[str]:
+    """Render trend + AI-slop charts. Returns paths written; [] if matplotlib absent."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+
+    written: list[str] = []
+    trend = engines.get("trend") or {}
+    series = [p for p in (trend.get("series") or []) if p.get("src_loc")]
+
+    plt.rcParams.update({
+        "font.size": 9, "axes.grid": True, "grid.alpha": 0.25,
+        "figure.facecolor": "white", "axes.axisbelow": True,
+    })
+
+    if len(series) >= 2:
+        fig, axes = plt.subplots(2, 2, figsize=(14, 9))
+        fig.suptitle("Code-quality metrics over history", fontsize=13, fontweight="bold")
+        dates = [p["date"] for p in series]
+
+        ax = axes[0][0]
+        ax.plot(dates, [p.get("test_ratio") for p in series], marker="o", ms=3, color="#2ca02c")
+        ax.axhline(1.0, ls="--", c="k", lw=0.8, alpha=0.5)
+        ax.set_title("Test-to-code ratio (higher = more test discipline)")
+        ax.tick_params(axis="x", rotation=40, labelsize=6)
+
+        ax = axes[0][1]
+        ax.plot(dates, [p.get("pct_ccn_gt10") for p in series], marker="o", ms=3, color="#d62728")
+        ax.set_title("% functions with cyclomatic >10 (McCabe risk)")
+        ax.tick_params(axis="x", rotation=40, labelsize=6)
+
+        ax = axes[1][0]
+        locs = [p.get("src_loc") for p in series]
+        ccns = [p.get("ccn_mean") for p in series]
+        ax.plot(locs, ccns, marker="o", ms=3, color="#1f77b4")
+        ax.set_title("Mean CCN vs source LOC\n(flat = complexity NOT tracking size — good)")
+        ax.set_xlabel("source LOC")
+        ax.set_ylabel("mean CCN / function")
+
+        ax = axes[1][1]
+        ax.plot(dates, [p.get("src_loc") for p in series], marker="o", ms=3, color="#9467bd")
+        ax.set_title("Source LOC over history (scale)")
+        ax.tick_params(axis="x", rotation=40, labelsize=6)
+
+        fig.tight_layout(rect=[0, 0.01, 1, 0.95])
+        p1 = os.path.join(out_dir, "trends.png")
+        fig.savefig(p1, dpi=130)
+        plt.close(fig)
+        written.append(p1)
+
+    # AI-slop signal bars: 14-day survival + duplication vs GitClear bands
+    survival = engines.get("survival") or {}
+    duplication = engines.get("duplication") or {}
+    surv_val = None
+    if not survival.get("skipped"):
+        s14 = ((survival.get("survival_by_age_days") or {}).get(14)
+               or (survival.get("survival_by_age_days") or {}).get("14") or {})
+        surv_val = s14.get("survival_pct")
+    dup_val = None if duplication.get("skipped") else duplication.get("duplication_pct_tokens")
+
+    if surv_val is not None or dup_val is not None:
+        fig, axes = plt.subplots(1, 2, figsize=(13, 4.2))
+        fig.suptitle("AI-slop signals vs GitClear baselines", fontsize=12, fontweight="bold")
+        axA, axB = axes
+        if surv_val is not None:
+            axA.barh(["this repo"], [surv_val], color="#1f77b4")
+            axA.axvline(96.9, ls="--", c="#555", lw=1.2)
+            axA.axvline(94.3, ls="--", c="#c00", lw=1.2)
+            axA.set_xlim(90, 100.5)
+            axA.set_title("14-day code survival (higher = less churn)\npre-AI 96.9% / AI 94.3%")
+            axA.set_xlabel("% lines surviving 14 days")
+        else:
+            axA.text(0.5, 0.5, "survival: skipped", ha="center", va="center")
+            axA.axis("off")
+        if dup_val is not None:
+            axB.barh(["this repo"], [dup_val], color="#d62728")
+            axB.axvline(8.3, ls="--", c="#555", lw=1.2)
+            axB.axvline(12.3, ls="--", c="#c00", lw=1.2)
+            axB.set_title("Production duplication (lower = better)\npre-AI 8.3% / AI 12.3%")
+            axB.set_xlabel("% duplicated tokens")
+        else:
+            axB.text(0.5, 0.5, "duplication: skipped", ha="center", va="center")
+            axB.axis("off")
+        fig.tight_layout(rect=[0, 0.01, 1, 0.9])
+        p2 = os.path.join(out_dir, "ai_slop_signals.png")
+        fig.savefig(p2, dpi=130)
+        plt.close(fig)
+        written.append(p2)
+
+    return written
+
+
+def _fmt(v, suffix: str = "") -> str:
+    return "n/a" if v is None else f"{v}{suffix}"
+
+
+def render_markdown(engines: dict, combined: dict, charts: list[str]) -> str:
+    """Emit a literature-grounded markdown report with honest caveats."""
+    s = combined["summary"]
+    churn = engines.get("churn") or {}
+    battery = engines.get("complexity") or {}
+    process = engines.get("process") or {}
+    survival = engines.get("survival") or {}
+    duplication = engines.get("duplication") or {}
+
+    lines: list[str] = []
+    lines.append(f"# Code-Quality Metrics — {s.get('repo') or 'repo'}")
+    lines.append("")
+    lines.append(
+        "Literature-grounded readout. Every metric is reported with its caveat; the "
+        "load-bearing truth is that **most product metrics are size in disguise** — the "
+        "signals that are *not* just SLOC (relative churn, duplication, survival) are the "
+        "trustworthy ones. See `docs/quality-metrics.md` for citations."
+    )
+    lines.append("")
+
+    # --- scale & discipline ---
+    lines.append("## Scale & process discipline")
+    lines.append("")
+    lines.append(f"- Commits: **{_fmt(s.get('commits'))}** over {_fmt(s.get('span_days'), ' days')} "
+                 f"({_fmt(s.get('first'))} → {_fmt(s.get('last'))})")
+    lines.append(f"- Source LOC: **{_fmt(s.get('src_loc'))}**, test LOC: {_fmt(s.get('test_loc'))}, "
+                 f"test:code ratio **{_fmt(s.get('test_ratio'))}**")
+    lines.append(f"- Conventional-commit %: {_fmt(s.get('conv_pct'), '%')}, "
+                 f"ticket-ref %: {_fmt(s.get('ticket_pct'), '%')}, "
+                 f"PR-merge %: {_fmt(s.get('pr_pct'), '%')}")
+    lines.append("")
+
+    # --- churn (strongest signal) ---
+    lines.append("## Churn (strongest, best-replicated signal — Nagappan & Ball 2005)")
+    lines.append("")
+    lines.append(f"- Added: {_fmt(s.get('added'))}, deleted: {_fmt(s.get('deleted'))}, "
+                 f"**rework ratio (del:add): {_fmt(s.get('rework_ratio'))}** "
+                 f"(lower = less churn/AI-slop)")
+    lines.append(f"- Churn per commit: {_fmt(s.get('churn_per_commit'))}")
+    lines.append("- Caveat: *relative/normalised* churn is the predictor; absolute churn is weak. "
+                 "This is the metric where AI-generated code shows the clearest degradation.")
+    hotspots = churn.get("hotspots") or []
+    if hotspots:
+        lines.append("")
+        lines.append("Top churn hotspots (file — churn / commits):")
+        for h in hotspots[:8]:
+            lines.append(f"  - `{h['file']}` — {h['churn']} / {h['commits']}")
+    lines.append("")
+
+    # --- complexity ---
+    lines.append("## Complexity (product metrics — read ALONGSIDE size)")
+    lines.append("")
+    if battery.get("skipped"):
+        lines.append(f"- Skipped: {battery['skipped']}")
+    else:
+        lines.append(f"- Functions: {_fmt(s.get('functions'))}, mean cyclomatic **{_fmt(s.get('ccn_mean'))}**, "
+                     f"max {_fmt(s.get('ccn_max'))}")
+        lines.append(f"- % functions CCN>10 (McCabe risk): **{_fmt(s.get('pct_ccn_gt10'), '%')}**, "
+                     f"% long methods (>60 lines): {_fmt(s.get('pct_len_gt60'), '%')}, "
+                     f"cognitive max: {_fmt(s.get('cog_max'))}")
+        lines.append("- Caveat: cyclomatic is ~0.7–0.9 collinear with SLOC at file level (Jay 2009) — "
+                     "a 'high CC' file may just be big. Cognitive complexity proxies comprehension "
+                     "*effort*, not correctness (Muñoz Barón 2020); no validated threshold. "
+                     "Maintainability Index (radon) is **directional only** (van Deursen 2014).")
+    lines.append("")
+
+    # --- process ---
+    lines.append("## Process/history metrics (Rahman & Devanbu 2013: > product metrics)")
+    lines.append("")
+    if process.get("commits_analyzed"):
+        own = process.get("ownership") or {}
+        cs = process.get("commit_size") or {}
+        lines.append(f"- Change entropy (Hassan HCM, 0–1): {_fmt(s.get('change_entropy'))}")
+        lines.append(f"- Bus factor (authors for 50% of churn): {_fmt(own.get('bus_factor_50pct'))}, "
+                     f"top-author share: {_fmt(own.get('top_author_share'))}")
+        lines.append(f"- Commit size: median churn {_fmt(cs.get('median_churn'))}, "
+                     f"p90 {_fmt(cs.get('p90_churn'))}, large (>400 LOC) {_fmt(cs.get('pct_large_commits_gt400'), '%')}")
+        lines.append(f"- Fix-commit % (SZZ-lite defect proxy): {_fmt(s.get('fix_commit_pct'), '%')}")
+        lines.append("- Caveat: **bus-factor assumes human authorship** — in an agentic pipeline the "
+                     "author often collapses to one operator identity, so read it as a signal about "
+                     "the attribution model, not team resilience.")
+    else:
+        lines.append("- No non-merge commits with code changes found.")
+    lines.append("")
+
+    # --- AI-slop signals ---
+    lines.append("## AI-slop signals vs GitClear baselines")
+    lines.append("")
+    if survival.get("skipped"):
+        lines.append(f"- Code survival: skipped ({survival['skipped']}).")
+    else:
+        lines.append(f"- 14-day code survival: **{_fmt(s.get('survival_14d_pct'), '%')}** "
+                     f"(GitClear [VENDOR] pre-AI 96.9% / AI 94.3%), half-life {_fmt(s.get('half_life_days'))} days")
+    if duplication.get("skipped"):
+        lines.append(f"- Duplication: skipped ({duplication['skipped']}).")
+    else:
+        lines.append(f"- Production duplication: **{_fmt(s.get('duplication_pct_tokens'), '%')}** tokens "
+                     f"(GitClear [VENDOR] pre-AI 8.3% / AI 12.3%)")
+    lines.append("- Caveat: GitClear is a **vendor** longitudinal series; the *direction* (churn & "
+                 "duplication up, reuse down) is corroborated by DORA 2024, but the exact multiples "
+                 "are framing-dependent — treat bands as reference, not verdicts.")
+    lines.append("")
+
+    if charts:
+        lines.append("## Charts")
+        lines.append("")
+        for c in charts:
+            lines.append(f"![{os.path.basename(c)}]({os.path.basename(c)})")
+        lines.append("")
+    else:
+        lines.append("_Charts skipped (matplotlib not installed)._")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_report(engines: dict, out_dir: str) -> str:
+    """Build combined.json, charts, and report.md in out_dir. Returns report.md path."""
+    os.makedirs(out_dir, exist_ok=True)
+    combined = build_combined(engines)
+    with open(os.path.join(out_dir, "combined.json"), "w") as fh:
+        json.dump(combined, fh, indent=2)
+    charts = render_charts(engines, out_dir)
+    md = render_markdown(engines, combined, charts)
+    report_path = os.path.join(out_dir, "report.md")
+    with open(report_path, "w") as fh:
+        fh.write(md)
+    return report_path

--- a/scripts/quality/survival.py
+++ b/scripts/quality/survival.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""survival.py — code-survival / 2-week churn from git-of-theseus output.
+
+Literature signal (GitClear/DORA): AI-generated code shows elevated churn —
+lines reverted/reworked soon after authoring. Code SURVIVAL is the inverse: of
+the lines a commit added, what fraction are still alive after age dt? GitClear
+baselines: pre-AI 2020 ~96.9% survive 2 weeks; AI-assisted 2024 ~94.3% (5.7%
+churn). This engine reports survival at 14/30/60 days so a repo can be placed
+against those bands.
+
+git-of-theseus survival.json = {commit_hash: [[unix_ts, lines_alive], ...]}
+(monotonic non-increasing). We anchor each commit to its author time, convert
+each snapshot to an AGE in days, normalise by the commit's initial line count,
+and aggregate a line-weighted survival curve across all commits.
+
+Requires the ``git-of-theseus-analyze`` CLI (pip install git-of-theseus). If it
+is absent, ``analyze`` returns ``{"skipped": ...}`` rather than raising.
+
+As a module:
+    from quality.survival import analyze
+    result = analyze("/path/to/repo", workdir="/tmp/survival")
+
+As a CLI:
+    python3 -m quality.survival <repo> --workdir <dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+AGES = [7, 14, 30, 60, 90]
+
+
+def _run_git_of_theseus(repo: str, outdir: str) -> str | None:
+    """Run git-of-theseus-analyze into outdir. Returns survival.json path or None."""
+    # Prefer a tool co-located with the running interpreter (venv install),
+    # then fall back to PATH — mirrors quality.complexity._tool discovery.
+    sibling = os.path.join(os.path.dirname(sys.executable), "git-of-theseus-analyze")
+    tool = sibling if os.path.exists(sibling) else shutil.which("git-of-theseus-analyze")
+    if not tool:
+        return None
+    os.makedirs(outdir, exist_ok=True)
+    subprocess.run(
+        # weekly interval → enough resolution for 14/30-day survival bins
+        [tool, repo, "--outdir", outdir, "--branch", "HEAD", "--interval", "604800"],
+        capture_output=True, text=True,
+    )
+    survival = os.path.join(outdir, "survival.json")
+    return survival if os.path.exists(survival) else None
+
+
+def analyze_survival_json(survival_path: str, repo: str, name: str | None = None) -> dict:
+    """Analyze an existing git-of-theseus survival.json against author times."""
+    name = name or repo.rstrip("/").split("/")[-1]
+    with open(survival_path) as fh:
+        surv = json.load(fh)
+
+    hashes = list(surv)
+    authored: dict[str, int] = {}
+    if hashes:
+        out = subprocess.run(
+            ["git", "-C", repo, "show", "-s", "--format=%H %at", *hashes],
+            capture_output=True, text=True,
+        ).stdout
+        for line in out.splitlines():
+            if " " in line:
+                h, at = line.split()
+                authored[h] = int(at)
+
+    agg = {a: {"num": 0.0, "den": 0.0} for a in AGES}
+    curve: list[tuple[float, float, int]] = []
+    total_lines = 0
+    for h, series in surv.items():
+        ct = authored.get(h)
+        if ct is None or not series:
+            continue
+        L0 = series[0][1]
+        if L0 <= 0:
+            continue
+        total_lines += L0
+        pts = [((ts - ct) / 86400.0, min(1.0, lines / L0)) for ts, lines in series]
+        pts = [(a, f) for a, f in pts if a >= 0]
+        if not pts:
+            continue
+        ages = [a for a, _ in pts]
+        fracs = [f for _, f in pts]
+        max_age = ages[-1]
+        for A in AGES:
+            if max_age >= A:  # commit has lived at least A days -> can measure
+                i = bisect.bisect_left(ages, A)
+                if i == 0:
+                    f = fracs[0]
+                elif i >= len(ages):
+                    f = fracs[-1]
+                else:
+                    a0, a1 = ages[i - 1], ages[i]
+                    f0, f1 = fracs[i - 1], fracs[i]
+                    f = f0 + (f1 - f0) * ((A - a0) / (a1 - a0)) if a1 > a0 else f1
+                agg[A]["num"] += f * L0
+                agg[A]["den"] += L0
+        for a, f in pts:
+            curve.append((a, f, L0))
+
+    result: dict = {
+        "repo": name, "total_lines_tracked": total_lines,
+        "survival_by_age_days": {},
+    }
+    for A in AGES:
+        d = agg[A]["den"]
+        result["survival_by_age_days"][A] = {
+            "survival_pct": round(100 * agg[A]["num"] / d, 1) if d else None,
+            "lines_old_enough": int(d),
+        }
+
+    # half-life: line-weighted survival across weekly age bins; first bin < 50%
+    bins: dict[int, list[float]] = {}
+    for a, f, w in curve:
+        b = int(a // 7) * 7
+        bins.setdefault(b, [0.0, 0.0])
+        bins[b][0] += f * w
+        bins[b][1] += w
+    curve_pts = sorted((b, num / den) for b, (num, den) in bins.items() if den)
+    half_life = None
+    for b, s in curve_pts:
+        if s < 0.5:
+            half_life = b
+            break
+    result["half_life_days"] = half_life if half_life is not None else ">observed"
+    result["weekly_survival_curve"] = [
+        {"age_days": b, "survival": round(s, 3)} for b, s in curve_pts
+    ]
+    result["baselines"] = {
+        "gitclear_pre_ai_2020_14d": 96.9,
+        "gitclear_ai_2024_14d": 94.3,
+        "note": "GitClear [VENDOR] longitudinal churn baselines — direction, not gospel.",
+    }
+    return result
+
+
+def analyze(repo: str, workdir: str, name: str | None = None) -> dict:
+    """Run git-of-theseus then analyze survival. Degrades gracefully if absent."""
+    name = name or repo.rstrip("/").split("/")[-1]
+    survival_path = _run_git_of_theseus(repo, workdir)
+    if not survival_path:
+        return {
+            "repo": name,
+            "skipped": "git-of-theseus not found",
+            "note": "code survival requires git-of-theseus (pip install git-of-theseus)",
+        }
+    return analyze_survival_json(survival_path, repo, name=name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="code survival / 2-week churn")
+    parser.add_argument("repo", help="path to the git repository")
+    parser.add_argument("--workdir", required=True, help="scratch dir for git-of-theseus output")
+    parser.add_argument("--name", default=None, help="display name for the repo")
+    args = parser.parse_args()
+    print(json.dumps(analyze(args.repo, args.workdir, name=args.name), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/trend.py
+++ b/scripts/quality/trend.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""trend.py — complexity/scale trend across git history for one repo.
+
+Samples N evenly-spaced commits on the first-parent (main) line, checks each
+out into a throwaway ``git worktree`` (non-destructive), and recomputes a core
+metric set so we can see whether complexity/test-ratio drift as the pipeline
+adds code over time. Literature motivation: a HEAD snapshot suffers survivorship
+bias — mine history to see whether complexity grows WITH size (the SLOC confound)
+or stays flat (good).
+
+Per sample point: date, commit, src_loc, test_loc, test_ratio, functions,
+ccn_mean, pct_ccn_gt10, pct_len_gt60.
+
+As a module:
+    from quality.trend import analyze
+    result = analyze("/path/to/repo", workdir="/tmp/wt", n=10)
+
+As a CLI:
+    python3 -m quality.trend <repo> --workdir <dir> [--n 10] [--venv <venv>] [--gobin <gobin>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+from .complexity import _tool, bucket, dist, lizard_ccn, loc_counts
+
+
+def run(*a, **kw):
+    return subprocess.run(a, capture_output=True, text=True, **kw)
+
+
+def sample_commits(repo: str, n: int) -> list[list[str]]:
+    out = run(
+        "git", "-C", repo, "log", "--first-parent", "--reverse",
+        "--format=%H\t%ad", "--date=short",
+    ).stdout.splitlines()
+    rows = [line.split("\t") for line in out if "\t" in line]
+    if len(rows) <= n:
+        return rows
+    step = (len(rows) - 1) / (n - 1)
+    picks = [rows[round(i * step)] for i in range(n)]
+    if picks[-1] != rows[-1]:  # ensure last commit included
+        picks[-1] = rows[-1]
+    return picks
+
+
+def measure_at(repo: str, commit: str, lizard_bin: str | None, workdir: str) -> dict:
+    wt = os.path.join(workdir, "wt_" + commit[:10])
+    run("git", "-C", repo, "worktree", "add", "--detach", "--force", wt, commit)
+    try:
+        b = bucket(wt)
+        src_files: list[str] = []
+        test_files: list[str] = []
+        for _lang, sets in b.items():
+            src_files += sets["src"]
+            test_files += sets["test"]
+        src_loc = loc_counts(src_files)
+        test_loc = loc_counts(test_files)
+        d = dist(lizard_ccn(src_files, lizard_bin)) or {}
+        return {
+            "src_loc": src_loc, "test_loc": test_loc,
+            "test_ratio": round(test_loc / src_loc, 2) if src_loc else 0,
+            "src_files": len(src_files),
+            "functions": d.get("functions"),
+            "ccn_mean": d.get("ccn_mean"),
+            "pct_ccn_gt10": d.get("pct_ccn_gt10"),
+            "pct_len_gt60": d.get("pct_len_gt60"),
+        }
+    finally:
+        run("git", "-C", repo, "worktree", "remove", "--force", wt)
+        shutil.rmtree(wt, ignore_errors=True)
+
+
+def analyze(
+    repo: str, workdir: str, n: int = 10,
+    venv: str | None = None, gobin: str | None = None,
+) -> dict:
+    """Sample N commits across history and recompute core metrics at each."""
+    lizard_bin = _tool("lizard", venv, gobin)
+    if not lizard_bin:
+        return {
+            "repo": repo.rstrip("/").split("/")[-1],
+            "skipped": "lizard not found",
+            "note": "trend sampling requires lizard (pip install lizard)",
+        }
+    os.makedirs(workdir, exist_ok=True)
+    series: list[dict] = []
+    for commit, date in sample_commits(repo, n):
+        m = measure_at(repo, commit, lizard_bin, workdir)
+        m["commit"] = commit[:10]
+        m["date"] = date
+        series.append(m)
+    return {
+        "repo": repo.rstrip("/").split("/")[-1],
+        "points": len(series),
+        "series": series,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="complexity/scale trend over history")
+    parser.add_argument("repo", help="path to the git repository")
+    parser.add_argument("--workdir", required=True, help="scratch dir for worktrees")
+    parser.add_argument("--n", type=int, default=10, help="number of sample points")
+    parser.add_argument("--venv", default=None, help="virtualenv with lizard")
+    parser.add_argument("--gobin", default=None, help="dir containing go tools")
+    args = parser.parse_args()
+    result = analyze(args.repo, args.workdir, n=args.n, venv=args.venv, gobin=args.gobin)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality_metrics.py
+++ b/scripts/quality_metrics.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""quality_metrics.py — orchestrator for the /code-metrics skill.
+
+Runs the literature-grounded code-quality engines over one repo and emits
+per-engine JSON + a consolidated report.md + charts into a session out dir.
+
+Always-run engines (pure Python + git + lizard): churn, complexity, trend,
+process. Optional engines run only when their external tool is present:
+survival (git-of-theseus), duplication (jscpd/node). Every engine degrades
+gracefully — a missing tool yields ``{"skipped": ...}``, never a crashed run.
+
+Target resolution mirrors the other skills:
+  - ``owner/repo``  -> resolved & cloned via scripts/repo.py
+  - ``--repo PATH`` -> a direct local path
+  - neither         -> the current git repo (git rev-parse --show-toplevel)
+
+Usage:
+    python3 scripts/quality_metrics.py [owner/repo] [--repo PATH] \\
+        [--out DIR] [--top N] [--trend-n N] \\
+        [--skip-trend] [--skip-survival] [--skip-duplication] \\
+        [--venv VENV] [--gobin GOBIN]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from quality import churn, complexity, duplication, process, report, survival, trend  # noqa: E402
+
+
+def _current_repo_root() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def resolve_target(owner_repo: str | None, repo_path: str | None) -> str:
+    """Resolve the target repo to a local absolute path."""
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        if not (p / ".git").exists():
+            print(f"Error: {p} is not a git repository", file=sys.stderr)
+            sys.exit(1)
+        return str(p)
+    if owner_repo:
+        from repo import resolve_repo  # local import: only needed for owner/repo
+        return str(resolve_repo(owner_repo))
+    root = _current_repo_root()
+    if not root:
+        print("Error: not inside a git repo; pass owner/repo or --repo PATH", file=sys.stderr)
+        sys.exit(1)
+    return root
+
+
+def _write(out_dir: str, name: str, data: dict) -> None:
+    with open(os.path.join(out_dir, f"{name}.json"), "w") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def run(args: argparse.Namespace) -> str:
+    target = resolve_target(args.owner_repo, args.repo)
+    if args.out:
+        out_dir = args.out
+    else:
+        import env  # session temp dir under ~/.chief-wiggum/tmp — never the target repo
+        out_dir = os.path.join(str(env.create_tmp()), "code-metrics", Path(target).name)
+    os.makedirs(out_dir, exist_ok=True)
+    print(f"[code-metrics] target: {target}", file=sys.stderr)
+    print(f"[code-metrics] out:    {out_dir}", file=sys.stderr)
+
+    engines: dict = {}
+
+    print("[code-metrics] churn...", file=sys.stderr)
+    engines["churn"] = churn.analyze(target, top_n=args.top, no_merges=True)
+    _write(out_dir, "churn", engines["churn"])
+
+    print("[code-metrics] complexity...", file=sys.stderr)
+    engines["complexity"] = complexity.analyze(target, venv=args.venv, gobin=args.gobin)
+    _write(out_dir, "complexity", engines["complexity"])
+
+    print("[code-metrics] process...", file=sys.stderr)
+    engines["process"] = process.analyze(target)
+    _write(out_dir, "process", engines["process"])
+
+    if args.skip_trend:
+        engines["trend"] = {"skipped": "--skip-trend"}
+    else:
+        print("[code-metrics] trend...", file=sys.stderr)
+        engines["trend"] = trend.analyze(
+            target, workdir=os.path.join(out_dir, "wt"),
+            n=args.trend_n, venv=args.venv, gobin=args.gobin,
+        )
+    _write(out_dir, "trend", engines["trend"])
+
+    if args.skip_survival:
+        engines["survival"] = {"skipped": "--skip-survival"}
+    else:
+        print("[code-metrics] survival...", file=sys.stderr)
+        engines["survival"] = survival.analyze(
+            target, workdir=os.path.join(out_dir, "survival"),
+        )
+    _write(out_dir, "survival", engines["survival"])
+
+    if args.skip_duplication:
+        engines["duplication"] = {"skipped": "--skip-duplication"}
+    else:
+        print("[code-metrics] duplication...", file=sys.stderr)
+        engines["duplication"] = duplication.analyze(
+            target, workdir=os.path.join(out_dir, "dup"),
+        )
+    _write(out_dir, "duplication", engines["duplication"])
+
+    print("[code-metrics] report...", file=sys.stderr)
+    report_path = report.write_report(engines, out_dir)
+    return report_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="code-quality metrics orchestrator")
+    parser.add_argument("owner_repo", nargs="?", default=None,
+                        help="owner/repo to resolve+clone (optional)")
+    parser.add_argument("--repo", default=None, help="direct local repo path")
+    parser.add_argument("--out", default=None, help="output directory")
+    parser.add_argument("--top", type=int, default=25, help="churn hotspots to keep")
+    parser.add_argument("--trend-n", type=int, default=10, help="trend sample points")
+    parser.add_argument("--skip-trend", action="store_true", help="skip history trend sampling")
+    parser.add_argument("--skip-survival", action="store_true", help="skip git-of-theseus survival")
+    parser.add_argument("--skip-duplication", action="store_true", help="skip jscpd duplication")
+    parser.add_argument("--venv", default=None, help="virtualenv with lizard/radon/complexipy")
+    parser.add_argument("--gobin", default=None, help="dir containing gocognit/gocyclo")
+    args = parser.parse_args()
+
+    report_path = run(args)
+    print(report_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_quality_metrics.py
+++ b/tests/test_quality_metrics.py
@@ -1,0 +1,211 @@
+"""Tests for the code-quality metric engines (/code-metrics).
+
+Covers the DETERMINISTIC pure-Python paths — churn parsing/attribution and
+process metrics (coupling/entropy/ownership) — against a tiny synthetic git repo
+built in a tmp dir. External-tool wrappers are only checked for graceful skip
+when the tool is absent; their numeric output is validated in the smoke run, not
+here (they depend on lizard/git-of-theseus/jscpd being installed).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+from quality import churn, complexity, duplication, process, report, survival, trend
+
+# --- synthetic repo fixture -------------------------------------------------
+
+
+def _git(repo, *args, env=None):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True, env=env)
+
+
+def _commit(repo, subject, files: dict, author="Ada <ada@example.com>"):
+    for rel, content in files.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    _git(repo, "add", "-A")
+    name, email = author.split(" <")
+    email = email.rstrip(">")
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", subject,
+         "--author", author, "--date", "2026-01-01T12:00:00"],
+        check=True, capture_output=True, text=True,
+        env={
+            "GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name, "GIT_COMMITTER_EMAIL": email,
+            "GIT_COMMITTER_DATE": "2026-01-01T12:00:00",
+            "PATH": os.environ.get("PATH", ""),
+        },
+    )
+
+
+@pytest.fixture()
+def synth_repo(tmp_path):
+    """A tiny repo: 5 commits, two authors, coupled files, a fix, a big commit."""
+    repo = tmp_path / "synth"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Ada")
+    _git(repo, "config", "user.email", "ada@example.com")
+
+    # a.py and b.py always change together -> change coupling
+    _commit(repo, "feat(core): add a and b", {
+        "a.py": "def a():\n    return 1\n",
+        "b.py": "def b():\n    return 2\n",
+    })
+    _commit(repo, "feat(core): grow a and b (#12)", {
+        "a.py": "def a():\n    return 1 + 1\n",
+        "b.py": "def b():\n    return 2 + 2\n",
+    }, author="Grace <grace@example.com>")
+    _commit(repo, "fix(core): bug in a", {
+        "a.py": "def a():\n    return 3\n",
+    })
+    _commit(repo, "refactor: touch a and b again", {
+        "a.py": "def a():\n    return 4\n",
+        "b.py": "def b():\n    return 5\n",
+    })
+    # a large commit (>400 changed lines)
+    big = "\n".join(f"x{i} = {i}" for i in range(500)) + "\n"
+    _commit(repo, "feat: big module", {"big.py": big})
+    return repo
+
+
+# --- churn ------------------------------------------------------------------
+
+
+def test_churn_scale_and_attribution(synth_repo):
+    r = churn.analyze(str(synth_repo), no_merges=True)
+    assert r["scale"]["commits"] == 5
+    attr = r["attribution"]
+    # every commit uses a conventional prefix
+    assert attr["conventional_pct"] == 100.0
+    # exactly one commit has a #ref
+    assert attr["ticket_ref_pct"] == 20.0
+    assert set(attr["type_histogram"]) >= {"feat", "fix", "refactor"}
+    # two distinct authors seen
+    assert set(attr["author_histogram"]) == {"Ada", "Grace"}
+
+
+def test_churn_hotspots_and_totals(synth_repo):
+    r = churn.analyze(str(synth_repo), no_merges=True)
+    files = {h["file"] for h in r["hotspots"]}
+    assert {"a.py", "b.py", "big.py"} <= files
+    # a.py touched in 4 commits, b.py in 3
+    a = next(h for h in r["hotspots"] if h["file"] == "a.py")
+    assert a["commits"] == 4
+    assert r["churn"]["added"] > 0
+
+
+def test_churn_empty_repo(tmp_path):
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    r = churn.analyze(str(repo))
+    assert r.get("error") == "no commits"
+
+
+# --- process ----------------------------------------------------------------
+
+
+def test_process_change_coupling(synth_repo):
+    r = process.analyze(str(synth_repo))
+    assert r["commits_analyzed"] == 5
+    # a.py <-> b.py co-changed in 3 commits (>= threshold of 4? no -> not listed)
+    # coupling requires co_changes >= 4; here they co-change 3 times, so empty.
+    # Lower-bound the invariant instead: coupling entries are well-formed if present.
+    for c in r["change_coupling_top"]:
+        assert 0 < c["confidence"] <= 1
+        assert c["co_changes"] >= 4
+
+
+def test_process_entropy_and_ownership(synth_repo):
+    r = process.analyze(str(synth_repo))
+    # entropy is a normalized 0..1 value
+    assert 0.0 <= r["change_entropy_normalized"] <= 1.0
+    own = r["ownership"]
+    assert own["distinct_authors"] == 2
+    assert own["bus_factor_50pct"] >= 1
+    assert 0 < own["top_author_share"] <= 1
+
+
+def test_process_commit_size_and_fix_ratio(synth_repo):
+    r = process.analyze(str(synth_repo))
+    # the 500-line commit should register as a large commit
+    assert r["commit_size"]["pct_large_commits_gt400"] > 0
+    # one fix commit out of five
+    assert r["defect_proxy"]["fix_commit_pct"] == 20.0
+
+
+def test_process_coupling_threshold(tmp_path):
+    """Files co-changing >=4 times should appear in coupling."""
+    repo = tmp_path / "coupled"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Ada")
+    _git(repo, "config", "user.email", "ada@example.com")
+    for i in range(5):
+        _commit(repo, f"feat: iter {i}", {
+            "x.py": f"v = {i}\n",
+            "y.py": f"w = {i}\n",
+        })
+    r = process.analyze(str(repo))
+    pairs = {(c["a"], c["b"]) for c in r["change_coupling_top"]}
+    assert ("x.py", "y.py") in pairs
+
+
+# --- report consolidation (pure) -------------------------------------------
+
+
+def test_report_build_combined_is_pure(synth_repo):
+    engines = {
+        "churn": churn.analyze(str(synth_repo)),
+        "complexity": {"skipped": "lizard not found"},
+        "process": process.analyze(str(synth_repo)),
+        "trend": {"skipped": "--skip-trend"},
+        "survival": {"skipped": "--skip-survival"},
+        "duplication": {"skipped": "--skip-duplication"},
+    }
+    combined = report.build_combined(engines)
+    s = combined["summary"]
+    assert s["repo"] == "synth"
+    assert s["commits"] == 5
+    assert s["rework_ratio"] >= 0
+    md = report.render_markdown(engines, combined, charts=[])
+    assert "Code-Quality Metrics" in md
+    assert "lizard not found" in md  # skip note surfaced honestly
+
+
+# --- graceful degradation of external-tool wrappers -------------------------
+
+
+def test_survival_skips_without_tool(tmp_path, monkeypatch):
+    monkeypatch.setattr(survival.shutil, "which", lambda _n: None)
+    r = survival.analyze(str(tmp_path), workdir=str(tmp_path / "s"))
+    assert "skipped" in r
+    assert "git-of-theseus" in r["skipped"]
+
+
+def test_duplication_skips_without_tool(tmp_path, monkeypatch):
+    monkeypatch.setattr(duplication.shutil, "which", lambda _n: None)
+    r = duplication.analyze(str(tmp_path), workdir=str(tmp_path / "d"))
+    assert "skipped" in r
+    assert "jscpd" in r["skipped"] or "node" in r["skipped"]
+
+
+def test_complexity_skips_without_lizard(synth_repo, monkeypatch):
+    monkeypatch.setattr(complexity.shutil, "which", lambda _n: None)
+    # also block the sys.executable sibling lookup
+    monkeypatch.setattr(complexity.os.path, "exists", lambda _p: False)
+    r = complexity.analyze(str(synth_repo))
+    assert r.get("skipped") == "lizard not found"
+
+
+def test_trend_skips_without_lizard(synth_repo, monkeypatch):
+    monkeypatch.setattr(trend, "_tool", lambda *a, **k: None)
+    r = trend.analyze(str(synth_repo), workdir=str(synth_repo / "wt"), n=3)
+    assert r.get("skipped") == "lizard not found"


### PR DESCRIPTION
## What & why

Adds `/code-metrics` — a **literature-grounded, quantitative code-quality analysis** skill. It answers "is the pipeline writing good code, and is quality tracking up or sliding?" with measured signals, not vibes. Born out of a July-2026 portfolio audit that showed this is both measurable and useful (e.g. one live repo held mean cyclomatic complexity flat at ~3.5 while growing 0→41k LOC, and every pipeline repo beat the *pre-AI human* baseline on both GitClear "AI-slop" signals).

Closes #109. Implements the process-metric set from #114 (change coupling, ownership/bus-factor, change entropy).

## Metrics (each reported with its caveat)

```mermaid
flowchart LR
  R[target repo + git history] --> C[churn / rework<br/>Nagappan-Ball 2005]
  R --> X[cyclomatic + cognitive<br/>McCabe / Campbell]
  R --> P[process: coupling, entropy,<br/>ownership Bird 2011]
  R --> T[trend over time<br/>history sampling]
  R --> S[code survival / 2-wk churn<br/>GitClear metric]
  R --> D[duplication<br/>jscpd vs GitClear bands]
  C & X & P & T & S & D --> RPT[report.md + charts]
```

- **Churn / rework** (normalized) — the strongest, best-replicated defect signal.
- **Cyclomatic** (lizard, cross-language) + **cognitive** (gocognit/complexipy) — reported *alongside SLOC* because CC is ~0.7–0.9 collinear with size (Jay 2009).
- **Maintainability Index** (radon) — **directional only** (van Deursen 2014).
- **Hotspots** = churn × complexity (Tornhill).
- **Process metrics** — change coupling, change entropy (Hassan 2009), ownership/bus-factor (Bird 2011), commit-size, fix-ratio.
- **Code survival** (git-of-theseus) = GitClear's 2-week churn; **duplication** (jscpd) vs GitClear's 8.3%/12.3% bands.
- **Trend over time** via git-history sampling; **attribution** via conventional/ticket/PR %.

Full citations + honest caveats in `docs/quality-metrics.md`.

## Design notes

- **Core path needs only `lizard` + `radon` + `matplotlib` + git.** Cognitive/survival/duplication are enrichment — every engine degrades to `{"skipped": ...}` if its tool is absent, never crashing the run.
- Output goes to the **session temp dir** (`env.create_tmp()`), never into the analyzed repo.
- New `quality-metrics` dependency profile in `check_deps.py`.

## Verification

- `pytest tests/test_quality_metrics.py` → **12 passed** (synthetic-git-repo tests for the deterministic churn/process/report paths + graceful-skip for external-tool wrappers).
- Full suite: **571 passed, 2 skipped** (pre-existing).
- Smoke run on this repo produces `report.md` + charts; survival, duplication, complexity all flowed on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
