### PR TITLE
chore: link deferred TBDs to their tracking tickets

### DIFF
--- a/config/model_pricing.json
+++ b/config/model_pricing.json
@@ -41,6 +41,6 @@
     "glm-4.7-flash": {"input_per_mtok": 0.0, "output_per_mtok": 0.0, "provider": "zhipu", "verified": true, "as_of": "2026-07-12", "note": "free tier"},
     "glm-4.5-flash": {"input_per_mtok": 0.0, "output_per_mtok": 0.0, "provider": "zhipu", "verified": true, "as_of": "2026-07-12", "note": "free tier"},
 
-    "codex": {"input_per_mtok": null, "output_per_mtok": null, "provider": "openai", "verified": false, "note": "TBD: identify the exact GPT model `codex exec` bills as, then map to its gpt-* row"}
+    "codex": {"input_per_mtok": null, "output_per_mtok": null, "provider": "openai", "verified": false, "note": "TBD (chief-wiggum#134): identify the exact GPT model `codex exec` bills as, then map to its gpt-* row"}
   }
 }

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -529,7 +529,7 @@ Smallest-first. Progress so far:
    (`scripts/apply_pattern.py` + `.claude/commands/apply-pattern.md`): binds
    params, stamps the invariant cluster + adoption record, registers protected
    paths. The pattern `scaffold/` (stamping code, not just contracts) is still to
-   come.
+   come — tracked in [chief-wiggum#135](https://github.com/plwp/chief-wiggum/issues/135).
 3. ✅ **`/seed` + `/architect` integration** — the full select → install → fold →
    hold loop is wired:
    - **`/seed` Step 4.5** *selects* — proposes applicable patterns from the catalog


### PR DESCRIPTION
Per the 'never defer without opening a ticket' rule: the `codex` pricing `TBD:` in model_pricing.json now points at #134, and the scaffold-stamping deferral in the registry rollout points at #135. No behavior change.