### PR TITLE
feat(ratchet): complexity + relative-churn high-water marks, report-only (#110)

### DIFF
--- a/docs/gate-rollout.md
+++ b/docs/gate-rollout.md
@@ -51,13 +51,14 @@ output), and only switch it to `--gate` once step 2 is satisfied.
 - [ ] Wired into the workflow report-only first; promoted to `--gate` in a follow-up that
       cites the dry-run.
 
-## Gate status
+## Gate ledger
 
-| Gate | Script | Status |
-| --- | --- | --- |
-| traceability | `check_traceability.py` | blocking (`--gate`) |
-| single-writer | `check_single_writer.py` | blocking (`--gate`) |
-| unresolved-markers | `check_unresolved.py` | blocking |
-| ratchet | `ratchet.py` | blocking |
-| SaaS NFR | `saas_gate.py` | blocking (`--gate`, on real `fail`) |
-| minimal-CI | `ci_scaffold.py` | **report-only** (new; wired into `/close-epic` report-only per this doc — has a `--gate` mode held off until validated across shipped repos) |
+| Gate | Script | Blocking flag | Status |
+| --- | --- | --- | --- |
+| Traceability | `check_traceability.py` | `--gate` | blocking (`/architect`, `/close-epic`) |
+| Single-writer | `check_single_writer.py` | `--gate` | blocking (precision fix in #93) |
+| Unresolved markers | `check_unresolved.py` | `--gate` | blocking (`/implement-wave`) |
+| Ratchet: pass-set + contract hashes | `ratchet.py check` | (blocks by default) | blocking (`/implement`, waves, `/close-epic`) |
+| **Ratchet: complexity + relative churn** | `ratchet.py check --gate-quality` | `--gate-quality` | **NEW — report-only** (#110); validate on a shipped repo before wiring as a blocker |
+| SaaS NFR | `saas_gate.py --gate` | `--gate` | blocking (`/saas-gate`) |
+| **Minimal-CI** | `ci_scaffold.py` | `--gate` | **report-only** (#111); wired into `/close-epic` report-only; `--gate` mode held off until validated across shipped repos |

--- a/docs/ratchet.md
+++ b/docs/ratchet.md
@@ -21,6 +21,52 @@ Three rules, all mechanical:
    **protected pathset**. A worker branch that touches them is *parked* for
    human review, never auto-merged.
 
+Plus one **report-only** dimension:
+
+4. **Complexity & churn only ratchet down.** Mean cyclomatic complexity (McCabe
+   1976), the share of functions over CCN 10, and relative churn (churned-LOC /
+   total-LOC — Nagappan & Ball 2005) are snapshotted alongside the scorecard.
+   This dimension is [new, so it ships **report-only**](gate-rollout.md): `check`
+   prints the deltas but does not block on them unless you pass `--gate-quality`.
+
+## Complexity & churn: direction and tolerance
+
+The pass-set ratchets **up** (its high-water mark is the *largest* set; it
+regresses when it *shrinks*). Complexity ratchets the **opposite** way: it is a
+cost, so the high-water mark is the **lowest (best)** value ever merged, and a
+metric that *rises* is the regression. The portfolio audit motivating this
+(issue #110) saw `duplicat-rex` mean CCN drift 3.1→5.2 and `chief-wiggum` reach
+16.7 % of functions over CCN 10 before self-correcting — exactly the upward
+creep this dimension catches.
+
+Because per-run noise is normal, a metric regresses only when it exceeds a
+**tolerance band** around the best value:
+
+```
+regressed  ⇔  current  >  best × (1 + <metric>_rel)  +  <metric>_abs
+```
+
+The band is configurable per repo under `quality_tolerance` in `ratchet.json`
+(defaults in `ratchet.py:DEFAULT_QUALITY_TOLERANCE`):
+
+```json
+{
+  "quality_tolerance": {
+    "ccn_mean_rel": 0.10,       "ccn_mean_abs": 0.5,
+    "pct_ccn_gt10_rel": 0.10,   "pct_ccn_gt10_abs": 1.0,
+    "relative_churn_rel": 0.25, "relative_churn_abs": 0.05
+  }
+}
+```
+
+`score` records `quality: {ccn_mean, pct_ccn_gt10, relative_churn, ...}` in the
+hash-chained record. The snapshot is **optional and fast-failing**: it leans on
+`lizard` (from the [code-metrics](../scripts/quality) engines), and if lizard is
+absent it records `quality: {"skipped": ...}` and never crashes `score` — skipped
+snapshots contribute nothing to the high-water mark and never register a
+regression. Journals written before this dimension existed carry no `quality`
+block; chain verification and high-water derivation tolerate that unchanged.
+
 ## Tamper-evident journal
 
 The journal (`docs/quality/ratchet-journal.jsonl` in the target repo) is an
@@ -55,7 +101,8 @@ parser (`go-test-json`, `junit-xml`, or `pass-fail-lines`):
      "cwd": "web", "parser": "junit-xml", "report": "web/junit.xml"}
   ],
   "epic_docs": "docs/epics",
-  "protected_paths": ["docs/epics/*/contracts.md", "docs/quality/**", "..."]
+  "protected_paths": ["docs/epics/*/contracts.md", "docs/quality/**", "..."],
+  "quality_tolerance": {"ccn_mean_rel": 0.10, "ccn_mean_abs": 0.5, "...": "..."}
 }
 ```
 
@@ -63,9 +110,12 @@ parser (`go-test-json`, `junit-xml`, or `pass-fail-lines`):
 
 ```bash
 python3 scripts/ratchet.py init --repo <target>        # starter config (autodetects go/pytest)
-python3 scripts/ratchet.py score                       # run suites + hash contracts → scorecard
+python3 scripts/ratchet.py score                       # run suites + hash contracts + complexity/churn → scorecard
 python3 scripts/ratchet.py score --no-tests            # contract hashes only (cheap baseline)
+python3 scripts/ratchet.py score --no-quality          # skip the complexity/churn snapshot (no lizard)
+python3 scripts/ratchet.py score --venv <venv>         # point the quality snapshot at a venv with lizard
 python3 scripts/ratchet.py check                       # exit 1 on regression/weakening/removal
+python3 scripts/ratchet.py check --gate-quality        # ALSO exit 1 on complexity/churn regression (opt-in)
 python3 scripts/ratchet.py protected --base origin/main  # exit 1 if goalposts touched
 python3 scripts/ratchet.py record --event ticket --ref "#42" --merged --notes "..."
 python3 scripts/ratchet.py record --event epic-close --ref order-lifecycle --merged \
@@ -91,6 +141,12 @@ scorecard (run `score` first), `4` journal tamper.
   the epic, then `record --event epic-close --merged`. Legitimate contract
   revisions are journaled here with `--amend`/`--retire` — a deliberate,
   visible human decision, not a silent edit.
+
+The **complexity/churn** dimension is not wired as a blocker anywhere yet: per
+[gate-rollout.md](gate-rollout.md) it ships report-only (`check` surfaces the
+deltas in the run output but only `--gate-quality` blocks) until it has been
+validated on a real, already-shipped repo. Promote it to `--gate-quality` in a
+follow-up that cites the dry-run.
 
 Like the other gates, it degrades gracefully: a target repo with no
 `docs/quality/ratchet.json` skips the ratchet (the workflows treat it as

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -22,6 +22,14 @@ Three ratcheted quantities, all project-agnostic:
   models, and the ratchet's own state are the goalposts. ``protected`` flags a
   branch diff that touches them so the orchestrator parks the change for human
   review instead of merging: workers must not move their own goalposts.
+- **Complexity & churn (report-only)** — mean cyclomatic complexity, %CCN>10,
+  and relative churn (churned-LOC/total-LOC) are snapshotted alongside the
+  scorecard. Their high-water mark is the LOWEST (best) value ever merged — the
+  ratchet drives them DOWN — and a value that rises beyond a tolerance band is a
+  regression. This dimension is NEW, so per docs/gate-rollout.md it is
+  REPORT-ONLY: ``check`` prints the deltas but only blocks on them when the
+  caller passes ``--gate-quality``. Missing lizard degrades to a skipped snapshot
+  and never crashes ``score``.
 
 Tamper-evidence: the journal is an append-only HASH CHAIN. The high-water mark
 is DERIVED from the verified chain, not read from a separately-editable file —
@@ -66,6 +74,21 @@ JOURNAL_NAME = "ratchet-journal.jsonl"
 HIGHWATER_NAME = "ratchet-highwater.json"
 SCORECARD_NAME = "ratchet-scorecard.json"
 DEFAULT_STATE_DIR = "docs/quality"
+
+# Complexity/churn ratchet tolerance (see docs/ratchet.md "Complexity & churn").
+# DIRECTION: unlike the pass-set (which may not SHRINK), complexity is a cost we
+# ratchet DOWNWARD — the high-water mark is the LOWEST (best) value ever merged,
+# and a metric that RISES beyond the band below is a regression. The band absorbs
+# ordinary noise: a metric regresses only if it exceeds
+#   best * (1 + rel) + abs_epsilon.
+DEFAULT_QUALITY_TOLERANCE = {
+    "ccn_mean_rel": 0.10,        # mean CCN may drift up ≤ 10%
+    "ccn_mean_abs": 0.5,         # ...plus an absolute epsilon (small repos)
+    "pct_ccn_gt10_rel": 0.10,    # %CCN>10 may drift up ≤ 10% (relative)
+    "pct_ccn_gt10_abs": 1.0,     # ...plus 1 absolute percentage point
+    "relative_churn_rel": 0.25,  # relative churn is advisory — a wide band
+    "relative_churn_abs": 0.05,
+}
 
 # Same stable-ID grammar as check_traceability.py: the ID ends at the 3-digit
 # suffix and must not run into more id chars.
@@ -119,6 +142,9 @@ class Config:
     suites: list[Suite] = field(default_factory=list)
     epic_docs: str = "docs/epics"
     protected_paths: list[str] = field(default_factory=lambda: list(DEFAULT_PROTECTED))
+    quality_tolerance: dict = field(
+        default_factory=lambda: dict(DEFAULT_QUALITY_TOLERANCE)
+    )
 
     @property
     def journal(self) -> Path:
@@ -152,12 +178,15 @@ def load_config(repo: Path) -> Config:
         )
     raw = json.loads(path.read_text())
     suites = [Suite(**s) for s in raw.get("suites", [])]
+    tol = dict(DEFAULT_QUALITY_TOLERANCE)
+    tol.update(raw.get("quality_tolerance", {}) or {})
     return Config(
         repo=repo,
         state_dir=path.parent,
         suites=suites,
         epic_docs=raw.get("epic_docs", "docs/epics"),
         protected_paths=raw.get("protected_paths", list(DEFAULT_PROTECTED)),
+        quality_tolerance=tol,
     )
 
 
@@ -297,6 +326,123 @@ def run_suite(cfg: Config, suite: Suite) -> set[str]:
     return {f"{suite.name}::{cid}" for cid in passed}
 
 
+# ---- complexity + churn snapshot (report-only dimension) -----------------------
+#
+# DIRECTION NOTE: complexity is a cost the ratchet drives DOWN. The high-water
+# mark for these fields is the LOWEST (best) value ever merged; a value that
+# RISES beyond the tolerance band is a regression. This is the OPPOSITE of the
+# pass-set, whose high-water mark is the LARGEST set and which regresses when it
+# SHRINKS. See docs/ratchet.md.
+
+
+def score_quality(cfg: Config, venv: str | None = None, gobin: str | None = None) -> dict:
+    """Snapshot mean CCN, %CCN>10, and relative churn for the target repo.
+
+    Optional and fast-failing: the ``quality`` engines live on the code-metrics
+    branch and lean on lizard. If they are unavailable (import error, or lizard
+    absent) this returns ``{"skipped": ...}`` and NEVER raises — ``score`` must
+    stay usable on repos without the metric toolchain installed.
+    """
+    try:
+        from quality import churn as _churn  # noqa: PLC0415
+        from quality import complexity as _complexity  # noqa: PLC0415
+    except Exception as e:  # pragma: no cover - import guard
+        return {"skipped": f"quality engines unavailable: {e}"}
+
+    repo = str(cfg.repo)
+    comp = _complexity.analyze(repo, venv=venv, gobin=gobin)
+    if "skipped" in comp:
+        return {"skipped": comp["skipped"], "note": comp.get("note")}
+
+    # Aggregate the per-language cyclomatic distributions into a single
+    # function-count-weighted mean CCN and %CCN>10 across all source functions.
+    total_fns = 0
+    ccn_sum = 0.0
+    ccn_gt10 = 0.0
+    for lang in (comp.get("languages") or {}).values():
+        cyc = lang.get("cyclomatic_src")
+        if not cyc:
+            continue
+        n = cyc.get("functions", 0)
+        if not n:
+            continue
+        total_fns += n
+        ccn_sum += cyc.get("ccn_mean", 0) * n
+        ccn_gt10 += cyc.get("pct_ccn_gt10", 0) / 100.0 * n
+
+    total_loc = (comp.get("src_loc_total", 0) or 0) + (comp.get("test_loc_total", 0) or 0)
+
+    # Relative churn = churned LOC (adds+deletes) / total tracked LOC. Nagappan &
+    # Ball (2005): absolute churn is a poor signal; always normalise by size.
+    ch = _churn.analyze(repo, no_merges=True)
+    churned = 0
+    if "error" not in ch:
+        c = ch.get("churn", {}) or {}
+        churned = (c.get("added", 0) or 0) + (c.get("deleted", 0) or 0)
+
+    out: dict = {
+        "functions": total_fns,
+        "total_loc": total_loc,
+        "ccn_mean": round(ccn_sum / total_fns, 2) if total_fns else None,
+        "pct_ccn_gt10": round(100 * ccn_gt10 / total_fns, 1) if total_fns else None,
+        "relative_churn": round(churned / total_loc, 3) if total_loc else None,
+        "churned_loc": churned,
+    }
+    return out
+
+
+# The complexity/churn fields ratcheted DOWN. Keys map to the tolerance-band
+# knobs ``<key>_rel`` / ``<key>_abs`` on ``quality_tolerance``.
+QUALITY_METRICS = ("ccn_mean", "pct_ccn_gt10", "relative_churn")
+
+
+def derive_quality_highwater(records: list[dict]) -> dict:
+    """Best-seen (LOWEST) complexity/churn per metric across MERGED records.
+
+    Backward-compatible: records predating this dimension carry no ``quality``
+    block (or a ``skipped`` one); they contribute nothing and never crash.
+    """
+    best: dict = {}
+    for rec in records:
+        if not rec.get("merged"):
+            continue
+        q = (rec.get("scorecard", {}) or {}).get("quality") or {}
+        if not isinstance(q, dict) or "skipped" in q:
+            continue
+        for m in QUALITY_METRICS:
+            v = q.get(m)
+            if isinstance(v, (int, float)):
+                cur = best.get(m)
+                if cur is None or v < cur:
+                    best[m] = v
+    return best
+
+
+def quality_regressions(quality: dict, hw: dict, tolerance: dict) -> list[dict]:
+    """Metrics that rose above ``best * (1 + rel) + abs`` — report-only findings.
+
+    ``quality`` is the current scorecard's block; ``hw`` the derived best-seen
+    high-water. Returns one entry per regressed metric (empty when none, or when
+    there is no baseline / the current snapshot was skipped)."""
+    if not isinstance(quality, dict) or "skipped" in quality:
+        return []
+    out: list[dict] = []
+    for m in QUALITY_METRICS:
+        best = hw.get(m)
+        cur = quality.get(m)
+        if not isinstance(best, (int, float)) or not isinstance(cur, (int, float)):
+            continue
+        rel = tolerance.get(f"{m}_rel", 0.0)
+        eps = tolerance.get(f"{m}_abs", 0.0)
+        limit = best * (1 + rel) + eps
+        if cur > limit:
+            out.append({
+                "metric": m, "current": cur, "best": best,
+                "limit": round(limit, 3), "delta": round(cur - best, 3),
+            })
+    return out
+
+
 # ---- hash-chained journal ------------------------------------------------------
 
 
@@ -338,7 +484,11 @@ def derive_highwater(records: list[dict]) -> dict:
             contract_hashes[cid] = h
         for cid in rec.get("retired", []) or []:
             contract_hashes.pop(cid, None)
-    return {"pass_set": sorted(pass_set), "contract_hashes": contract_hashes}
+    return {
+        "pass_set": sorted(pass_set),
+        "contract_hashes": contract_hashes,
+        "quality": derive_quality_highwater(records),
+    }
 
 
 def violations(scorecard: dict, highwater: dict) -> dict:
@@ -404,6 +554,7 @@ def cmd_init(args) -> int:
         "suites": detect_suites(repo),
         "epic_docs": "docs/epics",
         "protected_paths": list(DEFAULT_PROTECTED),
+        "quality_tolerance": dict(DEFAULT_QUALITY_TOLERANCE),
     }
     _write_json(path, cfg)
     print(f"ratchet: wrote {path} ({len(cfg['suites'])} suite(s) autodetected)")
