### PR TITLE
fix: add Claude Sonnet 5 to the pricing table (it shipped; I was wrong)

### DIFF
--- a/config/model_pricing.json
+++ b/config/model_pricing.json
@@ -13,6 +13,7 @@
     "claude-opus-4-8":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-opus-4-7":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-opus-4-6":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
+    "claude-sonnet-5":   {"input_per_mtok": 2.0,  "output_per_mtok": 10.0, "provider": "anthropic", "verified": true, "as_of": "2026-07-12", "note": "introductory pricing through 2026-08-31; standard 3.0/15.0 from 2026-09-01 (platform.claude.com/docs/en/about-claude/pricing)"},
     "claude-sonnet-4-6": {"input_per_mtok": 3.0,  "output_per_mtok": 15.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-haiku-4-5":  {"input_per_mtok": 1.0,  "output_per_mtok": 5.0,  "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
 

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -103,6 +103,7 @@ def test_cost_for_cross_provider_grounded():
     assert factory_log.cost_for("gpt-5.4", 1_000_000, 1_000_000) == 17.5      # 2.5 + 15
     assert factory_log.cost_for("gemini-2.5-flash", 1_000_000, 1_000_000) == 2.8  # 0.3 + 2.5
     assert factory_log.cost_for("glm-4.6", 1_000_000, 1_000_000) == 2.8       # 0.6 + 2.2
+    assert factory_log.cost_for("claude-sonnet-5", 1_000_000, 1_000_000) == 12.0  # 2 + 10 (intro)
 
 
 def test_emit_consult_records_tokens_and_grounded_cost(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Claude Sonnet 5 (`claude-sonnet-5`) **is real and generally available** — I
incorrectly said it didn't exist, reading a stale cached (2026-06-04) skill
reference instead of checking live. That's the exact "never answer model/pricing
from memory" failure the guidance warns about.

Verified against the live pricing page
(`platform.claude.com/docs/en/about-claude/pricing`) and added the row:
- **$2 / $10 per MTok** introductory (in effect through 2026-08-31)
- **$3 / $15 per MTok** standard from 2026-09-01 (noted on the row; `/update` flips it)

`claude-sonnet-5` — best speed/intelligence, 1M context, 128K output, new tokenizer.

+1 test. `make test` green.
