### PR TITLE
Instrument the rest of CW's gate suite for the cost/value verdict

### DIFF
--- a/scripts/check_cw_standards.py
+++ b/scripts/check_cw_standards.py
@@ -93,6 +93,12 @@ def main() -> int:
     args = parser.parse_args()
 
     findings = check()
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        from factory_log import emit_gate
+        emit_gate("check_cw_standards", "fail" if findings else "pass",
+                  caught=len(findings), repo="chief-wiggum")
+    except Exception:
+        pass
     if not findings:
         print("check_cw_standards: CW meets its own standards.")
         return 0

--- a/scripts/check_portability.py
+++ b/scripts/check_portability.py
@@ -192,6 +192,12 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     repo_root = argv[0] if argv else str(Path(__file__).resolve().parents[1])
     violations = check_repo(repo_root)
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        from factory_log import emit_gate
+        emit_gate("check_portability", "fail" if violations else "pass",
+                  caught=len(violations), repo="chief-wiggum")
+    except Exception:
+        pass
     if violations:
         print(f"Portability check FAILED ({len(violations)} violation(s)):", file=sys.stderr)
         for v in violations:

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -215,6 +215,18 @@ def test_ingest_writes_without_telemetry_enabled(tmp_path, monkeypatch):
     assert factory_log.ingest_claude_code(otel) == 1
 
 
+def test_cw_gates_emit_telemetry_when_enabled(tmp_path):
+    """The CW gate suite emits gate events under telemetry, feeding the verdict."""
+    import os
+    log = tmp_path / "gates.jsonl"
+    env = {**os.environ, "CW_FACTORY_LOG": str(log)}
+    for gate in ("check_patterns.py", "check_portability.py", "check_cw_standards.py"):
+        subprocess.run([sys.executable, str(SCRIPTS / gate)], capture_output=True, text=True, env=env)
+    names = {json.loads(ln)["name"] for ln in log.read_text().splitlines()
+             if json.loads(ln).get("event") == "gate"}
+    assert {"check_patterns", "check_portability", "check_cw_standards"} <= names
+
+
 def test_cli_emit_disabled_returns_1(tmp_path, monkeypatch):
     env = {k: v for k, v in __import__("os").environ.items()
            if k not in ("CW_TELEMETRY", "CW_FACTORY_LOG")}


### PR DESCRIPTION
## What

Only `check_patterns` emitted gate telemetry, so the cost/value verdict saw one
gate. Now `check_portability` and `check_cw_standards` emit too (name · result ·
caught) — guarded, no-op unless telemetry is enabled, never breaks the gate.

With `CW_TELEMETRY=1`, a `make lint` run now feeds the verdict from **CW's whole
own gate suite**, so each gate's value (findings caught) accrues as real data —
dogfooding the exact "every validation costed and valued" view on CW itself.

On the current (clean) repo all three show `caught: 0` — correct: they passed with
nothing to catch. Catches accrue as the gates actually fire on violations.

+1 test (all three gate CLIs emit under `CW_FACTORY_LOG`). `make lint` +
`make test` **761 passed**.
