### PR TITLE
Promote build-test-floor to specified — clears the last validator warning (registry OK)

### DIFF
--- a/patterns/build-test-floor/manifest.json
+++ b/patterns/build-test-floor/manifest.json
@@ -1,0 +1,54 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/build-test-floor/pattern.md. Expressed AS an invariant cluster (see docs/patterns-registry.md#patterns-as-clusters-of-invariants). Promoted from candidate; realized by the factory on itself (chief-wiggum Makefile + ci.yml).",
+  "id": "build-test-floor",
+  "version": 1,
+  "title": "Language-Agnostic Build/Test Floor",
+  "category": "gate",
+  "trust_class": "floor-definition-is-protected-path",
+
+  "applies_when": [
+    "every repo — it is the pre-condition gate deploy + the improvement loop stand on",
+    "the local mirror is non-negotiable; only the CI trigger policy varies",
+    "polyglot repos need every language gated, not just one"
+  ],
+
+  "components": [
+    "one-command-local-and-ci: a single entrypoint (make lint && make test / pre-merge-check) is the whole gate; CI runs THAT command, not a re-specification, so green-locally predicts green-in-CI",
+    "polyglot-auto-detect: set up + gate every language present (build + lint + test each)",
+    "fail-closed-no-skip: any failing step or missing required tool fails the floor; never degrades to skipped-therefore-green",
+    "pre-condition-for-merge-and-deploy: CI runs the floor on every PR; no deploy proceeds without it; the floor is a protected path workers can't weaken",
+    "zero-cost-until-opt-in(optional): manual-dispatch CI trigger for cost-sensitive private repos; the local mirror still gives the full gate for free"
+  ],
+
+  "invariants": {
+    "$comment": "The cluster this pattern guarantees; grounded in chief-wiggum's OWN floor (the factory held to this pattern) + dogeared-coach's zero-cost trigger.",
+    "cluster": [
+      {"id": "INV-BTF-001", "statement": "One entrypoint is the whole gate, and CI runs that same command, so green-locally predicts green-in-CI.", "realized_as": {"app": "chief-wiggum", "code": "Makefile (lint/test) == .github/workflows/ci.yml (run: make lint / make test)"}},
+      {"id": "INV-BTF-002", "statement": "Polyglot: every language in the repo is set up and gated (build + lint + test), not just one.", "realized_as": {"app": "chief-wiggum", "code": ".github/workflows/ci.yml (Python + Node setup; make lint = ruff + py_compile + CW gates)"}},
+      {"id": "INV-BTF-003", "statement": "Fail-closed: any step failing or a required tool missing fails the floor; never a silent skip.", "realized_as": {"app": "chief-wiggum", "code": "make step-failure semantics; each gate exits non-zero on violation"}},
+      {"id": "INV-BTF-004", "statement": "Pre-condition for merge/deploy: CI runs the floor on every PR; no deploy proceeds without it.", "realized_as": {"app": "chief-wiggum", "code": ".github/workflows/ci.yml (on: pull_request); deployment-release INV-DRL floor-gated"}},
+      {"id": "INV-BTF-005", "statement": "(optional) Zero-cost-until-opt-in: manual-dispatch CI for cost-sensitive private repos; the local mirror still gives the full gate for free.", "realized_as": {"app": "dogeared-coach", "code": ".github/workflows/ci.yml (workflow_dispatch-only to save private-repo Actions minutes)"}}
+    ]
+  },
+
+  "parameters": {
+    "floor_cmd": {"type": "string", "required": true, "description": "The single local entrypoint CI also runs (make lint && make test, pre-merge-check)."},
+    "languages": {"type": "array", "required": true, "description": "Toolchains set up + gated (each gets build + lint + test)."},
+    "ci_trigger": {"enum": ["on-push-and-pr", "manual-dispatch"], "required": false, "default": "on-push-and-pr", "description": "Trigger policy; manual-dispatch is zero-cost-until-opt-in."}
+  },
+
+  "success_metrics": {
+    "metrics": [
+      {"id": "local_ci_divergence", "goal": "down", "desc": "changes green locally but red in CI or vice versa (target 0 — same command)"},
+      {"id": "silent_skip_incidents", "goal": "down", "desc": "floor steps that no-op'd instead of failing (target 0)"},
+      {"id": "unfloored_merges", "goal": "down", "desc": "merges/deploys that bypassed the floor (target 0)"}
+    ]
+  },
+
+  "protected_paths": ["the floor entrypoint (Makefile / pre-merge-check)", "the CI workflow that runs it"],
+
+  "feeds": {
+    "deployment-release": "the floor is deployment-release's explicit pre-condition (floor_cmd); no stage/promote runs without it",
+    "improvement-loop": "the floor is the deterministic pass/fail the ratchet high-water mark is built on"
+  }
+}

