### PR TITLE
/seed pattern selection: the front door of the registry loop

### DIFF
--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -108,6 +108,31 @@ Once the key decisions are made, write them to `$CW_TMP/architecture-decisions.m
 
 Show the user a summary and confirm the decisions look right before proceeding.
 
+### Step 4.5: Select applicable registry patterns
+
+Registry patterns are proven, opinionated architecture + process shapes CW can stamp into the product (see `docs/patterns-registry.md`). Selecting them here means `/architect` folds their invariant clusters into epic contracts by stable id instead of re-deriving them — the connected requirements and their gates arrive as a set.
+
+Load the selectable catalog:
+
+```bash
+python3 "$CW_HOME/scripts/apply_pattern.py" --catalog --format json
+```
+
+Each entry has an `id`, `category`, and `applies_when` (the selection criteria). **Reason over `applies_when` against this product's shape** and propose the patterns that fit — think in groups: the **saas-infra floor** (`multi-tenant-isolation` for any multi-tenant product; `provider-neutral-adapter` for any swappable external vendor), the **monetization surface** you're actually charging for (`tiered-subscription`, `frictionless-onboarding`), and always the **monitoring group** underneath (`engagement-instrumentation`) so the rest are measurable. Note `depends_on` — selecting a pattern pulls its floor.
+
+**This is a "chosen, not converged" human checkpoint** — like `/design`. Present the proposed set with one-line rationale each, and get the user's confirmation. Two bindings are the user's call, not a default:
+- **Which patterns** actually apply (don't over-stamp — a pattern is real attack surface + maintenance).
+- **The per-app trust bindings.** For every pattern with signal sources (`improvement-loop`, `engagement-instrumentation`), bind each source `trusted` (internal/authenticated) or `untrusted` (end-user-supplied). A public app's user-feedback source is `untrusted` and auto-gets the quarantine gate; an internal tool binds everything `trusted`. Same pattern, trust-appropriate behavior.
+
+For each confirmed pattern, install its contract pack into the target repo (binding what you can from the architecture decisions; leave required params you can't confirm as `TBD:`):
+
+```bash
+python3 "$CW_HOME/scripts/apply_pattern.py" <id> --target-dir "$TARGET_REPO" \
+  --param <k>=<v> ...   # e.g. --param billing_provider=stripe --param tenant_key=provider_id
+```
+
+Record the chosen set + trust bindings in `$CW_TMP/architecture-decisions.md` (they're part of the product's design record). The written `docs/patterns/` artifacts are committed with the architecture at Step 7; `/architect` reads them via `--list-adopted`. If no pattern fits (rare for a SaaS), say so and move on — don't force it.
+
 ### Step 5: Multi-AI consultation
 
 Write a consultation prompt to `$CW_TMP/consultation-prompt.md` asking for a critical review of the architecture decisions. The prompt should ask:
@@ -137,13 +162,15 @@ When both reviews are back:
 
 Copy the finalised architecture decisions to the target repo as `ARCHITECTURE.md`. If Step 2.5 produced domain context, copy it to `docs/domain-context.md` — `/architect` loads it before writing data contracts. If Step 2.5 produced a compliance-requirements doc (regulated-data products), copy it to `docs/compliance-requirements.md` — `/architect` folds it into security/privacy contracts and `/saas-gate` verifies it. Update `CLAUDE.md` if the tech stack has changed from what was previously documented.
 
+If Step 4.5 selected patterns, the installer already wrote `docs/patterns/` (adoption record + contract packs) and registered protected paths in `docs/quality/ratchet.json` — commit those too.
+
 Commit and push:
 ```bash
 cd "$TARGET_DIR"
 mkdir -p docs
 cp "$CW_TMP/domain-context.md" docs/domain-context.md 2>/dev/null || true
 cp "$CW_TMP/compliance-requirements.md" docs/compliance-requirements.md 2>/dev/null || true
-git add ARCHITECTURE.md CLAUDE.md docs/domain-context.md docs/compliance-requirements.md
+git add ARCHITECTURE.md CLAUDE.md docs/domain-context.md docs/compliance-requirements.md docs/patterns docs/quality/ratchet.json
 git commit -m "Add architecture decisions from seed session"
 git push
 ```
@@ -177,7 +204,8 @@ Run issue creation in an **issue-authoring worker** (contract: `docs/worker-cont
 Present the user with:
 1. Link to the ARCHITECTURE.md commit
 2. Summary of issues created (count by group, with issue numbers/URLs)
