### PR TITLE
test(scripts): dogfood — unit tests for high-churn orchestrator scripts (#112)

### DIFF
--- a/tests/test_check_portability.py
+++ b/tests/test_check_portability.py
@@ -1,0 +1,173 @@
+"""Tests for check_portability.py — the harness-neutrality conformance gate.
+
+Exercises the pure detection/parsing logic: Claude-only marker detection,
+worker-launch binding to contract anchors, contract-section parsing, and the
+completeness check for ``*-worker`` sections. Uses synthetic markdown so no
+real command files are touched.
+"""
+
+from __future__ import annotations
+
+import check_portability as cp
+
+# --- _markers_on ------------------------------------------------------------
+
+
+def test_markers_on_detects_claude_only_tokens():
+    assert "subagent_type" in cp._markers_on("launch with subagent_type: general-purpose")
+    assert "run_in_background" in cp._markers_on("set run_in_background true")
+    assert cp._markers_on("Opus model") == ["Opus model tier"]
+
+
+def test_markers_on_clean_line():
+    assert cp._markers_on("Delegate to a worker per the contract.") == []
+
+
+# --- check_command_markers --------------------------------------------------
+
+
+def _md(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text)
+    return p
+
+
+def test_marker_outside_adapter_note_is_violation(tmp_path):
+    p = _md(tmp_path, "cmd.md", "Just run with subagent_type: general-purpose here.\n")
+    violations, anchors = cp.check_command_markers(p)
+    assert len(violations) == 1
+    assert "outside an adapter note" in violations[0].detail
+    assert anchors == set()
+
+
+def test_adapter_note_bound_to_anchor_is_clean(tmp_path):
+    text = (
+        "See docs/worker-contracts.md#implement-worker for the contract.\n"
+        "Claude Code adapter: launch with subagent_type: general-purpose.\n"
+    )
+    p = _md(tmp_path, "cmd.md", text)
+    violations, anchors = cp.check_command_markers(p)
+    assert violations == []
+    assert anchors == {"implement-worker"}
+
+
+def test_adapter_note_without_anchor_is_launder_violation(tmp_path):
+    text = "Claude Code adapter: launch with subagent_type: general-purpose.\n"
+    p = _md(tmp_path, "cmd.md", text)
+    violations, _ = cp.check_command_markers(p)
+    assert len(violations) == 1
+    assert "not bound" in violations[0].detail
+
+
+def test_unanchored_worker_launch_is_violation(tmp_path):
+    # A launch verb + "worker" with no adapter marker still must bind a contract.
+    p = _md(tmp_path, "cmd.md", "Launch a review worker to check the diff.\n")
+    violations, _ = cp.check_command_markers(p)
+    assert len(violations) == 1
+    assert "not bound to a worker-contracts.md#<anchor>" in violations[0].detail
+
+
+def test_anchored_worker_launch_is_clean(tmp_path):
+    text = (
+        "Per docs/worker-contracts.md#review-worker:\n"
+        "Launch a review worker to check the diff.\n"
+    )
+    p = _md(tmp_path, "cmd.md", text)
+    violations, anchors = cp.check_command_markers(p)
+    assert violations == []
+    assert "review-worker" in anchors
+
+
+# --- check_contract_reference -----------------------------------------------
+
+
+def test_contract_reference_required_for_worker_commands(tmp_path):
+    p = _md(tmp_path, "implement.md", "Do stuff without any contract link.\n")
+    violations = cp.check_contract_reference(p)
+    assert len(violations) == 1
+    assert "does not reference" in violations[0].detail
+
+
+def test_contract_reference_satisfied_when_anchor_present(tmp_path):
+    p = _md(tmp_path, "implement.md", "See docs/worker-contracts.md#implement-worker.\n")
+    assert cp.check_contract_reference(p) == []
+
+
+def test_contract_reference_ignored_for_non_worker_commands(tmp_path):
+    p = _md(tmp_path, "setup.md", "No contract needed here.\n")
+    assert cp.check_contract_reference(p) == []
+
+
+# --- parse_contract_sections ------------------------------------------------
+
+
+def test_parse_contract_sections_splits_by_heading():
+    doc = (
+        "# Worker Contracts\n"
+        "### implement-worker\n"
+        "body A\n"
+        "### review-worker\n"
+        "body B\n"
+    )
+    sections = cp.parse_contract_sections(doc)
+    assert set(sections.keys()) == {"implement-worker", "review-worker"}
+    assert "body A" in sections["implement-worker"]
+    assert "body B" in sections["review-worker"]
+
+
+# --- check_contract_doc -----------------------------------------------------
+
+
+_COMPLETE_WORKER = (
+    "### implement-worker\n"
+    "- **role**: builder\n"
+    "- **inputs**: ticket\n"
+    "- **output**: diff\n"
+    "- **write scope**: worktree\n"
+    "- **isolation**: worktree\n"
+    "- **stop**: on green\n"
+)
+
+
+def test_check_contract_doc_missing_file(tmp_path):
+    violations = cp.check_contract_doc(tmp_path / "nope.md", set())
+    assert len(violations) == 1
+    assert "missing" in violations[0].detail
+
+
+def test_check_contract_doc_flags_undefined_referenced_anchor(tmp_path):
+    doc = _md(tmp_path, "worker-contracts.md", _COMPLETE_WORKER)
+    violations = cp.check_contract_doc(doc, {"implement-worker", "ghost-worker"})
+    details = " ".join(v.detail for v in violations)
+    assert "ghost-worker" in details
+    # implement-worker is defined and complete -> no complaint about it.
+    assert "#implement-worker not defined" not in details
+
+
+def test_check_contract_doc_flags_incomplete_worker_section(tmp_path):
+    incomplete = (
+        "### broken-worker\n"
+        "- **role**: builder\n"
+        "- **inputs**: ticket\n"
+        # missing output / write scope / isolation / stop
+    )
+    doc = _md(tmp_path, "worker-contracts.md", incomplete)
+    violations = cp.check_contract_doc(doc, set())
+    assert len(violations) == 1
+    detail = violations[0].detail
+    assert "broken-worker" in detail
+    for missing in ("output", "write scope", "isolation", "stop"):
+        assert missing in detail
+
+
+def test_check_contract_doc_complete_worker_passes(tmp_path):
+    doc = _md(tmp_path, "worker-contracts.md", _COMPLETE_WORKER)
+    assert cp.check_contract_doc(doc, {"implement-worker"}) == []
+
+
+# --- Violation str ----------------------------------------------------------
+
+
+def test_violation_str_format():
+    v = cp.Violation("cmd.md", 12, "something wrong")
+    assert str(v) == "cmd.md:12: something wrong"

--- a/tests/test_domain_to_formal.py
+++ b/tests/test_domain_to_formal.py
@@ -1,0 +1,186 @@
+"""Tests for domain_to_formal.py — the duplicat-rex DomainModel → formal model bridge.
+
+All logic here is pure transformation (dict in, dict out), so these are direct
+behavioural assertions on synthetic domain-model fragments.
+"""
+
+from __future__ import annotations
+
+import domain_to_formal as d2f
+
+# --- entity_to_contracts ----------------------------------------------------
+
+
+def test_entity_to_contracts_maps_field_types_and_required():
+    entity = {
+        "fields": {
+            "name": {"field_type": "string", "required": True},
+            "count": {"field_type": "integer", "required": False},
+            "ratio": {"field_type": "float"},
+        }
+    }
+    contracts = d2f.entity_to_contracts(entity, "Widget")
+    by_name = {f["name"]: f for f in contracts["fields"]}
+
+    assert contracts["name"] == "Widget"
+    assert by_name["name"]["type"] == "string"
+    assert by_name["name"]["required"] == "always"
+    assert by_name["count"]["type"] == "integer"
+    assert by_name["count"]["required"] == "optional"
+    # float maps to "number"
+    assert by_name["ratio"]["type"] == "number"
+
+
+def test_entity_to_contracts_enum_notes_and_unique_immutable():
+    entity = {
+        "fields": {
+            "status": {"field_type": "enum", "enum_values": ["open", "closed"]},
+            "slug": {"field_type": "string", "unique": True},
+        }
+    }
+    contracts = d2f.entity_to_contracts(entity, "Ticket")
+    by_name = {f["name"]: f for f in contracts["fields"]}
+
+    assert "Valid values: open, closed" in by_name["status"]["notes"]
+    assert by_name["slug"]["immutable"] is True
+
+
+def test_entity_to_contracts_relation_becomes_objectid_with_source():
+    entity = {"fields": {"owner": {"field_type": "relation", "related_entity": "User"}}}
+    contracts = d2f.entity_to_contracts(entity, "Post")
+    owner = contracts["fields"][0]
+    assert owner["type"] == "ObjectID"
+    assert owner["source_of_truth"] == "users collection"
+
+
+def test_entity_to_contracts_limits_evidence_to_three():
+    entity = {
+        "fields": {
+            "x": {"field_type": "string", "evidence": ["e1", "e2", "e3", "e4", "e5"]},
+        }
+    }
+    contracts = d2f.entity_to_contracts(entity, "E")
+    derived = contracts["fields"][0]["derived_from"]
+    assert len(derived) == 3
+    assert [d["ref"] for d in derived] == ["e1", "e2", "e3"]
+
+
+def test_entity_to_contracts_operation_preconditions_and_required_fields():
+    entity = {
+        "fields": {},
+        "operations": [
+            {
+                "name": "create",
+                "method": "POST",
+                "endpoint_pattern": "/widgets",
+                "preconditions": ["user is authenticated"],
+                "required_fields": ["name"],
+                "postconditions": ["widget is persisted"],
+                "error_cases": [{"status": 409, "condition": "duplicate"}],
+            }
+        ],
+    }
+    contracts = d2f.entity_to_contracts(entity, "Widget")
+    op = contracts["operations"][0]
+
+    assert op["name"] == "Create Widget"
+    assert op["method"] == "POST"
+    assert op["path"] == "/widgets"
+    # One authored precondition + one required-field precondition.
+    descs = [p["description"] for p in op["preconditions"]]
+    assert "user is authenticated" in descs
+    assert "name is provided" in descs
+    assert op["postconditions"][0]["description"] == "widget is persisted"
+    assert op["error_cases"][0] == {"status": 409, "condition": "duplicate"}
+
+
+# --- entity_to_state_machine ------------------------------------------------
+
+
+def test_entity_to_state_machine_none_without_states_or_transitions():
+    assert d2f.entity_to_state_machine({"states": [], "transitions": []}, "X") is None
+    assert d2f.entity_to_state_machine({"states": ["a"], "transitions": []}, "X") is None
+
+
+def test_entity_to_state_machine_classifies_initial_and_terminal():
+    entity = {
+        "states": ["draft", "active", "closed"],
+        "transitions": [
+            {"from_state": "draft", "to_state": "active", "operation": "activate"},
+            {"from_state": "active", "to_state": "closed", "operation": "close"},
+        ],
+    }
+    sm = d2f.entity_to_state_machine(entity, "Deal")
+    assert sm["initial"] == "draft"
+    assert sm["states"]["draft"]["type"] == "initial"
+    assert sm["states"]["active"]["type"] == "normal"
+    # "closed" has no outgoing transition -> terminal.
+    assert sm["states"]["closed"]["type"] == "terminal"
+
+
+def test_entity_to_state_machine_terminal_state_gets_invalid_out_transitions():
+    entity = {
+        "states": ["open", "done"],
+        "transitions": [{"from_state": "open", "to_state": "done", "operation": "finish"}],
+    }
+    sm = d2f.entity_to_state_machine(entity, "Job")
+    invalids = sm.get("invalid_transitions", [])
+    # 'done' is terminal, so a done->open transition must be flagged invalid.
+    assert any(iv["from"] == "done" and iv["to"] == "open" for iv in invalids)
+
+
+def test_entity_to_state_machine_guards_from_operation_preconditions():
+    entity = {
+        "states": ["open", "done"],
+        "transitions": [{"from_state": "open", "to_state": "done", "operation": "finish"}],
+        "operations": [
+            {"name": "finish", "preconditions": ["all tasks complete"]},
+        ],
+    }
+    sm = d2f.entity_to_state_machine(entity, "Job")
+    tx = sm["transitions"][0]
+    assert tx["guards"][0]["description"] == "all tasks complete"
+
+
+# --- convert_domain_model ---------------------------------------------------
+
+
+def test_convert_domain_model_produces_contracts_and_state_machines():
+    dm = {
+        "version": 2,
+        "target": "acme/app",
+        "entities": {
+            "Board": {
+                "fields": {"title": {"field_type": "string", "required": True}},
+                "states": ["draft", "published"],
+                "transitions": [
+                    {"from_state": "draft", "to_state": "published", "operation": "publish"}
+                ],
+            },
+            "Tag": {
+                "fields": {"label": {"field_type": "string"}},
+                # no states -> no state machine
+            },
+        },
+    }
+    contracts, state_machines = d2f.convert_domain_model(dm)
+
+    assert {e["name"] for e in contracts["entities"]} == {"Board", "Tag"}
+    # Only Board (which has states+transitions) yields a state machine.
+    assert len(state_machines) == 1
+    assert state_machines[0]["name"] == "Board Lifecycle"
+    # Provenance references the domain model version + target.
+    assert contracts["derived_from"][0]["ref"] == "domain-model-v2"
+    assert "acme/app" in contracts["derived_from"][0]["description"]
+
+
+def test_convert_domain_model_entity_filter():
+    dm = {
+        "entities": {
+            "Board": {"fields": {}, "states": ["a", "b"],
+                      "transitions": [{"from_state": "a", "to_state": "b", "operation": "go"}]},
+            "Card": {"fields": {}},
+        }
+    }
+    contracts, _ = d2f.convert_domain_model(dm, entity_filter="Board")
+    assert [e["name"] for e in contracts["entities"]] == ["Board"]

--- a/tests/test_formal_models_generation.py
+++ b/tests/test_formal_models_generation.py
@@ -1,0 +1,301 @@
+"""Behavioural tests for formal_models.py's pure analysis + code generation.
+
+The existing tests/test_formal_models.py smoke-tests the happy path on the
+committed example. This file drives the deterministic logic with synthetic
+models that isolate specific behaviours: schema detection, unreachable/dead
+state detection, path enumeration with cycles, and the four code generators.
+"""
+
+from __future__ import annotations
+
+import formal_models as fm
+
+# --- detect_schema_type -----------------------------------------------------
+
+
+def test_detect_schema_type_variants():
+    assert fm.detect_schema_type({"states": {}, "transitions": []}) == "state-machine"
+    assert fm.detect_schema_type({"entities": [], "summary": {}}) == "transition-map"
+    assert fm.detect_schema_type({"entities": []}) == "contracts"
+    assert fm.detect_schema_type({"gaps": []}) == "gap"
+    assert fm.detect_schema_type({"pages": [], "navigation": []}) == "ui-spec"
+    assert fm.detect_schema_type({"id": "m", "states": {}}) == "xstate"
+
+
+def test_detect_schema_type_unknown_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        fm.detect_schema_type({"foo": "bar"})
+
+
+# --- analyze_graph ----------------------------------------------------------
+
+
+def _sm(states, transitions, initial="a", **extra):
+    return {"name": "M", "initial": initial, "states": states, "transitions": transitions, **extra}
+
+
+def test_analyze_graph_flags_unreachable_state():
+    sm = _sm(
+        states={"a": {}, "b": {}, "orphan": {}},
+        transitions=[{"from": "a", "to": "b", "event": "go"}],
+    )
+    analysis = fm.analyze_graph(sm)
+    assert analysis.unreachable_states == {"orphan"}
+    assert analysis.has_unreachable_states
+    assert analysis.reachable_states == {"a", "b"}
+
+
+def test_analyze_graph_flags_dead_state():
+    # 'b' is non-terminal with no outgoing transitions -> dead.
+    sm = _sm(
+        states={"a": {}, "b": {}},
+        transitions=[{"from": "a", "to": "b", "event": "go"}],
+    )
+    analysis = fm.analyze_graph(sm)
+    assert analysis.dead_states == {"b"}
+    assert analysis.has_dead_states
+
+
+def test_analyze_graph_terminal_state_is_not_dead():
+    sm = _sm(
+        states={"a": {}, "done": {"type": "terminal"}},
+        transitions=[{"from": "a", "to": "done", "event": "finish"}],
+    )
+    analysis = fm.analyze_graph(sm)
+    assert analysis.dead_states == set()
+    assert analysis.terminal_states == ["done"]
+    assert analysis.all_terminals_reachable
+
+
+def test_analyze_graph_unreachable_terminal_flagged():
+    sm = _sm(
+        states={"a": {}, "b": {}, "done": {"type": "terminal"}},
+        transitions=[{"from": "a", "to": "b", "event": "go"}],
+    )
+    analysis = fm.analyze_graph(sm)
+    assert not analysis.all_terminals_reachable
+    assert "done" in analysis.unreachable_states
+
+
+def test_analyze_graph_counts():
+    sm = _sm(
+        states={"a": {}, "b": {}, "done": {"type": "terminal"}},
+        transitions=[
+            {"from": "a", "to": "b", "event": "go"},
+            {"from": "b", "to": "done", "event": "finish"},
+        ],
+        invariants=[{"id": "INV-1", "description": "x"}],
+    )
+    analysis = fm.analyze_graph(sm)
+    assert analysis.transition_count == 2
+    assert analysis.invariant_count == 1
+
+
+# --- enumerate_paths --------------------------------------------------------
+
+
+def test_enumerate_paths_finds_all_simple_paths():
+    sm = _sm(
+        states={"a": {}, "b": {}, "c": {}, "done": {"type": "terminal"}},
+        transitions=[
+            {"from": "a", "to": "b", "event": "e1"},
+            {"from": "a", "to": "c", "event": "e2"},
+            {"from": "b", "to": "done", "event": "e3"},
+            {"from": "c", "to": "done", "event": "e4"},
+        ],
+    )
+    paths = fm.enumerate_paths(sm)
+    assert len(paths) == 2
+    # Each path ends at a transition into the terminal state.
+    for path in paths:
+        assert path[-1]["next_state"] == "done"
+
+
+def test_enumerate_paths_does_not_loop_on_cycle():
+    # a <-> b cycle, plus an exit to done. Simple-path DFS must terminate.
+    sm = _sm(
+        states={"a": {}, "b": {}, "done": {"type": "terminal"}},
+        transitions=[
+            {"from": "a", "to": "b", "event": "e1"},
+            {"from": "b", "to": "a", "event": "e2"},
+            {"from": "b", "to": "done", "event": "e3"},
+        ],
+    )
+    paths = fm.enumerate_paths(sm)
+    # a->b->done is the only simple path (a->b->a->... is pruned as visited).
+    assert len(paths) == 1
+    events = [step["event"] for step in paths[0]]
+    assert events == ["e1", "e3"]
+
+
+def test_enumerate_paths_captures_guard_descriptions():
+    sm = _sm(
+        states={"a": {}, "done": {"type": "terminal"}},
+        transitions=[
+            {
+                "from": "a",
+                "to": "done",
+                "event": "finish",
+                "guards": [{"description": "payment settled"}],
+            }
+        ],
+    )
+    paths = fm.enumerate_paths(sm)
+    assert paths[0][0]["guards"] == ["payment settled"]
+
+
+# --- to_xstate --------------------------------------------------------------
+
+
+def test_to_xstate_marks_terminal_as_final_and_lowercases_id():
+    sm = _sm(
+        states={"a": {}, "done": {"type": "terminal"}},
+        transitions=[{"from": "a", "to": "done", "event": "GO"}],
+    )
+    sm["name"] = "My Machine"
+    xs = fm.to_xstate(sm)
+    assert xs["id"] == "my_machine"
+    assert xs["initial"] == "a"
+    assert xs["states"]["done"]["type"] == "final"
+    assert xs["states"]["a"]["on"]["GO"] == {"target": "done"}
+
+
+def test_to_xstate_multiple_transitions_same_event_become_array():
+    sm = _sm(
+        states={"a": {}, "b": {}, "c": {}},
+        transitions=[
+            {"from": "a", "to": "b", "event": "SUBMIT", "guards": [{"id": "g1", "description": "d"}]},
+            {"from": "a", "to": "c", "event": "SUBMIT", "guards": [{"id": "g2", "description": "d"}]},
+        ],
+    )
+    xs = fm.to_xstate(sm)
+    submit = xs["states"]["a"]["on"]["SUBMIT"]
+    assert isinstance(submit, list)
+    assert {t["target"] for t in submit} == {"b", "c"}
+    assert {t["guard"] for t in submit} == {"g1", "g2"}
+
+
+def test_to_xstate_actions_and_entry_exit():
+    sm = _sm(
+        states={
+            "a": {"entry_actions": ["log_entry"], "exit_actions": ["log_exit"]},
+            "b": {},
+        },
+        transitions=[{"from": "a", "to": "b", "event": "GO", "actions": ["notify"]}],
+    )
+    xs = fm.to_xstate(sm)
+    assert xs["states"]["a"]["entry"] == [{"type": "log_entry"}]
+    assert xs["states"]["a"]["exit"] == [{"type": "log_exit"}]
+    assert xs["states"]["a"]["on"]["GO"]["actions"] == [{"type": "notify"}]
+
+
+# --- generate_hypothesis ----------------------------------------------------
+
+
+def test_generate_hypothesis_emits_rule_per_transition():
+    sm = _sm(
+        states={"a": {}, "done": {"type": "terminal"}},
+        transitions=[{"from": "a", "to": "done", "event": "finish"}],
+        invariants=[{"id": "INV-1", "description": "always true", "expression": "x > 0"}],
+    )
+    sm["name"] = "Order Flow"
+    code = fm.generate_hypothesis(sm)
+    assert "class OrderFlow(RuleBasedStateMachine):" in code
+    assert "def transition_a_to_done_via_finish(self):" in code
+    assert 'self.state = "done"' in code
+    assert "def check_inv_1(self):" in code
+    assert "TestStateMachine = OrderFlow.TestCase" in code
+    # Generated source must be syntactically valid Python.
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_hypothesis_emits_invalid_transition_assertions():
+    sm = _sm(
+        states={"a": {}, "b": {}},
+        transitions=[{"from": "a", "to": "b", "event": "go"}],
+        invalid_transitions=[{"from": "b", "to": "a", "reason": "no going back"}],
+    )
+    code = fm.generate_hypothesis(sm)
+    assert "def invalid_b_to_a(self):" in code
+    assert "no going back" in code
+    compile(code, "<generated>", "exec")
+
+
+# --- generate_deal_decorators / guards --------------------------------------
+
+
+def _contracts():
+    return {
+        "entities": [
+            {
+                "name": "Order",
+                "invariants": [{"description": "total >= 0", "expression": "total >= 0"}],
+                "operations": [
+                    {
+                        "name": "Create Order",
+                        "method": "POST",
+                        "path": "/orders",
+                        "description": "Create an order",
+                        "preconditions": [
+                            {"description": "customer exists", "expression": "customer is not None"}
+                        ],
+                        "postconditions": [
+                            {"description": "order persisted", "expression": "result.id is not None"}
+                        ],
+                        "error_cases": [{"status": 404, "condition": "customer not found"}],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_generate_deal_decorators_emits_pre_post():
+    code = fm.generate_deal_decorators(_contracts())
+    assert "import deal" in code
+    assert "@deal.pre(lambda: customer is not None" in code
+    assert "@deal.post(lambda result: result.id is not None" in code
+    assert "def create_order(request):" in code
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_python_maps_error_status_from_condition():
+    code = fm.generate_guards_python(_contracts())
+    assert "def create_order(request):" in code
+    assert "if not (customer is not None):" in code
+    # "customer exists" precondition shares the word "customer" with the
+    # error condition "customer not found" -> status 404 is selected.
+    assert "raise HTTPError(404" in code
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_python_defaults_to_400_when_no_match():
+    contracts = {
+        "entities": [
+            {
+                "name": "X",
+                "operations": [
+                    {
+                        "name": "Do Thing",
+                        "method": "POST",
+                        "path": "/x",
+                        "preconditions": [
+                            {"description": "flag set", "expression": "flag"}
+                        ],
+                        "error_cases": [{"status": 409, "condition": "totally unrelated wording"}],
+                    }
+                ],
+            }
+        ]
+    }
+    code = fm.generate_guards_python(contracts)
+    assert "raise HTTPError(400" in code
+
+
+def test_generate_guards_go_emits_capitalized_func_and_http_error():
+    code = fm.generate_guards_go(_contracts())
+    assert "package handlers" in code
+    assert "func CreateOrder(w http.ResponseWriter, r *http.Request) {" in code
+    assert 'http.Error(w, "customer exists", 404)' in code

--- a/tests/test_verify_transitions.py
+++ b/tests/test_verify_transitions.py
@@ -1,0 +1,259 @@
+"""Tests for the state-machine transition-map verifier (verify_transitions.py).
+
+Exercises the deterministic pure logic: entity-name extraction, CamelCase
+conversion, Go source scanning for status writes, and the model-vs-code diff
+that classifies transitions as covered / missing / undocumented.
+"""
+
+from __future__ import annotations
+
+import json
+
+import verify_transitions as vt
+
+# --- camel_to_snake ---------------------------------------------------------
+
+
+def test_camel_to_snake_basic():
+    assert vt.camel_to_snake("CheckedIn") == "checked_in"
+    assert vt.camel_to_snake("InProgress") == "in_progress"
+    assert vt.camel_to_snake("Confirmed") == "confirmed"
+
+
+def test_camel_to_snake_with_digits_and_acronyms():
+    assert vt.camel_to_snake("Status2FA") == "status2_fa"
+    assert vt.camel_to_snake("already_snake") == "already_snake"
+
+
+# --- _extract_entity_name ---------------------------------------------------
+
+
+def test_extract_entity_name_strips_suffixes():
+    assert vt._extract_entity_name("Booking Status State Machine") == "Booking"
+    assert vt._extract_entity_name("Order Lifecycle") == "Order"
+    assert vt._extract_entity_name("Payment Status") == "Payment"
+
+
+def test_extract_entity_name_multiword():
+    assert vt._extract_entity_name("Support Ticket State Machine") == "SupportTicket"
+
+
+# --- load_model -------------------------------------------------------------
+
+
+def _write_model(tmp_path, name="Booking Status State Machine"):
+    model = {
+        "name": name,
+        "states": {
+            "pending": {"type": "initial"},
+            "confirmed": {"type": "normal"},
+            "checked_in": {"type": "terminal"},
+        },
+        "transitions": [
+            {
+                "from": "pending",
+                "to": "confirmed",
+                "event": "confirm",
+                "derived_from": [
+                    {"type": "ticket", "ref": "#42"},
+                    {"type": "observed_fact", "ref": "obs-1"},
+                ],
+            },
+            {"from": "confirmed", "to": "checked_in", "event": "check_in"},
+        ],
+    }
+    path = tmp_path / "model.json"
+    path.write_text(json.dumps(model))
+    return path
+
+
+def test_load_model_parses_entity_states_and_tickets(tmp_path):
+    path = _write_model(tmp_path)
+    entity, transitions, states = vt.load_model(path)
+
+    assert entity == "Booking"
+    assert states == {"pending", "confirmed", "checked_in"}
+    assert len(transitions) == 2
+
+    first = transitions[0]
+    assert first.from_state == "pending"
+    assert first.to_state == "confirmed"
+    assert first.event == "confirm"
+    # Only ticket-typed provenance entries become tickets.
+    assert first.tickets == ["#42"]
+    assert transitions[1].tickets == []
+
+
+def test_load_model_falls_back_to_stem_for_missing_name(tmp_path):
+    path = tmp_path / "widget.json"
+    path.write_text(json.dumps({"states": {"a": {}}, "transitions": []}))
+    entity, transitions, states = vt.load_model(path)
+    # stem "widget" -> entity "Widget"
+    assert entity == "Widget"
+    assert transitions == []
+
+
+# --- scan_go_files ----------------------------------------------------------
+
+
+def test_scan_go_files_detects_status_assignment(tmp_path):
+    (tmp_path / "handler.go").write_text(
+        "package main\n"
+        "func ConfirmBooking() {\n"
+        '    update := bson.M{"$set": bson.M{"status": "confirmed"}}\n'
+        "    _ = update\n"
+        "}\n"
+    )
+    matches = vt.scan_go_files(tmp_path)
+    targets = {m.target_status for m in matches}
+    assert "confirmed" in targets
+    m = next(m for m in matches if m.target_status == "confirmed")
+    assert m.handler == "ConfirmBooking"
+    assert m.file == "handler.go"
+
+
+def test_scan_go_files_detects_models_status_constant(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        "package main\n"
+        "func CheckIn() {\n"
+        "    booking.Status = models.BookingStatusCheckedIn\n"
+        "}\n"
+    )
+    matches = vt.scan_go_files(tmp_path)
+    assert any(m.target_status == "checked_in" for m in matches)
+
+
+def test_scan_go_files_skips_test_files_and_vendor(tmp_path):
+    (tmp_path / "x_test.go").write_text(
+        'func T() { s := bson.M{"$set": bson.M{"status": "confirmed"}} ; _ = s }\n'
+    )
+    vendor = tmp_path / "vendor" / "lib"
+    vendor.mkdir(parents=True)
+    (vendor / "v.go").write_text(
+        'func V() { s := bson.M{"$set": bson.M{"status": "confirmed"}} ; _ = s }\n'
+    )
+    matches = vt.scan_go_files(tmp_path)
+    assert matches == []
+
+
+def test_scan_go_files_ignores_commented_lines(tmp_path):
+    (tmp_path / "c.go").write_text(
+        "package main\n"
+        "func F() {\n"
+        '    // status = "confirmed" -- this is a comment\n'
+        "}\n"
+    )
+    matches = vt.scan_go_files(tmp_path)
+    assert matches == []
+
+
+# --- diff_transitions -------------------------------------------------------
+
+
+def _model_tx(frm, to, event="e", tickets=None):
+    return vt.ModelTransition(from_state=frm, to_state=to, event=event, tickets=tickets or [])
+
+
+def _code(target, file="f.go", line=1, handler="H", guards=None):
+    return vt.CodeMatch(
+        file=file,
+        line=line,
+        handler=handler,
+        target_status=target,
+        guard_statuses=guards or [],
+    )
+
+
+def test_diff_marks_transition_covered_when_code_matches():
+    model = [_model_tx("pending", "confirmed", tickets=["#1"])]
+    code = [_code("confirmed", handler="Confirm")]
+    states = {"pending", "confirmed"}
+
+    results, undocumented = vt.diff_transitions("Booking", model, code, states)
+
+    assert len(results) == 1
+    assert results[0].status == "covered"
+    assert results[0].code_locations[0]["handler"] == "Confirm"
+    assert undocumented == []
+
+
+def test_diff_marks_transition_missing_when_no_code():
+    model = [_model_tx("pending", "confirmed")]
+    results, undocumented = vt.diff_transitions("Booking", model, [], {"pending", "confirmed"})
+    assert results[0].status == "missing"
+    assert results[0].code_locations == []
+
+
+def test_diff_reports_undocumented_code_for_known_state():
+    # Code writes "cancelled" but no model transition targets it.
+    model = [_model_tx("pending", "confirmed")]
+    code = [_code("cancelled", handler="Cancel")]
+    states = {"pending", "confirmed", "cancelled"}
+
+    results, undocumented = vt.diff_transitions("Booking", model, code, states)
+
+    assert [r.status for r in results] == ["missing"]
+    assert len(undocumented) == 1
+    assert undocumented[0].to_state == "cancelled"
+    assert undocumented[0].code_locations[0]["handler"] == "Cancel"
+
+
+def test_diff_skips_undocumented_for_unknown_state():
+    # A status written in code that isn't part of THIS entity's model is ignored
+    # (likely a different entity's status).
+    model = [_model_tx("pending", "confirmed")]
+    code = [_code("shipped")]  # not in states
+    states = {"pending", "confirmed"}
+
+    _results, undocumented = vt.diff_transitions("Booking", model, code, states)
+    assert undocumented == []
+
+
+def test_diff_infers_from_state_from_single_guard():
+    model = [_model_tx("pending", "confirmed")]
+    code = [_code("cancelled", guards=["confirmed"])]
+    states = {"pending", "confirmed", "cancelled"}
+
+    _results, undocumented = vt.diff_transitions("Booking", model, code, states)
+    assert undocumented[0].from_state == "confirmed"
+
+
+def test_diff_ticket_filter_restricts_model_transitions():
+    model = [
+        _model_tx("a", "b", tickets=["#1"]),
+        _model_tx("b", "c", tickets=["#2"]),
+    ]
+    code = [_code("b"), _code("c")]
+    states = {"a", "b", "c"}
+
+    results, _ = vt.diff_transitions("E", model, code, states, ticket_filter="#1")
+    # Only the #1 transition is considered.
+    assert len(results) == 1
+    assert (results[0].from_state, results[0].to_state) == ("a", "b")
+
+
+# --- format_text ------------------------------------------------------------
+
+
+def test_format_text_summary_counts_and_percentage():
+    results = [
+        vt.TransitionResult("a", "b", "e", ["#1"], "covered",
+                            code_locations=[{"file": "f.go", "line": 3, "handler": "H"}]),
+        vt.TransitionResult("b", "c", "e", [], "missing"),
+    ]
+    undocumented = [
+        vt.UndocumentedResult("*", "d", code_locations=[{"file": "g.go", "line": 9, "handler": "X"}]),
+    ]
+    out = vt.format_text("Booking", results, undocumented)
+
+    assert "COVERED (1)" in out
+    assert "MISSING (1)" in out
+    assert "UNDOCUMENTED (1)" in out
+    # 1 covered of 2 total -> 50% coverage
+    assert "50% coverage" in out
+
+
+def test_format_text_zero_transitions_is_safe():
+    out = vt.format_text("Empty", [], [])
+    assert "0 covered, 0 missing, 0 undocumented" in out
+    assert "0% coverage" in out


### PR DESCRIPTION
## What & why

Closes #112 (tests portion; baseline deferred — see below). The portfolio audit's sharpest self-criticism was that the orchestrator's own `scripts/` are the least-tested, highest-churn code in the portfolio — CW isn't fully built by its own TDD loop. This adds **genuine** unit coverage to high-complexity scripts that had none.

## Coverage added — 64 tests, 4 previously-uncovered scripts

| Script | New tests | What's exercised |
|---|--:|---|
| `verify_transitions.py` | 18 | Go `$set`/`models.XStatusY`/`.Status=` parsing, test/vendor/comment skips, covered/missing/undocumented classification, guard-based from-state inference |
| `formal_models.py` | 19 | schema-type detection (6 variants), unreachable/dead-state analysis, cycle-safe path enumeration, xstate conversion, all 4 generators (with `compile()` checks on generated Python) |
| `domain_to_formal.py` | 11 | entity→contracts type mapping, state-machine initial/terminal classification, invalid-transition + guard generation |
| `check_portability.py` | 16 | marker-outside-adapter detection, anchor binding, launder guards, contract-doc section validation |

All synthetic inputs — no network, no real repos, no hollow assertions.

## Honesty notes

- **`check_single_writer.py` and `tutorial_video.py`** — the ticket prioritized these, but both are **already well-covered** (`test_check_single_writer.py` = 38 cases; `test_tutorial_video.py` = 262 lines). The audit's grade predated June-2026 test additions. Redirected effort to genuinely-uncovered scripts instead of padding.
- **No bugs found** — the targeted logic behaves as documented; these tests lock it in.
- **Deferred:** the "commit a `/code-metrics` baseline" acceptance criterion depends on #115 (code-metrics skill) landing first. Follow-up once merged.

## Verification
- New tests → **64 passed**. Full suite → **623 passed, 2 skipped**. Pure test additions, zero source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
