### PR TITLE
/apply-pattern installer: stamp a pattern's invariant-cluster contract pack into a target repo

### DIFF
--- a/.claude/commands/apply-pattern.md
+++ b/.claude/commands/apply-pattern.md
@@ -1,0 +1,77 @@
+# Apply Pattern — Install a Registry Pattern's Contract Pack
+
+Installs a specified registry pattern's **invariant cluster** (its contract pack) into a target repo, so `/architect` can fold the connected requirements in by stable id instead of re-deriving them. See `docs/patterns-registry.md`.
+
+This installs the **contract pack** (invariant cluster + adoption record + protected-path registration), not code — scaffold stamping is deferred until patterns ship a `scaffold/`.
+
+## When to use
+
+- During product/epic design, once you've chosen which registry patterns a product realizes (the `/seed` "select" moment).
+- Before `/architect`, so the epic's `invariants.md` is folded from a real cluster rather than invented.
+
+## Usage
+
+```
+/apply-pattern <owner/repo> --pattern <id> [--param k=v]... [--dry-run]
+```
+
+## Parameters
+
+- `owner/repo`: Target GitHub repository (resolved + cloned via `repo.py`).
+- `--pattern <id>`: A `status: specified` pattern id from `patterns/registry.json`.
+- `--param k=v`: Bind a pattern parameter (repeatable). Unbound **required** params are written as `TBD:` markers.
+- `--dry-run`: Print the plan without writing.
+
+## Autonomy
+
+Run to completion. The one judgement call is **parameter binding** — resolve each parameter from the target repo's context where you can (its billing vendor, its tenant key, its build command); leave the rest as `TBD:` for a human. Never guess a required parameter — a `TBD:` that the unresolved gate catches is correct; a wrong guess is not.
+
+---
+
+## Workflow
+
+### Step 1: Resolve paths
+
+```bash
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+```
+
+### Step 2: Pick the pattern and inspect its cluster
+
+List specified patterns and read the chosen one's manifest so you know its parameters and invariant cluster:
+
+```bash
+python3 -c "import json; d=json.load(open('$CW_HOME/patterns/registry.json')); [print(p['id'], '—', p.get('invariants','')) for p in d['patterns']]"
+cat "$CW_HOME/patterns/<id>/manifest.json"
+```
+
+If the id is a **candidate** (not specified), stop: it has no manifest to install. Offer to specify it first.
+
+### Step 3: Bind parameters from the target repo
+
+Read `manifest.json`'s `parameters`. For each, resolve a value from the **target repo's** context (grep its config, its stack, its build commands). Assemble `--param k=v` flags for what you can confidently bind; leave required params you can't confirm unbound (they become `TBD:`).
+
+### Step 4: Install
+
+```bash
+python3 "$CW_HOME/scripts/apply_pattern.py" <id> \
+  --target-dir "$TARGET_REPO" \
+  --param resource=subscription --param projected_field=plan   # example
+```
+
+Dry-run first (`--dry-run`) to preview. This writes, in the target repo:
+- `docs/patterns/<id>/invariants.md` — the cluster as a stable-id contract pack.
+- `docs/patterns/adopted.json` — the adoption record (id, version, bound params, provenance, cluster ids).
+- registers `docs/patterns/**` into `docs/quality/ratchet.json` protected paths.
+
+### Step 5: Verify and hand off
+
+Confirm the unresolved gate sees any `TBD:` markers (so dependent work can't build on a guess):
+
+```bash
+python3 "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/patterns/<id>/invariants.md"
+```
+
+Then report the adopted cluster and point the user at the next step: **`/architect`** folds this cluster into the epic's `invariants.md` by stable id, and the traceability / single-writer / ratchet gates hold it from there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 /create-issue owner/repo        # Create a GitHub issue
 /seed owner/repo                # Architecture brainstorm & issue seeding
 /design owner/repo              # Product design: mockups → human choice → docs/design/
+/apply-pattern owner/repo --pattern <id>  # Install a registry pattern's invariant-cluster contract pack
 
 # Epic flow (the core loop)
 /plan-epic owner/repo           # Group issues into epic with dependency graph

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -88,32 +88,36 @@ filter patterns without opening each manifest. It also carries **candidates**
 (patterns mined but not yet fully specified) and **meta-disciplines** (recurring
 cross-pattern rules — fail-closed, idempotency, injected seams, documented TOCTOU).
 
-## How a pattern gets applied (proposed `/apply-pattern`)
+## How a pattern gets applied (`/apply-pattern`)
 
-A pattern is installed into a target repo by a new thin workflow (or a mode of
-`/architect`):
+A pattern is installed into a target repo by a thin workflow
+(`.claude/commands/apply-pattern.md` → `scripts/apply_pattern.py`):
 
 ```
-/apply-pattern owner/repo --pattern improvement-loop
+/apply-pattern owner/repo --pattern fetch-on-webhook-reconcile --param resource=subscription
 ```
 
-Mechanically:
+Mechanically — the **contract-pack** steps (1, 2, 4, 5) are **built**; scaffold
+stamping (3) is deferred until patterns ship a `scaffold/`:
 
-1. **Resolve** the target repo (`scripts/repo.py`, as every workflow does).
+1. **Resolve** the target repo (`scripts/repo.py`, as every workflow does). ✅
 2. **Bind parameters** — read `manifest.json`'s parameter schema and resolve each
    from the target app's context (its signal sources, its build/test commands,
-   its model family, its protected paths). Unresolved facts become `TBD:`
-   markers, gated exactly like every other CW artifact
-   (`scripts/check_unresolved.py`).
-3. **Stamp** the scaffold into the target repo with parameters bound.
-4. **Register protected paths** — add the pattern's `protected_paths` to the
-   product's `docs/quality/ratchet.json`, so the pattern's own guards/objective
-   become goalposts the app's autonomous machinery cannot move
-   (reuses the existing [ratchet](ratchet.md)).
+   its model family, its protected paths). Unresolved **required** params become
+   `TBD:` markers in the installed contract pack, gated exactly like every other
+   CW artifact (`scripts/check_unresolved.py`). ✅
+3. **Stamp** the scaffold into the target repo with parameters bound. ⏳ *(deferred
+   — no pattern ships a `scaffold/` yet.)*
+4. **Register protected paths** — add `docs/patterns/**` (the installed contract
+   pack) to the product's `docs/quality/ratchet.json`, so the adopted cluster
+   becomes a goalpost the app's autonomous machinery cannot move (reuses the
+   existing [ratchet](ratchet.md)). The manifest's prose `protected_paths` are
+   recorded in the adoption record as *intents* for a human to map to real code
+   paths. ✅
 5. **Record adoption** — write `docs/patterns/adopted.json` in the target repo
