### PR TITLE
End-to-end factory token cost: consult data + Claude Code OTEL, costed per loop

### DIFF
--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -73,6 +73,49 @@ python3 "$CW_HOME/scripts/factory_log.py" emit --event consult --repo "$owner_re
 `check_patterns.py` is the wired exemplar (guarded so it's a no-op when telemetry is
 off). Other gates and skills adopt the same one-liner as telemetry proves its worth.
 
+## End-to-end token cost (Claude Code's own telemetry)
+
+`factory_log` captures the pieces CW *runs* — gate outcomes and **consults**
+(`consult_ai` emits a `consult` event per provider call: provider · model · repo,
+with token/cost where a provider surfaces usage). But the biggest cost is the
+**Claude Code session itself** — the orchestrator plus every sub-agent it spawns.
+Claude Code emits that natively via OpenTelemetry, and CW folds it into the same
+log so `/reflect` reports one end-to-end number.
+
+**Capture it with the console exporter (no collector needed):**
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=console
+export OTEL_LOGS_EXPORTER=console
+export OTEL_METRIC_EXPORT_INTERVAL=10000
+# run the factory session, capturing the telemetry stream:
+claude <args> 2> "$CW_TMP/claude-otel.jsonl"
+```
+
+Claude Code emits per-request `api_request` events carrying `model`,
+`input_tokens`/`output_tokens` (+ `cache_read_tokens`/`cache_creation_tokens`),
+`cost_usd`, and **`query_source`** — which separates `repl_main_thread` (the
+orchestrator) from `subagent` (delegated work). Fold them in:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-code "$CW_TMP/claude-otel.jsonl" --repo acme/app
+```
+
+`ingest-claude-code` parses the `api_request` events (tolerant of the flat console
+shape and OTLP `attributes` shape; skips everything else) and writes `claude_code`
+records. It's an **explicit** ingest — it always writes, unlike passive emit. Then:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app
+# → { consults, claude_code: {repl_main_thread, subagent}, consult_cost_usd,
+#     claude_code_cost_usd, cost_usd_total }   ← end-to-end
+```
+
+`aggregate` splits Claude Code cost by `query_source` (orchestrator vs subagent)
+and reports `cost_usd_total = consult_cost + claude_code_cost` — the nominal cost
+of a factory run end to end. `/reflect` surfaces it as a factory-log finding.
+
 ## Reading
 
 ```bash

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -242,15 +242,37 @@ TOOLS = {
 }
 
 
+def _emit_consult_telemetry(provider_label: str, model: str | None, cwd: str | None) -> None:
+    """Best-effort factory telemetry for a consult. No-op unless telemetry is enabled
+    (CW_TELEMETRY / CW_FACTORY_LOG); never breaks the consult. Records provider +
+    model + repo now; per-provider token/cost capture is tracked in chief-wiggum#134.
+    """
+    try:
+        import os
+        import sys as _sys
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in _sys.path:
+            _sys.path.insert(0, _here)
+        import factory_log
+        repo = os.path.basename(os.path.abspath(cwd)) if cwd else None
+        factory_log.emit_consult(provider_label, model, repo=repo)
+    except Exception:
+        pass
+
+
 def consult_provider(provider: Provider, prompt: str, model: str | None, cwd: str | None) -> str:
     if provider.type == "tool":
         if not provider.tool or provider.tool not in TOOLS:
             raise ValueError(f"unsupported tool provider: {provider.name}")
-        return TOOLS[provider.tool](prompt, model=model, cwd=cwd)
+        result = TOOLS[provider.tool](prompt, model=model, cwd=cwd)
+        _emit_consult_telemetry(provider.tool, model, cwd)
+        return result
     if provider.type == "delegate":
         if provider.delegate != "claude-interactive":
             raise ValueError(f"unsupported delegate provider: {provider.name}")
-        return consult_claude_interactive(prompt, model=model, cwd=cwd)
+        result = consult_claude_interactive(prompt, model=model, cwd=cwd)
+        _emit_consult_telemetry("claude-interactive", model, cwd)
+        return result
     raise ValueError(f"unsupported provider type: {provider.type}")
 
 

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -38,6 +38,7 @@ GATE = "gate"
 CONSULT = "consult"
 WORKER = "worker"
 SKILL = "skill"
