### PR TITLE
cost<->value verdict: every validation costed and its value quantified

### DIFF
--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -276,10 +276,43 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
     for bl in by_loop.values():
         bl["cost_usd"] = round(bl["cost_usd"], 6)
     return {"gates": gates, "consults": consults, "claude_code": claude_code,
-            "cost_by_loop": by_loop, "records": len(records),
+            "cost_by_loop": by_loop, "verdict": cost_value_verdict(gates, by_loop),
+            "records": len(records),
             "consult_cost_usd": round(consult_cost, 4),
             "claude_code_cost_usd": round(cc_cost, 4),
             "cost_usd_total": round(consult_cost + cc_cost, 4)}
+
+
+def cost_value_verdict(gates: dict, by_loop: dict) -> dict:
+    """Join cost (per loop/validation) with value (findings caught) into a keep/demote
+    verdict per validation — the "every loop is costed and its value quantified" view.
+
+    A gate's value is its `caught` count; its cost is what its loop spent (LLM
+    validations via cost_by_loop; deterministic gates are ~$0). cost_per_catch is the
+    dollars spent per finding surfaced. The verdict:
+      - earning         — caught > 0 (deterministic gates: free value; LLM loops: paid but productive)
+      - demote-candidate — spent real $ over >=3 runs and caught nothing (noise you're paying for)
+      - noise-candidate  — ran >=3 times, caught nothing, ~free (noisy but cheap)
+      - unproven         — too few runs to judge
+    """
+    out: dict[str, dict] = {}
+    for name in set(gates) | set(by_loop):
+        g, loop = gates.get(name, {}), by_loop.get(name, {})
+        cost = round(loop.get("cost_usd", 0.0), 6)
+        caught = g.get("caught", 0)
+        runs = g.get("runs", 0) or loop.get("calls", 0)
+        if caught > 0:
+            v = "earning"
+        elif runs >= 3 and cost > 0:
+            v = "demote-candidate"
+        elif runs >= 3:
+            v = "noise-candidate"
+        else:
+            v = "unproven"
+        out[name] = {"cost_usd": cost, "caught": caught, "runs": runs,
+                     "cost_per_catch": round(cost / caught, 6) if caught else None,
+                     "verdict": v}
+    return out
 
 
 def main() -> int:

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -156,6 +156,25 @@ def test_ingest_claude_code_folds_api_requests(tmp_path, monkeypatch):
     assert agg["cost_usd_total"] == 0.02  # end-to-end (no consults here)
 
 
+def test_cost_value_verdict():
+    """Every validation costed + its value quantified into a keep/demote verdict."""
+    gates = {
+        "check_patterns": {"runs": 5, "caught": 2, "total_ms": 40},   # free, catches -> earning
+        "expensive_noise": {"runs": 4, "caught": 0, "total_ms": 0},   # runs but nothing; paid via loop
+        "cheap_noise": {"runs": 4, "caught": 0, "total_ms": 5},       # runs, nothing, ~free
+    }
+    by_loop = {"expensive_noise": {"calls": 4, "cost_usd": 1.20}}
+    v = factory_log.cost_value_verdict(gates, by_loop)
+    assert v["check_patterns"]["verdict"] == "earning" and v["check_patterns"]["cost_per_catch"] == 0.0
+    assert v["expensive_noise"]["verdict"] == "demote-candidate"  # $1.20 over 4 runs, 0 catches
+    assert v["cheap_noise"]["verdict"] == "noise-candidate"       # noisy but free
+    # an LLM validation that caught something -> cost_per_catch
+    v2 = factory_log.cost_value_verdict(
+        {"code-review": {"runs": 2, "caught": 4}}, {"code-review": {"calls": 2, "cost_usd": 0.80}})
+    assert v2["code-review"]["verdict"] == "earning"
+    assert v2["code-review"]["cost_per_catch"] == 0.2  # $0.80 / 4 findings
+
+
 def test_cost_attributed_per_loop_via_skill(tmp_path, monkeypatch):
     """The end state: every loop/validation is costed (via skill.name/agent.name)."""
     log = tmp_path / "f.jsonl"


### PR DESCRIPTION
## What

The synthesis of the telemetry arc: `aggregate` now joins **cost** (per
loop/validation, from `cost_by_loop`) with **value** (findings caught, from gate
events) into a per-validation **verdict**, plus `cost_per_catch`.

```
verdict:
  check_patterns   earning          (caught 2, $0.00 — free value)
  code-review      earning          (caught 4, $0.80 → $0.20/catch)
  expensive_noise  demote-candidate ($1.20 over 4 runs, caught 0 — noise you pay for)
  cheap_noise      noise-candidate  (0 catches, ~free)
```

- **earning** — caught > 0
- **demote-candidate** — real $ over ≥3 runs, 0 catches (the expensive-noise case worth killing)
- **noise-candidate** — ≥3 runs, 0 catches, ~free
- **unproven** — too few runs

This makes the gate-rollout question (`docs/gate-rollout.md`) quantitative: a
validation that costs money and never catches anything is now a *measured*
demote-candidate, not a hunch.

## Data-wire that lights it up
The verdict shows **cost** for every loop today; the **value** side (caught count)
lights up as LLM validations emit their finding counts — tracked in a follow-up
ticket. Deterministic gates (`check_patterns`, `check_cw_standards`) already emit
`caught`, so they're fully verdicted now.

+1 test. `make lint` + `make test` **760 passed**.
