### PR TITLE
Instrument the last two gates — all deterministic gates now feed the verdict (closes #146)

### DIFF
--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -680,6 +680,20 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(render_text(report))
 
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+        caught = len(report.violations) + len(report.malformed)
+        parts = os.path.abspath(args.epic_dir).split(os.sep)
+        repo = parts[parts.index("docs") - 1] if "docs" in parts and parts.index("docs") > 0 \
+            else os.path.basename(os.path.abspath(args.epic_dir))
+        emit_gate("check_single_writer", "fail" if caught else "pass", caught=caught, repo=repo)
+    except Exception:
+        pass
+
     if args.gate == "soundness" and not report.soundness_ok:
         return 1
     if args.gate == "coverage" and not report.coverage_ok:

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -355,11 +355,34 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(render_markdown(report))
 
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+        caught = (len(report.orphan_business_rules) + len(report.uncovered_contracts)
+                  + len(report.untested_contracts) + len(report.dangling)
+                  + len(report.invalid_links))
+        emit_gate("check_traceability", "fail" if caught else "pass",
+                  caught=caught, repo=_repo_from_epic_dir(args.epic_dir))
+    except Exception:
+        pass
+
     if args.gate == "soundness" and not report.soundness_ok:
         return 1
     if args.gate == "coverage" and not report.coverage_ok:
         return 1
     return 0
+
+
+def _repo_from_epic_dir(epic_dir: str) -> str:
+    """Best-effort repo name from an epic dir (<repo>/docs/epics/<slug>)."""
+    import os
+    parts = os.path.abspath(epic_dir).split(os.sep)
+    if "docs" in parts and parts.index("docs") > 0:
+        return parts[parts.index("docs") - 1]
+    return os.path.basename(os.path.abspath(epic_dir))
 
 
 if __name__ == "__main__":

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -268,6 +268,21 @@ def test_cli_coverage_gate_fails_on_violation(tmp_path, capsys):
     assert data["violations"][0]["symbol"] == "ChangePlan"
 
 
+def test_cli_emits_telemetry_with_caught_count(tmp_path, capsys, monkeypatch):
+    """The gate emits a real gate event with the finding count (feeds the verdict)."""
+    log = tmp_path / "tel.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    epic = _write_billing_epic(tmp_path)
+    src = tmp_path / "src"
+    (src / "internal" / "admin").mkdir(parents=True)
+    (src / "internal" / "admin" / "h.go").write_text("func ChangePlan(p *Provider) {\n\tp.StripePlan = \"x\"\n}\n")
+    sw.main([str(epic), "--source", str(src), "--gate", "coverage", "--format", "json"])
+    capsys.readouterr()
+    events = [json.loads(ln) for ln in log.read_text().splitlines()]
+    gate = next(e for e in events if e.get("event") == "gate" and e["name"] == "check_single_writer")
+    assert gate["caught"] == 1 and gate["result"] == "fail"
+
+
 def test_cli_soundness_gate_fails_on_malformed(tmp_path, capsys):
     epic = tmp_path / "epic"
     epic.mkdir()


### PR DESCRIPTION
check_traceability + check_single_writer now emit gate telemetry with the exact finding count from their report (traceability: orphans+uncovered+untested+dangling+invalid_links; single_writer: violations+malformed), repo derived from the epic dir. Guarded, never breaks the gate. **Proven firing** with the right count via a new CLI telemetry test (caught=1 on a real unsanctioned-writer fixture). All 6 deterministic gates now feed the cost/value verdict. make test green. Closes #146.