### PR TITLE
Promote immutable-assignment-snapshot to a specified pattern (INV-IAS-001..003)

### DIFF
--- a/patterns/immutable-assignment-snapshot/manifest.json
+++ b/patterns/immutable-assignment-snapshot/manifest.json
@@ -1,0 +1,53 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/immutable-assignment-snapshot/pattern.md. Expressed AS an invariant cluster (see docs/patterns-registry.md#patterns-as-clusters-of-invariants). Promoted from candidate; grounded in dogeared-coach course versioning.",
+  "id": "immutable-assignment-snapshot",
+  "version": 1,
+  "title": "Immutable Assignment Snapshot",
+  "category": "data-structure",
+  "trust_class": "published-version-store-is-protected-path",
+
+  "applies_when": [
+    "a template is assigned/issued and then edited over its lifetime",
+    "an outstanding assignment must reflect the template AS IT WAS when assigned",
+    "longitudinal completion analysis must stay drift-free (stable denominator)",
+    "NOT when assignments should always track the latest template (then a live reference is correct — say so explicitly)"
+  ],
+
+  "components": [
+    "write-once-version: publishing snapshots the template into a Version whose store exposes ONLY insert + find (no update/delete); immutable by construction",
+    "edit-forks-new-version: an edit produces a new version id; every prior published version is frozen",
+    "assignment-references-version-id: assignment stores version_id (+ item ids) by reference, not an embedded copy; hydrate reads from the pinned version",
+    "value-copy-at-publish: must-not-drift item fields (titles, durations, ordering, metadata) are value-copied into the version at publish and read from the pin at hydrate",
+    "documented-mutable-exceptions: any field deliberately read live is an explicit documented asymmetry, decided per field, not an accidental live reference"
+  ],
+
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees; grounded in dogeared-coach course versioning.",
+    "cluster": [
+      {"id": "INV-IAS-001", "statement": "Published version is write-once: no in-place patch (version store exposes insert + find only).", "realized_as": {"app": "dogeared-coach", "code": "db/store.go:95-118; models/course.go:20-40"}},
+      {"id": "INV-IAS-002", "statement": "Editing creates a NEW version; outstanding assignments keep referencing the old immutable version id.", "realized_as": {"app": "dogeared-coach", "code": "services/course.go:609-629; models/assignment.go:8-23"}},
+      {"id": "INV-IAS-003", "statement": "Composite-item fields are value-copied into the version at publish (snapshot), read from the pin at hydrate.", "realized_as": {"app": "dogeared-coach", "code": "services/assignment_view.go:364-389"}}
+    ]
+  },
+
+  "parameters": {
+    "composite": {"type": "string", "required": true, "description": "The assignable template (course/checklist/form/plan)."},
+    "version_store": {"type": "string", "required": true, "description": "Write-once store for published versions (insert + find only)."},
+    "pinned_fields": {"type": "array", "required": true, "description": "Item fields value-copied into the version at publish (must-not-drift)."},
+    "live_fields": {"type": "array", "required": false, "description": "Fields deliberately read live at hydrate (documented mutable exceptions)."}
+  },
+
+  "success_metrics": {
+    "metrics": [
+      {"id": "retroactive_mutation_incidents", "goal": "down", "desc": "outstanding assignments whose content changed from a template edit (target 0)"},
+      {"id": "denominator_drift", "goal": "down", "desc": "longitudinal completion measured against a shifted denominator (target 0)"},
+      {"id": "version_store_mutations", "goal": "down", "desc": "in-place updates/deletes on a published version (target 0; store forbids them)"}
+    ]
+  },
+
+  "protected_paths": ["the published-version store (insert+find only)", "the publish-time snapshot copy"],
+
+  "feeds": {
+    "engagement-instrumentation": "the pinned version is the trusted denominator completion is measured against"
+  }
+}

