### PR TITLE
/reflect: factory self-assessment — mine a built repo into CW-improvement issues

### DIFF
--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -1,0 +1,83 @@
+# Reflect — Factory Self-Assessment from a Built Repo
+
+Looks at a repo the CW factory built, mines the evidence CW leaves behind (git + PR history, the ratchet journal, TBD markers, adopted-pattern records, retrospectives), and reasons about **how well the factory served it** — which gates add value, what slipped through, how well assumptions got filled — then drafts improvement issues **in the CW repo**.
+
+This is the improvement-loop pattern turned back on the factory. Every signal here is trusted (it's CW's own output), so this runs autonomously to a proposed issue set — but **filing issues is a human checkpoint** (see Autonomy).
+
+## When to use
+
+- After an epic or a few epics land in a product repo — reflect on how the factory performed.
+- Periodically, to keep a CW-improvement backlog grounded in real production evidence rather than intuition.
+- Point it at CW's own repo too (dogfood): CW should be held to the standards it imposes.
+
+## Usage
+
+```
+/reflect <owner/repo> [--commits N] [--create-issues]
+```
+
+## Parameters
+
+- `owner/repo`: The built repo to reflect on (resolved via `repo.py`). Use `plwp/chief-wiggum` to reflect on the factory itself.
+- `--commits N`: How far back to scan (default 400).
+- `--create-issues`: File the confirmed issues without a second confirmation (default: draft + confirm).
+
+## Autonomy
+
+Run the analysis to completion autonomously. **Filing issues is the one checkpoint** — present the drafted issues and get confirmation before `gh issue create`, because they're outward-facing writes to the CW repo. Never file a vague issue; every issue must cite the specific evidence (commit, marker, journal record) that motivates it.
+
+---
+
+## Workflow
+
+### Step 1: Resolve paths
+
+```bash
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+```
+
+### Step 2: Collect the evidence
+
+Fetch merged-PR history (review outcomes + bodies carry gate signal) and run the miner:
+
+```bash
+gh --repo "$owner_repo" pr list --state merged --limit 200 \
+  --json number,title,body,reviewDecision,labels > "$CW_TMP/prs.json" 2>/dev/null || echo '[]' > "$CW_TMP/prs.json"
+python3 "$CW_HOME/scripts/reflect.py" "$TARGET_REPO" --prs "$CW_TMP/prs.json" --commits "${commits:-400}" --format json > "$CW_TMP/reflection.json"
+```
+
+The report has: `commit_kinds`, `gate_mentions`, `force_bypasses`, `slippage_commits`, `assumptions` (TBD markers), `ratchet` health, `pattern_coverage`, `retrospectives`, and mechanical `findings` seeding your analysis.
+
+### Step 3: Reason across the dimensions
+
+The mechanical findings are a starting point, not the analysis. Reason over the evidence:
+
+- **Which gates add value?** A gate that appears in the record alongside a fix (it caught something) is earning its keep. A gate with **zero mentions** across many commits/PRs is either never firing here or its value is invisible — worth logging. **This is where the factory-telemetry log (`docs/quality/factory-log.jsonl`, when present) is authoritative** over git archaeology — prefer it for gate value/noise/token-cost.
+- **Which are noise?** `--force`/`--no-verify` bypasses, or a gate repeatedly fixed with trivial/annotation-only commits, signal a gate that's noisy on real code — the operator is routing around it, which erodes trust in *every* gate (see `docs/gate-rollout.md`).
+- **What slipped through?** For each `fix(`/`revert`/`hotfix` commit, ask: *what class of bug is this, and should a gate have caught it?* A slippage with no covering gate is a candidate for a **new** gate or a strengthened contract. Read the actual diff of the top slippage commits to classify them.
+- **How well are assumptions filled?** Unresolved `TBD:` markers still in `docs/` mean the factory guessed and never confirmed. Adopted patterns with `missing` invariants (promised but never folded into an epic) mean the contract pack didn't fully land.
+- **Factory-log health.** Forced ratchet merges = the bar was lowered under override. Retrospective "what the loop caught" vs "deferred/not done" sections are first-person factory signal — read them.
+
+### Step 4: Draft CW-improvement issues
+
+For each substantiated finding, draft an issue **for the CW repo** (not the target). Each must have:
+- A specific title (the improvement, not the symptom).
+- A body citing the **evidence** (commit hashes/subjects, marker locations, journal records, PR numbers) and the **dimension** (gate-value / slippage / assumption-fill / pattern-coverage).
+- A concrete proposal (new gate, strengthen an existing gate, report-only→blocking promotion, a pattern to specify, a telemetry point to add).
+- Appropriate labels (`enhancement`, `gate`, `reflection`).
+
+Prefer a few high-signal issues over many speculative ones. Group related slippage into one "gap" issue.
+
+### Step 5: Confirm and file
+
+Present the drafted issues (titles + one-line rationale). On confirmation (or `--create-issues`):
+
+```bash
+gh --repo "$(python3 "$CW_HOME/scripts/repo.py" home >/dev/null; echo plwp/chief-wiggum)" \
+  issue create --title "<title>" --body-file "$CW_TMP/issue-<n>.md" --label reflection --label enhancement
+```
+
+Report the filed issue URLs and a one-paragraph factory-health summary (what's working, what's slipping, the single highest-leverage improvement).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 /ship                           # Create PR with mermaid diagrams (standalone)
 /stitch-audit owner/repo --trace keyword   # Cross-layer data flow audit
 /code-metrics owner/repo                    # Literature-grounded code-quality metrics (churn/complexity/survival/duplication)