--- a/patterns/build-test-floor/pattern.md
+++ b/patterns/build-test-floor/pattern.md
@@ -1,0 +1,85 @@
+# Pattern: Language-Agnostic Build/Test Floor
+
+- **Category:** gate
+- **Trust class:** the floor definition is a protected path (the pre-condition every deploy/merge stands on)
+- **Status:** specified (spec complete; `scaffold/` not yet built — see [chief-wiggum#135](https://github.com/plwp/chief-wiggum/issues/135))
+
+## What it is
+
+The **pre-condition gate** everything else stands on: one command that builds,
+tests, and lints the whole repo — every language in it — and that a human runs
+locally byte-for-byte the same as CI runs it. "Green locally" *predicts* "green in
+CI" because they are the **same command**, not two drifting definitions of "passing."
+Nothing merges or deploys without it.
+
+Why a pattern and not "just add a CI workflow": the value is in the *invariants* that
+make the floor trustworthy — the local mirror (so the feedback loop is fast and CI
+holds no surprises), fail-closed-on-missing-tool (so a skipped step can't read as a
+pass), polyglot coverage (so the Go half isn't gated while the TS half rots), and
+the deploy pre-condition ([`deployment-release`](../deployment-release) stands on
+this). Miss the mirror and developers debug in CI; miss fail-closed and a broken
+gate silently greenlights.
+
+## When to apply
+
+Every repo. It's the floor `deployment-release` and the improvement loop both
+require. The only variation is the **trigger policy** (see zero-cost-until-opt-in) —
+whether CI runs on every push or on manual dispatch to save minutes on a
+cost-sensitive private repo — but the *local mirror* is non-negotiable regardless.
+
+## Mechanism — generic components
+
+- **One command, run identically local and in CI.** A single entrypoint
+  (`make lint && make test`, a `pre-merge-check` script) is the whole gate; CI's job
+  is to *run that same command*, not to re-specify the checks. This is what makes
+  "passes locally" mean something.
+- **Auto-detecting / polyglot.** The floor covers **every** language present (set up
+  each toolchain, run each language's build+lint+test), so a multi-language repo
+  can't have one half gated and the other unchecked.
+- **Fail-closed — no silent skip.** Any step failing, or a required tool being
+  missing, **fails the floor** — it never degrades to "skipped, therefore green." A
+  gate that can silently no-op is worse than no gate.
+- **Pre-condition for merge and deploy.** CI runs the floor on every pull request /
+  pre-merge; no deploy proceeds without it (the floor is `deployment-release`'s
+  first step). The floor is a *protected path*: workers can't weaken it to get their
+  change through.
+- **Zero-cost-until-opt-in (optional).** For a cost-sensitive private repo, CI can
+  trigger on **manual dispatch** (`workflow_dispatch`) instead of every push to save
+  Actions minutes — the local mirror still gives every developer the full gate for
+  free, so the floor holds even when auto-CI is throttled.
+
+## Invariant cluster
+
+| Generic ID | Invariant | Realized as (provenance) |
+|--|--|--|
+| `INV-BTF-001` | One entrypoint is the whole gate, and CI runs *that same command* — so "green locally" predicts "green in CI". | chief-wiggum `Makefile` (`lint`/`test`) == `.github/workflows/ci.yml` (`run: make lint` / `make test`) |
+| `INV-BTF-002` | Polyglot: every language in the repo is set up and gated (build + lint + test), not just one. | chief-wiggum `ci.yml` (sets up Python **and** Node; `make lint` = ruff + py_compile + the CW gates) |
+| `INV-BTF-003` | Fail-closed: any step failing or a required tool missing fails the floor — never a silent skip. | `make` step-failure semantics; each gate exits non-zero on violation |
+| `INV-BTF-004` | Pre-condition for merge/deploy: CI runs the floor on every PR; no deploy proceeds without it. | chief-wiggum `ci.yml` (`on: pull_request`); `deployment-release` `INV-DRL` floor-gated |
+| `INV-BTF-005` | *(optional)* Zero-cost-until-opt-in: CI triggers on manual dispatch for cost-sensitive private repos; the local mirror still gives the full gate for free. | dogeared-coach `ci.yml` (`workflow_dispatch`-only to save private-repo Actions minutes) |
+
+## Parameters
+
+| Parameter | Required | Description |
+|--|--|--|
+| `floor_cmd` | yes | The single local entrypoint CI also runs (`make lint && make test`, `pre-merge-check`). |
+| `languages` | yes | Toolchains set up + gated (each gets build + lint + test). |
+| `ci_trigger` | no (default `on-push-and-pr`) | `on-push-and-pr` or `manual-dispatch` (zero-cost-until-opt-in). |
+
+## Success metrics
+
+| ID | Goal | Description |
+|--|--|--|
+| `local_ci_divergence` | down | changes green locally but red in CI, or vice versa (target 0 — same command). |
+| `silent_skip_incidents` | down | floor steps that no-op'd instead of failing (target 0). |
+| `unfloored_merges` | down | merges/deploys that bypassed the floor (target 0). |
+
+## Relationship to other patterns
+
+- **`deployment-release`** — the floor is that pattern's explicit pre-condition
+  (`floor_cmd`); no stage/promote runs without it.
+- **`improvement-loop`** — the floor is the deterministic pass/fail the ratchet
+  high-water mark is built on; the loop can't fix-forward without a trustworthy floor.
+- **The factory's own [`check_cw_standards`](../../scripts/check_cw_standards.py)** —
+  an instance of this pattern's "gates are tested / no silent skip" discipline turned
+  on CW itself.

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -136,6 +136,18 @@
       "feeds": "engagement-instrumentation",
       "spec": "patterns/immutable-assignment-snapshot/pattern.md",
       "manifest": "patterns/immutable-assignment-snapshot/manifest.json"
+    },
+    {
+      "id": "build-test-floor",
+      "title": "Language-Agnostic Build/Test Floor",
+      "category": "gate",
+      "status": "specified",
+      "trust_class": "floor-definition-is-protected-path",
+      "summary": "The pre-condition gate everything stands on: one command builds+tests+lints the whole (polyglot) repo, run byte-identically local and in CI, so green-locally predicts green-in-CI. Fail-closed (no silent skip), pre-condition for every merge/deploy, optional zero-cost-until-opt-in (manual-dispatch CI). Realized by the factory on itself (chief-wiggum Makefile == ci.yml). Promoted from candidate; INV-BTF-001..005.",
+      "invariants": "INV-BTF-001..005",
+      "feeds": "deployment-release, improvement-loop",
+      "spec": "patterns/build-test-floor/pattern.md",
+      "manifest": "patterns/build-test-floor/manifest.json"
     }
   ],
   "stacks": {
@@ -150,8 +162,7 @@
     {"id": "transactional-email-and-dunning", "title": "Transactional Email & Dunning Lifecycle", "category": "process-loop", "status": "candidate", "summary": "Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge (fires if a signed-up user hasn't hit the activation event), re-engagement, and a failed-payment dunning sequence with bounded retries before degrade. Send-once keys prevent duplicate sends across retries. Recovery outcomes are conversion/retention signal.", "reusability": "high"},
     {"id": "referral-invite-loop", "title": "Referral / Invite Growth Loop", "category": "process-loop", "status": "candidate", "summary": "Invite -> signed invite token (server-trusted, single-use, expiring) -> attribution on accept -> reward both sides. Reuses the signed-token discipline; attribution is trust-tagged signal. A self-serve growth loop the improvement loop can optimize (reward size/copy) under admin gating.", "reusability": "medium-high"},
     {"id": "feature-entitlements", "title": "Feature Entitlements Read-Model", "category": "saas-infra", "status": "candidate", "summary": "A single entitlement resolver deriving capability flags from tier + per-account overrides + grandfathering, consumed identically by backend gates and the frontend (one source of 'what can this account do'). Distinct from the tier matrix: it layers overrides and is the read model onboarding + UI both query.", "reusability": "medium-high"},
-    {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"},
-    {"id": "build-test-floor", "title": "Language-Agnostic Build/Test Floor", "category": "gate", "status": "candidate", "summary": "Auto-detecting build+test+lint gate across a polyglot repo, with a local pre-merge script mirroring CI; optionally zero-cost-until-opt-in (manual-dispatch trigger) for cost-sensitive private repos.", "reusability": "medium"}
+    {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"}
   ],
   "meta_disciplines": {
     "$comment": "Recurring cross-pattern engineering rules worth stating once, not registry entries themselves.",

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -43,7 +43,7 @@ def test_unknown_pattern_raises():
 
 def test_candidate_pattern_raises():
     with pytest.raises(apply_pattern.ApplyError, match="candidate"):
-        apply_pattern.build_plan("build-test-floor", {}, now=FIXED_NOW)
+        apply_pattern.build_plan("reconciliation-sweep", {}, now=FIXED_NOW)  # still a candidate
 
 
 def test_unknown_param_raises():


### PR DESCRIPTION
## What

Promotes `build-test-floor` from candidate to specified. It's the pre-condition gate
`deployment-release` and `improvement-loop` both stand on, and since
`deployment-release depends_on build-test-floor`, promoting it **clears the one
standing `check_patterns` warning** — the validator now reports `registry OK` (0/0).

Cluster `INV-BTF-001..005`, grounded in **the factory on itself**:
- `INV-BTF-001` — one command is the whole gate, run byte-identically local and in CI (chief-wiggum `Makefile` == `ci.yml`), so green-locally predicts green-in-CI
- `INV-BTF-002` — polyglot (Python + Node here), every language gated
- `INV-BTF-003` — fail-closed, no silent skip
- `INV-BTF-004` — pre-condition for every merge/deploy
- `INV-BTF-005` — *(optional)* zero-cost-until-opt-in (manual-dispatch CI), grounded in dogeared-coach's `workflow_dispatch`-only ci.yml

Registry: **12 specified patterns, 5 candidates**. `make lint` + `make test` (754) green.