--- a/patterns/immutable-assignment-snapshot/pattern.md
+++ b/patterns/immutable-assignment-snapshot/pattern.md
@@ -1,0 +1,83 @@
+# Pattern: Immutable Assignment Snapshot
+
+- **Category:** data-structure
+- **Trust class:** the published-version store is a protected path (edits must never mutate an outstanding assignment)
+- **Status:** specified (spec complete; `scaffold/` not yet built — see [chief-wiggum#135](https://github.com/plwp/chief-wiggum/issues/135))
+
+## What it is
+
+The shape that lets you **edit a template without retroactively changing work
+already assigned from it**. When a composite item (a course, a checklist, a form, a
+plan) is assigned to someone, the assignment pins the exact *version* that was
+published — not a live reference to the template. Later edits create a **new
+immutable version**; outstanding assignments keep pointing at the old one. Nobody's
+in-flight work silently changes underneath them, and longitudinal completion
+analysis stays drift-free (the denominator an assignment was measured against never
+moves).
+
+The subtle, load-bearing detail (mined from real code): immutability lives in a
+**write-once version snapshot created at publish time** — *not* a copy of the whole
+composite stuffed into the assignment. The assignment stores only a **version id by
+reference**; the version is the liability boundary that is never patched.
+
+## When to apply
+
+Any product where a template is *assigned* or *issued* and then edited over its
+lifetime, and where an outstanding assignment must reflect the template **as it was
+when assigned**: course/curriculum platforms, checklists/SOPs, forms, care/workout
+plans, policy acknowledgements, quizzes. Skip it when assignments should *always*
+track the latest template (then a live reference is correct — but say so explicitly,
+because "edit silently changed everyone's assignment" is a classic latent bug).
+
+## Mechanism — generic components
+
+- **Write-once published version.** Publishing a template snapshots it into a
+  `Version` record whose store exposes **only insert + find** — no update, no delete.
+  The version is immutable by construction; there is no code path that patches it.
+- **Editing forks a new version.** An edit to the template produces a *new* version
+  (new id / version number). The template's live/draft state moves forward; every
+  prior published version is frozen.
+- **Assignments reference a version id, not the template.** An assignment stores the
+  `version_id` (and item ids) **by reference** — it does not embed a copy of the
+  composite. Hydration reads the composite from the pinned version.
+- **Composite-item fields are value-copied at publish (the snapshot).** Fields that
+  must not drift (titles, durations, ordering, per-item metadata) are **value-copied
+  into the version at publish** and read from that pin at hydrate time — so editing
+  the underlying item later doesn't leak into an outstanding assignment.
+- **Deliberate mutable exceptions are documented, not accidental.** Some fields may
+  intentionally read live (e.g. a directly-assigned single item's display title);
+  where that's the design, it's an explicit, documented asymmetry — not an
+  accidental live reference. Make the choice per field, on purpose.
+
+## Invariant cluster
+
+| Generic ID | Invariant | Realized as (provenance) |
+|--|--|--|
+| `INV-IAS-001` | Published version is write-once: no in-place patch (the version store exposes insert + find only). | dogeared-coach `db/store.go:95-118`; `models/course.go:20-40` |
+| `INV-IAS-002` | Editing creates a NEW version; outstanding assignments keep referencing the old immutable version id. | `services/course.go:609-629`; `models/assignment.go:8-23` |
+| `INV-IAS-003` | Composite-item fields are value-copied into the version at publish (snapshot), read from the pin at hydrate. | `services/assignment_view.go:364-389` |
+
+## Parameters
+
+| Parameter | Required | Description |
+|--|--|--|
+| `composite` | yes | The assignable template (course/checklist/form/plan). |
+| `version_store` | yes | Write-once store for published versions (insert + find only). |
+| `pinned_fields` | yes | Item fields value-copied into the version at publish (must-not-drift). |
+| `live_fields` | no | Fields deliberately read live at hydrate (documented mutable exceptions). |
+
+## Success metrics
+
+| ID | Goal | Description |
+|--|--|--|
+| `retroactive_mutation_incidents` | down | outstanding assignments whose content changed from a template edit (target 0). |
+| `denominator_drift` | down | longitudinal completion measured against a shifted denominator (target 0). |
+| `version_store_mutations` | down | in-place updates/deletes on a published version (target 0; the store forbids them). |
+
+## Relationship to other patterns
+
+- **`engagement-instrumentation`** — the pinned version *is* the trusted
+  denominator its completion tracking measures against; without the snapshot, the
+  denominator drifts and drop-off becomes uncomputable.
+- **`multi-tenant-isolation`** — the version store is tenant-scoped like every other
+  repository; the snapshot is orthogonal to (and composes with) the tenant floor.

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -124,6 +124,18 @@
       "feeds": "improvement-loop",
       "spec": "patterns/entitlement-overlay/pattern.md",
       "manifest": "patterns/entitlement-overlay/manifest.json"
+    },
+    {
+      "id": "immutable-assignment-snapshot",
+      "title": "Immutable Assignment Snapshot",
+      "category": "data-structure",
+      "status": "specified",
+      "trust_class": "published-version-store-is-protected-path",
+      "summary": "Edit a template without retroactively changing work already assigned from it: publishing snapshots the template into a write-once Version (insert+find only), editing forks a NEW version, and assignments pin a version id by reference (must-not-drift item fields value-copied at publish). Keeps outstanding assignments as-assigned and longitudinal completion drift-free. Nuance mined from code: immutability lives in the write-once version snapshot at publish, not a copy-into-the-assignment. Promoted from candidate; INV-IAS-001..003.",
+      "invariants": "INV-IAS-001..003",
+      "feeds": "engagement-instrumentation",
+      "spec": "patterns/immutable-assignment-snapshot/pattern.md",
+      "manifest": "patterns/immutable-assignment-snapshot/manifest.json"
     }
   ],
   "stacks": {
@@ -139,7 +151,6 @@
     {"id": "referral-invite-loop", "title": "Referral / Invite Growth Loop", "category": "process-loop", "status": "candidate", "summary": "Invite -> signed invite token (server-trusted, single-use, expiring) -> attribution on accept -> reward both sides. Reuses the signed-token discipline; attribution is trust-tagged signal. A self-serve growth loop the improvement loop can optimize (reward size/copy) under admin gating.", "reusability": "medium-high"},
     {"id": "feature-entitlements", "title": "Feature Entitlements Read-Model", "category": "saas-infra", "status": "candidate", "summary": "A single entitlement resolver deriving capability flags from tier + per-account overrides + grandfathering, consumed identically by backend gates and the frontend (one source of 'what can this account do'). Distinct from the tier matrix: it layers overrides and is the read model onboarding + UI both query.", "reusability": "medium-high"},
     {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"},
-    {"id": "immutable-assignment-snapshot", "title": "Immutable Assignment Snapshot", "category": "data-structure", "status": "candidate", "summary": "Pin the exact version of a composite item at PUBLISH time (edit -> new immutable published version; assignment references a version id, not the live template) so later edits never retroactively mutate outstanding assignments. The version snapshot is the liability boundary: write-once (Insert/Find only, no Update/Delete), item fields value-copied at publish. Keeps longitudinal completion analysis clean (no denominator drift). Nuance mined from code: immutability lives in the write-once version snapshot at publish, not a copy-into-the-assignment.", "reusability": "medium-high", "invariants": [{"id": "INV-IAS-001", "statement": "Published version is write-once: no in-place patch (repo exposes Insert+Find only).", "realized_as": {"app": "dogeared-coach", "code": "db/store.go:95-118; models/course.go:20-40"}}, {"id": "INV-IAS-002", "statement": "Editing creates a NEW version; outstanding assignments keep referencing the old immutable version id.", "realized_as": {"app": "dogeared-coach", "code": "services/course.go:609-629; models/assignment.go:8-23"}}, {"id": "INV-IAS-003", "statement": "Composite-item fields are value-copied into the version at publish (snapshot), read from the pin at hydrate.", "realized_as": {"app": "dogeared-coach", "code": "services/assignment_view.go:364-389"}}]},
     {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test+lint gate across a polyglot repo, with a local pre-merge script mirroring CI; optionally zero-cost-until-opt-in (manual-dispatch trigger) for cost-sensitive private repos.", "reusability": "medium"}
   ],
   "meta_disciplines": {


### PR DESCRIPTION
## What

Promotes `immutable-assignment-snapshot` from candidate to a specified pattern — it
already carried a grounded cluster; this adds the `pattern.md` + `manifest.json`.

The shape: edit a template without retroactively changing work already assigned
from it. Cluster `INV-IAS-001..003` (grounded in dogeared-coach course versioning):
- published version is **write-once** (store exposes insert+find only)
- editing **forks a new version**; outstanding assignments keep the old immutable version id
- must-not-drift item fields are **value-copied at publish**, read from the pin at hydrate

The mined nuance is baked into the spec: immutability lives in the write-once
version snapshot at publish, **not** a copy-into-the-assignment. Self-contained (no
deps). Registry: **11 specified patterns**, 6 candidates. `make lint` +
`make test` (754) green.