@@ -419,16 +570,28 @@ def cmd_score(args) -> int:
     if not args.no_tests:
         for suite in cfg.suites:
             pass_set |= run_suite(cfg, suite)
+    quality = {"skipped": "quality metrics disabled (--no-quality)"}
+    if not args.no_quality:
+        quality = score_quality(cfg, venv=args.venv, gobin=args.gobin)
     sc = {
         "passed": len(pass_set),
         "pass_set": sorted(pass_set),
         "contract_hashes": contract_hashes,
         "tests_run": not args.no_tests,
+        "quality": quality,
     }
     _write_json(cfg.scorecard, sc)
+    if "skipped" in quality:
+        qmsg = f"quality={quality['skipped']}"
+    else:
+        qmsg = (
+            f"ccn_mean={quality.get('ccn_mean')} "
+            f"pct_ccn_gt10={quality.get('pct_ccn_gt10')} "
+            f"relative_churn={quality.get('relative_churn')}"
+        )
     print(
         f"ratchet: scored — {len(pass_set)} passing case(s), "
-        f"{len(contract_hashes)} contract definition(s)"
+        f"{len(contract_hashes)} contract definition(s); {qmsg}"
     )
     return 0
 
@@ -436,17 +599,36 @@ def cmd_score(args) -> int:
 def cmd_check(args) -> int:
     cfg = load_config(repo_root(args.repo))
     hw = derive_highwater(load_journal(cfg))
