### PR TITLE
Factory telemetry: production-time gate/consult metrics feeding /reflect

### DIFF
--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -1,0 +1,78 @@
+# Factory Telemetry
+
+Post-hoc git archaeology (`/reflect`) can tell you *that* a fix commit happened,
+but not a gate's duration, how many findings it caught, or an AI consultation's
+token cost. Those have to be emitted **as the factory produces**. `scripts/factory_log.py`
+is the append-only ledger for that, and `/reflect` reads it as the authoritative
+source for the value-vs-noise and token-cost questions.
+
+## Opt-in by default
+
+Emitting is a **no-op** unless telemetry is enabled — so tests and CI have no side
+effects:
+
+- `CW_TELEMETRY=1` — enable, writing to the default log `~/.chief-wiggum/factory-log.jsonl`.
+- `CW_FACTORY_LOG=/path/to/log.jsonl` — enable *and* redirect the log.
+
+Enable it when you want to measure a factory run (an `/implement-wave`, an
+`/architect`, a batch of gates). `/reflect` then folds the aggregates into its
+report and flags gates that ran repeatedly but caught nothing (`noise-candidate`)
+and the total logged consult cost.
+
+## Event schema
+
+One JSON object per line. Each call site fills what it **knows** and omits the rest:
+
+```
+{ts, event, repo?, ticket?, name?, result?, duration_ms?, caught?,
+ provider?, tokens_in?, tokens_out?, cost_usd?, details?}
+```
+
+| event | who emits | key fields |
+|--|--|--|
+| `gate` | a gate script | `name`, `result` (pass/fail/error), `duration_ms`, `caught` |
+| `consult` | an AI consultation | `provider`, `tokens_in`, `tokens_out`, `cost_usd` |
+| `worker` | a sub-agent run | `name`/role, tokens/cost if the harness surfaces them |
+| `skill` | a workflow step | `name`, `result` |
+
+Token/cost fields are only present where the call site can measure them (e.g. an
+SDK response with usage). CLI-provider consults that don't expose usage simply omit
+them — better an honest gap than a fabricated number.
+
+## Emitting
+
+From Python (the ergonomic path for gates):
+
+```python
+from factory_log import gate_timer
+with gate_timer("check_patterns", repo="chief-wiggum") as g:
+    errors = run()
+    g.caught = len(errors)
+    g.result = "fail" if errors else "pass"
+# emits {event: gate, name: check_patterns, result, caught, duration_ms} — or nothing if disabled
+```
+
+Or one-shot: `factory_log.emit_gate("ratchet", "pass", caught=0, repo=repo)`.
+
+From a skill / shell:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --repo "$owner_repo" \
+  --name ratchet --result pass --caught 0
+python3 "$CW_HOME/scripts/factory_log.py" emit --event consult --repo "$owner_repo" \
+  --provider opus --tokens-in 1200 --tokens-out 400 --cost-usd 0.03
+```
+
+`check_patterns.py` is the wired exemplar (guarded so it's a no-op when telemetry is
+off). Other gates and skills adopt the same one-liner as telemetry proves its worth.
+
+## Reading
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app   # per-gate value + consult cost
+```
+
+`aggregate` marks each gate `earning` (caught > 0), `noise-candidate` (≥3 runs, 0
+caught), or `unproven` (too few runs to judge) — the input to the gate-rollout
+question in `docs/gate-rollout.md`: a gate that never catches anything on real code
+is a candidate to demote or delete before it trains operators to `--force` past it.

--- a/scripts/check_patterns.py
+++ b/scripts/check_patterns.py
@@ -196,6 +196,13 @@ def main() -> int:
     errors = [f for f in findings if f.severity == ERROR]
     warns = [f for f in findings if f.severity == WARN]
 