-   with the pattern id, version, bound parameters, and provenance. This is the
-   product's manifest of "which CW patterns am I running, and how were they
-   configured".
+   with the pattern id, version, bound parameters, cluster ids, and provenance,
+   plus `docs/patterns/<id>/invariants.md` — the invariant cluster as a stable-id
+   contract pack `/architect` folds into the epic's `invariants.md`. ✅
 
 Patterns are **project-agnostic** and installed by *value* into the target — the
 same principle as every other CW skill. CW never hardcodes the target's
@@ -516,18 +520,19 @@ frictionless autonomous mode with no quarantine gate.
 
 ## Rollout
 
-Proposed, smallest-first:
+Smallest-first. Progress so far:
 
-1. **This PR** — the registry structure + pattern #1 captured as a spec
-   (`pattern.md` + `manifest.json`) + this design doc. No workflow wiring yet.
-2. **`/apply-pattern` skill** — the thin installer described above, plus the
-   `scaffold/` for pattern #1 (the generic loop skill + scripts, with the
-   trust/quarantine gate added).
-3. **`/seed` + `/architect` integration** — pattern *selection* becomes part of
-   product design: the architecture stage proposes applicable patterns and
-   records the choice, the way `/design` records a chosen design direction.
-4. **Fill the backlog** — capture the standalone candidate patterns above as
-   their own entries.
-
-Steps 2–4 are deliberately out of scope here — this PR is about *starting to
-capture*, with one real, fully-specified entry to prove the shape.
+1. ✅ **Registry structure** + the invariant-cluster model, with 9 specified
+   patterns (`pattern.md` + `manifest.json` each) mined + grounded, and
+   `check_patterns.py` enforcing the model in CI.
+2. 🟡 **`/apply-pattern` skill** — the thin **contract-pack** installer is built
+   (`scripts/apply_pattern.py` + `.claude/commands/apply-pattern.md`): binds
+   params, stamps the invariant cluster + adoption record, registers protected
+   paths. The pattern `scaffold/` (stamping code, not just contracts) is still to
+   come.
+3. ⏳ **`/seed` + `/architect` integration** — pattern *selection* becomes part of
+   product design: the architecture stage proposes applicable patterns and records
+   the choice, the way `/design` records a chosen design direction; `/architect`
+   folds an adopted cluster into the epic's `invariants.md` by stable id.
+4. ⏳ **Fill the backlog** — capture the remaining candidate patterns as their own
+   entries.

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Install a registry pattern's *contract pack* into a target repo.
+
+A registry pattern is, first, a cluster of invariants plus the parameters and
+protected paths that make it real (see docs/patterns-registry.md). This installer
+does the mechanical, scaffold-independent half of `/apply-pattern`:
+
+  1. Loads the pattern manifest (must be `status: specified`).
+  2. Binds parameters from `--param k=v`; any unbound REQUIRED parameter becomes a
+     `TBD:` marker so `check_unresolved.py` blocks dependent work on a guess.
+  3. Stamps the invariant cluster into the target as a contract-pack doc
+     (`docs/patterns/<id>/invariants.md`) with stable ids, ready for `/architect`
+     to fold into an epic's `invariants.md`.
+  4. Records the adoption in `docs/patterns/adopted.json` (id, version, provenance,
+     bound params, cluster ids, protected-path intents).
+  5. Registers `docs/patterns/**` into the target's `docs/quality/ratchet.json`
+     protected paths, so the adopted contract pack becomes a goalpost workers
+     can't move.
+
+Scaffold stamping (the pattern's `scaffold/` files) is deliberately out of scope
+until scaffolds exist — this installs the contract pack, not the code.
+
+    python3 scripts/apply_pattern.py fetch-on-webhook-reconcile \\
+        --target-dir /path/to/repo --param resource=subscription --param projected_field=plan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+from check_patterns import cluster_entries  # noqa: E402
+from ratchet import DEFAULT_PROTECTED  # noqa: E402
+
+ROOT = SCRIPTS.parent
+REGISTRY = ROOT / "patterns" / "registry.json"
+
+ADOPTED_REL = "docs/patterns/adopted.json"
+RATCHET_REL = "docs/quality/ratchet.json"
+PATTERN_GLOB = "docs/patterns/**"
+
+
+class ApplyError(Exception):
+    """Usage / resolution problem. Maps to exit 2."""
+
+
+@dataclass
+class Plan:
+    pattern_id: str
+    version: int
+    files: dict[str, str] = field(default_factory=dict)   # repo-rel path -> content
+    ratchet_add: list[str] = field(default_factory=list)  # globs to merge into protected_paths
+    bound: dict[str, str] = field(default_factory=dict)
+    unresolved: list[str] = field(default_factory=list)   # required params with no value
+    _adoption: dict = field(default_factory=dict)         # adopted.json record, built in build_plan
+
+
+def load_registry(path: Path = REGISTRY) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ApplyError(f"registry not found: {path}") from exc
+
+
+def find_specified(registry: dict, pattern_id: str) -> dict:
+    for entry in registry.get("patterns", []):
+        if entry.get("id") == pattern_id:
+            return entry
+    for entry in registry.get("candidates", []):
+        if entry.get("id") == pattern_id:
+            raise ApplyError(
+                f"'{pattern_id}' is a candidate, not a specified pattern — it has no "
+                f"manifest to install. Specify it first.")
+    raise ApplyError(f"unknown pattern id: {pattern_id!r}")
+
+
+def load_manifest(entry: dict, base: Path = ROOT) -> dict:
+    rel = entry.get("manifest")
+    if not rel:
+        raise ApplyError(f"registry entry for {entry.get('id')} has no manifest path")
+    path = base / rel
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ApplyError(f"manifest not found: {path}") from exc
+
+
+def resolve_params(manifest: dict, provided: dict[str, str]) -> tuple[dict, list[str]]:
+    """Bind provided params over the manifest schema. Returns (bound, unresolved)."""
+    schema = manifest.get("parameters", {}) or {}
+    bound: dict[str, str] = {}
+    unresolved: list[str] = []
+    for name, spec in schema.items():
+        if name in provided:
+            bound[name] = provided[name]
+        elif not spec.get("required", False) and "default" in spec:
+            bound[name] = spec["default"]
+        elif spec.get("required", False):
+            unresolved.append(name)
+    unknown = [k for k in provided if k not in schema]
+    if unknown:
+        raise ApplyError(f"unknown parameter(s) for {manifest.get('id')}: {', '.join(sorted(unknown))}")
+    return bound, unresolved
+
+
+def _protected_intents(manifest: dict) -> list[str]:
+    return manifest.get("protected_paths") or manifest.get("protected_paths_added") or []
+
+
+def _invariants_doc(manifest: dict, cluster: list[dict], bound: dict, unresolved: list[str]) -> str:
+    pid = manifest.get("id")
+    lines = [
+        f"# Pattern contract pack: {manifest.get('title', pid)}",
+        "",
+        f"> Installed by `apply_pattern.py` from the `{pid}` registry pattern.",
+        "> `/architect` folds this invariant cluster into the epic's `invariants.md`",
+        "> with these stable ids; the traceability, single-writer, and ratchet gates",
+        "> then hold the cluster. Do not edit the ids — they are the pattern's contract.",
+        "",
+        "## Invariant cluster",
+        "",
+    ]
+    for e in cluster:
+        cid = e.get("id", "?")
+        stmt = e.get("statement", "").strip()
+        lines.append(f"- **{cid}** — {stmt}")
+        ra = e.get("realized_as")
+        if isinstance(ra, dict):
+            ref = ra.get("code") or ra.get("id") or ""
+            app = ra.get("app", "")
+            if ref:
+                lines.append(f"  - _reference impl:_ {app} `{ref}`")
+            elif app:
+                lines.append(f"  - _reference impl:_ {app}")
+    lines += ["", "## Bound parameters", ""]
+    if bound:
+        for k, v in bound.items():
+            lines.append(f"- `{k}` = `{v}`")
+    else:
+        lines.append("_(none bound yet)_")
+    if unresolved:
+        lines += ["", "## Unbound required parameters", ""]
+        schema = manifest.get("parameters", {})
+        for name in unresolved:
+            desc = schema.get(name, {}).get("description", "")
+            lines.append(f"- TBD: bind `{name}` — {desc}".rstrip())
+    intents = _protected_intents(manifest)
+    if intents:
+        lines += ["", "## Protected-path intents", "",
+                  "_Map these to real code paths and add them to the ratchet's `protected_paths`:_", ""]
+        lines += [f"- {p}" for p in intents]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_plan(pattern_id: str, provided: dict[str, str],
+               registry_path: Path = REGISTRY, base: Path = ROOT,
+               now: str | None = None) -> Plan:
+    registry = load_registry(registry_path)
+    entry = find_specified(registry, pattern_id)
+    manifest = load_manifest(entry, base)
+    cluster = [e for e in cluster_entries(manifest.get("invariants")) if isinstance(e, dict)]
+    bound, unresolved = resolve_params(manifest, provided)
+
+    plan = Plan(pattern_id=pattern_id, version=int(manifest.get("version", 1)),
+                bound=bound, unresolved=unresolved,
+                ratchet_add=[PATTERN_GLOB])
+    plan.files[f"docs/patterns/{pattern_id}/invariants.md"] = _invariants_doc(
+        manifest, cluster, bound, unresolved)
+    plan._adoption = {  # stashed for the adopted.json merge in apply_plan
+        "version": plan.version,
+        "applied_at": now or datetime.now(timezone.utc).isoformat(),
+        "provenance": {"registry": "chief-wiggum", "manifest": entry.get("manifest")},
+        "parameters": bound,
+        "unresolved": unresolved,
+        "invariants": [e.get("id") for e in cluster if e.get("id")],
+        "protected_path_intents": _protected_intents(manifest),
+    }
+    return plan
+
+
+def _merge_adopted(target: Path, pattern_id: str, adoption: dict) -> str:
+    path = target / ADOPTED_REL
+    if path.is_file():
+        doc = json.loads(path.read_text())
+    else:
+        doc = {"$comment": "CW registry patterns adopted by this product (apply_pattern.py).",
+               "patterns": {}}
+    doc.setdefault("patterns", {})[pattern_id] = adoption
+    return json.dumps(doc, indent=2) + "\n"
+
+
+def _merge_ratchet(target: Path, add: list[str]) -> tuple[str | None, list[str]]:
+    """Return (new content or None if no change, list of globs actually added)."""
+    path = target / RATCHET_REL
+    if path.is_file():
+        cfg = json.loads(path.read_text())
+        existing = list(cfg.get("protected_paths", list(DEFAULT_PROTECTED)))
+    else:
+        cfg = {"$comment": "Ratchet config stub created by apply_pattern.py; run `ratchet.py init` to complete it.",
+               "protected_paths": list(DEFAULT_PROTECTED)}
+        existing = cfg["protected_paths"]
+    added = [g for g in add if g not in existing]
+    if not added and path.is_file():
+        return None, []
+    cfg["protected_paths"] = existing + added
+    return json.dumps(cfg, indent=2) + "\n", added
+
+
+def apply_plan(plan: Plan, target: Path, write: bool = True) -> list[str]:
+    actions: list[str] = []
+    for rel, content in plan.files.items():
+        actions.append(f"write {rel}")
+        if write:
+            path = target / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+
+    adopted = _merge_adopted(target, plan.pattern_id, plan._adoption)
+    actions.append(f"record adoption in {ADOPTED_REL}")
+    if write:
+        p = target / ADOPTED_REL
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(adopted)
+
+    ratchet_content, added = _merge_ratchet(target, plan.ratchet_add)
+    if added:
+        actions.append(f"register protected paths in {RATCHET_REL}: {', '.join(added)}")
+        if write:
+            p = target / RATCHET_REL
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(ratchet_content)
+    return actions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install a registry pattern's contract pack into a target repo.")
+    parser.add_argument("pattern_id", help="Specified pattern id from patterns/registry.json")
+    parser.add_argument("--target-dir", required=True, type=Path, help="Local path to the target repo")
+    parser.add_argument("--param", action="append", default=[], metavar="k=v", help="Bind a pattern parameter")
+    parser.add_argument("--now", help="ISO timestamp for the adoption record (testing)")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    provided: dict[str, str] = {}
+    for kv in args.param:
+        if "=" not in kv:
+            print(f"bad --param {kv!r} (want k=v)", file=sys.stderr)
+            return 2
+        k, v = kv.split("=", 1)
+        provided[k.strip()] = v.strip()
+
+    try:
+        plan = build_plan(args.pattern_id, provided, now=args.now)
+        actions = apply_plan(plan, args.target_dir, write=not args.dry_run)
+    except ApplyError as exc:
+        print(f"apply_pattern: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"pattern": plan.pattern_id, "actions": actions,
+                          "unresolved": plan.unresolved, "dry_run": args.dry_run}, indent=2))
+    else:
+        verb = "PLAN (dry-run)" if args.dry_run else "applied"
+        print(f"apply_pattern: {verb} {plan.pattern_id} -> {args.target_dir}")
+        for a in actions:
+            print(f"  - {a}")
+        if plan.unresolved:
+            print(f"  ! {len(plan.unresolved)} unbound required param(s) written as TBD: {', '.join(plan.unresolved)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -1,0 +1,132 @@
+"""Tests for scripts/apply_pattern.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import apply_pattern  # noqa: E402
+
+FIXED_NOW = "2026-01-01T00:00:00+00:00"
+REAL = "fetch-on-webhook-reconcile"
+
+
+# --- resolution & binding ---------------------------------------------------
+
+def test_build_plan_on_real_pattern_returns_cluster_and_unresolved():
+    plan = apply_pattern.build_plan(REAL, {}, now=FIXED_NOW)
+    ids = plan._adoption["invariants"]
+    assert "INV-FOWR-001" in ids
+    # resource/state_shape/projected_field/signing_secrets are required in the manifest
+    assert set(plan.unresolved) >= {"resource", "state_shape", "projected_field", "signing_secrets"}
+
+
+def test_provided_params_bind_and_reduce_unresolved():
+    plan = apply_pattern.build_plan(
+        REAL,
+        {"resource": "subscription", "state_shape": "non-monotonic",
+         "projected_field": "plan", "signing_secrets": "rotation"},
+        now=FIXED_NOW)
+    assert plan.bound["resource"] == "subscription"
+    assert plan.unresolved == []
+
+
+def test_unknown_pattern_raises():
+    with pytest.raises(apply_pattern.ApplyError, match="unknown pattern"):
+        apply_pattern.build_plan("nope", {}, now=FIXED_NOW)
+
+
+def test_candidate_pattern_raises():
+    with pytest.raises(apply_pattern.ApplyError, match="candidate"):
+        apply_pattern.build_plan("build-test-floor", {}, now=FIXED_NOW)
+
+
+def test_unknown_param_raises():
+    with pytest.raises(apply_pattern.ApplyError, match="unknown parameter"):
+        apply_pattern.build_plan(REAL, {"bogus": "x"}, now=FIXED_NOW)
+
+
+# --- application ------------------------------------------------------------
+
+def test_apply_writes_contract_pack_adoption_and_ratchet(tmp_path):
+    plan = apply_pattern.build_plan(REAL, {"resource": "subscription"}, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+
+    inv = tmp_path / "docs/patterns" / REAL / "invariants.md"
+    assert inv.is_file()
+    text = inv.read_text()
+    assert "INV-FOWR-001" in text
+    # reference-impl lines have balanced backticks (regression: rstrip ate the closer)
+    for line in text.splitlines():
+        if "_reference impl:_" in line and "`" in line:
+            assert line.count("`") % 2 == 0, line
+
+    adopted = json.loads((tmp_path / "docs/patterns/adopted.json").read_text())
+    assert REAL in adopted["patterns"]
+    assert adopted["patterns"][REAL]["applied_at"] == FIXED_NOW
+    assert adopted["patterns"][REAL]["parameters"]["resource"] == "subscription"
+
+    ratchet = json.loads((tmp_path / "docs/quality/ratchet.json").read_text())
+    assert apply_pattern.PATTERN_GLOB in ratchet["protected_paths"]
+
+
+def test_unresolved_required_params_written_as_tbd(tmp_path):
+    plan = apply_pattern.build_plan(REAL, {}, now=FIXED_NOW)  # nothing bound
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+    doc = (tmp_path / "docs/patterns" / REAL / "invariants.md").read_text()
+    assert "TBD: bind `resource`" in doc
+
+
+def test_apply_is_idempotent(tmp_path):
+    for _ in range(2):
+        plan = apply_pattern.build_plan(REAL, {"resource": "subscription"}, now=FIXED_NOW)
+        apply_pattern.apply_plan(plan, tmp_path, write=True)
+    adopted = json.loads((tmp_path / "docs/patterns/adopted.json").read_text())
+    assert list(adopted["patterns"].keys()) == [REAL]
+    ratchet = json.loads((tmp_path / "docs/quality/ratchet.json").read_text())
+    assert ratchet["protected_paths"].count(apply_pattern.PATTERN_GLOB) == 1
+
+
+def test_merge_into_existing_ratchet_preserves_and_dedupes(tmp_path):
+    rp = tmp_path / "docs/quality/ratchet.json"
+    rp.parent.mkdir(parents=True)
+    rp.write_text(json.dumps({"suites": [{"name": "x"}], "protected_paths": ["docs/epics/**"]}))
+    plan = apply_pattern.build_plan(REAL, {}, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+    cfg = json.loads(rp.read_text())
+    assert "docs/epics/**" in cfg["protected_paths"]          # preserved
+    assert apply_pattern.PATTERN_GLOB in cfg["protected_paths"]  # added
+    assert cfg["suites"] == [{"name": "x"}]                    # untouched
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    plan = apply_pattern.build_plan(REAL, {}, now=FIXED_NOW)
+    actions = apply_pattern.apply_plan(plan, tmp_path, write=False)
+    assert actions  # a plan is produced
+    assert not (tmp_path / "docs/patterns").exists()
+
+
+def test_second_pattern_coexists_in_adopted(tmp_path):
+    for pid in (REAL, "elevated-access-session"):
+        plan = apply_pattern.build_plan(pid, {}, now=FIXED_NOW)
+        apply_pattern.apply_plan(plan, tmp_path, write=True)
+    adopted = json.loads((tmp_path / "docs/patterns/adopted.json").read_text())
+    assert set(adopted["patterns"]) == {REAL, "elevated-access-session"}
+
+
+# --- CLI --------------------------------------------------------------------
+
+def test_cli_dry_run(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply_pattern.py"), REAL,
+         "--target-dir", str(tmp_path), "--dry-run", "--format", "json"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["pattern"] == REAL and out["dry_run"] is True
+    assert not (tmp_path / "docs").exists()


### PR DESCRIPTION
## What

The step where the invariant-cluster model **earns its keep**: install a specified
pattern's cluster into a target repo, so `/architect` folds the connected
requirements in by stable id instead of re-deriving them. This is Rollout step 2's
**contract-pack** half (scaffold/code-stamping still deferred until patterns ship a
`scaffold/`).

## `scripts/apply_pattern.py` (filesystem-only → fully testable)

Loads a `status: specified` manifest, binds `--param k=v` over the parameter
schema, and stamps into the target repo:

- **`docs/patterns/<id>/invariants.md`** — the invariant cluster as a stable-id
  contract pack (with reference-impl provenance), ready for `/architect`.
- **`docs/patterns/adopted.json`** — the adoption record (id, version, bound
  params, provenance, cluster ids, protected-path intents).
- registers **`docs/patterns/**`** into the target's `docs/quality/ratchet.json`
  `protected_paths`, so the adopted pack is a goalpost workers can't move.

Unbound **required** params are written as `TBD:` markers (caught by
`check_unresolved.py`, so dependent work can't build on a guess). Idempotent;
`--dry-run`; rejects candidates and unknown params.

### End-to-end (real pattern, throwaway target)
```
$ apply_pattern.py elevated-access-session --target-dir /tmp/x --param signer=firebase
  - write docs/patterns/elevated-access-session/invariants.md
  - record adoption in docs/patterns/adopted.json
  - register protected paths in docs/quality/ratchet.json: docs/patterns/**
  ! 1 unbound required param(s) written as TBD: deny_prefixes
```
The contract pack lands with `INV-EAS-001..007` and their reference impls; defaults
(`ttl=15m`) bind from the manifest; `deny_prefixes` → `TBD:`.

## `.claude/commands/apply-pattern.md`
Thin skill adapter: resolve repo → inspect the cluster → bind params from the
**target's** context (never guess a required one) → install → verify unresolved →
hand to `/architect`.

## Tests / checks
- `tests/test_apply_pattern.py` — 12 tests: resolution, binding, TBD, idempotence,
  ratchet merge/dedupe, dry-run, coexistence, CLI, and a balanced-backtick
  regression.
- `make lint` green; `make test` green (**716 passed**, 4 skipped).

## Docs
Rollout + "how a pattern gets applied" updated to mark the contract-pack steps
built (✅) and scaffold stamping deferred (⏳); `/apply-pattern` added to CLAUDE.md.
