### PR TITLE
fix: reword Claude-only 'sub-agent' marker that turned main red (#149 follow-up)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -338,7 +338,7 @@ The worker should:
 
    Also return the **checklist scorecard**: pass/fail for each item in the structured checklist, with one-line justification for any failures.
 
-6. **Record validation telemetry.** The review's cost already flows (its reviewer consults + the Claude Code sub-agent tokens); record its *value* so the cost↔value verdict can rate it. Emit one gate event with the count of substantive findings (high + medium + low real defects; exclude style-only) — no-op unless telemetry is enabled, never blocks:
+6. **Record validation telemetry.** The review's cost already flows (its reviewer consults + the review worker's tokens); record its *value* so the cost↔value verdict can rate it. Emit one gate event with the count of substantive findings (high + medium + low real defects; exclude style-only) — no-op unless telemetry is enabled, never blocks:
 
    ```bash
    python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name code-review \


### PR DESCRIPTION
PR #149's telemetry note used 'sub-agent' — a Claude-only marker `check_portability` flags outside adapter notes — and I merged before CI reported, turning main red. Reworded to CW's harness-neutral 'worker'. `make lint` green.