-    v = violations(_read_scorecard(cfg), hw)
+    sc = _read_scorecard(cfg)
+    v = violations(sc, hw)
+    # Complexity/churn is a NEW, report-only dimension (docs/gate-rollout.md): it
+    # prints its deltas vs the best-seen high-water but does NOT influence the
+    # exit code unless the caller opts in with --gate-quality. The pass-set and
+    # contract-hash gates keep their exact prior blocking semantics.
+    qregs = quality_regressions(
+        sc.get("quality", {}) or {}, hw.get("quality", {}) or {}, cfg.quality_tolerance
+    )
+    hard = {k: v[k] for k in ("missing_tests", "weakened_contracts", "removed_contracts")}
     if args.format == "json":
-        print(json.dumps(v, indent=2))
-    if any(v.values()):
+        print(json.dumps({**hard, "quality_regressions": qregs}, indent=2))
+    elif qregs:
+        tag = "VIOLATED (gated)" if args.gate_quality else "report-only"
+        sys.stderr.write(f"ratchet: complexity/churn regressions [{tag}]:\n")
+        for r in qregs:
+            sys.stderr.write(
+                f"  {r['metric']}: {r['current']} > limit {r['limit']} "
+                f"(best {r['best']}, +{r['delta']})\n"
+            )
+    if any(hard.values()):
         if args.format != "json":
             sys.stderr.write(
                 "ratchet: VIOLATED —"
-                f" missing_tests={v['missing_tests']}"
-                f" weakened_contracts={v['weakened_contracts']}"
-                f" removed_contracts={v['removed_contracts']}\n"
+                f" missing_tests={hard['missing_tests']}"
+                f" weakened_contracts={hard['weakened_contracts']}"
+                f" removed_contracts={hard['removed_contracts']}\n"
             )
