### PR TITLE
Instrument check_unresolved gate for the cost/value verdict

### DIFF
--- a/scripts/check_unresolved.py
+++ b/scripts/check_unresolved.py
@@ -178,6 +178,18 @@ def main() -> int:
                 for ticket, count in sorted(blocked.items()):
                     print(f"  {ticket}: {count} unresolved marker(s)")
 
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+        repo = os.path.basename(os.path.abspath(str(targets[0]))) if targets else None
+        emit_gate("check_unresolved", "fail" if findings else "pass",
+                  caught=len(findings), repo=repo)
+    except Exception:
+        pass
+
     return 1 if findings else 0
 
 


### PR DESCRIPTION
check_unresolved now emits gate telemetry (caught = unresolved markers found, repo from the scanned target path) — guarded, no-op unless enabled. It runs during /architect and /implement-wave, so dogeared-coach builds feed real value data into the verdict. Smoke: a 2-marker target emits `caught: 2, result: fail, repo: epic-x`. make test 761 passed.