### PR TITLE
/architect + /close-epic report validation value (closes #143)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -389,6 +389,15 @@ python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view
 
 Flag genuine disagreements for the user in Step 6.
 
+**Record validation telemetry.** The review's cost already flows (its reviewer consults + the worker tokens); record its *value* — emit one gate event with the count of substantive findings the multi-AI validation raised (contradictions, missing transitions, incomplete invariants, uncovered ACs — exclude nits). No-op unless telemetry is enabled, never blocks:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name architect-review \
+  --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
+```
+
+(Convention: `docs/factory-telemetry.md` → "LLM validations report their value". The deterministic soundness gates in 5a — traceability/single-writer — already emit their own.)
+
 ### Step 6: Present artifacts to user
 
 **CHECKPOINT**: Show the user a summary of all artifacts:

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -467,6 +467,15 @@ Write the retrospective to `$EPIC_DIR/retrospective.md` and commit.
 
 ### Step 11: Final report
 
+**Record validation telemetry.** `/close-epic` is the epic-level validation — record its value. The deterministic audits (traceability, unresolved, single-writer, ratchet) already emit their own gate events; this captures the epic-level LLM analysis (Step 9) + cross-surface/UX findings. Emit one gate event with the total count of substantive findings surfaced across the close (exclude nits) — no-op unless telemetry is enabled, never blocks:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name close-epic \
+  --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
+```
+
+(Convention: `docs/factory-telemetry.md` → "LLM validations report their value".)
+
 Present the full epic close report:
 
 ```markdown


### PR DESCRIPTION
Both now emit a gate event with their LLM-validation finding count (`architect-review`, `close-epic`), following the documented convention. Cost already flows (reviewer consults + worker tokens); this supplies the value side. Deterministic gates in both already self-emit. Harness-neutral wording (lint clean — no repeat of the #149 portability slip). With #148 (/reflect) + #149 (/implement review), this completes the LLM-validation wiring across the core skills. Closes #143.