### PR TITLE
/architect consumes adopted patterns + fix ratchet uppercase-id blindspot

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -50,6 +50,14 @@ ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 
 `docs/domain-context.md` (written by `/seed` Step 2.5) is the **ground truth for data contracts**: canonical metric definitions, real schema names, source caveats, and mined use cases — each with citations. If the epic touches an existing data source and this file doesn't exist, run the `/seed` Step 2.5 ingestion now (semantic layer, schema introspection, transformation-repo history) before writing any data contract. Contracts authored from guessed table/column names are how query layers get built against names that don't exist.
 
+**Adopted patterns.** If the product has adopted registry patterns (via `/apply-pattern`), load their invariant clusters now — they are **pre-derived contracts** this epic must not re-invent:
+
+```bash
+python3 "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted --format json
+```
+
+Each adopted pattern reports its `id`, its invariant cluster (stable `INV-<ABBR>-NNN` ids + statements), its `contract_pack` doc (`docs/patterns/<id>/invariants.md`), and any `unresolved` (unbound required) parameters. Note which of these patterns **this epic realizes** — you'll fold their clusters into `invariants.md` (Step 4e) by their existing stable ids, thread their integration tests (Step 4g), and any `unresolved` parameter is a hard blocker to resolve before contracts depend on it (`check_unresolved.py` already gates the stamped `TBD:` markers).
+
 ### Step 2: Explore the codebase
 
 Launch an **explorer worker** (contract: `docs/worker-contracts.md#read-only-explorer-worker`) to understand the current state of the areas this epic will touch. *Claude Code adapter:* `subagent_type: "Explore"`, thoroughness "very thorough". The worker should report:
@@ -215,6 +223,17 @@ Write `invariants.md` by extracting and consolidating all invariants from both `
 
 Each invariant MUST have a unique ID (e.g., INV-001) that matches its ID in the JSON models. This enables traceability from prose → model → test → code.
 
+**Fold in adopted-pattern clusters (do not re-derive).** For each adopted pattern this epic realizes (from Step 1's `--list-adopted`), add its invariant cluster under a dedicated subsection, **keeping the pattern's own stable ids verbatim** (`INV-<ABBR>-NNN` — e.g. `INV-FOWR-004`, `INV-EAS-003`). These are the pattern's contract; re-numbering them or paraphrasing away their meaning breaks the link back to the contract pack and the ratchet. Cite the source so the provenance is legible:
+
+```markdown
+### Adopted pattern: fetch-on-webhook-reconcile
+*(installed by /apply-pattern — cluster from docs/patterns/fetch-on-webhook-reconcile/invariants.md)*
+- **INV-FOWR-001** — Trigger-only: the webhook handler never reads mutable state from the payload; state comes from a live fetch.
+- **INV-FOWR-004** — Unknown external id is fatal: no write, no floor fallback, alert.
+```
+
+The connected requirements arrive as a set — adopt the **whole** cluster for a realized pattern, not a subset. Any `unresolved` parameter reported for that pattern must be resolved (or explicitly re-marked `TBD:`) before an invariant depends on it.
+
 #### 4f. ADR (`adr.md`)
 
 Architectural Decision Record capturing the key decisions for this epic:
@@ -271,6 +290,8 @@ Tests that validate cross-ticket behaviour. These are NOT run per-ticket — the
 - **Assert**: Email-dependent operations return an error, UI disables the action
 - **Why**: Catches false-success pattern
 ```
+
+**Adopted-pattern tests.** For each adopted pattern this epic realizes, thread the executable proof its cluster implies — e.g. `multi-tenant-isolation` contributes a standing cross-tenant isolation test (denial AND no-mutation across vectors); `fetch-on-webhook-reconcile` contributes an out-of-order/stale-event convergence test; `elevated-access-session` contributes a TTL-expiry + revocation + deny-list test. Reference the folded `INV-<ABBR>-NNN` ids in the **Why** so `/close-epic` can confirm the pattern's cluster held.
 
 #### 4h. Requirements Traceability Matrix (`traceability.md`)
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -530,9 +530,13 @@ Smallest-first. Progress so far:
    params, stamps the invariant cluster + adoption record, registers protected
    paths. The pattern `scaffold/` (stamping code, not just contracts) is still to
    come.
