### PR TITLE
feat(ci-scaffold): detect + scaffold minimal CI in target repos (#111)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -164,7 +164,17 @@ python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-
 
 Otherwise, once the check passes, record the epic close (same command without `--amend`/`--retire`) and commit `docs/quality/`. The journal entry is the epic's quality sign-off and feeds the next epic's amnesia context.
 
-### Step 2g: SaaS NFR gate (optional)
+### Step 2g: Minimal-CI check (report-only)
+
+An epic's quality is only as durable as the enforcement layer that keeps it green on `main`. Report whether the target repo has any GitHub Actions workflow at all — a repo with no CI lets red tests, lint errors, and uninstallable deps merge unnoticed:
+
+```bash
+python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
+```
+
+This is **report-only** (always exits 0, per `docs/gate-rollout.md`) — surface a `MISSING` finding in the close report, don't block on it. It also prints the detected stack(s); `/setup` can scaffold a minimal CI workflow (`--scaffold`) for a repo that has none.
+
+### Step 2h: SaaS NFR gate (optional)
 
 For SaaS products, validate non-functional requirements (security headers + CSRF posture, auth rate-limiting, tenant isolation, health + structured logging) against the running app. Start the app if needed (don't punt), then:
 
@@ -174,7 +184,7 @@ python3 "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" --base-url "$BASE_
 
 It reports five statuses (`pass`/`fail`/`warn`/`skipped`/`not_applicable`); a real `fail` (e.g. missing CSP, a cross-tenant data leak) blocks the epic close, while `warn`/`skipped` are surfaced but don't block. See `/saas-gate` for the full check list (tenant isolation, performance, data integrity need the live multi-user app).
 
-### Step 2h: Adversarial security review (user-facing / auth / money epics)
+### Step 2i: Adversarial security review (user-facing / auth / money epics)
 
 If the epic touches **user input, authentication, identity, or money** (public or authed endpoints, login/reset/invite flows, billing), run an adversarial security review. The deterministic NFR gate (2g) checks a running app's *posture* (headers, CSRF, a live isolation probe); it cannot reason about *this epic's* logic. This step exists because functional tests, traceability, and the ratchet all pass while a real vulnerability ships — a feedback epic once closed green with an unthrottled submit endpoint (a spam/abuse vector) and a PII-in-logs leak that only a manual audit caught afterward.
 

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -121,3 +121,15 @@ python3 $CW_HOME/scripts/check_deps.py --for vertex
 ```
 
 Provider roles are configured in `$CW_HOME/config/providers.json`. Validate role dependencies by running the matching provider profiles before a workflow starts.
+
+### Step 6: Guarantee a minimal CI workflow
+
+A target repo with no CI lets red tests, lint errors, and uninstallable deps sit unnoticed on `main`. Check whether the repo has any GitHub Actions workflow, and offer to scaffold a minimal, stack-appropriate one (checkout → install deps → build → test → lint) if it has none:
+
+```bash
+python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
+# If MISSING, scaffold one (idempotent; won't overwrite an existing workflow without --force):
+python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --scaffold
+```
+
+The stack is auto-detected (Go / Python / Node — possibly several) from `go.mod`, `pyproject.toml`/`requirements.txt`/`setup.py`, and `package.json`. Commit the generated `.github/workflows/ci.yml` so CI runs on the next push.

--- a/docs/gate-rollout.md
+++ b/docs/gate-rollout.md
@@ -50,3 +50,14 @@ output), and only switch it to `--gate` once step 2 is satisfied.
 - [ ] Known limitations documented in the script docstring/`--help` and its `docs/` page.
 - [ ] Wired into the workflow report-only first; promoted to `--gate` in a follow-up that
       cites the dry-run.
+
+## Gate status
+
+| Gate | Script | Status |
+| --- | --- | --- |
+| traceability | `check_traceability.py` | blocking (`--gate`) |
+| single-writer | `check_single_writer.py` | blocking (`--gate`) |
+| unresolved-markers | `check_unresolved.py` | blocking |
+| ratchet | `ratchet.py` | blocking |
+| SaaS NFR | `saas_gate.py` | blocking (`--gate`, on real `fail`) |
+| minimal-CI | `ci_scaffold.py` | **report-only** (new; wired into `/close-epic` report-only per this doc — has a `--gate` mode held off until validated across shipped repos) |

--- a/scripts/ci_scaffold.py
+++ b/scripts/ci_scaffold.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Detect and scaffold a minimal CI workflow in a target repo (#111).
+
+The portfolio audit found target repos shipping with **no CI** — so red tests,
+lint errors, and uninstallable deps sat unnoticed on `main`. This script is the
+enforcement-layer guard: it detects whether a repo has any GitHub Actions
+workflow, detects the language stack(s), and — on request — scaffolds a minimal,
+real CI workflow (checkout -> setup toolchain -> install deps -> build -> test ->
+lint) tailored to each detected stack.
+
+Per `docs/gate-rollout.md`, this ships **report-only by default**:
+
+    --report   (default) print CI presence + detected stack(s); exit 0 always.
+    --scaffold write .github/workflows/ci.yml (idempotent; needs --force to
+               overwrite an existing workflow).
+    --gate     exit non-zero if CI is missing (the future blocking mode, off by
+               default). A gate is only wired into a workflow with --gate after
+               it has been validated report-only on real repos.
+
+Target resolution mirrors the other scripts: `owner/repo` (via repo.py),
+`--repo PATH`, or the current directory.
+
+CLI:
+    python3 scripts/ci_scaffold.py --repo . --report
+    python3 scripts/ci_scaffold.py acme/app --scaffold
+    python3 scripts/ci_scaffold.py --repo . --gate
+
+Exit codes: 0 = ok (or report-only), 1 = CI missing under --gate, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Templates live under templates/ci/ next to this script's repo root.
+CW_HOME = Path(__file__).resolve().parent.parent
+TEMPLATE_DIR = CW_HOME / "templates" / "ci"
+
+WORKFLOW_DIR = ".github/workflows"
+DEFAULT_WORKFLOW = "ci.yml"
+
+# Detected stack -> template fragment (a `jobs:` entry, no header).
+STACK_TEMPLATES = {
+    "go": "ci-go.yml",
+    "python": "ci-python.yml",
+    "node": "ci-node.yml",
+}
+
+
+def detect_ci(repo: str | Path) -> tuple[bool, list[str]]:
+    """Return (present, workflows) for GitHub Actions workflows in a repo.
+
+    A workflow is any `.github/workflows/*.yml` or `*.yaml` file. Paths are
+    returned repo-relative and sorted for stable output.
+    """
+    root = Path(repo)
+    wf_dir = root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return False, []
+    workflows = sorted(
+        str(p.relative_to(root))
+        for p in wf_dir.iterdir()
+        if p.is_file() and p.suffix in (".yml", ".yaml")
+    )
+    return bool(workflows), workflows
+
+
+def detect_stack(repo: str | Path) -> list[str]:
+    """Detect language stack(s) from marker files. May return multiple."""
+    root = Path(repo)
+    stack: list[str] = []
+    if (root / "go.mod").is_file():
+        stack.append("go")
+    if (root / "package.json").is_file():
+        stack.append("node")
+    if (
+        (root / "pyproject.toml").is_file()
+        or (root / "setup.py").is_file()
+        or (root / "requirements.txt").is_file()
+    ):
+        stack.append("python")
+    return stack
+
+
+def _read_template(name: str) -> str:
+    return (TEMPLATE_DIR / name).read_text()
+
+
+def render_ci(stacks: list[str]) -> str:
+    """Render a full CI workflow YAML for the given detected stacks.
+
+    Composes the shared header (name/on/jobs) with one job fragment per stack.
+    With no recognized stack, emits a valid generic skeleton so the workflow
+    still parses and prompts the author for real steps.
+    """
+    header = _read_template("ci-header.yml")
+    job_templates = [STACK_TEMPLATES[s] for s in stacks if s in STACK_TEMPLATES]
+    if not job_templates:
+        job_templates = ["ci-generic.yml"]
+    jobs = "\n".join(_read_template(t).rstrip("\n") for t in job_templates)
+    return header.rstrip("\n") + "\n" + jobs + "\n"
+
+
+def scaffold_ci(
+    repo: str | Path, stacks: list[str], *, force: bool = False
+) -> list[Path]:
+    """Write .github/workflows/ci.yml for the detected stacks.
+
+    Idempotent: if the workflow already exists and `force` is False, writes
+    nothing and returns []. Returns the list of paths written.
+    """
+    root = Path(repo)
+    wf_dir = root / ".github" / "workflows"
+    target = wf_dir / DEFAULT_WORKFLOW
+    if target.exists() and not force:
+        return []
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_ci(stacks))
+    return [target]
+
+
+def resolve_target(args: argparse.Namespace) -> Path:
+    """Resolve the target repo from --repo, an owner/repo positional, or cwd."""
+    if args.owner_repo:
+        # Import lazily so unit tests that only touch detect/scaffold don't need gh.
+        sys.path.insert(0, str(CW_HOME / "scripts"))
+        from repo import resolve_repo
+
+        return resolve_repo(args.owner_repo)
+    return Path(args.repo)
+
+
+def build_report(repo: Path) -> dict:
+    present, workflows = detect_ci(repo)
+    stack = detect_stack(repo)
+    return {
+        "repo": str(repo),
+        "ci_present": present,
+        "workflows": workflows,
+        "stack": stack,
+    }
+
+
+def render_text(report: dict) -> str:
+    lines: list[str] = []
+    stack = ", ".join(report["stack"]) or "unknown"
+    if report["ci_present"]:
+        lines.append(f"OK: CI present ({len(report['workflows'])} workflow(s))")
+        for wf in report["workflows"]:
+            lines.append(f"  {wf}")
+        lines.append(f"Detected stack: {stack}")
+    else:
+        lines.append("MISSING: no CI workflow found (.github/workflows/*.yml)")
+        lines.append(f"Detected stack: {stack}")
+        lines.append(
+            "  A minimal CI workflow would be scaffolded with --scaffold "
+            "(checkout -> install deps -> build -> test -> lint)."
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect and scaffold a minimal CI workflow in a target repo"
+    )
+    parser.add_argument(
+        "owner_repo", nargs="?", help="owner/repo to resolve via gh (optional)"
+    )
+    parser.add_argument("--repo", default=".", help="Path to target repo (default: cwd)")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--report", action="store_true", help="Report CI presence + stack (default)"
+    )
+    mode.add_argument(
+        "--scaffold", action="store_true", help="Write a minimal CI workflow"
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit non-zero if CI is missing (blocking mode; off by default)",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite an existing workflow on scaffold"
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        repo = resolve_target(args)
+    except SystemExit:
+        raise
+    if not repo.exists():
+        print(f"ERROR: repo path does not exist: {repo}", file=sys.stderr)
+        return 2
+
+    report = build_report(repo)
+
+    if args.scaffold:
+        written = scaffold_ci(repo, report["stack"], force=args.force)
+        report["scaffolded"] = [str(p) for p in written]
+        if args.json:
+            print(json.dumps(report, indent=2))
+        elif written:
+            print(f"Scaffolded {written[0].relative_to(repo)} for stack: "
+                  f"{', '.join(report['stack']) or 'unknown'}")
+        elif report["ci_present"]:
+            print("CI already present; nothing written (use --force to overwrite).")
+        else:
+            print("Nothing written.")
+        return 0
+
+    # Report mode (default). --gate can turn a missing-CI finding into a failure.
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+
+    if args.gate and not report["ci_present"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/ci/ci-generic.yml
+++ b/templates/ci/ci-generic.yml
@@ -1,0 +1,8 @@
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # No recognized stack (go.mod / pyproject.toml / package.json) was found.
+      # Replace this placeholder with the project's real build, test, and lint steps.
+      - name: Placeholder
+        run: echo "TODO add build, test, and lint steps for this project"

--- a/templates/ci/ci-go.yml
+++ b/templates/ci/ci-go.yml
@@ -1,0 +1,15 @@
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Download dependencies
+        run: go mod download
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/templates/ci/ci-header.yml
+++ b/templates/ci/ci-header.yml
@@ -1,0 +1,8 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:

--- a/templates/ci/ci-node.yml
+++ b/templates/ci/ci-node.yml
@@ -1,0 +1,15 @@
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Build
+        run: npm run build --if-present
+      - name: Test
+        run: npm test

--- a/templates/ci/ci-python.yml
+++ b/templates/ci/ci-python.yml
@@ -1,0 +1,17 @@
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e .; fi
+          pip install pytest ruff
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest

--- a/tests/test_ci_scaffold.py
+++ b/tests/test_ci_scaffold.py
@@ -1,0 +1,251 @@
+"""Tests for scripts/ci_scaffold.py — detect + scaffold a minimal CI workflow."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import ci_scaffold  # noqa: E402
+
+yaml = pytest.importorskip("yaml")
+
+
+# --- detect_ci ------------------------------------------------------------
+
+
+def test_detect_ci_absent_on_empty_repo(tmp_path):
+    present, workflows = ci_scaffold.detect_ci(tmp_path)
+    assert present is False
+    assert workflows == []
+
+
+def test_detect_ci_present_with_yml(tmp_path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text("name: ci\n")
+    present, workflows = ci_scaffold.detect_ci(tmp_path)
+    assert present is True
+    assert workflows == [".github/workflows/ci.yml"]
+
+
+def test_detect_ci_present_with_yaml_extension(tmp_path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "build.yaml").write_text("name: build\n")
+    (wf / "release.yml").write_text("name: release\n")
+    present, workflows = ci_scaffold.detect_ci(tmp_path)
+    assert present is True
+    assert sorted(workflows) == [
+        ".github/workflows/build.yaml",
+        ".github/workflows/release.yml",
+    ]
+
+
+def test_detect_ci_ignores_non_yaml_files(tmp_path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "README.md").write_text("# workflows\n")
+    present, workflows = ci_scaffold.detect_ci(tmp_path)
+    assert present is False
+    assert workflows == []
+
+
+# --- detect_stack ---------------------------------------------------------
+
+
+def test_detect_stack_go(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    assert ci_scaffold.detect_stack(tmp_path) == ["go"]
+
+
+def test_detect_stack_python_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'app'\n")
+    assert ci_scaffold.detect_stack(tmp_path) == ["python"]
+
+
+def test_detect_stack_python_requirements(tmp_path):
+    (tmp_path / "requirements.txt").write_text("requests\n")
+    assert ci_scaffold.detect_stack(tmp_path) == ["python"]
+
+
+def test_detect_stack_python_setup_py(tmp_path):
+    (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+    assert ci_scaffold.detect_stack(tmp_path) == ["python"]
+
+
+def test_detect_stack_node(tmp_path):
+    (tmp_path / "package.json").write_text('{"name": "app"}\n')
+    assert ci_scaffold.detect_stack(tmp_path) == ["node"]
+
+
+def test_detect_stack_multiple(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    (tmp_path / "package.json").write_text('{"name": "app"}\n')
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'app'\n")
+    assert set(ci_scaffold.detect_stack(tmp_path)) == {"go", "node", "python"}
+
+
+def test_detect_stack_empty(tmp_path):
+    assert ci_scaffold.detect_stack(tmp_path) == []
+
+
+# --- scaffold_ci ----------------------------------------------------------
+
+
+def _load_ci(tmp_path):
+    path = tmp_path / ".github" / "workflows" / "ci.yml"
+    assert path.is_file(), "scaffold_ci must write .github/workflows/ci.yml"
+    return path, yaml.safe_load(path.read_text())
+
+
+def test_scaffold_ci_writes_parseable_yaml(tmp_path):
+    written = ci_scaffold.scaffold_ci(tmp_path, ["go"])
+    path, doc = _load_ci(tmp_path)
+    assert str(path) in [str(p) for p in written]
+    assert isinstance(doc, dict)
+    # a workflow must have jobs and a trigger
+    assert "jobs" in doc
+    assert doc.get("on") or doc.get(True)  # PyYAML parses bare `on:` as True key
+
+
+def _all_run_steps(doc):
+    runs = []
+    for job in doc.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            if isinstance(step, dict) and "run" in step:
+                runs.append(step["run"])
+    return "\n".join(runs)
+
+
+def test_scaffold_go_has_build_test_vet(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["go"])
+    _, doc = _load_ci(tmp_path)
+    runs = _all_run_steps(doc)
+    assert "go build ./..." in runs
+    assert "go test ./..." in runs
+    assert "go vet" in runs
+
+
+def test_scaffold_python_has_install_test_lint(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["python"])
+    _, doc = _load_ci(tmp_path)
+    runs = _all_run_steps(doc)
+    # dependency-install sanity step
+    assert "pip install" in runs
+    assert "pytest" in runs
+    assert "ruff" in runs
+
+
+def test_scaffold_node_has_ci_install_test(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["node"])
+    _, doc = _load_ci(tmp_path)
+    runs = _all_run_steps(doc)
+    assert "npm ci" in runs
+    assert "npm test" in runs
+
+
+def test_scaffold_multi_stack_covers_each(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["go", "python", "node"])
+    _, doc = _load_ci(tmp_path)
+    runs = _all_run_steps(doc)
+    assert "go test ./..." in runs
+    assert "pytest" in runs
+    assert "npm ci" in runs
+
+
+def test_scaffold_is_idempotent_without_force(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["go"])
+    first = (tmp_path / ".github" / "workflows" / "ci.yml").read_text()
+    # a second call must NOT overwrite an existing workflow
+    written = ci_scaffold.scaffold_ci(tmp_path, ["python"])
+    second = (tmp_path / ".github" / "workflows" / "ci.yml").read_text()
+    assert first == second
+    assert written == []
+
+
+def test_scaffold_force_overwrites(tmp_path):
+    ci_scaffold.scaffold_ci(tmp_path, ["go"])
+    written = ci_scaffold.scaffold_ci(tmp_path, ["python"], force=True)
+    assert written
+    _, doc = _load_ci(tmp_path)
+    runs = _all_run_steps(doc)
+    assert "pytest" in runs
+
+
+def test_scaffold_unknown_stack_still_valid(tmp_path):
+    # no recognized stack: still produce a valid, parseable workflow skeleton
+    ci_scaffold.scaffold_ci(tmp_path, [])
+    _, doc = _load_ci(tmp_path)
+    assert "jobs" in doc
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "ci_scaffold.py"), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_report_missing_exits_zero(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    result = _run("--repo", str(tmp_path), "--report")
+    assert result.returncode == 0, result.stderr
+    assert "go" in result.stdout.lower()
+    assert "missing" in result.stdout.lower() or "no ci" in result.stdout.lower()
+
+
+def test_cli_report_is_default(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    result = _run("--repo", str(tmp_path))
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_gate_missing_exits_nonzero(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    result = _run("--repo", str(tmp_path), "--gate")
+    assert result.returncode != 0
+
+
+def test_cli_gate_present_exits_zero(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text("name: ci\n")
+    result = _run("--repo", str(tmp_path), "--gate")
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_scaffold_writes_file(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    result = _run("--repo", str(tmp_path), "--scaffold")
+    assert result.returncode == 0, result.stderr
+    ci = tmp_path / ".github" / "workflows" / "ci.yml"
+    assert ci.is_file()
+    assert yaml.safe_load(ci.read_text())
+
+
+def test_cli_scaffold_idempotent(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/app\n")
+    _run("--repo", str(tmp_path), "--scaffold")
+    before = (tmp_path / ".github" / "workflows" / "ci.yml").read_text()
+    _run("--repo", str(tmp_path), "--scaffold")
+    after = (tmp_path / ".github" / "workflows" / "ci.yml").read_text()
+    assert before == after
+
+
+def test_cli_json_report(tmp_path):
+    import json
+    (tmp_path / "package.json").write_text('{"name": "app"}\n')
+    result = _run("--repo", str(tmp_path), "--report", "--json")
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["ci_present"] is False
+    assert data["stack"] == ["node"]


### PR DESCRIPTION
## What & why

Closes #111. The July-2026 portfolio audit found target repos shipping with **no CI at all** (`duplicat-rex`, and chief-wiggum itself) — so red tests, lint errors, and an uninstallable dependency set sat unnoticed on `main`. The pipeline authors good code but didn't guarantee the cheapest enforcement control that keeps it good. "Process metrics beat code metrics" (Rahman & Devanbu 2013) — CI is the canonical one.

This adds detection + scaffolding of a minimal CI workflow, wired **report-only** into `/close-epic` per `docs/gate-rollout.md`.

## What it does

`scripts/ci_scaffold.py`:
- **`--report`** (default, exit 0): is CI present? what stack(s)? if missing, says it would scaffold.
- **`--scaffold`** (idempotent; `--force` to overwrite): writes `.github/workflows/ci.yml`.
- **`--gate`** (off by default): exits non-zero when CI is missing — the future blocking mode, held back until validated on real repos.

Stack detection (Go / Python / Node, multiple allowed) composes a header + per-stack job fragment from `templates/ci/` into one valid workflow: checkout → setup toolchain → install deps → build → test → lint. Go gets `go build/vet/test`; Python `pip install` sanity + `pytest` + `ruff`; Node `npm ci` + lint + test.

## Rollout discipline

Ships **report-only** — a `/close-epic` step surfaces missing CI as a finding but never blocks; `/setup` offers to scaffold. Follows the gate-rollout rule that a new gate is validated on shipped repos before becoming a blocker.

## Verification

- `pytest tests/test_ci_scaffold.py` → **26 passed** (TDD: tests written first; synthetic repos, YAML parse-checked).
- Full suite → **585 passed, 2 skipped**.
- Smoke: multi-stack (go+node) repo → report detects both (exit 0), scaffold writes valid 2-job YAML, `--gate` exits 1 on missing CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