+CLAUDE_CODE = "claude_code"  # per-request api_request events from Claude Code's own OTEL telemetry
 
 
 def log_path() -> Path:
@@ -49,15 +50,8 @@ def telemetry_enabled() -> bool:
     return bool(os.environ.get("CW_TELEMETRY") or os.environ.get("CW_FACTORY_LOG"))
 
 
-def emit(event: str, *, ts: float | None = None, **fields) -> bool:
-    """Append one telemetry record. No-op (returns False) unless telemetry is on.
-
-    Never raises — telemetry must never break the thing it measures.
-    """
-    if not telemetry_enabled():
-        return False
-    record = {"ts": ts if ts is not None else time.time(), "event": event}
-    record.update({k: v for k, v in fields.items() if v is not None})
+def _append(record: dict) -> bool:
+    """Write one record to the log. Never raises."""
     try:
         path = log_path()
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -66,6 +60,17 @@ def emit(event: str, *, ts: float | None = None, **fields) -> bool:
         return True
     except OSError:
         return False
+
+
+def emit(event: str, *, ts: float | None = None, **fields) -> bool:
+    """Append one telemetry record. No-op (returns False) unless telemetry is on
+    (passive emission from live gates/consults). Never raises.
+    """
+    if not telemetry_enabled():
+        return False
+    record = {"ts": ts if ts is not None else time.time(), "event": event}
+    record.update({k: v for k, v in fields.items() if v is not None})
+    return _append(record)
 
 
 def emit_gate(name: str, result: str, *, caught: int | None = None,
@@ -99,16 +104,20 @@ def cost_for(model: str, tokens_in: int, tokens_out: int, pricing: dict | None =
     return round((tokens_in / 1_000_000) * pin + (tokens_out / 1_000_000) * pout, 6)
 
 
-def emit_consult(provider: str, model: str, tokens_in: int, tokens_out: int, *,
-                 repo: str | None = None, ticket: str | None = None) -> bool:
-    """Record an AI consultation with its token usage and (grounded) cost.
+def emit_consult(provider: str, model: str | None, tokens_in: int | None = None,
+                 tokens_out: int | None = None, *, repo: str | None = None,
+                 ticket: str | None = None) -> bool:
+    """Record an AI consultation, with token usage + grounded cost when known.
 
-    Cost is computed from config/model_pricing.json; omitted when the model is
-    unpriced (rather than logged as $0).
+    When token counts are known, cost is computed from config/model_pricing.json
+    (omitted when the model is unpriced — never logged as $0). When tokens are
+    unknown (a CLI provider that didn't surface a usage summary), the event still
+    records that a consult happened, for whom, in which repo — honest frequency
+    telemetry without a fabricated token count.
     """
+    cost = cost_for(model, tokens_in, tokens_out) if (model and tokens_in is not None and tokens_out is not None) else None
     return emit(CONSULT, provider=provider, name=model,
-                tokens_in=tokens_in, tokens_out=tokens_out,
-                cost_usd=cost_for(model, tokens_in, tokens_out),
+                tokens_in=tokens_in, tokens_out=tokens_out, cost_usd=cost,
                 repo=repo, ticket=ticket)
 
 
@@ -140,6 +149,67 @@ class gate_timer:
         return False  # never suppress
 
 
+# ---- Claude Code OTEL ingestion (the end-to-end top layer) -------------------
+
+def _cc_field(event: dict, *names):
+    """Pull a field from a Claude Code OTEL record — flat key or nested attributes."""
+    attrs = event.get("attributes") if isinstance(event.get("attributes"), dict) else {}
+    body = event.get("body") if isinstance(event.get("body"), dict) else {}
+    for n in names:
+        for src in (event, attrs, body):
+            if n in src and src[n] is not None:
+                return src[n]
+    return None
+
+
+def ingest_claude_code(path: Path, repo: str | None = None) -> int:
+    """Fold a Claude Code OTEL export (console-exporter stderr capture, or OTLP file)
+    into the factory log so /reflect sees end-to-end orchestrator+subagent token cost
+    alongside consult/gate telemetry.
+
+    Parses per-request `api_request` events (model, input/output/cache tokens,
+    cost_usd, query_source that separates repl_main_thread vs subagent). Tolerant of
+    both flat-key and OTLP attributes shapes; skips anything that isn't an
+    api_request. Explicit ingest — always writes (does not require CW_TELEMETRY).
+    Returns the number of records ingested. See docs/factory-telemetry.md.
+    """
+    path = Path(path)
+    if not path.is_file():
+        return 0
+    n = 0
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            e = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        name = _cc_field(e, "event.name", "name", "event")
+        if name != "api_request":
+            continue
+        rec = {"ts": _cc_field(e, "ts") or 0, "event": CLAUDE_CODE}
+        for key, srcnames in (
+            ("model", ("model",)),
+            ("query_source", ("query_source",)),
+            ("tokens_in", ("input_tokens",)),
+            ("tokens_out", ("output_tokens",)),
+            ("cache_read", ("cache_read_tokens",)),
+            ("cache_creation", ("cache_creation_tokens",)),
+            ("cost_usd", ("cost_usd",)),
+            ("session_id", ("session.id", "session_id")),
+            ("skill", ("skill.name", "agent.name", "skill", "agent")),
+        ):
+            v = _cc_field(e, *srcnames)
+            if v is not None:
+                rec[key] = v
+        if repo:
+            rec["repo"] = repo
+        if _append(rec):
+            n += 1
+    return n
+
+
 # ---- reading / aggregation ---------------------------------------------------
 
 def read_log(path: Path | None = None) -> list[dict]:
@@ -162,7 +232,11 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
         records = [r for r in records if r.get("repo") == repo]
     gates: dict[str, dict] = {}
     consults: dict[str, dict] = {}
-    cost_total = 0.0
+    # Claude Code's own token cost, split orchestrator (repl_main_thread) vs subagent,
+    # and (when the OTEL events carry skill.name/agent.name) by loop/validation.
+    claude_code: dict[str, dict] = {}
+    by_loop: dict[str, dict] = {}
+    consult_cost = cc_cost = 0.0
     for r in records:
         if r.get("event") == GATE and r.get("name"):
             g = gates.setdefault(r["name"], {"runs": 0, "passed": 0, "failed": 0,
@@ -180,12 +254,32 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
             c["tokens_in"] += r.get("tokens_in") or 0
             c["tokens_out"] += r.get("tokens_out") or 0
             c["cost_usd"] += r.get("cost_usd") or 0.0
-            cost_total += r.get("cost_usd") or 0.0
+            consult_cost += r.get("cost_usd") or 0.0
+        elif r.get("event") == CLAUDE_CODE:
+            src = r.get("query_source") or "unknown"
+            cc = claude_code.setdefault(src, {"calls": 0, "tokens_in": 0,
+                                              "tokens_out": 0, "cost_usd": 0.0})
+            cc["calls"] += 1
+            cc["tokens_in"] += r.get("tokens_in") or 0
+            cc["tokens_out"] += r.get("tokens_out") or 0
+            cc["cost_usd"] += r.get("cost_usd") or 0.0
+            cc_cost += r.get("cost_usd") or 0.0
+            if r.get("skill"):
+                bl = by_loop.setdefault(r["skill"], {"calls": 0, "cost_usd": 0.0})
+                bl["calls"] += 1
+                bl["cost_usd"] += r.get("cost_usd") or 0.0
     # value/noise hint: a gate with runs but zero caught is a noise candidate
     for g in gates.values():
         g["value"] = "earning" if g["caught"] > 0 else ("noise-candidate" if g["runs"] >= 3 else "unproven")
-    return {"gates": gates, "consults": consults, "records": len(records),
-            "cost_usd_total": round(cost_total, 4)}
+    for cc in claude_code.values():
+        cc["cost_usd"] = round(cc["cost_usd"], 6)
+    for bl in by_loop.values():
+        bl["cost_usd"] = round(bl["cost_usd"], 6)
+    return {"gates": gates, "consults": consults, "claude_code": claude_code,
+            "cost_by_loop": by_loop, "records": len(records),
+            "consult_cost_usd": round(consult_cost, 4),
+            "claude_code_cost_usd": round(cc_cost, 4),
+            "cost_usd_total": round(consult_cost + cc_cost, 4)}
 
 
 def main() -> int:
@@ -205,11 +299,19 @@ def main() -> int:
     a.add_argument("--repo")
     a.add_argument("--format", choices=["text", "json"], default="json")
 
+    ic = sub.add_parser("ingest-claude-code", help="Fold a Claude Code OTEL export into the log")
+    ic.add_argument("otel_file", help="JSONL from `... 2>capture.jsonl` with the console OTEL exporter")
+    ic.add_argument("--repo", help="Tag ingested records with this repo")
+
     sub.add_parser("path", help="Print the log path")
     args = parser.parse_args()
 
     if args.cmd == "path":
         print(log_path())
+        return 0
+    if args.cmd == "ingest-claude-code":
+        n = ingest_claude_code(Path(args.otel_file), repo=args.repo)
+        print(f"factory_log: ingested {n} api_request event(s) from {args.otel_file}")
         return 0
     if args.cmd == "emit":
         fields = {k: getattr(args, k) for k in

--- a/scripts/reflect.py
+++ b/scripts/reflect.py
@@ -265,8 +265,11 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
             findings.append(Finding("gates", "warn",
                 f"telemetry: gate '{gname}' ran {g['runs']}x but caught 0 findings ({round(g['total_ms'])}ms total) — value unproven, candidate noise"))
     if telemetry.get("cost_usd_total"):
+        cc = telemetry.get("claude_code_cost_usd") or 0.0
+        cons = telemetry.get("consult_cost_usd") or 0.0
         findings.append(Finding("factory-logs", "info",
-            f"telemetry: ${telemetry['cost_usd_total']} in logged AI-consult cost across {telemetry['records']} events"))
+            f"telemetry: ${telemetry['cost_usd_total']} end-to-end logged AI cost "
+            f"(Claude Code ${cc} + consults ${cons}) across {telemetry['records']} events"))
 
     return {
         "repo": str(repo),

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -124,6 +124,78 @@ def test_emit_consult_omits_cost_when_unpriced(tmp_path, monkeypatch):
     assert "cost_usd" not in rec  # unpriced -> no fabricated dollar figure
 
 
+def test_emit_consult_without_tokens_records_frequency(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    factory_log.emit_consult("codex", None, repo="dogeared-coach")  # CLI provider, usage not surfaced
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["event"] == "consult" and rec["provider"] == "codex" and rec["repo"] == "dogeared-coach"
+    assert "tokens_in" not in rec and "cost_usd" not in rec  # no fabricated count/cost
+
+
+def test_ingest_claude_code_folds_api_requests(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    otel = tmp_path / "otel.jsonl"
+    otel.write_text("\n".join([
+        json.dumps({"event.name": "api_request", "model": "claude-opus-4-8",
+                    "input_tokens": 1000, "output_tokens": 500, "cost_usd": 0.0175,
+                    "query_source": "repl_main_thread", "session.id": "s1"}),
+        json.dumps({"event.name": "api_request", "model": "claude-haiku-4-5",
+                    "input_tokens": 2000, "output_tokens": 100, "cost_usd": 0.0025,
+                    "query_source": "subagent", "session.id": "s1"}),
+        json.dumps({"event.name": "tool_decision", "tool_name": "Bash"}),  # ignored
+        "not json",  # skipped
+    ]) + "\n")
+    n = factory_log.ingest_claude_code(otel, repo="dogeared-coach")
+    assert n == 2
+    agg = factory_log.aggregate(factory_log.read_log())
+    assert agg["claude_code"]["repl_main_thread"]["cost_usd"] == 0.0175
+    assert agg["claude_code"]["subagent"]["tokens_in"] == 2000
+    assert agg["claude_code_cost_usd"] == 0.02  # 0.0175 + 0.0025
+    assert agg["cost_usd_total"] == 0.02  # end-to-end (no consults here)
+
+
+def test_cost_attributed_per_loop_via_skill(tmp_path, monkeypatch):
+    """The end state: every loop/validation is costed (via skill.name/agent.name)."""
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    otel = tmp_path / "otel.jsonl"
+    otel.write_text("\n".join(json.dumps(x) for x in [
+        {"event.name": "api_request", "cost_usd": 0.42, "query_source": "subagent", "skill.name": "code-review"},
+        {"event.name": "api_request", "cost_usd": 0.05, "query_source": "subagent", "skill.name": "code-review"},
+        {"event.name": "api_request", "cost_usd": 0.31, "query_source": "subagent", "agent.name": "architect"},
+    ]) + "\n")
+    factory_log.ingest_claude_code(otel)
+    loops = factory_log.aggregate(factory_log.read_log())["cost_by_loop"]
+    assert loops["code-review"] == {"calls": 2, "cost_usd": 0.47}
+    assert loops["architect"] == {"calls": 1, "cost_usd": 0.31}
+
+
+def test_ingest_tolerates_otlp_attributes_shape(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    otel = tmp_path / "otel.jsonl"
+    # OTLP-style: fields under an `attributes` dict, event name under `name`
+    otel.write_text(json.dumps({
+        "name": "api_request",
+        "attributes": {"model": "claude-sonnet-5", "input_tokens": 10,
+                       "output_tokens": 5, "cost_usd": 0.0001, "query_source": "subagent"}}) + "\n")
+    assert factory_log.ingest_claude_code(otel) == 1
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["event"] == "claude_code" and rec["model"] == "claude-sonnet-5"
+
+
+def test_ingest_writes_without_telemetry_enabled(tmp_path, monkeypatch):
+    # explicit ingest always writes (unlike passive emit)
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))  # sets the path (also enables, but ingest doesn't depend on it)
+    otel = tmp_path / "o.jsonl"
+    otel.write_text(json.dumps({"event.name": "api_request", "model": "m", "cost_usd": 0.01}) + "\n")
+    assert factory_log.ingest_claude_code(otel) == 1
+
+
 def test_cli_emit_disabled_returns_1(tmp_path, monkeypatch):
     env = {k: v for k, v in __import__("os").environ.items()
            if k not in ("CW_TELEMETRY", "CW_FACTORY_LOG")}


### PR DESCRIPTION
## What

Gets **real telemetry data flowing** (your dogeared-coach runs will start producing
it) and closes the **end-to-end token-cost** picture, costed **per loop/validation**.

## Two token sources, one log
- **Consults** — `consult_ai` now emits a `consult` event at the single dispatch
  seam (`consult_provider`): provider · model · repo. No-op unless telemetry is
  enabled; never breaks the consult. Frequency/provider-mix data flows immediately.
  (Per-provider token capture stays in #134.)
- **Claude Code itself** — `ingest_claude_code()` folds Claude Code's own
  OpenTelemetry `api_request` events (the orchestrator **and** every sub-agent)
  into the same log: model, in/out/cache tokens, `cost_usd`, `query_source`
  (`repl_main_thread` vs `subagent`), and `skill.name`/`agent.name`.

## Costed per loop
`aggregate` now reports:
- `cost_usd_total = consult_cost + claude_code_cost` — the nominal cost of a run end to end
- split by `query_source` (orchestrator vs subagent)
- **`cost_by_loop`** — cost attributed to each validation/loop via `skill.name`/`agent.name`

```
cost_by_loop: { "code-review": {calls: 2, cost_usd: 0.47},
                "architect":   {calls: 1, cost_usd: 0.31} }
end-to-end total: $0.78
```

## Enablement (for the dogeared-coach agent)
```bash
export CW_TELEMETRY=1            # CW consult/gate telemetry
export CLAUDE_CODE_ENABLE_TELEMETRY=1
export OTEL_METRICS_EXPORTER=console OTEL_LOGS_EXPORTER=console
claude <args> 2> claude-otel.jsonl
python3 scripts/factory_log.py ingest-claude-code claude-otel.jsonl --repo plwp/dogeared-coach
```
Full how-to in `docs/factory-telemetry.md`.

## Tests / checks
+6 tests (consult-without-tokens, ingest flat + OTLP shapes, always-writes,
end-to-end aggregate, **cost-per-loop**). `make lint` + `make test` **759 passed**.