-3. Suggested next steps:
+3. **Selected patterns** (if any) — the chosen set with their trust bindings; note that `/architect` will fold their invariant clusters into the relevant epics
+4. Suggested next steps:
    - `/design owner/repo` to produce the product design (mockups → human choice → `docs/design/`) — for any product with a UI, run this before architecting epics
    - `/plan-epic owner/repo` to group issues into an epic with dependency ordering
    - `/architect owner/repo --epic "Epic: [Name]"` to define contracts and invariants

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -530,13 +530,17 @@ Smallest-first. Progress so far:
    params, stamps the invariant cluster + adoption record, registers protected
    paths. The pattern `scaffold/` (stamping code, not just contracts) is still to
    come.
-3. 🟡 **`/seed` + `/architect` integration** — `/architect` now **consumes**
-   adopted patterns: Step 1 loads them (`apply_pattern.py --list-adopted`), Step 4e
-   folds each realized cluster into the epic's `invariants.md` by its existing
-   stable id (not re-derived), and Step 4g threads the pattern's integration
-   tests. The uppercase-id gap that made the ratchet skip these ids is fixed, so
-   the folded cluster is genuinely held. Still to come: `/seed` pattern *selection*
-   (proposing applicable patterns and recording the choice, the way `/design`
-   records a chosen direction).
+3. ✅ **`/seed` + `/architect` integration** — the full select → install → fold →
+   hold loop is wired:
+   - **`/seed` Step 4.5** *selects* — proposes applicable patterns from the catalog
+     (`apply_pattern.py --catalog`, reasoning over each pattern's `applies_when`),
+     takes the "chosen, not converged" human checkpoint incl. the per-app trust
+     bindings, and installs each confirmed pattern's contract pack.
+   - **`/architect`** *binds* — Step 1 loads adopted patterns
+     (`apply_pattern.py --list-adopted`), Step 4e folds each realized cluster into
+     `invariants.md` by its existing stable id (not re-derived), Step 4g threads
+     the pattern's integration tests.
+   - The uppercase-id gap that made the ratchet skip these ids is fixed, so the
+     folded cluster is genuinely held.
 4. ⏳ **Fill the backlog** — capture the remaining candidate patterns as their own
    entries.

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -269,17 +269,72 @@ def list_adopted(target_dir: Path, registry_path: Path = REGISTRY, base: Path = 
     return out
 
 
+def catalog(registry_path: Path = REGISTRY, base: Path = ROOT) -> list[dict]:
+    """The selectable menu for `/seed`: every pattern with its `applies_when`.
+
+    Specified patterns carry their manifest `applies_when` (the selection criteria
+    a human/model reasons over); candidates are listed with `status: candidate` so
+    `/seed` can flag them as available-but-not-yet-installable.
+    """
+    reg = load_registry(registry_path)
+    out: list[dict] = []
+    for entry in reg.get("patterns", []):
+        try:
+            manifest = load_manifest(entry, base)
+            applies = manifest.get("applies_when", [])
+        except ApplyError:
+            applies = []
+        out.append({
+            "id": entry.get("id"),
+            "title": entry.get("title"),
+            "category": entry.get("category"),
+            "status": "specified",
+            "applies_when": applies,
+            "invariants": entry.get("invariants", ""),
+            "depends_on": entry.get("depends_on"),
+            "summary": entry.get("summary", ""),
+        })
+    for c in reg.get("candidates", []):
+        out.append({
+            "id": c.get("id"),
+            "title": c.get("title"),
+            "category": c.get("category"),
+            "status": "candidate",
+            "applies_when": [],
+            "summary": c.get("summary", ""),
+        })
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Install a registry pattern's contract pack into a target repo.")
     parser.add_argument("pattern_id", nargs="?", help="Specified pattern id from patterns/registry.json")
-    parser.add_argument("--target-dir", required=True, type=Path, help="Local path to the target repo")
+    parser.add_argument("--target-dir", type=Path, help="Local path to the target repo")
     parser.add_argument("--param", action="append", default=[], metavar="k=v", help="Bind a pattern parameter")
+    parser.add_argument("--catalog", action="store_true",
+                        help="Print the selectable pattern menu (for /seed) and exit")
     parser.add_argument("--list-adopted", action="store_true",
                         help="List the target's adopted patterns + clusters (for /architect) and exit")
     parser.add_argument("--now", help="ISO timestamp for the adoption record (testing)")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args()
+
+    if args.catalog:
+        items = catalog()
+        if args.format == "json":
+            print(json.dumps(items, indent=2))
+        else:
+            for c in items:
+                mark = "" if c["status"] == "specified" else "  [candidate]"
+                print(f"{c['id']} ({c['category']}){mark}")
+                for w in c.get("applies_when", []):
+                    print(f"    · {w}")
+        return 0
+
+    if not args.target_dir:
+        print("apply_pattern: --target-dir is required (except with --catalog)", file=sys.stderr)
+        return 2
 
     if args.list_adopted:
         adopted = list_adopted(args.target_dir)

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -148,6 +148,34 @@ def test_cli_list_adopted(tmp_path):
     assert out[0]["id"] == REAL and any(i["id"] == "INV-FOWR-001" for i in out[0]["invariants"])
 
 
+# --- catalog (the /seed selection seam) -------------------------------------
+
+def test_catalog_lists_specified_with_applies_when():
+    items = {c["id"]: c for c in apply_pattern.catalog()}
+    assert REAL in items
+    assert items[REAL]["status"] == "specified"
+    assert items[REAL]["applies_when"]  # non-empty selection criteria from the manifest
+    # candidates are listed too, flagged
+    assert any(c["status"] == "candidate" for c in apply_pattern.catalog())
+
+
+def test_cli_catalog_needs_no_target(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply_pattern.py"), "--catalog", "--format", "json"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    ids = {c["id"] for c in json.loads(proc.stdout)}
+    assert {"multi-tenant-isolation", "tiered-subscription"} <= ids
+
+
+def test_cli_apply_requires_target_dir():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply_pattern.py"), REAL],
+        capture_output=True, text=True)
+    assert proc.returncode == 2
+    assert "target-dir" in proc.stderr
+
+
 # --- CLI --------------------------------------------------------------------
 
 def test_cli_dry_run(tmp_path):


### PR DESCRIPTION
## What

Completes the registry loop: `/seed` now *selects* patterns for a product, closing
**select → install → fold → hold**.

```
/seed (select + install)  →  /apply-pattern (contract pack)  →
/architect (fold cluster by stable id)  →  ratchet + traceability (hold)
```

## `/seed` Step 4.5 — pattern selection
A new "chosen, not converged" human checkpoint (like `/design`):
- Loads the catalog (`apply_pattern.py --catalog`) and **reasons over each pattern's
  `applies_when`** against the product's shape, thinking in groups: the saas-infra
  floor (`multi-tenant-isolation`, `provider-neutral-adapter`), the monetization
  surface actually being charged for (`tiered-subscription`, `frictionless-onboarding`),
  and the monitoring group underneath (`engagement-instrumentation`).
- Takes the two decisions that are the **user's call**: which patterns apply (don't
  over-stamp), and the **per-app trust bindings** (a public app's user-feedback
  source is `untrusted` → auto quarantine gate; an internal tool binds everything
  `trusted`).
- Installs each confirmed pattern's contract pack; Step 7 commits `docs/patterns/` +
  the ratchet registration; Step 9 reports the selected set.

## `--catalog` seam
`apply_pattern.py --catalog` surfaces the selectable menu (id, category,
`applies_when`, `depends_on`) — the deterministic seam `/seed` reasons over
(mechanical, not trusted). `--target-dir` is now optional, required only for
`apply` / `--list-adopted` and validated per-mode.

## Tests / checks
- +3 tests (catalog contents; CLI catalog needs no target; apply requires target).
- `make lint` green; `make test` green (**723 passed**, 4 skipped).

The registry is now a working loop end-to-end. Remaining: pattern `scaffold/`
stamping (code, not just contracts), and specifying more candidates.