-3. ⏳ **`/seed` + `/architect` integration** — pattern *selection* becomes part of
-   product design: the architecture stage proposes applicable patterns and records
-   the choice, the way `/design` records a chosen design direction; `/architect`
-   folds an adopted cluster into the epic's `invariants.md` by stable id.
+3. 🟡 **`/seed` + `/architect` integration** — `/architect` now **consumes**
+   adopted patterns: Step 1 loads them (`apply_pattern.py --list-adopted`), Step 4e
+   folds each realized cluster into the epic's `invariants.md` by its existing
+   stable id (not re-derived), and Step 4g threads the pattern's integration
+   tests. The uppercase-id gap that made the ratchet skip these ids is fixed, so
+   the folded cluster is genuinely held. Still to come: `/seed` pattern *selection*
+   (proposing applicable patterns and recording the choice, the way `/design`
+   records a chosen direction).
 4. ⏳ **Fill the backlog** — capture the remaining candidate patterns as their own
    entries.

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -240,15 +240,64 @@ def apply_plan(plan: Plan, target: Path, write: bool = True) -> list[str]:
     return actions
 
 
+def list_adopted(target_dir: Path, registry_path: Path = REGISTRY, base: Path = ROOT) -> list[dict]:
+    """Read a target repo's adopted.json and return each pattern's fresh cluster.
+
+    Statements are re-read from the registry manifest (source of truth), so
+    `/architect` folds current invariant text — not whatever was stamped earlier.
+    """
+    path = Path(target_dir) / ADOPTED_REL
+    if not path.is_file():
+        return []
+    doc = json.loads(path.read_text())
+    registry = load_registry(registry_path)
+    out: list[dict] = []
+    for pid, rec in doc.get("patterns", {}).items():
+        try:
+            manifest = load_manifest(find_specified(registry, pid), base)
+            cluster = [e for e in cluster_entries(manifest.get("invariants")) if isinstance(e, dict)]
+        except ApplyError:
+            cluster = []
+        out.append({
+            "id": pid,
+            "version": rec.get("version"),
+            "contract_pack": f"docs/patterns/{pid}/invariants.md",
+            "invariants": [{"id": e.get("id"), "statement": e.get("statement", "")}
+                           for e in cluster if e.get("id")],
+            "unresolved": rec.get("unresolved", []),
+        })
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Install a registry pattern's contract pack into a target repo.")
-    parser.add_argument("pattern_id", help="Specified pattern id from patterns/registry.json")
+    parser.add_argument("pattern_id", nargs="?", help="Specified pattern id from patterns/registry.json")
     parser.add_argument("--target-dir", required=True, type=Path, help="Local path to the target repo")
     parser.add_argument("--param", action="append", default=[], metavar="k=v", help="Bind a pattern parameter")
+    parser.add_argument("--list-adopted", action="store_true",
+                        help="List the target's adopted patterns + clusters (for /architect) and exit")
     parser.add_argument("--now", help="ISO timestamp for the adoption record (testing)")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args()
+
+    if args.list_adopted:
+        adopted = list_adopted(args.target_dir)
+        if args.format == "json":
+            print(json.dumps(adopted, indent=2))
+        elif not adopted:
+            print(f"apply_pattern: no adopted patterns in {args.target_dir}")
+        else:
+            for a in adopted:
+                tbd = f"  (unbound: {', '.join(a['unresolved'])})" if a["unresolved"] else ""
+                print(f"{a['id']} v{a['version']} — {len(a['invariants'])} invariants{tbd}")
+                for inv in a["invariants"]:
+                    print(f"  {inv['id']}: {inv['statement']}")
+        return 0
+
+    if not args.pattern_id:
+        print("apply_pattern: a pattern id is required (or use --list-adopted)", file=sys.stderr)
+        return 2
 
     provided: dict[str, str] = {}
     for kv in args.param:

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -91,10 +91,13 @@ DEFAULT_QUALITY_TOLERANCE = {
 }
 
 # Same stable-ID grammar as check_traceability.py: the ID ends at the 3-digit
