### PR TITLE
feat(close-epic): report-only code-survival + duplication AI-slop gates (#113)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -204,6 +204,16 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer "$CW_TMP/security-revie
 
 Triage every finding like the other gates: a confirmed exploitable issue is **blocking** (fix before close); a plausible-but-unproven one is **parked for the human** with the `file:line` and the concrete attack. Never close a user-facing/auth/money epic on an unreviewed security surface. Skip only when the epic is purely internal/back-office with **no new external surface** — and say so explicitly in the close report.
 
+### Step 2i: AI-slop signals (report-only)
+
+Two signals the literature converged on for AI-generated code degradation: **elevated 2-week churn** (code reverted/reworked soon after authoring — GitClear; DORA 2024 stability drop) and **rising production duplication** (copy/paste written to be added, not reused). Run them over the target as a standing guardrail on top of the one-off `/code-metrics` audit:
+
+```bash
+python3 "$CW_HOME/scripts/quality_slop_gate.py" --repo "$TARGET_REPO" --report
+```
+
+This is **report-only** (per `docs/gate-rollout.md`): it computes code survival (% of added lines surviving 14/30 days via git-of-theseus) and production-only duplication (% clones, tests excluded, via jscpd), prints each against GitClear's `[VENDOR]` reference bands (survival: pre-AI ~96.9% / AI-assisted ~94.3%; duplication: pre-AI 8.3% / AI 12.3%), and **always exits 0** — it never blocks the close. Surface its output verbatim in the final report under `### AI-slop signals`. It degrades gracefully: if git-of-theseus / jscpd / node are absent it prints `skipped (tool not found)`, and survival self-skips when the repo has < 14 days of history (too young to measure 2-week survival) — report that caveat honestly rather than treating a young repo as a pass. A future blocking mode is behind `--gate` (off by default, and even then only a regression *past* the AI band counts — the bands are directional).
+
 ### Step 3: Integration test execution
 
 Run the integration tests defined in `integration-tests.md`. These test cross-ticket behaviour that no individual ticket validates.
@@ -499,6 +509,11 @@ Present the full epic close report:
 ### Invariants
 - X/Y verified
 - Failures: [details]
+
+### AI-slop signals (report-only)
+- Code survival (14d/30d): X% / Y% — [beats pre-AI baseline / between bands / past AI band] (or skipped: too young / tool absent)
+- Production duplication: Z% — [beats pre-AI baseline / between bands / past AI band] (or skipped: tool absent)
+- _[VENDOR] GitClear bands; directional. Informational — does not block the close._
 
 ### Multi-AI Analysis
 - Consensus risks: [areas both AIs flagged]

--- a/docs/gate-rollout.md
+++ b/docs/gate-rollout.md
@@ -62,3 +62,4 @@ output), and only switch it to `--gate` once step 2 is satisfied.
 | **Ratchet: complexity + relative churn** | `ratchet.py check --gate-quality` | `--gate-quality` | **NEW — report-only** (#110); validate on a shipped repo before wiring as a blocker |
 | SaaS NFR | `saas_gate.py --gate` | `--gate` | blocking (`/saas-gate`) |
 | **Minimal-CI** | `ci_scaffold.py` | `--gate` | **report-only** (#111); wired into `/close-epic` report-only; `--gate` mode held off until validated across shipped repos |
+| **AI-slop signals (code survival + duplication)** | `quality_slop_gate.py` | `--gate` | **report-only** (#113); `/close-epic`; promote after a dry-run shows the GitClear bands don't false-positive on shipped repos |

--- a/scripts/quality_slop_gate.py
+++ b/scripts/quality_slop_gate.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""quality_slop_gate.py — report-only AI-"slop" signals for /close-epic.
+
+Two signals the literature converged on for AI-generated code degradation:
+
+  - **code survival / 2-week churn** (GitClear [VENDOR]; DORA 2024 stability drop):
+    AI-assisted code is reverted/reworked soon after authoring. We report the
+    fraction of added lines still alive at 14/30 days via git-of-theseus, placed
+    against GitClear's bands (pre-AI 2020 ~96.9% survive 2 weeks; AI-assisted
+    2024 ~94.3%).
+  - **production duplication** (GitClear [VENDOR]): copy/paste written to be added
+    not reused. We report production-only clone % (tests excluded) via jscpd,
+    against GitClear's bands (pre-AI 8.3%; AI 12.3%).
+
+**Report-only** per docs/gate-rollout.md: compute, print against the reference
+bands, exit 0 — never block. A future blocking mode is behind ``--gate`` (off by
+default). The bands are directional (corroborated by DORA 2024; the exact
+multiples are vendor framing, not independently replicated) — they are printed
+as context, and even in ``--gate`` mode only regressions *past* the AI band
+count as findings.
+
+Degrades gracefully: git-of-theseus / jscpd / node absent -> "skipped (tool not
+found)", exit 0, never crash. Survival also self-skips when the repo has < 14
+days of history (too young to measure 2-week survival) — surfaced honestly.
+
+Target resolution mirrors the other skills:
+  - ``owner/repo``  -> resolved & cloned via scripts/repo.py
+  - ``--repo PATH`` -> a direct local path
+  - neither         -> the current git repo (git rev-parse --show-toplevel)
+
+Usage:
+    python3 scripts/quality_slop_gate.py [owner/repo] [--repo PATH] \\
+        [--report | --gate] [--workdir DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from quality import duplication, survival  # noqa: E402
+
+# GitClear [VENDOR] reference bands — direction is credible, exact multiples are
+# framing-dependent (corroborated directionally by DORA 2024, not independently
+# replicated). Kept here so the gate's messaging can't drift from the engines.
+SURVIVAL_PRE_AI_14D = 96.9
+SURVIVAL_AI_14D = 94.3
+DUP_PRE_AI = 8.3
+DUP_AI = 12.3
+
+CAVEAT = (
+    "[VENDOR] GitClear bands; directional (corroborated by DORA 2024), "
+    "exact multiples not independently replicated."
+)
+
+
+def _current_repo_root() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def resolve_target(owner_repo: str | None, repo_path: str | None) -> str:
+    """Resolve the target repo to a local absolute path."""
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        if not (p / ".git").exists():
+            print(f"Error: {p} is not a git repository", file=sys.stderr)
+            sys.exit(1)
+        return str(p)
+    if owner_repo:
+        from repo import resolve_repo  # local import: only needed for owner/repo
+        return str(resolve_repo(owner_repo))
+    root = _current_repo_root()
+    if not root:
+        print("Error: not inside a git repo; pass owner/repo or --repo PATH", file=sys.stderr)
+        sys.exit(1)
+    return root
+
+
+def _band(value: float | None, pre_ai: float, ai: float, higher_is_better: bool) -> str:
+    """Classify a measured value against the pre-AI / AI reference bands.
+
+    Returns one of: better-than-pre-ai, pre-ai..ai, past-ai (the finding band).
+    """
+    if value is None:
+        return "unknown"
+    if higher_is_better:  # survival: higher survival is healthier
+        if value >= pre_ai:
+            return "better-than-pre-ai"
+        if value >= ai:
+            return "pre-ai..ai"
+        return "past-ai"
+    # duplication: lower is healthier
+    if value <= pre_ai:
+        return "better-than-pre-ai"
+    if value <= ai:
+        return "pre-ai..ai"
+    return "past-ai"
+
+
+def evaluate_survival(result: dict) -> dict:
+    """Reduce a survival engine result to a report-friendly verdict.
+
+    verdict.status: 'skipped' | 'too_young' | 'measured'
+    On 'measured', carries survival_14d/30d and the 14-day band classification.
+    """
+    if "skipped" in result:
+        return {"status": "skipped", "detail": result["skipped"]}
+    by_age = result.get("survival_by_age_days", {})
+    # git-of-theseus ran but no commit has lived >= 14 days -> repo too young.
+    band14 = by_age.get(14) or by_age.get("14") or {}
+    if not band14 or (band14.get("lines_old_enough") or 0) == 0:
+        return {
+            "status": "too_young",
+            "detail": "no commits have lived >= 14 days — too young to measure 2-week survival",
+        }
+    band30 = by_age.get(30) or by_age.get("30") or {}
+    s14 = band14.get("survival_pct")
+    s30 = band30.get("survival_pct")
+    return {
+        "status": "measured",
+        "survival_14d": s14,
+        "survival_30d": s30,
+        "lines_14d": band14.get("lines_old_enough"),
+        "band_14d": _band(s14, SURVIVAL_PRE_AI_14D, SURVIVAL_AI_14D, higher_is_better=True),
+    }
+
+
+def evaluate_duplication(result: dict) -> dict:
+    """Reduce a duplication engine result to a report-friendly verdict."""
+    if "skipped" in result:
+        return {"status": "skipped", "detail": result["skipped"]}
+    pct = result.get("duplication_pct_lines")
+    return {
+        "status": "measured",
+        "duplication_pct": pct,
+        "band": _band(pct, DUP_PRE_AI, DUP_AI, higher_is_better=False),
+    }
+
+
+def format_report(sv: dict, dup: dict) -> str:
+    """Render both verdicts as a human-readable block for the epic report."""
+    lines: list[str] = []
+    lines.append("## AI-slop signals (report-only)")
+    lines.append(f"_{CAVEAT}_")
+    lines.append("")
+
+    # --- survival ---
+    lines.append("### Code survival (2-week churn)")
+    lines.append(
+        f"Reference bands: pre-AI ~{SURVIVAL_PRE_AI_14D}% / AI-assisted ~{SURVIVAL_AI_14D}% "
+        "of added lines survive 14 days."
+    )
+    if sv["status"] == "skipped":
+        lines.append(f"- skipped: {sv['detail']}")
+    elif sv["status"] == "too_young":
+        lines.append(f"- skipped: {sv['detail']}")
+    else:
+        s14 = sv["survival_14d"]
+        s30 = sv["survival_30d"]
+        lines.append(
+            f"- 14-day survival: {s14}% ({_band_label(sv['band_14d'])}); "
+            f"30-day survival: {s30}%"
+        )
+    lines.append("")
+
+    # --- duplication ---
+    lines.append("### Production duplication (copy/paste)")
+    lines.append(
+        f"Reference bands: pre-AI {DUP_PRE_AI}% / AI-assisted {DUP_AI}% duplicated blocks "
+        "(production code only, tests excluded)."
+    )
+    if dup["status"] == "skipped":
+        lines.append(f"- skipped: {dup['detail']}")
+    else:
+        pct = dup["duplication_pct"]
+        lines.append(f"- production duplication: {pct}% ({_band_label(dup['band'])})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _band_label(band: str) -> str:
+    return {
+        "better-than-pre-ai": "beats the pre-AI human baseline",
+        "pre-ai..ai": "between the pre-AI and AI-assisted bands",
+        "past-ai": "past the AI-assisted band — worth a look",
+        "unknown": "unclassified",
+    }.get(band, band)
+
+
+def has_findings(sv: dict, dup: dict) -> list[str]:
+    """Return the list of findings (only 'past-ai' regressions count)."""
+    findings: list[str] = []
+    if sv.get("status") == "measured" and sv.get("band_14d") == "past-ai":
+        findings.append(
+            f"code survival {sv['survival_14d']}% at 14 days is below the AI-assisted "
+            f"band (~{SURVIVAL_AI_14D}%) — elevated 2-week churn"
+        )
+    if dup.get("status") == "measured" and dup.get("band") == "past-ai":
+        findings.append(
+            f"production duplication {dup['duplication_pct']}% exceeds the AI-assisted "
+            f"band ({DUP_AI}%)"
+        )
+    return findings
+
+
+def run(args: argparse.Namespace) -> int:
+    target = resolve_target(args.owner_repo, args.repo)
+    if args.workdir:
+        workdir = args.workdir
+    else:
+        import env  # session temp dir under ~/.chief-wiggum/tmp — never the target repo
+        workdir = os.path.join(str(env.create_tmp()), "slop-gate", Path(target).name)
+    os.makedirs(workdir, exist_ok=True)
+
+    print(f"[slop-gate] target: {target}", file=sys.stderr)
+    print("[slop-gate] survival...", file=sys.stderr)
+    sv_raw = survival.analyze(target, workdir=os.path.join(workdir, "survival"))
+    print("[slop-gate] duplication...", file=sys.stderr)
+    dup_raw = duplication.analyze(target, workdir=os.path.join(workdir, "dup"))
+
+    sv = evaluate_survival(sv_raw)
+    dup = evaluate_duplication(dup_raw)
+
+    print(format_report(sv, dup))
+
+    findings = has_findings(sv, dup)
+    if findings:
+        print("Findings (informational):", file=sys.stderr)
+        for f in findings:
+            print(f"  - {f}", file=sys.stderr)
+
+    # Report-only is the default (exit 0). --gate opts into blocking, and even
+    # then only a regression PAST the AI band blocks — the bands are directional.
+    if args.gate and findings:
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="report-only AI-slop signals (code survival + duplication)",
+    )
+    parser.add_argument("owner_repo", nargs="?", default=None,
+                        help="owner/repo to resolve+clone (optional)")
+    parser.add_argument("--repo", default=None, help="direct local repo path")
+    parser.add_argument("--workdir", default=None, help="scratch dir for tool output")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--report", action="store_true", default=True,
+                      help="report-only mode (default): print findings, exit 0")
+    mode.add_argument("--gate", action="store_true",
+                      help="blocking mode (opt-in): exit 1 if a signal is past the AI band")
+    args = parser.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_quality_slop_gate.py
+++ b/tests/test_quality_slop_gate.py
@@ -1,0 +1,264 @@
+"""Tests for the report-only AI-slop gate (scripts/quality_slop_gate.py).
+
+Covers the DETERMINISTIC parts against synthesized engine outputs: band
+classification, report formatting, findings extraction, and report-only exit 0.
+Graceful-skip is asserted when the underlying tools/history are absent. The
+tool-dependent live path is exercised only when git-of-theseus is importable
+(built from a tiny synthetic git repo) and is gated on availability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+
+import pytest
+import quality_slop_gate as gate
+
+# --- band classification ----------------------------------------------------
+
+
+def test_survival_band_beats_pre_ai():
+    r = gate.evaluate_survival({
+        "survival_by_age_days": {
+            14: {"survival_pct": 98.0, "lines_old_enough": 500},
+            30: {"survival_pct": 97.0, "lines_old_enough": 400},
+        }
+    })
+    assert r["status"] == "measured"
+    assert r["survival_14d"] == 98.0
+    assert r["survival_30d"] == 97.0
+    assert r["band_14d"] == "better-than-pre-ai"
+
+
+def test_survival_band_between():
+    r = gate.evaluate_survival({
+        "survival_by_age_days": {
+            14: {"survival_pct": 95.0, "lines_old_enough": 500},
+            30: {"survival_pct": 94.0, "lines_old_enough": 400},
+        }
+    })
+    assert r["band_14d"] == "pre-ai..ai"
+
+
+def test_survival_band_past_ai_is_a_finding():
+    r = gate.evaluate_survival({
+        "survival_by_age_days": {
+            14: {"survival_pct": 90.0, "lines_old_enough": 500},
+            30: {"survival_pct": 88.0, "lines_old_enough": 400},
+        }
+    })
+    assert r["band_14d"] == "past-ai"
+
+
+def test_survival_too_young_when_no_lines_old_enough():
+    """git-of-theseus ran but no commit lived >= 14 days -> too_young, not a crash."""
+    r = gate.evaluate_survival({
+        "survival_by_age_days": {
+            14: {"survival_pct": None, "lines_old_enough": 0},
+            30: {"survival_pct": None, "lines_old_enough": 0},
+        }
+    })
+    assert r["status"] == "too_young"
+    assert "14 days" in r["detail"]
+
+
+def test_survival_skipped_passthrough():
+    r = gate.evaluate_survival({"skipped": "git-of-theseus not found"})
+    assert r["status"] == "skipped"
+    assert "git-of-theseus" in r["detail"]
+
+
+def test_survival_handles_string_keys():
+    """git-of-theseus JSON round-trips can key ages as strings."""
+    r = gate.evaluate_survival({
+        "survival_by_age_days": {
+            "14": {"survival_pct": 95.0, "lines_old_enough": 500},
+            "30": {"survival_pct": 94.0, "lines_old_enough": 400},
+        }
+    })
+    assert r["status"] == "measured"
+    assert r["survival_14d"] == 95.0
+
+
+def test_duplication_band_beats_pre_ai():
+    r = gate.evaluate_duplication({"duplication_pct_lines": 4.0})
+    assert r["status"] == "measured"
+    assert r["band"] == "better-than-pre-ai"
+
+
+def test_duplication_band_between():
+    r = gate.evaluate_duplication({"duplication_pct_lines": 10.0})
+    assert r["band"] == "pre-ai..ai"
+
+
+def test_duplication_band_past_ai_is_a_finding():
+    r = gate.evaluate_duplication({"duplication_pct_lines": 20.0})
+    assert r["band"] == "past-ai"
+
+
+def test_duplication_skipped_passthrough():
+    r = gate.evaluate_duplication({"skipped": "jscpd/node not found"})
+    assert r["status"] == "skipped"
+    assert "jscpd" in r["detail"] or "node" in r["detail"]
+
+
+# --- report formatting ------------------------------------------------------
+
+
+def test_format_report_measured_shows_bands_and_caveat():
+    sv = gate.evaluate_survival({
+        "survival_by_age_days": {
+            14: {"survival_pct": 98.0, "lines_old_enough": 500},
+            30: {"survival_pct": 97.0, "lines_old_enough": 400},
+        }
+    })
+    dup = gate.evaluate_duplication({"duplication_pct_lines": 5.0})
+    out = gate.format_report(sv, dup)
+    assert "report-only" in out
+    assert "[VENDOR]" in out          # caveat labelling
+    assert "DORA 2024" in out
+    assert "96.9" in out and "94.3" in out   # survival bands
+    assert "8.3" in out and "12.3" in out    # duplication bands
+    assert "98.0%" in out
+    assert "5.0%" in out
+    assert "beats the pre-AI human baseline" in out
+
+
+def test_format_report_surfaces_skips_honestly():
+    sv = gate.evaluate_survival({"skipped": "git-of-theseus not found"})
+    dup = gate.evaluate_duplication({"skipped": "jscpd/node not found"})
+    out = gate.format_report(sv, dup)
+    assert "skipped: git-of-theseus not found" in out
+    assert "skipped: jscpd/node not found" in out
+
+
+def test_format_report_surfaces_too_young():
+    sv = gate.evaluate_survival({
+        "survival_by_age_days": {14: {"survival_pct": None, "lines_old_enough": 0}}
+    })
+    dup = gate.evaluate_duplication({"duplication_pct_lines": 5.0})
+    out = gate.format_report(sv, dup)
+    assert "too young" in out
+
+
+# --- findings extraction ----------------------------------------------------
+
+
+def test_no_findings_when_healthy():
+    sv = gate.evaluate_survival({
+        "survival_by_age_days": {14: {"survival_pct": 98.0, "lines_old_enough": 500}}
+    })
+    dup = gate.evaluate_duplication({"duplication_pct_lines": 4.0})
+    assert gate.has_findings(sv, dup) == []
+
+
+def test_findings_when_both_past_ai():
+    sv = gate.evaluate_survival({
+        "survival_by_age_days": {14: {"survival_pct": 90.0, "lines_old_enough": 500}}
+    })
+    dup = gate.evaluate_duplication({"duplication_pct_lines": 20.0})
+    findings = gate.has_findings(sv, dup)
+    assert len(findings) == 2
+    assert any("survival" in f for f in findings)
+    assert any("duplication" in f for f in findings)
+
+
+def test_no_findings_when_skipped():
+    sv = gate.evaluate_survival({"skipped": "git-of-theseus not found"})
+    dup = gate.evaluate_duplication({"skipped": "jscpd/node not found"})
+    assert gate.has_findings(sv, dup) == []
+
+
+# --- run() exit-code contract (report-only vs --gate) -----------------------
+
+
+def _args(**kw):
+    base = dict(owner_repo=None, repo=None, workdir=None, report=True, gate=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _patch_engines(monkeypatch, sv_result, dup_result):
+    monkeypatch.setattr(gate.survival, "analyze", lambda *a, **k: sv_result)
+    monkeypatch.setattr(gate.duplication, "analyze", lambda *a, **k: dup_result)
+
+
+def test_run_report_only_exit_0_even_with_findings(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(gate, "resolve_target", lambda o, r: str(tmp_path))
+    _patch_engines(
+        monkeypatch,
+        {"survival_by_age_days": {14: {"survival_pct": 90.0, "lines_old_enough": 500}}},
+        {"duplication_pct_lines": 20.0},
+    )
+    rc = gate.run(_args(workdir=str(tmp_path / "wd")))
+    assert rc == 0  # report-only NEVER blocks
+    out = capsys.readouterr().out
+    assert "report-only" in out
+
+
+def test_run_gate_blocks_only_on_past_ai(tmp_path, monkeypatch):
+    monkeypatch.setattr(gate, "resolve_target", lambda o, r: str(tmp_path))
+    _patch_engines(
+        monkeypatch,
+        {"survival_by_age_days": {14: {"survival_pct": 90.0, "lines_old_enough": 500}}},
+        {"duplication_pct_lines": 20.0},
+    )
+    rc = gate.run(_args(workdir=str(tmp_path / "wd"), report=False, gate=True))
+    assert rc == 1
+
+
+def test_run_gate_passes_when_healthy(tmp_path, monkeypatch):
+    monkeypatch.setattr(gate, "resolve_target", lambda o, r: str(tmp_path))
+    _patch_engines(
+        monkeypatch,
+        {"survival_by_age_days": {14: {"survival_pct": 98.0, "lines_old_enough": 500}}},
+        {"duplication_pct_lines": 4.0},
+    )
+    rc = gate.run(_args(workdir=str(tmp_path / "wd"), report=False, gate=True))
+    assert rc == 0
+
+
+def test_run_gate_does_not_block_on_skipped_tools(tmp_path, monkeypatch):
+    """A missing tool must never turn --gate into a false block."""
+    monkeypatch.setattr(gate, "resolve_target", lambda o, r: str(tmp_path))
+    _patch_engines(
+        monkeypatch,
+        {"skipped": "git-of-theseus not found"},
+        {"skipped": "jscpd/node not found"},
+    )
+    rc = gate.run(_args(workdir=str(tmp_path / "wd"), report=False, gate=True))
+    assert rc == 0
+
+
+# --- live tool-gated path (deterministic-ish, availability-gated) -----------
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.mark.skipif(
+    shutil.which("git-of-theseus-analyze") is None,
+    reason="git-of-theseus not installed on PATH",
+)
+def test_survival_live_young_repo_self_skips(tmp_path):
+    """A brand-new repo has < 14 days of history -> the gate reports too_young."""
+    repo = tmp_path / "young"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Ada")
+    _git(repo, "config", "user.email", "ada@example.com")
+    (repo / "a.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    env = {**os.environ}
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"],
+                   check=True, capture_output=True, text=True, env=env)
+    raw = gate.survival.analyze(str(repo), workdir=str(tmp_path / "s"))
+    sv = gate.evaluate_survival(raw)
+    # young repo: either the analyzer produced no 14-day-old lines (too_young)
+    # or the tool skipped — both are graceful, neither crashes.
+    assert sv["status"] in {"too_young", "skipped"}


### PR DESCRIPTION
## Closes #113  (re-opened — original #119 auto-closed when its stacked base branch was deleted after #115 merged; rebased cleanly onto main)

Adds **code-survival** (git-of-theseus 2-week churn) and **production duplication** (jscpd) as **report-only** signals in `/close-epic` — the metrics the literature uses to detect AI "slop." Rebased onto current main (post #115/#116/#120); the gate-rollout ledger and `close-epic.md` now carry the CI-scaffold (#111), ratchet-quality (#110), and this AI-slop step side by side.

- `scripts/quality_slop_gate.py`: `--report` default (exit 0) vs `--gate` (blocks only on a past-AI-band regression, off by default). Reports vs GitClear bands (survival pre-AI ~96.9% / AI ~94.3%; duplication 8.3% / 12.3%), `[VENDOR]`-labelled, DORA-corroborated.
- Graceful + honest: missing tools skip; <14-day-history repos surfaced as "too young", not a false pass.
- Verified: `pytest tests/test_quality_slop_gate.py` → 20 passed, 1 skipped; full suite **688 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