+    # Factory telemetry (opt-in; no-op unless CW_TELEMETRY/CW_FACTORY_LOG set).
+    try:
+        from factory_log import emit_gate
+        emit_gate("check_patterns", "fail" if errors else "pass", caught=len(errors), repo="chief-wiggum")
+    except Exception:  # telemetry must never break the gate
+        pass
+
     if args.format == "json":
         print(json.dumps([f.__dict__ for f in findings], indent=2))
     else:

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Factory telemetry — a production-time event log CW writes as it produces.
+
+Post-hoc git archaeology (`reflect.py`) can't recover a gate's duration, how many
+findings it caught, or an AI consultation's token cost — those have to be emitted
+as the factory runs. This is the append-only ledger for that.
+
+**Opt-in by default.** Emitting is a no-op unless telemetry is enabled
+(`CW_TELEMETRY=1`, or `CW_FACTORY_LOG=<path>`), so tests/CI have no side effects.
+Enable it when you want to measure a factory run; `reflect.py` reads whatever log
+exists.
+
+Event schema (one JSON object per line):
+    {ts, event, repo?, ticket?, name?, result?, duration_ms?, caught?,
+     provider?, tokens_in?, tokens_out?, cost_usd?, details?}
+
+  event: "gate" | "consult" | "worker" | "skill"
+  A gate records name/result/duration_ms/caught; a consult records
+  provider/tokens/cost; each call site fills what it KNOWS and omits the rest.
+
+    factory_log.py emit --event gate --repo acme/app --name ratchet --result pass --caught 0
+    factory_log.py aggregate [--repo acme/app]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_LOG = Path.home() / ".chief-wiggum" / "factory-log.jsonl"
+
+GATE = "gate"
+CONSULT = "consult"
+WORKER = "worker"
+SKILL = "skill"
+
+
+def log_path() -> Path:
+    env = os.environ.get("CW_FACTORY_LOG")
+    return Path(env).expanduser() if env else DEFAULT_LOG
+
+
+def telemetry_enabled() -> bool:
+    return bool(os.environ.get("CW_TELEMETRY") or os.environ.get("CW_FACTORY_LOG"))
+
+
+def emit(event: str, *, ts: float | None = None, **fields) -> bool:
+    """Append one telemetry record. No-op (returns False) unless telemetry is on.
+
+    Never raises — telemetry must never break the thing it measures.
+    """
+    if not telemetry_enabled():
+        return False
+    record = {"ts": ts if ts is not None else time.time(), "event": event}
+    record.update({k: v for k, v in fields.items() if v is not None})
+    try:
+        path = log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def emit_gate(name: str, result: str, *, caught: int | None = None,
+              duration_ms: float | None = None, repo: str | None = None,
+              ticket: str | None = None) -> bool:
+    return emit(GATE, name=name, result=result, caught=caught,
+                duration_ms=duration_ms, repo=repo, ticket=ticket)
+
+
+class gate_timer:
+    """Context manager that times a gate and emits on exit.
+
+        with gate_timer("check_patterns", repo=repo) as g:
+            errors = run()
+            g.caught = len(errors)
+            g.result = "fail" if errors else "pass"
+    """
+
+    def __init__(self, name: str, *, repo: str | None = None, ticket: str | None = None):
+        self.name, self.repo, self.ticket = name, repo, ticket
+        self.result = "pass"
+        self.caught: int | None = None
+        self._t0 = 0.0
+
+    def __enter__(self):
+        self._t0 = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is not None:
+            self.result = "error"
+        emit_gate(self.name, self.result, caught=self.caught,
+                  duration_ms=round((time.time() - self._t0) * 1000, 1),
+                  repo=self.repo, ticket=self.ticket)
+        return False  # never suppress
+
+
+# ---- reading / aggregation ---------------------------------------------------
+
+def read_log(path: Path | None = None) -> list[dict]:
+    path = path or log_path()
+    if not path.is_file():
+        return []
+    out = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def aggregate(records: list[dict], repo: str | None = None) -> dict:
+    if repo:
+        records = [r for r in records if r.get("repo") == repo]
+    gates: dict[str, dict] = {}
+    consults: dict[str, dict] = {}
+    cost_total = 0.0
+    for r in records:
+        if r.get("event") == GATE and r.get("name"):
+            g = gates.setdefault(r["name"], {"runs": 0, "passed": 0, "failed": 0,
+                                             "caught": 0, "total_ms": 0.0})
+            g["runs"] += 1
+            g["passed"] += 1 if r.get("result") == "pass" else 0
+            g["failed"] += 1 if r.get("result") in ("fail", "error") else 0
+            g["caught"] += r.get("caught") or 0
+            g["total_ms"] += r.get("duration_ms") or 0.0
+        elif r.get("event") in (CONSULT, WORKER):
+            key = r.get("provider") or r.get("name") or r.get("event")
+            c = consults.setdefault(key, {"calls": 0, "tokens_in": 0,
+                                          "tokens_out": 0, "cost_usd": 0.0})
+            c["calls"] += 1
+            c["tokens_in"] += r.get("tokens_in") or 0
+            c["tokens_out"] += r.get("tokens_out") or 0
+            c["cost_usd"] += r.get("cost_usd") or 0.0
+            cost_total += r.get("cost_usd") or 0.0
+    # value/noise hint: a gate with runs but zero caught is a noise candidate
+    for g in gates.values():
+        g["value"] = "earning" if g["caught"] > 0 else ("noise-candidate" if g["runs"] >= 3 else "unproven")
+    return {"gates": gates, "consults": consults, "records": len(records),
+            "cost_usd_total": round(cost_total, 4)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Factory telemetry emitter / aggregator.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("emit", help="Append a telemetry event")
+    e.add_argument("--event", required=True, choices=[GATE, CONSULT, WORKER, SKILL])
+    for opt in ("repo", "ticket", "name", "result", "provider", "details"):
+        e.add_argument(f"--{opt}")
+    for opt in ("caught", "tokens-in", "tokens-out"):
+        e.add_argument(f"--{opt}", type=int)
+    e.add_argument("--duration-ms", type=float)
+    e.add_argument("--cost-usd", type=float)
+
+    a = sub.add_parser("aggregate", help="Summarize the log")
+    a.add_argument("--repo")
+    a.add_argument("--format", choices=["text", "json"], default="json")
+
+    sub.add_parser("path", help="Print the log path")
+    args = parser.parse_args()
+
+    if args.cmd == "path":
+        print(log_path())
+        return 0
+    if args.cmd == "emit":
+        fields = {k: getattr(args, k) for k in
+                  ("repo", "ticket", "name", "result", "provider", "details",
+                   "caught", "cost_usd", "duration_ms")}
+        fields["tokens_in"] = args.tokens_in
+        fields["tokens_out"] = args.tokens_out
+        ok = emit(args.event, **fields)
+        if not ok:
+            print("factory_log: telemetry disabled (set CW_TELEMETRY=1 to enable)", file=sys.stderr)
+            return 1
+        return 0
+    if args.cmd == "aggregate":
+        agg = aggregate(read_log(), repo=args.repo)
+        print(json.dumps(agg, indent=2))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reflect.py
+++ b/scripts/reflect.py
@@ -35,6 +35,7 @@ SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
 
 import check_unresolved  # noqa: E402
+import factory_log  # noqa: E402
 
 # Known CW gates and the tokens that betray them in commit/PR text.
 GATE_TOKENS = {
@@ -219,6 +220,13 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
     coverage = pattern_coverage(read_adopted(repo), read_epic_invariants(repo))
     retros = read_retrospectives(repo)
 
+    # Production-time telemetry, when the factory logged it — authoritative for
+    # gate value/noise + token cost (things git archaeology can't recover).
+    repo_key = repo.name
+    telemetry = factory_log.aggregate(factory_log.read_log(), repo=repo_key)
+    if not telemetry["records"]:
+        telemetry = factory_log.aggregate(factory_log.read_log())  # fall back to unfiltered
+
     findings: list[Finding] = []
     mentions = gate_mentions(subjects + pr_texts)
     for gate, n in mentions.items():
@@ -252,6 +260,13 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
     if journal["forced_merges"]:
         findings.append(Finding("factory-logs", "warn",
             f"{journal['forced_merges']} forced ratchet merge(s) — quality bar was lowered under override"))
+    for gname, g in (telemetry.get("gates") or {}).items():
+        if g.get("value") == "noise-candidate":
+            findings.append(Finding("gates", "warn",
+                f"telemetry: gate '{gname}' ran {g['runs']}x but caught 0 findings ({round(g['total_ms'])}ms total) — value unproven, candidate noise"))
+    if telemetry.get("cost_usd_total"):
+        findings.append(Finding("factory-logs", "info",
+            f"telemetry: ${telemetry['cost_usd_total']} in logged AI-consult cost across {telemetry['records']} events"))
 
     return {
         "repo": str(repo),
@@ -265,6 +280,7 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
         "ratchet": journal,
         "pattern_coverage": coverage,
         "retrospectives": retros,
+        "telemetry": telemetry,
         "pr_count": len(prs or []),
         "findings": [asdict(f) for f in findings],
     }

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -1,0 +1,99 @@
+"""Tests for scripts/factory_log.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import factory_log  # noqa: E402
+
+
+def test_emit_is_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    monkeypatch.delenv("CW_FACTORY_LOG", raising=False)
+    assert factory_log.emit(factory_log.GATE, name="x", result="pass") is False
+
+
+def test_emit_writes_when_enabled(tmp_path, monkeypatch):
+    log = tmp_path / "factory-log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    assert factory_log.emit(factory_log.GATE, name="ratchet", result="pass", repo="acme/app", caught=2, ts=1.0)
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["event"] == "gate" and rec["name"] == "ratchet" and rec["caught"] == 2
+    assert rec["ts"] == 1.0
+    # None-valued fields are omitted
+    assert "ticket" not in rec
+
+
+def test_gate_timer_emits_with_duration(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    with factory_log.gate_timer("check_patterns", repo="acme/app") as g:
+        g.caught = 3
+        g.result = "fail"
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["name"] == "check_patterns" and rec["result"] == "fail" and rec["caught"] == 3
+    assert "duration_ms" in rec
+
+
+def test_gate_timer_records_error_on_exception(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    try:
+        with factory_log.gate_timer("g", repo="r"):
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["result"] == "error"
+
+
+def test_aggregate_gate_value_and_cost():
+    records = [
+        {"event": "gate", "name": "ratchet", "result": "pass", "caught": 0, "duration_ms": 10, "repo": "a"},
+        {"event": "gate", "name": "ratchet", "result": "pass", "caught": 0, "duration_ms": 10, "repo": "a"},
+        {"event": "gate", "name": "ratchet", "result": "fail", "caught": 1, "duration_ms": 10, "repo": "a"},
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": "a"},
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": "a"},
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": "a"},
+        {"event": "consult", "provider": "opus", "tokens_in": 100, "tokens_out": 50, "cost_usd": 0.02, "repo": "a"},
+    ]
+    agg = factory_log.aggregate(records)
+    assert agg["gates"]["ratchet"]["caught"] == 1
+    assert agg["gates"]["ratchet"]["value"] == "earning"
+    assert agg["gates"]["noisy"]["value"] == "noise-candidate"  # 3 runs, 0 caught
+    assert agg["consults"]["opus"]["cost_usd"] == 0.02
+    assert agg["cost_usd_total"] == 0.02
+
+
+def test_aggregate_filters_by_repo():
+    records = [
+        {"event": "gate", "name": "g", "result": "pass", "repo": "a"},
+        {"event": "gate", "name": "g", "result": "pass", "repo": "b"},
+    ]
+    assert factory_log.aggregate(records, repo="a")["gates"]["g"]["runs"] == 1
+
+
+def test_cli_emit_disabled_returns_1(tmp_path, monkeypatch):
+    env = {k: v for k, v in __import__("os").environ.items()
+           if k not in ("CW_TELEMETRY", "CW_FACTORY_LOG")}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "factory_log.py"), "emit", "--event", "gate", "--name", "x", "--result", "pass"],
+        capture_output=True, text=True, env=env)
+    assert proc.returncode == 1
+    assert "telemetry disabled" in proc.stderr
+
+
+def test_cli_emit_and_aggregate(tmp_path):
+    import os
+    log = tmp_path / "f.jsonl"
+    env = {**os.environ, "CW_FACTORY_LOG": str(log)}
+    subprocess.run([sys.executable, str(SCRIPTS / "factory_log.py"), "emit",
+                    "--event", "gate", "--name", "ratchet", "--result", "pass", "--caught", "0", "--repo", "a"],
+                   check=True, env=env)
+    proc = subprocess.run([sys.executable, str(SCRIPTS / "factory_log.py"), "aggregate", "--repo", "a"],
+                          capture_output=True, text=True, env=env, check=True)
+    assert json.loads(proc.stdout)["gates"]["ratchet"]["runs"] == 1

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -104,6 +104,22 @@ def test_collect_end_to_end(tmp_path):
     assert any("never folded" in f["message"] for f in report["findings"])
 
 
+def test_collect_consumes_factory_telemetry(tmp_path, monkeypatch):
+    _init_repo(tmp_path)
+    _commit(tmp_path, "feat: init")
+    log = tmp_path / "factory-log.jsonl"
+    repo_key = tmp_path.name  # reflect filters telemetry by repo.name
+    log.write_text("\n".join(json.dumps(r) for r in [
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": repo_key},
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": repo_key},
+        {"event": "gate", "name": "noisy", "result": "pass", "caught": 0, "duration_ms": 5, "repo": repo_key},
+    ]) + "\n")
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    report = reflect.collect(tmp_path)
+    assert report["telemetry"]["gates"]["noisy"]["value"] == "noise-candidate"
+    assert any("candidate noise" in f["message"] for f in report["findings"])
+
+
 def test_cli_json(tmp_path):
     _init_repo(tmp_path)
     _commit(tmp_path, "feat: init")


### PR DESCRIPTION
## What

The production-time half of factory observability. `/reflect` (post-hoc) can tell
you a fix commit happened, but not a gate's duration, how many findings it caught,
or a consult's token cost — those must be **emitted as the factory runs**. This is
the append-only ledger for that, and the authoritative source for the
value-vs-noise + token-costing analysis you asked for.

## `scripts/factory_log.py`
- `emit` / `emit_gate` / `gate_timer` (a context manager that times a gate and
  emits on exit) + `aggregate`.
- **Opt-in by default** — a no-op unless `CW_TELEMETRY=1` or `CW_FACTORY_LOG=<path>`
  is set, so tests/CI have zero side effects. Never raises (telemetry must not break
  what it measures).
- **Honest gaps** — each call site logs what it *knows*; CLI-provider consults that
  don't expose usage omit the token fields rather than fabricate a number.
- `aggregate` marks each gate `earning` (caught > 0) / `noise-candidate` (≥3 runs,
  0 caught) / `unproven`, and rolls up consult tokens + cost.

## Wiring
- `check_patterns.py` is the wired exemplar gate emit (guarded — no-op when off).
- `reflect.py` consumes the log (filtered by repo) as the **authoritative** gate
  value/noise + cost signal — flags `noise-candidate` gates and total consult cost,
  overriding git archaeology where telemetry exists.
- `docs/factory-telemetry.md` — schema, emit convention (Python one-liner + shell),
  and how `/reflect` reads it. Ties into `docs/gate-rollout.md`: a gate that never
  catches on real code is a candidate to demote before it trains operators to
  `--force` past it.

## Proven end-to-end
`check_patterns` emits a gate event; a consult emit records `$0.03` / 1600 tokens;
`aggregate` rolls both up.

## Tests / checks
9 telemetry tests + a reflect-consumes-telemetry test. `make lint` green; `make
test` **740 passed**, 4 skipped.