+/reflect owner/repo                         # Factory self-assessment: mine a built repo → CW-improvement issues
 /tutorial-video owner/repo --feature "..."  # Narrated click-through tutorial video
 /saas-gate owner/repo --base-url <url>     # SaaS non-functional-requirements gate (security/isolation/perf/observability)
 /update                         # Refresh model IDs and library versions

--- a/scripts/reflect.py
+++ b/scripts/reflect.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Reflect on how well the CW factory served a repo it built — mine the evidence.
+
+The improvement-loop pattern turned back on the factory itself: read what CW leaves
+behind in a target repo (git history, the ratchet journal, TBD/UNRESOLVED markers,
+adopted-pattern records, epic retrospectives) and surface mechanical signals about:
+
+  - **Which gates add value** — how often each gate appears in the history, and how
+    often it was bypassed (`--force`).
+  - **What's slipping through** — reverts and fix/hotfix commits (a bug a gate
+    should have caught reached main).
+  - **How well the factory fills assumptions** — TBD/UNRESOLVED markers still
+    unresolved, and adopted-pattern invariants that were promised but never folded
+    into an epic's invariants.md.
+  - **Factory-log health** — ratchet regressions / forced merges; retrospective
+    "what the loop caught" vs "deferred/not done".
+
+This produces structured EVIDENCE + heuristic FINDINGS. The `/reflect` skill reasons
+over them and drafts CW-improvement issues; this script does not create issues.
+
+    python3 scripts/reflect.py /path/to/repo --prs prs.json --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+import check_unresolved  # noqa: E402
+
+# Known CW gates and the tokens that betray them in commit/PR text.
+GATE_TOKENS = {
+    "traceability": ["traceability", "check_traceability", "@cw-trace"],
+    "single_writer": ["single_writer", "single-writer", "check_single_writer", "@cw-writes"],
+    "unresolved": ["check_unresolved", "unresolved marker"],
+    "ratchet": ["ratchet"],
+    "check_patterns": ["check_patterns", "invariant cluster"],
+    "saas_gate": ["saas-gate", "saas_gate"],
+    "stitch_audit": ["stitch-audit", "stitch_audit"],
+    "design_fidelity": ["design-fidelity", "design fidelity"],
+    "portability": ["check_portability", "portability"],
+}
+
+CONVENTIONAL_RE = re.compile(r"^(feat|fix|chore|docs|test|refactor|perf|build|ci|revert)(\([^)]*\))?!?:")
+
+
+@dataclass
+class Finding:
+    dimension: str   # gates | slippage | assumptions | patterns | factory-logs
+    severity: str    # info | warn
+    message: str
+    evidence: list[str] = field(default_factory=list)
+
+
+# ---- git history -------------------------------------------------------------
+
+def parse_git_log(text: str) -> list[dict]:
+    """Parse `git log --pretty=%H%x1f%s` output into {hash, subject} rows."""
+    rows = []
+    for line in text.splitlines():
+        if "\x1f" in line:
+            h, subject = line.split("\x1f", 1)
+            rows.append({"hash": h.strip(), "subject": subject.strip()})
+    return rows
+
+
+def classify_commits(commits: list[dict]) -> dict:
+    counts: dict[str, int] = {}
+    for c in commits:
+        m = CONVENTIONAL_RE.match(c["subject"])
+        kind = m.group(1) if m else "other"
+        counts[kind] = counts.get(kind, 0) + 1
+    return counts
+
+
+def detect_reverts(commits: list[dict]) -> list[dict]:
+    return [c for c in commits if c["subject"].lower().startswith("revert")
+            or c["subject"].lower().startswith("revert(")]
+
+
+def slippage_commits(commits: list[dict]) -> list[dict]:
+    """fix/hotfix/revert commits — a defect that reached main after the gate ran."""
+    out = []
+    for c in commits:
+        s = c["subject"].lower()
+        if s.startswith(("fix(", "fix:", "revert", "hotfix")) or "hotfix" in s:
+            out.append(c)
+    return out
+
+
+def gate_mentions(texts: list[str]) -> dict[str, int]:
+    joined = "\n".join(t.lower() for t in texts)
+    return {gate: sum(joined.count(tok.lower()) for tok in toks)
+            for gate, toks in GATE_TOKENS.items()}
+
+
+def force_bypasses(texts: list[str]) -> int:
+    joined = "\n".join(texts).lower()
+    return joined.count("--force") + joined.count("--no-verify")
+
+
+# ---- assumptions (TBD/UNRESOLVED) -------------------------------------------
+
+def scan_markers(root: Path) -> dict:
+    docs = root / "docs"
+    targets = [docs] if docs.is_dir() else [root]
+    findings = check_unresolved.scan(targets)
+    by_marker: dict[str, int] = {}
+    for f in findings:
+        by_marker[f.marker] = by_marker.get(f.marker, 0) + 1
+    return {"total": len(findings), "by_marker": by_marker,
+            "locations": [f"{f.file}:{f.location}" for f in findings[:25]]}
+
+
+# ---- ratchet journal ---------------------------------------------------------
+
+def ratchet_health(records: list[dict]) -> dict:
+    forced = failed = weakened = removed = merged = 0
+    for r in records:
+        if r.get("gate_result") == "forced" or r.get("forced"):
+            forced += 1
+        if r.get("gate_result") == "fail":
+            failed += 1
+        if r.get("merged"):
+            merged += 1
+        if isinstance(r.get("amended"), dict):
+            weakened += len(r["amended"])
+        removed += len(r.get("retired") or [])
+    return {"records": len(records), "merged": merged, "gate_failed": failed,
+            "forced_merges": forced, "amended_contracts": weakened, "retired_contracts": removed}
+
+
+def load_journal(root: Path) -> list[dict]:
+    path = root / "docs" / "quality" / "ratchet-journal.jsonl"
+    if not path.is_file():
+        return []
+    out = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+# ---- adopted-pattern coverage -----------------------------------------------
+
+INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[A-Za-z]?[0-9]+")
+
+
+def pattern_coverage(adopted: dict, invariants_text: str) -> list[dict]:
+    """For each adopted pattern, which promised INV ids actually appear in the epics."""
+    present = set(INV_ID_RE.findall(invariants_text))
+    out = []
+    for pid, rec in (adopted.get("patterns") or {}).items():
+        promised = [i for i in (rec.get("invariants") or []) if i]
+        missing = [i for i in promised if i not in present]
+        out.append({"pattern": pid, "promised": len(promised),
+                    "folded": len(promised) - len(missing), "missing": missing,
+                    "unresolved_params": rec.get("unresolved") or []})
+    return out
+
+
+def read_adopted(root: Path) -> dict:
+    path = root / "docs" / "patterns" / "adopted.json"
+    if path.is_file():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def read_epic_invariants(root: Path) -> str:
+    return "\n".join(p.read_text(errors="ignore")
+                     for p in sorted((root / "docs" / "epics").glob("*/invariants.md"))) \
+        if (root / "docs" / "epics").is_dir() else ""
+
+
+def read_retrospectives(root: Path) -> list[dict]:
+    out = []
+    epics = root / "docs" / "epics"
+    if not epics.is_dir():
+        return out
+    for p in sorted(epics.glob("*/retrospective.md")):
+        text = p.read_text(errors="ignore")
+        headers = [ln.strip("# ").strip() for ln in text.splitlines() if ln.startswith("#")]
+        out.append({"epic": p.parent.name, "sections": headers, "bytes": len(text)})
+    return out
+
+
+# ---- orchestration -----------------------------------------------------------
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None) -> dict:
+    log = _git(repo, "log", f"-{commits_limit}", "--pretty=%H%x1f%s")
+    commits = parse_git_log(log)
+    subjects = [c["subject"] for c in commits]
+    pr_texts = [f"{p.get('title', '')}\n{p.get('body', '')}" for p in (prs or [])]
+
+    reverts = detect_reverts(commits)
+    slips = slippage_commits(commits)
+    markers = scan_markers(repo)
+    journal = ratchet_health(load_journal(repo))
+    coverage = pattern_coverage(read_adopted(repo), read_epic_invariants(repo))
+    retros = read_retrospectives(repo)
+
+    findings: list[Finding] = []
+    mentions = gate_mentions(subjects + pr_texts)
+    for gate, n in mentions.items():
+        if n == 0:
+            findings.append(Finding("gates", "info",
+                f"gate '{gate}' never appears in {len(commits)} commits / {len(prs or [])} PRs — "
+                f"either it never fires here, or its value is invisible in the record"))
+    forces = force_bypasses(subjects + pr_texts)
+    if forces:
+        findings.append(Finding("gates", "warn",
+            f"{forces} gate-bypass token(s) (--force/--no-verify) in history — a gate operators route around erodes trust in every gate",
+            [c["subject"] for c in commits if "--force" in c["subject"].lower()][:5]))
+    if slips:
+        findings.append(Finding("slippage", "warn",
+            f"{len(slips)} fix/revert/hotfix commit(s) — candidate defects that reached main after the gates ran",
+            [c["subject"] for c in slips[:8]]))
+    if reverts:
+        findings.append(Finding("slippage", "warn", f"{len(reverts)} revert(s) in history",
+                                 [c["subject"] for c in reverts[:5]]))
+    if markers["total"]:
+        findings.append(Finding("assumptions", "warn",
+            f"{markers['total']} unresolved assumption marker(s) still in docs ({markers['by_marker']}) — the factory guessed and never confirmed",
+            markers["locations"][:8]))
+    for cov in coverage:
+        if cov["missing"]:
+            findings.append(Finding("patterns", "warn",
+                f"pattern '{cov['pattern']}' promised {cov['promised']} invariants but {len(cov['missing'])} were never folded into an epic: {cov['missing']}"))
+        if cov["unresolved_params"]:
+            findings.append(Finding("patterns", "info",
+                f"pattern '{cov['pattern']}' still has unbound params: {cov['unresolved_params']}"))
+    if journal["forced_merges"]:
+        findings.append(Finding("factory-logs", "warn",
+            f"{journal['forced_merges']} forced ratchet merge(s) — quality bar was lowered under override"))
+
+    return {
+        "repo": str(repo),
+        "commits_scanned": len(commits),
+        "commit_kinds": classify_commits(commits),
+        "gate_mentions": mentions,
+        "force_bypasses": forces,
+        "reverts": len(reverts),
+        "slippage_commits": len(slips),
+        "assumptions": markers,
+        "ratchet": journal,
+        "pattern_coverage": coverage,
+        "retrospectives": retros,
+        "pr_count": len(prs or []),
+        "findings": [asdict(f) for f in findings],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mine a CW-built repo for factory-effectiveness evidence.")
+    parser.add_argument("repo", type=Path, help="Local path to the target repo")
+    parser.add_argument("--prs", type=Path, help="JSON file of `gh pr list --json ...` output (optional)")
+    parser.add_argument("--commits", type=int, default=400, help="How many commits back to scan")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    if not (args.repo / ".git").exists():
+        print(f"reflect: {args.repo} is not a git repo", file=sys.stderr)
+        return 2
+
+    prs = None
+    if args.prs:
+        try:
+            prs = json.loads(args.prs.read_text())
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            print(f"reflect: could not read --prs: {exc}", file=sys.stderr)
+            return 2
+
+    report = collect(args.repo, commits_limit=args.commits, prs=prs)
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"reflect: {report['repo']} — {report['commits_scanned']} commits, {report['pr_count']} PRs")
+        print(f"  commit kinds: {report['commit_kinds']}")
+        print(f"  slippage: {report['slippage_commits']} fix/revert  |  bypasses: {report['force_bypasses']}  |  unresolved markers: {report['assumptions']['total']}")
+        print(f"  ratchet: {report['ratchet']}")
+        print(f"\n  {len(report['findings'])} finding(s):")
+        for f in report["findings"]:
+            print(f"  [{f['severity']}] ({f['dimension']}) {f['message']}")
+            for e in f["evidence"]:
+                print(f"      · {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/reflect.py (post-hoc factory-effectiveness miner)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import reflect  # noqa: E402
+
+# --- pure parsers -----------------------------------------------------------
+
+def test_parse_git_log_and_classify():
+    log = "abc\x1ffeat(x): add\ndef\x1ffix(y): repair\nghi\x1fRevert \"feat(x): add\""
+    commits = reflect.parse_git_log(log)
+    assert [c["hash"] for c in commits] == ["abc", "def", "ghi"]
+    kinds = reflect.classify_commits(commits)
+    # conventional-commit histogram; GitHub-style `Revert "..."` has no `:` -> "other"
+    assert kinds["feat"] == 1 and kinds["fix"] == 1 and kinds["other"] == 1
+    # ...but it IS caught as a revert for slippage
+    assert len(reflect.detect_reverts(commits)) == 1
+
+
+def test_detect_reverts_and_slippage():
+    commits = [
+        {"hash": "1", "subject": "feat(a): new"},
+        {"hash": "2", "subject": "fix(a): broke prod"},
+        {"hash": "3", "subject": "Revert \"feat(a): new\""},
+        {"hash": "4", "subject": "hotfix: urgent"},
+        {"hash": "5", "subject": "docs: readme"},
+    ]
+    assert len(reflect.detect_reverts(commits)) == 1
+    slips = reflect.slippage_commits(commits)
+    assert {c["hash"] for c in slips} == {"2", "3", "4"}
+
+
+def test_gate_mentions_and_force_bypasses():
+    texts = ["ran check_traceability and ratchet", "merged with --force past the ratchet",
+             "fixed @cw-writes single-writer violation"]
+    mentions = reflect.gate_mentions(texts)
+    assert mentions["traceability"] >= 1
+    assert mentions["ratchet"] >= 2
+    assert mentions["single_writer"] >= 1
+    assert reflect.force_bypasses(texts) == 1
+
+
+def test_ratchet_health():
+    records = [
+        {"gate_result": "pass", "merged": True, "amended": {"CTR-a-001": ["h"]}},
+        {"gate_result": "forced", "merged": True, "retired": ["INV-b-002"]},
+        {"gate_result": "fail", "merged": False},
+    ]
+    h = reflect.ratchet_health(records)
+    assert h["records"] == 3 and h["merged"] == 2
+    assert h["forced_merges"] == 1 and h["gate_failed"] == 1
+    assert h["amended_contracts"] == 1 and h["retired_contracts"] == 1
+
+
+def test_pattern_coverage_flags_unfolded_invariants():
+    adopted = {"patterns": {"p": {"invariants": ["INV-FOWR-001", "INV-FOWR-004"],
+                                   "unresolved": ["resource"]}}}
+    invariants = "## Epic\n- **INV-FOWR-001** — trigger only\n"  # 004 missing
+    cov = reflect.pattern_coverage(adopted, invariants)[0]
+    assert cov["promised"] == 2 and cov["folded"] == 1
+    assert cov["missing"] == ["INV-FOWR-004"]
+    assert cov["unresolved_params"] == ["resource"]
+
+
+# --- end-to-end over a synthetic repo ---------------------------------------
+
+def _init_repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+
+
+def _commit(tmp_path, subject):
+    (tmp_path / "f.txt").write_text(subject)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-q", "-m", subject], check=True)
+
+
+def test_collect_end_to_end(tmp_path):
+    _init_repo(tmp_path)
+    _commit(tmp_path, "feat(x): thing")
+    _commit(tmp_path, "fix(x): slipped bug")
+    # an unresolved marker in docs
+    (tmp_path / "docs" / "epics" / "e").mkdir(parents=True)
+    (tmp_path / "docs/epics/e/invariants.md").write_text(
+        "## Epic\n- **INV-FOWR-001** — trigger only\nTBD: confirm the schema name\n")
+    (tmp_path / "docs/patterns").mkdir(parents=True)
+    (tmp_path / "docs/patterns/adopted.json").write_text(json.dumps(
+        {"patterns": {"fetch-on-webhook-reconcile":
+                      {"invariants": ["INV-FOWR-001", "INV-FOWR-004"], "unresolved": []}}}))
+
+    report = reflect.collect(tmp_path)
+    assert report["slippage_commits"] == 1
+    assert report["assumptions"]["total"] >= 1
+    dims = {f["dimension"] for f in report["findings"]}
+    assert "slippage" in dims and "assumptions" in dims and "patterns" in dims
+    # INV-FOWR-004 promised but not folded -> a patterns finding
+    assert any("never folded" in f["message"] for f in report["findings"])
+
+
+def test_cli_json(tmp_path):
+    _init_repo(tmp_path)
+    _commit(tmp_path, "feat: init")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "reflect.py"), str(tmp_path), "--format", "json"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert json.loads(proc.stdout)["commits_scanned"] == 1
+
+
+def test_cli_rejects_non_repo(tmp_path):
+    proc = subprocess.run([sys.executable, str(SCRIPTS / "reflect.py"), str(tmp_path)],
+                          capture_output=True, text=True)
+    assert proc.returncode == 2


