### PR TITLE
LLM validations report their value: convention + /reflect exemplar

### DIFF
--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -81,3 +81,14 @@ gh --repo "$(python3 "$CW_HOME/scripts/repo.py" home >/dev/null; echo plwp/chief
 ```
 
 Report the filed issue URLs and a one-paragraph factory-health summary (what's working, what's slipping, the single highest-leverage improvement).
+
+### Step 6: Record validation telemetry
+
+`/reflect` is itself a validation — record its value (findings) so the cost↔value verdict can judge it. After filing, emit one gate event with the finding count (no-op unless telemetry is enabled; never blocks):
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name reflect \
+  --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
+```
+
+This is the convention every LLM validation should follow (see `docs/factory-telemetry.md`): after producing findings, `factory_log.py emit --event gate --name <validation> --caught <N> --repo <owner/repo>`. Its **cost** already flows (consults + Claude Code OTEL, attributed by skill name); this supplies the **value** side (`caught`) so `aggregate`'s verdict can rate the validation `earning` vs `demote-candidate`. See [chief-wiggum#143](https://github.com/plwp/chief-wiggum/issues/143).

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -71,7 +71,29 @@ python3 "$CW_HOME/scripts/factory_log.py" emit --event consult --repo "$owner_re
 ```
 
 `check_patterns.py` is the wired exemplar (guarded so it's a no-op when telemetry is
-off). Other gates and skills adopt the same one-liner as telemetry proves its worth.
+off). All six deterministic gates (`check_patterns`, `check_portability`,
+`check_cw_standards`, `check_unresolved`, `check_traceability`, `check_single_writer`)
+emit their `caught` count this way.
+
+### LLM validations report their value
+
+A deterministic gate knows its finding count in Python. An **LLM validation**
+(multi-AI code review, `/architect` soundness, `/reflect`, browser-use/design
+fidelity) reconciles findings *model-side*, so it must report the count itself.
+Its **cost** already flows (the consults it runs + the Claude Code sub-agent tokens,
+attributed by `skill.name`); the missing half is **value**. Convention — after
+producing findings, emit one gate event keyed by the same name its cost is
+attributed under:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name code-review \
+  --result "$([ "$n" -gt 0 ] && echo fail || echo pass)" --caught "$n" --repo "$owner_repo"
+```
+
+Then `aggregate`'s verdict joins `cost_by_loop[name]` (what it spent) with
+`gates[name].caught` (what it found) → `cost_per_catch` + `earning`/`demote-candidate`.
+`/reflect` is the wired exemplar; `/implement`'s review, `/architect`, and
+`/close-epic` adopt the same line (tracked in chief-wiggum#143).
 
 ## End-to-end token cost (Claude Code's own telemetry)
 


### PR DESCRIPTION
Deterministic gates know their catch count in Python; **LLM validations** (code-review, /architect, /reflect) reconcile findings model-side, so they self-report. Cost already flows (consults + Claude Code OTEL by skill.name); this adds the **value** side.

- **Convention** (docs/factory-telemetry.md): after producing findings, emit `factory_log.py emit --event gate --name <v> --caught <N> --repo <repo>`. `aggregate`'s verdict joins `cost_by_loop[v]` with `gates[v].caught` → cost_per_catch + earning/demote-candidate.
- **/reflect wired** as the exemplar (Step 6): emits its filed-issue count.
- **Proven**: the documented line emits `caught: 4` → verdict rates `reflect` **earning**.

Advances #143 — /implement's review, /architect, /close-epic adopt the same one-liner next. make lint green.