### PR TITLE
Make the registry index uniform: invariants summary on all specified entries

### DIFF
--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -10,6 +10,7 @@
       "status": "specified",
       "trust_class": "trust-aware",
       "summary": "Autonomous, signal-driven, ratchet-gated fix-forward refinement installed into the product. Trusted-signal changes deploy autonomously; untrusted-signal (end-user) changes quarantine for blocking admin approval.",
+      "invariants": "INV-IMP-001..005",
       "spec": "patterns/improvement-loop/pattern.md",
       "manifest": "patterns/improvement-loop/manifest.json"
     },
@@ -21,6 +22,7 @@
       "trust_class": "produces-trust-tagged-signal",
       "summary": "Server-trusted, tamper-resistant capture of how far users get through assigned work/content, robust to out-of-order/replay/concurrent/clock-drift. The instrumentation tier that feeds the improvement loop; each signal annotated with its trust class.",
       "feeds": "improvement-loop",
+      "invariants": "INV-EIN-001..007",
       "spec": "patterns/engagement-instrumentation/pattern.md",
       "manifest": "patterns/engagement-instrumentation/manifest.json"
     },
@@ -32,6 +34,7 @@
       "trust_class": "entitlement-changes-are-protected-path",
       "summary": "Subscribe -> enforce -> lifecycle machinery for a plan-tiered SaaS: single-source tier matrix, injected gate seams, stateless quota, billing-webhook as source of truth, and non-destructive graceful degradation on downgrade/lapse. Absorbs the former tiered-saas-enforcement candidate.",
       "feeds": "frictionless-onboarding, improvement-loop",
+      "invariants": "INV-TSB-001..005",
       "spec": "patterns/tiered-subscription/pattern.md",
       "manifest": "patterns/tiered-subscription/manifest.json"
     },
@@ -44,6 +47,7 @@
       "summary": "Minimize time-to-value on a free tier, convert at contextual friction points (limit-hit prompts, optional reverse trial), self-serve. The mini-SaaS pattern most improved by the loop -- and, since its proposals touch pricing/paywall driven by end-user behavior, always admin-gated.",
       "depends_on": "tiered-subscription, engagement-instrumentation",
       "feeds": "improvement-loop",
+      "invariants": "INV-FON-001..004",
       "spec": "patterns/frictionless-onboarding/pattern.md",
       "manifest": "patterns/frictionless-onboarding/manifest.json"
     },
@@ -55,6 +59,7 @@
       "trust_class": "deploy-pipeline-and-promotion-authority-are-protected-path",
       "summary": "build -> stage -> promote machinery that gets a change to prod safely and provably: keyless federated CI identity, environment split with a human-gated prod promotion, promotion of the byte-identical staged artifact, a config-leak fence, a least-privilege deploy identity that can roll releases but not mutate infra/read secrets, and post-deploy smoke verification. Mined from two shipped GCP apps.",
       "feeds": "improvement-loop",
+      "invariants": "INV-DRL-001..006",
       "spec": "patterns/deployment-release/pattern.md",
       "manifest": "patterns/deployment-release/manifest.json"
     },

--- a/scripts/check_patterns.py
+++ b/scripts/check_patterns.py
@@ -14,6 +14,9 @@ This linter makes the model's rules mechanical rather than trusted:
   3. Invariant ids are well-formed (`INV-<ABBR>-<SEQ>`) and unique within a pattern.
   4. Cross-references (`depends_on` / `feeds`) resolve to known ids, and no
      specified pattern depends on a mere candidate (a dangling floor).
+  5. Every specified index entry carries an `invariants` summary string, keeping
+     the registry index uniform with the manifests (so you can list clusters
+     without opening each manifest).
 
 Run report-only:   python3 scripts/check_patterns.py
 Errors exit 1 (wired into `make lint`); warnings are reported but do not fail.
@@ -149,6 +152,12 @@ def validate(registry_path: Path = REGISTRY) -> list[Finding]:
             findings.append(Finding(ERROR, where, f"manifest id {manifest.get('id')!r} != registry id {pid!r}"))
         if man_path.parent.name != pid:
             findings.append(Finding(ERROR, where, f"manifest directory {man_path.parent.name!r} != id {pid!r}"))
+
+        if not str(entry.get("invariants", "")).strip():
+            findings.append(Finding(
+                ERROR, where,
+                "registry index entry missing `invariants` summary string "
+                "(keep the index uniform with the manifest cluster)"))
 
         entries = cluster_entries(manifest.get("invariants"))
         if not entries:

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -32,6 +32,7 @@ def _write(tmp_path, registry, manifests=None):
 
 def _specified(pid, **extra):
     entry = {"id": pid, "status": "specified",
+             "invariants": "INV-XYZ-001",
              "spec": f"patterns/{pid}/pattern.md",
              "manifest": f"patterns/{pid}/manifest.json"}
     entry.update(extra)
@@ -139,6 +140,18 @@ def test_specified_depends_on_candidate_is_warning_not_error(tmp_path):
     findings = check_patterns.validate(path)
     assert _errors(findings) == []
     assert any(f.severity == check_patterns.WARN and "not-yet-specified floor" in f.message for f in findings)
+
+
+def test_specified_missing_index_invariants_summary_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo", invariants="")], "candidates": []}  # index entry lacks the summary
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert any("index entry missing `invariants` summary" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_specified_with_index_summary_passes(tmp_path):
+    reg = {"patterns": [_specified("foo", invariants="INV-XYZ-001")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert _errors(check_patterns.validate(path)) == []
 
 
 def test_manifest_id_mismatch_is_error(tmp_path):


### PR DESCRIPTION
## Polish

The 4 newest specified patterns carried an `invariants` summary string in the
registry *index* (e.g. `"invariants": "INV-FOWR-001..008"`); the 5 backfilled ones
only had the cluster in their manifests. This makes the index uniform:

- Adds the summary to all 5: `INV-IMP-001..005`, `INV-EIN-001..007`,
  `INV-TSB-001..005`, `INV-FON-001..004`, `INV-DRL-001..006`. Now you can list
  every pattern's cluster range without opening a manifest.
- `check_patterns.py` now **requires** the `invariants` summary on every specified
  index entry, so the uniformity can't rot as new patterns are added.
- +2 tests (16 total).

Validator: 0 errors, 1 tracked warning (`deployment-release → build-test-floor`).
Pure polish — no behavior change to any pattern.