+        return 1
+    if args.gate_quality and qregs:
         return 1
     if args.format != "json":
         print("ratchet: OK (pass-set and contract definitions hold the high-water mark)")
@@ -456,7 +638,12 @@ def cmd_check(args) -> int:
 def cmd_regressed(args) -> int:
     cfg = load_config(repo_root(args.repo))
     hw = derive_highwater(load_journal(cfg))
-    print(json.dumps(violations(_read_scorecard(cfg), hw), indent=2))
+    sc = _read_scorecard(cfg)
+    out = violations(sc, hw)
+    out["quality_regressions"] = quality_regressions(
+        sc.get("quality", {}) or {}, hw.get("quality", {}) or {}, cfg.quality_tolerance
+    )
+    print(json.dumps(out, indent=2))
     return 0
 
 
@@ -578,12 +765,19 @@ def main() -> int:
     sp = sub.add_parser("score", help="run suites + hash contracts, write scorecard")
     common(sp)
     sp.add_argument("--no-tests", action="store_true", help="contract hashes only (cheap baseline)")
+    sp.add_argument("--no-quality", action="store_true",
+                    help="skip the complexity/churn snapshot (skip if lizard is unavailable)")
+    sp.add_argument("--venv", default=None, help="virtualenv with lizard/radon for the quality snapshot")
+    sp.add_argument("--gobin", default=None, help="dir containing gocognit for the quality snapshot")
 
     for name in ("check", "regressed", "highwater", "recent"):
         sp = sub.add_parser(name)
         common(sp)
         if name == "check":
             sp.add_argument("--format", choices=["text", "json"], default="text")
