### PR TITLE
Enforce the invariant-cluster model: check_patterns.py + backfill all clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ lint:
 	python3 -m ruff check scripts tests
 	python3 -m py_compile scripts/*.py scripts/extractors/*.py scripts/chief_wiggum/*.py
 	python3 scripts/check_portability.py
+	python3 scripts/check_patterns.py
 
 test:
 	python3 -m pytest

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -216,6 +216,14 @@ requirements" a copy-paste loses.
 > vibe. Declaring the cluster is the bar for `status: specified`, the same way
 > [declaring a success metric](#success-metrics-make-patterns-improvable) is.
 
+This bar is **mechanically enforced**, not trusted: `scripts/check_patterns.py`
+(wired into `make lint`, so it runs in CI) fails the build if any `specified`
+pattern lacks a non-empty invariant cluster, if an invariant id is malformed or
+duplicated within a pattern, if a `realized_as` provenance block is present but
+ill-formed, or if a `depends_on`/`feeds` reference dangles. A specified pattern
+that depends on a not-yet-specified candidate is reported as a *warning* (tracked
+debt), not an error — consistent with the smallest-first rollout.
+
 ## Success metrics make patterns improvable
 
 Every pattern **must declare its own success metrics** (`success_metrics` in the

--- a/patterns/deployment-release/manifest.json
+++ b/patterns/deployment-release/manifest.json
@@ -23,6 +23,18 @@
     "secret-containers-out-of-band-values: IaC creates secret containers + grants runtime read; values added out-of-band, never in state or repo"
   ],
 
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees; grounded in dogeared-coach CI/CD (terraform/cicd.tf + workflows).",
+    "cluster": [
+      {"id": "INV-DRL-001", "statement": "Keyless federated CI identity: CI mints a short-lived OIDC token scoped to the exact repo; no long-lived cloud key at rest.", "realized_as": {"app": "dogeared-coach", "code": "terraform/cicd.tf (WIF pool + provider)"}},
+      {"id": "INV-DRL-002", "statement": "Environment split: merge -> staging auto-deploys after the floor; production is a manual, human-gated promotion.", "realized_as": {"app": "dogeared-coach", "code": ".github/workflows/deploy-staging.yml + promote-prod.yml"}},
+      {"id": "INV-DRL-003", "statement": "Prod ships the byte-identical staged artifact (image retag/push, no rebuild); per-env rebuild is a documented fenced exception.", "realized_as": {"app": "dogeared-coach", "code": ".github/workflows/promote-prod.yml"}},
+      {"id": "INV-DRL-004", "statement": "Least-privilege deploy identity: rolls releases but cannot mutate infra or read secret values; infra is a separate human-run privileged path.", "realized_as": {"app": "dogeared-coach", "code": "terraform/cicd.tf (github-deployer SA: run.admin + AR.writer + actAs only)"}},
+      {"id": "INV-DRL-005", "statement": "Config-leak fence: a mechanical, fail-closed assertion that the artifact carries no lower-env config/secrets.", "realized_as": {"app": "dogeared-coach", "code": "ui bundle guard (greps dist/assets for wrong-env config)"}},
+      {"id": "INV-DRL-006", "statement": "Post-deploy smoke asserts liveness + core-dependency health before the release is considered live.", "realized_as": {"app": "dogeared-coach", "code": "/api/v1/healthz db:ok probe"}}
+    ]
+  },
+
   "parameters": {
     "ci_provider": {"type": "string", "required": true, "description": "CI system minting the OIDC identity."},
     "cloud": {"type": "string", "required": true, "description": "Target cloud."},

--- a/patterns/engagement-instrumentation/manifest.json
+++ b/patterns/engagement-instrumentation/manifest.json
@@ -19,6 +19,19 @@
     "dual-scope-audit-log: append-only tenant-scoped + system-global event trails"
   ],
 
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees; grounded in dogeared-coach adherence-tracking (INV-WP-*) + friction emit-only invariants.",
+    "cluster": [
+      {"id": "INV-EIN-001", "statement": "Progress is monotonic — a tracked value never decreases.", "realized_as": {"app": "dogeared-coach", "id": "INV-WP-001"}},
+      {"id": "INV-EIN-002", "statement": "Completion is a one-way latch: once tripped past the threshold it never un-completes.", "realized_as": {"app": "dogeared-coach", "id": "INV-WP-002"}},
+      {"id": "INV-EIN-003", "statement": "pct/denominator is computed only from server-trusted durations; client-supplied duration is advisory.", "realized_as": {"app": "dogeared-coach", "id": "INV-WP-003"}},
+      {"id": "INV-EIN-004", "statement": "Robust to out-of-order / replay / concurrent / clock-drift: one idempotent, collision-free-keyed upsert per (assignment, item).", "realized_as": {"app": "dogeared-coach", "id": "INV-WP-008"}},
+      {"id": "INV-EIN-005", "statement": "Instrumentation never alters the observed outcome: emit-only, no-outcome, no-latency — emitted after the response, gated on the mutation's applied flag.", "realized_as": {"app": "dogeared-coach", "code": "handlers/webhook.go:200-265 (INV-FE emit-only/no-outcome/no-latency)"}},
+      {"id": "INV-EIN-006", "statement": "Anti-probe on the write path; preview/read paths never write progress.", "realized_as": {"app": "dogeared-coach", "id": "INV-WP-005/006"}},
+      {"id": "INV-EIN-007", "statement": "Every captured signal is annotated with its trust class (trusted vs untrusted origin) so the loop can't optimize against a gameable proxy."}
+    ]
+  },
+
   "parameters": {
     "work_item": {"type": "string", "required": true, "description": "The entity whose engagement is tracked."},
     "completion_threshold": {"type": "number", "required": true, "description": "Fraction past which the one-way completed latch trips."},

--- a/patterns/frictionless-onboarding/manifest.json
+++ b/patterns/frictionless-onboarding/manifest.json
@@ -21,6 +21,16 @@
     "recovery-loops: activation nudges + failed-payment dunning via transactional-email-and-dunning"
   ],
 
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees. Mostly design-derived (a growth pattern is more policy than mechanism); INV-FON-003 is grounded in dogeared-coach's bounded Free caps.",
+    "cluster": [
+      {"id": "INV-FON-001", "statement": "Value-first free tier: a user reaches a complete unit of value without payment or a credit card."},
+      {"id": "INV-FON-002", "statement": "Upgrade prompts fire at contextual friction points (a limit-hit 409 / locked-capability tap is the trigger), not time-based nags or generic interstitials."},
+      {"id": "INV-FON-003", "statement": "The free tier is a bounded loss-leader: its caps bound per-user cost so free usage can never be unbounded.", "realized_as": {"app": "dogeared-coach", "code": "services/plan.go Free caps (3 videos / 5-min / 10 clients)"}},
+      {"id": "INV-FON-004", "statement": "Conversion changes are end-user-signal-driven and touch pricing/paywall, so they are admin-gated -- never autonomously deployed."}
+    ]
+  },
+
   "parameters": {
     "activation_event": {"type": "string", "required": true, "description": "The instrumented aha moment (funnel success step)."},
     "free_tier_value_unit": {"type": "string", "required": true, "description": "The complete unit of value the free tier delivers."},

--- a/patterns/improvement-loop/manifest.json
+++ b/patterns/improvement-loop/manifest.json
@@ -12,6 +12,17 @@
     "editable surfaces (prompts/config/code) are separable from goalposts (objective/guardrails/gate)"
   ],
 
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees. INV-IMP-002/003 are grounded in chief-wiggum's OWN ratchet (the loop already runs on CW itself); the trust-model invariants are design-derived (see the trust_model block below).",
+    "cluster": [
+      {"id": "INV-IMP-001", "statement": "Every heterogeneous signal is normalized to a uniform, pointer-only, idempotent Finding carrying its source trust class."},
+      {"id": "INV-IMP-002", "statement": "Quality ratchets, never slides: the ever-passed high-water mark may not shrink; enforced by an append-only hash-chained journal that fails closed (tamper-evident).", "realized_as": {"app": "chief-wiggum", "code": "scripts/ratchet.py; docs/ratchet.md"}},
+      {"id": "INV-IMP-003", "statement": "Changes touching a protected path are park-and-notify: goalposts (objective/guardrails/gate) are always human-reviewed, never auto-moved.", "realized_as": {"app": "chief-wiggum", "code": "docs/ratchet.md (workers can't touch contracts/specs/ratchet state)"}},
+      {"id": "INV-IMP-004", "statement": "Any change derived from an untrusted signal is quarantined for BLOCKING admin approval before it can enter the deployable set (an untrusted-derived change can at worst become a proposal in quarantine)."},
+      {"id": "INV-IMP-005", "statement": "Admin approval is verified against a real authority (CODEOWNERS / signed commit / operator allowlist), not self-asserted by the loop, and is appended to the tamper-evident journal."}
+    ]
+  },
+
   "parameters": {
     "signal_sources": {
       "type": "array",

--- a/patterns/tiered-subscription/manifest.json
+++ b/patterns/tiered-subscription/manifest.json
@@ -21,6 +21,17 @@
     "graceful-degradation: past_due -> dunning grace window; cancel/expire -> free-tier or read-only, never hard-delete; over-cap downgrade -> block-new keep-existing"
   ],
 
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees; grounded in dogeared-coach (services/plan.go + billing).",
+    "cluster": [
+      {"id": "INV-TSB-001", "statement": "Single-source tier matrix: one structure holds every tier's caps/flags; -1 unlimited sentinel; unknown/empty tier -> most-restrictive fallback, never a silent higher grant.", "realized_as": {"app": "dogeared-coach", "id": "INV-ADM-010", "code": "services/plan.go LimitsFor"}},
+      {"id": "INV-TSB-002", "statement": "Enforced at every mutating action via injected gate seams; limits gate CREATION, never deletion (grandfathered-frozen).", "realized_as": {"app": "dogeared-coach", "id": "INV-ADM-011/012/014", "code": "services/plan.go enforcement seams"}},
+      {"id": "INV-TSB-003", "statement": "Billing webhook (not the client redirect) is the authoritative subscription state.", "realized_as": {"app": "dogeared-coach", "id": "INV-BIL-001/003"}},
+      {"id": "INV-TSB-004", "statement": "Entitlement recomputed per lifecycle transition: upgrade immediate/prorated; downgrade/cancel preserve access until period end.", "realized_as": {"app": "dogeared-coach", "id": "INV-BIL-004"}},
+      {"id": "INV-TSB-005", "statement": "Non-destructive degradation: past_due -> grace; cancel/expire -> free/read-only, never hard-delete; over-cap downgrade blocks-new keeps-existing.", "realized_as": {"app": "dogeared-coach", "id": "INV-BIL-005"}}
+    ]
+  },
+
   "parameters": {
     "tiers": {"type": "array", "required": true, "description": "Tier ids in ascending order."},
     "matrix": {"type": "object", "required": true, "description": "Per-tier capability/limit matrix; -1 = unlimited."},

--- a/scripts/check_patterns.py
+++ b/scripts/check_patterns.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Validate the pattern registry and enforce the invariant-cluster model.
+
+The registry (`patterns/registry.json` + each `patterns/<id>/manifest.json`) models
+patterns as clusters of invariants (see docs/patterns-registry.md#patterns-as-clusters-of-invariants).
+This linter makes the model's rules mechanical rather than trusted:
+
+  1. registry.json + every referenced manifest parse, and the manifest `id`
+     matches both the registry entry and its directory name.
+  2. The bar for `status: specified`: the manifest declares a NON-EMPTY invariant
+     cluster, and every entry has a well-formed `id` + non-empty `statement`.
+     (`realized_as` provenance is OPTIONAL — an invariant may be design-derived —
+     but when present it must name an `app` plus `code` or `id`.)
+  3. Invariant ids are well-formed (`INV-<ABBR>-<SEQ>`) and unique within a pattern.
+  4. Cross-references (`depends_on` / `feeds`) resolve to known ids, and no
+     specified pattern depends on a mere candidate (a dangling floor).
+
+Run report-only:   python3 scripts/check_patterns.py
+Errors exit 1 (wired into `make lint`); warnings are reported but do not fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PATTERNS_DIR = ROOT / "patterns"
+REGISTRY = PATTERNS_DIR / "registry.json"
+
+# Generic invariant id: INV-<ABBR>-<SEQ>, uppercase. SEQ allows a leading letter
+# (e.g. the sibling branch id INV-FOWR-M1) and digits.
+ID_RE = re.compile(r"^INV-[A-Z]+-[A-Z]?[0-9]+$")
+
+ERROR = "error"
+WARN = "warn"
+
+
+@dataclass
+class Finding:
+    severity: str
+    where: str
+    message: str
+
+    def __str__(self) -> str:
+        tag = "ERROR" if self.severity == ERROR else "warn "
+        return f"  [{tag}] {self.where}: {self.message}"
+
+
+def _load_json(path: Path, where: str, findings: list[Finding]):
+    """Return parsed JSON or None (appending an error finding on failure)."""
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        findings.append(Finding(ERROR, where, f"file not found: {path}"))
+    except json.JSONDecodeError as exc:
+        findings.append(Finding(ERROR, where, f"invalid JSON: {exc}"))
+    return None
+
+
+def cluster_entries(invariants) -> list:
+    """Flatten a manifest/candidate `invariants` value into a list of entries.
+
+    Accepts either a bare list (candidate inline form) or a dict with `cluster`
+    plus an optional `sibling_*` branch that also carries a `cluster`.
+    """
+    if isinstance(invariants, list):
+        return list(invariants)
+    if isinstance(invariants, dict):
+        entries = list(invariants.get("cluster", []))
+        for key, val in invariants.items():
+            if key.startswith("sibling") and isinstance(val, dict):
+                entries.extend(val.get("cluster", []))
+        return entries
+    return []
+
+
+def validate_cluster(entries: list, where: str, findings: list[Finding]) -> None:
+    seen: set[str] = set()
+    for i, entry in enumerate(entries):
+        loc = f"{where}[{i}]"
+        if not isinstance(entry, dict):
+            findings.append(Finding(ERROR, loc, "invariant entry must be an object"))
+            continue
+        cid = entry.get("id", "")
+        if not cid:
+            findings.append(Finding(ERROR, loc, "invariant missing `id`"))
+        elif not ID_RE.match(cid):
+            findings.append(Finding(ERROR, loc, f"malformed invariant id: {cid!r} (want INV-ABBR-SEQ)"))
+        elif cid in seen:
+            findings.append(Finding(ERROR, loc, f"duplicate invariant id within pattern: {cid}"))
+        else:
+            seen.add(cid)
+        if not str(entry.get("statement", "")).strip():
+            findings.append(Finding(ERROR, loc, f"invariant {cid or '?'} missing `statement`"))
+        ra = entry.get("realized_as")
+        if ra is not None:  # provenance is optional, but well-formed when present
+            if not isinstance(ra, dict) or not ra.get("app") or not (ra.get("code") or ra.get("id")):
+                findings.append(Finding(ERROR, loc, f"invariant {cid or '?'} `realized_as` needs `app` plus `code` or `id`"))
+
+
+def _refs(value) -> list[str]:
+    """Parse a comma-joined ref string (registry index form) into ids."""
+    if isinstance(value, str):
+        return [r.strip() for r in value.split(",") if r.strip()]
+    if isinstance(value, dict):
+        return list(value.keys())
+    return []
+
+
+def validate(registry_path: Path = REGISTRY) -> list[Finding]:
+    findings: list[Finding] = []
+    reg = _load_json(registry_path, "registry.json", findings)
+    if reg is None:
+        return findings
+    # Resolve spec/manifest paths relative to the registry's repo root
+    # (patterns/registry.json -> repo root), so the linter is testable on a
+    # fixture registry, not just the real one.
+    base = registry_path.resolve().parent.parent
+
+    specified = reg.get("patterns", [])
+    candidates = reg.get("candidates", [])
+    known_ids = {e.get("id") for e in specified + candidates if e.get("id")}
+    candidate_ids = {e.get("id") for e in candidates if e.get("id")}
+
+    for entry in specified:
+        pid = entry.get("id", "?")
+        where = f"patterns/{pid}"
+        if entry.get("status") != "specified":
+            findings.append(Finding(WARN, where, f"listed under patterns[] but status={entry.get('status')!r}"))
+
+        man_rel = entry.get("manifest")
+        if not man_rel or not entry.get("spec"):
+            findings.append(Finding(ERROR, where, "registry entry missing `spec` and/or `manifest` path"))
+            continue
+        spec_path = base / entry["spec"]
+        if not spec_path.exists():
+            findings.append(Finding(ERROR, where, f"spec file missing: {entry['spec']}"))
+        man_path = base / man_rel
+        manifest = _load_json(man_path, f"{where} (manifest)", findings)
+        if manifest is None:
+            continue
+
+        if manifest.get("id") != pid:
+            findings.append(Finding(ERROR, where, f"manifest id {manifest.get('id')!r} != registry id {pid!r}"))
+        if man_path.parent.name != pid:
+            findings.append(Finding(ERROR, where, f"manifest directory {man_path.parent.name!r} != id {pid!r}"))
+
+        entries = cluster_entries(manifest.get("invariants"))
+        if not entries:
+            findings.append(Finding(
+                ERROR, where,
+                "specified pattern must declare a non-empty invariant cluster "
+                "(the bar for status: specified)"))
+        else:
+            validate_cluster(entries, f"{where}.invariants.cluster", findings)
+
+        for dep in _refs(entry.get("depends_on")) + _refs(manifest.get("depends_on")):
+            if dep not in known_ids:
+                findings.append(Finding(ERROR, where, f"depends_on unknown pattern id: {dep}"))
+            elif dep in candidate_ids:
+                findings.append(Finding(WARN, where, f"specified pattern depends_on a candidate (not-yet-specified floor): {dep}"))
+        for fed in _refs(entry.get("feeds")):
+            if fed not in known_ids:
+                findings.append(Finding(ERROR, where, f"feeds unknown pattern id: {fed}"))
+
+    for entry in candidates:
+        cid = entry.get("id", "?")
+        inv = entry.get("invariants")
+        if inv is not None:
+            validate_cluster(cluster_entries(inv), f"candidates/{cid}.invariants", findings)
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the pattern registry / invariant-cluster model.")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--registry", type=Path, default=REGISTRY, help="registry.json path (for testing)")
+    args = parser.parse_args()
+
+    findings = validate(args.registry)
+    errors = [f for f in findings if f.severity == ERROR]
+    warns = [f for f in findings if f.severity == WARN]
+
+    if args.format == "json":
+        print(json.dumps([f.__dict__ for f in findings], indent=2))
+    else:
+        if not findings:
+            print("check_patterns: registry OK — invariant-cluster model holds.")
+        else:
+            print(f"check_patterns: {len(errors)} error(s), {len(warns)} warning(s)")
+            for f in findings:
+                print(f)
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -1,0 +1,156 @@
+"""Tests for scripts/check_patterns.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import check_patterns  # noqa: E402
+
+ERRORS = check_patterns.ERROR
+
+
+def _errors(findings):
+    return [f for f in findings if f.severity == check_patterns.ERROR]
+
+
+def _write(tmp_path, registry, manifests=None):
+    """Materialize a fake registry + manifests under tmp_path/patterns."""
+    pdir = tmp_path / "patterns"
+    pdir.mkdir(exist_ok=True)
+    (pdir / "registry.json").write_text(json.dumps(registry))
+    for pid, manifest in (manifests or {}).items():
+        d = pdir / pid
+        d.mkdir(exist_ok=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+        (d / "pattern.md").write_text(f"# {pid}\n")
+    return pdir / "registry.json"
+
+
+def _specified(pid, **extra):
+    entry = {"id": pid, "status": "specified",
+             "spec": f"patterns/{pid}/pattern.md",
+             "manifest": f"patterns/{pid}/manifest.json"}
+    entry.update(extra)
+    return entry
+
+
+def _manifest(pid, cluster=None, **extra):
+    m = {"id": pid, "title": pid}
+    if cluster is not None:
+        m["invariants"] = {"cluster": cluster}
+    m.update(extra)
+    return m
+
+
+GOOD_INV = {"id": "INV-XYZ-001", "statement": "must stay true"}
+
+
+# --- the real registry must pass -------------------------------------------
+
+def test_real_registry_has_no_errors():
+    """The shipped registry satisfies the invariant-cluster model."""
+    findings = check_patterns.validate()
+    assert _errors(findings) == [], "\n".join(str(f) for f in _errors(findings))
+
+
+def test_cli_exit_zero_on_real_registry():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "check_patterns.py")],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# --- the bar for `specified` ------------------------------------------------
+
+def test_specified_without_cluster_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo")})  # no cluster
+    errs = _errors(check_patterns.validate(path))
+    assert any("non-empty invariant cluster" in e.message for e in errs)
+
+
+def test_specified_with_cluster_passes(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert _errors(check_patterns.validate(path)) == []
+
+
+# --- cluster entry validation ----------------------------------------------
+
+def test_malformed_invariant_id_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    bad = [{"id": "inv-lowercase-1", "statement": "x"}]
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=bad)})
+    assert any("malformed invariant id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_duplicate_invariant_id_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    dup = [dict(GOOD_INV), dict(GOOD_INV)]
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=dup)})
+    assert any("duplicate invariant id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_missing_statement_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[{"id": "INV-XYZ-001"}])})
+    assert any("missing `statement`" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_realized_as_is_optional(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert _errors(check_patterns.validate(path)) == []
+
+
+def test_malformed_realized_as_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    bad = [{"id": "INV-XYZ-001", "statement": "x", "realized_as": {"app": "a"}}]  # no code/id
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=bad)})
+    assert any("realized_as" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_sibling_branch_cluster_is_validated(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    manifest = _manifest("foo", cluster=[GOOD_INV])
+    manifest["invariants"]["sibling_monotonic_branch"] = {"cluster": [{"id": "bad", "statement": "x"}]}
+    path = _write(tmp_path, reg, {"foo": manifest})
+    assert any("malformed invariant id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+# --- cross-reference integrity ---------------------------------------------
+
+def test_unknown_dependency_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo", depends_on="ghost")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert any("depends_on unknown" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_specified_depends_on_candidate_is_warning_not_error(tmp_path):
+    reg = {
+        "patterns": [_specified("foo", depends_on="floor")],
+        "candidates": [{"id": "floor", "status": "candidate"}],
+    }
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    findings = check_patterns.validate(path)
+    assert _errors(findings) == []
+    assert any(f.severity == check_patterns.WARN and "not-yet-specified floor" in f.message for f in findings)
+
+
+def test_manifest_id_mismatch_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("bar", cluster=[GOOD_INV])})
+    assert any("!= registry id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_candidate_malformed_cluster_is_error(tmp_path):
+    reg = {
+        "patterns": [],
+        "candidates": [{"id": "cand", "invariants": [{"id": "nope", "statement": "x"}]}],
+    }
+    path = _write(tmp_path, reg, {})
+    assert any("malformed invariant id" in e.message for e in _errors(check_patterns.validate(path)))


### PR DESCRIPTION
## What

Turns the invariant-cluster model from a convention into a **mechanical gate** —
CW's "mechanical, not trusted" discipline applied to its own pattern registry. The
line the previous PR wrote ("declaring the cluster is the bar for `status:
specified`") is now enforced in CI instead of hoped-for.

## `scripts/check_patterns.py`

A registry linter (wired into `make lint`, so it runs on every CI build). It fails
the build when:
- a `specified` pattern lacks a **non-empty invariant cluster** (the bar);
- an invariant `id` is malformed (`INV-<ABBR>-<SEQ>`) or duplicated within a pattern;
- a `realized_as` provenance block is present but ill-formed (needs `app` + `code`/`id`);
- a manifest `id` / directory disagrees with the registry, or a spec/manifest file is missing;
- a `depends_on` / `feeds` reference dangles.

A specified→candidate dependency is a **warning** (tracked debt), not an error —
consistent with the smallest-first rollout. Report-only by default (exits 1 only on
errors). `realized_as` is deliberately **optional**: an invariant may be
design-derived, so the bar is "can you state what must stay true", and provenance
is added when mined.

## Backfilled all 5 pre-existing clusters

The 5 patterns that predate the cluster model now clear the bar, grounded in real
code where it exists and honest design-derived statements where it doesn't:

| Pattern | Cluster | Grounding |
|--|--|--|
| `tiered-subscription` | INV-TSB-001..005 | dogeared-coach `plan.go` + `INV-BIL/ADM-*` |
| `engagement-instrumentation` | INV-EIN-001..007 | dogeared-coach adherence `INV-WP-*` + friction emit-only |
| `deployment-release` | INV-DRL-001..006 | dogeared-coach `terraform/cicd.tf` + workflows |
| `frictionless-onboarding` | INV-FON-001..004 | mostly design-derived; Free-caps grounded |
| `improvement-loop` | INV-IMP-001..005 | CW's own ratchet (`scripts/ratchet.py`) + trust model |

**All 9 specified patterns now declare a cluster.**

## Tests / checks
- `tests/test_check_patterns.py` — 14 tests (the real registry passes; fixture
  registries exercise every rule).
- `make lint` green (validator: 0 errors, 1 warning — the tracked
  `deployment-release → build-test-floor` candidate dep).
- `make test` green: 702 passed, 4 skipped.