-# suffix and must not run into more id chars.
-ID_RE = re.compile(r"\b(?:BR|CTR|INV)-[a-z0-9][a-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])")
+# suffix and must not run into more id chars. Case-insensitive body: uppercase
+# ids (INV-BIL-001, adopted-pattern INV-FOWR-001) must be hashed too — a
+# lowercase-only grammar silently skipped them, leaving weakening-detection
+# vacuous for uppercase-id repos (same class as chief-wiggum#86).
+ID_RE = re.compile(r"\b(?:BR|CTR|INV)-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])")
 DEFINE_RE = re.compile(
-    r"(?:^#{1,6}\s+|\*\*\s*)((?:BR|CTR|INV)-[a-z0-9][a-z0-9-]*-[0-9]{3})(?![A-Za-z0-9-])"
+    r"(?:^#{1,6}\s+|\*\*\s*)((?:BR|CTR|INV)-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3})(?![A-Za-z0-9-])"
 )
 
 DEFAULT_PROTECTED = [

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -119,6 +119,35 @@ def test_second_pattern_coexists_in_adopted(tmp_path):
     assert set(adopted["patterns"]) == {REAL, "elevated-access-session"}
 
 
+# --- list-adopted (the /architect fold-in seam) -----------------------------
+
+def test_list_adopted_empty_when_no_adoption(tmp_path):
+    assert apply_pattern.list_adopted(tmp_path) == []
+
+
+def test_list_adopted_returns_fresh_clusters(tmp_path):
+    for pid in (REAL, "elevated-access-session"):
+        apply_pattern.apply_plan(apply_pattern.build_plan(pid, {}, now=FIXED_NOW), tmp_path, write=True)
+    adopted = {a["id"]: a for a in apply_pattern.list_adopted(tmp_path)}
+    assert set(adopted) == {REAL, "elevated-access-session"}
+    fowr_ids = [i["id"] for i in adopted[REAL]["invariants"]]
+    assert "INV-FOWR-001" in fowr_ids
+    # statements come fresh from the registry manifest, not the stamped copy
+    assert all(i["statement"] for i in adopted[REAL]["invariants"])
+    assert adopted[REAL]["contract_pack"] == f"docs/patterns/{REAL}/invariants.md"
+
+
+def test_cli_list_adopted(tmp_path):
+    apply_pattern.apply_plan(apply_pattern.build_plan(REAL, {}, now=FIXED_NOW), tmp_path, write=True)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply_pattern.py"),
+         "--target-dir", str(tmp_path), "--list-adopted", "--format", "json"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = json.loads(proc.stdout)
+    assert out[0]["id"] == REAL and any(i["id"] == "INV-FOWR-001" for i in out[0]["invariants"])
+
+
 # --- CLI --------------------------------------------------------------------
 
 def test_cli_dry_run(tmp_path):

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -38,6 +38,23 @@ def make_repo(tmp_path, contracts_md=None, suites=None):
     return ratchet.load_config(tmp_path)
 
 
+def test_uppercase_stable_ids_are_hashed(tmp_path):
+    """Regression (chief-wiggum#86 class): uppercase INV-/CTR- ids must be detected
+    for weakening-hashing, not silently skipped by a lowercase-only grammar."""
+    cfg = make_repo(
+        tmp_path,
+        contracts_md=(
+            "### CTR-BIL-001 — customer uniqueness\n"
+            "REQUIRES: one customer per provider\n"
+            "\n"
+            "- **INV-FOWR-004** — unknown price id is fatal, no floor fallback\n"
+        ),
+    )
+    hashes = ratchet.load_contract_hashes(cfg)
+    assert "CTR-BIL-001" in hashes
+    assert "INV-FOWR-004" in hashes
+
+
 def scorecard_from(cfg, pass_set):
     return {
         "passed": len(pass_set),


### PR DESCRIPTION
## What

Closes the last link of the invariant-cluster spine: an adopted pattern's cluster
is now **folded into the epic by `/architect` and actually held by the gates**.

```
mine → specify → enforce (check_patterns) → install (/apply-pattern) → FOLD IN (/architect) → hold (ratchet/traceability)
```

## `/architect` consumes adopted patterns
- **Step 1** loads them: `apply_pattern.py --target-dir <repo> --list-adopted` reports
  each adopted pattern's cluster (stable id + statement, re-read fresh from the
  registry manifest), its contract-pack doc, and any unbound params.
- **Step 4e** folds each *realized* cluster into `invariants.md` under a dedicated
  subsection, **keeping the pattern's existing `INV-<ABBR>-NNN` ids verbatim** (not
  re-derived) with provenance — the whole cluster, not a subset.
- **Step 4g** threads the pattern's implied integration tests, referencing the
  folded ids so `/close-epic` can confirm the cluster held.

New `--list-adopted` mode in `apply_pattern.py` is the deterministic seam (mechanical, not trusted) — with `list_adopted()` unit-tested.

## Fix: ratchet uppercase-id blindspot (chief-wiggum#86 class)
While wiring this I found `ratchet.py`'s `ID_RE`/`DEFINE_RE` were **lowercase-only**,
so uppercase stable ids were silently skipped by the contract-weakening hash — which
means not just the adopted-pattern `INV-FOWR-*` ids but **real shipped repos'
`INV-BIL-*`/`INV-ADM-*` (dogeared) were never weakening-hashed**. `check_traceability.py`
was already fixed for this (#86); `ratchet.py` was missed. Widened both regexes to
`[A-Za-z0-9]`. Without this, "the ratchet holds the folded cluster" was false.

## Tests / checks
- `list_adopted` x3 (empty, fresh clusters, CLI) + uppercase-id-hashed ratchet
  regression.
- `make lint` green; `make test` green (**720 passed**, 4 skipped).

Still to come (separate): `/seed` pattern *selection*, and pattern `scaffold/` stamping.