+            sp.add_argument("--gate-quality", action="store_true",
+                            help="also block on complexity/churn regressions "
+                                 "(off by default — report-only, see docs/gate-rollout.md)")
         if name == "recent":
             sp.add_argument("--n", type=int, default=5)
 

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -1,6 +1,8 @@
 """Tests for scripts/ratchet.py."""
 
+import argparse
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -224,3 +226,132 @@ def test_protected_hits_matches_goalpost_files(tmp_path):
         "docs/epics/order-lifecycle/models/contracts.json",
         "docs/quality/ratchet-journal.jsonl",
     ]
+
+
+# ---- complexity + churn (report-only dimension) --------------------------------
+
+
+def quality_scorecard(cfg, pass_set, quality):
+    sc = scorecard_from(cfg, pass_set)
+    sc["quality"] = quality
+    return sc
+
+
+def test_quality_block_is_recorded_and_hash_chained(tmp_path):
+    """A quality block rides inside the scorecard, so it is covered by the
+    per-record hash and survives chain verification untouched."""
+    cfg = make_repo(tmp_path)
+    q = {"functions": 100, "total_loc": 5000, "ccn_mean": 3.1,
+         "pct_ccn_gt10": 4.0, "relative_churn": 0.2, "churned_loc": 1000}
+    append_record(cfg, quality_scorecard(cfg, {"s::t1"}, q))
+    recs = ratchet.load_journal(cfg)  # raises TamperError if the chain is broken
+    assert recs[0]["scorecard"]["quality"]["ccn_mean"] == 3.1
+
+
+def test_quality_highwater_is_the_lowest_merged_value(tmp_path):
+    """Direction check: complexity ratchets DOWN — best-seen = the minimum."""
+    cfg = make_repo(tmp_path)
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"ccn_mean": 5.2, "pct_ccn_gt10": 16.7, "relative_churn": 0.4}), merged=True)
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"ccn_mean": 3.1, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}), merged=True)
+    # a WORSE unmerged snapshot must not pollute the high-water mark
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"ccn_mean": 9.9, "pct_ccn_gt10": 40.0, "relative_churn": 0.9}), merged=False)
+    hw = ratchet.derive_highwater(ratchet.load_journal(cfg))["quality"]
+    assert hw == {"ccn_mean": 3.1, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}
+
+
+def test_quality_regression_when_complexity_rises_beyond_tolerance(tmp_path):
+    cfg = make_repo(tmp_path)
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}), merged=True)
+    hw = ratchet.derive_highwater(ratchet.load_journal(cfg))["quality"]
+    # within band (3.0 * 1.1 + 0.5 = 3.8): no regression
+    ok = {"ccn_mean": 3.7, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}
+    assert ratchet.quality_regressions(ok, hw, cfg.quality_tolerance) == []
+    # beyond band: 5.2 > 3.8 -> ccn_mean regresses
+    bad = {"ccn_mean": 5.2, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}
+    regs = ratchet.quality_regressions(bad, hw, cfg.quality_tolerance)
+    assert [r["metric"] for r in regs] == ["ccn_mean"]
+    assert regs[0]["best"] == 3.0 and regs[0]["current"] == 5.2
+
+
+def _write_scorecard(cfg, sc):
+    ratchet._write_json(cfg.scorecard, sc)
+
+
+def test_check_quality_regression_is_report_only_by_default(tmp_path, capsys):
+    """A complexity regression prints but MUST NOT change check's exit code
+    unless --gate-quality is passed — the pass-set/contract gates are unchanged."""
+    cfg = make_repo(tmp_path)
+    append_record(cfg, quality_scorecard(cfg, {"s::t1"},
+        {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}), merged=True)
+    # current snapshot: pass-set intact, but complexity blew past the band
+    _write_scorecard(cfg, quality_scorecard(cfg, {"s::t1"},
+        {"ccn_mean": 9.9, "pct_ccn_gt10": 40.0, "relative_churn": 0.9}))
+
+    report = argparse.Namespace(repo=str(tmp_path), format="text", gate_quality=False)
+    assert ratchet.cmd_check(report) == 0  # report-only: exits OK
+    assert "regressions" in capsys.readouterr().err
+
+    gated = argparse.Namespace(repo=str(tmp_path), format="text", gate_quality=True)
+    assert ratchet.cmd_check(gated) == 1  # opt-in gate: now blocks
+
+
+def test_check_pass_set_gate_unchanged_by_quality(tmp_path):
+    """Existing blocking behavior is preserved: a missing high-water test still
+    exits 1 regardless of the (absent/held) quality dimension."""
+    cfg = make_repo(tmp_path)
+    append_record(cfg, quality_scorecard(cfg, {"s::t1", "s::t2"},
+        {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}), merged=True)
+    _write_scorecard(cfg, quality_scorecard(cfg, {"s::t1"},  # t2 regressed
+        {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}))
+    args = argparse.Namespace(repo=str(tmp_path), format="text", gate_quality=False)
+    assert ratchet.cmd_check(args) == 1
+
+
+def test_backward_compat_journal_without_quality(tmp_path):
+    """Pre-existing records carry no quality block. Chain verification, high-water
+    derivation, and regression checks must all tolerate that and not crash."""
+    cfg = make_repo(tmp_path)
+    # scorecard_from() deliberately omits the quality field (old shape)
+    append_record(cfg, scorecard_from(cfg, {"s::t1", "s::t2"}), merged=True)
+    append_record(cfg, scorecard_from(cfg, {"s::t1", "s::t2", "s::t3"}), merged=True)
+    recs = ratchet.load_journal(cfg)  # verifies fine
+    hw = ratchet.derive_highwater(recs)
+    assert hw["pass_set"] == ["s::t1", "s::t2", "s::t3"]
+    assert hw["quality"] == {}  # no quality high-water derivable — empty, not error
+    # a current snapshot without quality yields no quality regressions
+    assert ratchet.quality_regressions({}, hw["quality"], cfg.quality_tolerance) == []
+
+
+def test_skipped_quality_snapshot_never_regresses(tmp_path):
+    """If lizard was absent, the snapshot is {'skipped': ...}; it must be inert
+    for both high-water derivation and regression detection."""
+    cfg = make_repo(tmp_path)
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}), merged=True)
+    hw = ratchet.derive_highwater(ratchet.load_journal(cfg))["quality"]
+    assert ratchet.quality_regressions({"skipped": "lizard not found"}, hw,
+                                       cfg.quality_tolerance) == []
+    # and a skipped record contributes nothing to the high-water mark
+    append_record(cfg, quality_scorecard(cfg, set(),
+        {"skipped": "lizard not found"}), merged=True)
+    hw2 = ratchet.derive_highwater(ratchet.load_journal(cfg))["quality"]
+    assert hw2 == {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}
+
+
+@pytest.mark.skipif(shutil.which("lizard") is None,
+                    reason="lizard required for the end-to-end quality snapshot")
+def test_score_quality_end_to_end_on_a_real_repo(tmp_path):
+    """score_quality runs the code-metrics engines against chief-wiggum itself."""
+    repo = Path(__file__).resolve().parent.parent  # chief-wiggum repo root
+    cfg = make_repo(tmp_path)
+    cfg.repo = repo
+    q = ratchet.score_quality(cfg)
+    assert "skipped" not in q, q
+    assert q["functions"] > 0 and q["ccn_mean"] is not None
+    assert q["total_loc"] > 0 and 0 <= q["pct_ccn_gt10"] <= 100
+    # relative_churn requires git history; chief-wiggum has plenty
+    assert q["relative_churn"] is None or q["relative_churn"] >= 0


### PR DESCRIPTION
## Closes #110  (re-opened — the original #118 got auto-closed when its stacked base branch was deleted after #115 merged; rebased cleanly onto main here)

Extends the quality ratchet to record **cyclomatic complexity** (mean CCN, %CCN>10) and **relative churn** as high-water marks — **additive & report-only**, gated only behind opt-in `--gate-quality`. Existing pass-set/contract gating unchanged; old journals still verify. Rebased onto current main (post #115/#116) with the gate-rollout ledger unified to include both the ratchet-quality and minimal-CI rows.

- Complexity ratchets **down** (high-water = lowest merged value); regression = rise beyond `best × (1+rel) + abs`.
- Backward compatible; graceful skip when lizard absent.
- Verified: `pytest tests/test_ratchet.py` → 20 passed, 1 skipped (21 with lizard on PATH); full suite **668 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