### PR DESCRIPTION
## What

A `/reflect` skill: point it at a repo the factory built, mine the evidence CW
leaves behind, and reason about **how well the factory served it** — then draft
CW-improvement issues. The improvement-loop pattern turned back on the factory
(all-trusted signal → autonomous analysis; filing issues is the one checkpoint).

This is the **post-hoc miner** half. A companion PR will add **factory telemetry**
(production-time gate/token/cost logging) for the value-vs-noise + token-costing
analysis that can't be reconstructed from git after the fact.

## `scripts/reflect.py` (pure-function parsers → git-backed `collect`)
Signals mined:
- **Slippage** — `fix(`/`revert`/`hotfix` commits (a defect reached main after the gates ran).
- **Gate value/noise** — each gate's mentions in commit/PR text; `--force`/`--no-verify` bypasses (a gate operators route around erodes trust in all gates).
- **Assumption-fill** — unresolved `TBD:`/`UNRESOLVED:` markers still in `docs/` (reuses `check_unresolved.scan`).
- **Factory-log health** — ratchet-journal forced merges / weakened / removed contracts.
- **Pattern coverage** — adopted-pattern invariants *promised but never folded* into an epic's `invariants.md`.
- **Retrospectives** — section inventory ("what the loop caught" vs "deferred/not done").

Emits structured evidence + heuristic findings; **creates no issues** (the skill does, with confirmation).

## Proven on a real repo
`reflect.py .../dogeared-coach` surfaces 11 slippage fix-commits and several gates
entirely absent from the record — real, actionable signal on day one.

## `.claude/commands/reflect.md`
Reasons across the dimensions (gate value→noise, slippage→missing-gate, assumption
quality, pattern coverage) and drafts **evidence-cited** issues for the CW repo;
filing is a human checkpoint. Works pointed at CW's own repo too (dogfooding).

## Tests / checks
10 tests (parsers + end-to-end over a synthetic git repo + CLI). `make lint` green;
`make test` **731 passed**, 4 skipped.
