### PR TITLE
Human-readable factory cost/value report (aggregate --format text)

### DIFF
--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -295,8 +295,11 @@ def cost_value_verdict(gates: dict, by_loop: dict) -> dict:
       - noise-candidate  — ran >=3 times, caught nothing, ~free (noisy but cheap)
       - unproven         — too few runs to judge
     """
+    # Only validations get a verdict — a name must have emitted gate events. A loop
+    # with cost but no gate events (e.g. `implement`, the build loop / orchestrator)
+    # is build cost, not a validation, and belongs in cost_by_loop, not the verdict.
     out: dict[str, dict] = {}
-    for name in set(gates) | set(by_loop):
+    for name in gates:
         g, loop = gates.get(name, {}), by_loop.get(name, {})
         cost = round(loop.get("cost_usd", 0.0), 6)
         caught = g.get("caught", 0)
@@ -313,6 +316,41 @@ def cost_value_verdict(gates: dict, by_loop: dict) -> dict:
                      "cost_per_catch": round(cost / caught, 6) if caught else None,
                      "verdict": v}
     return out
+
+
+_VERDICT_ORDER = {"demote-candidate": 0, "noise-candidate": 1, "unproven": 2, "earning": 3}
+
+
+def render_report(agg: dict, repo: str | None = None) -> str:
+    """Human-readable cost/value report from an aggregate() result."""
+    L: list[str] = []
+    scope = f" — {repo}" if repo else ""
+    total, cc, cons = agg["cost_usd_total"], agg["claude_code_cost_usd"], agg["consult_cost_usd"]
+    L.append(f"Factory cost/value report{scope}")
+    L.append(f"  {agg['records']} telemetry events · end-to-end cost ${total}"
+             f"  (Claude Code ${cc} + consults ${cons})")
+
+    if agg.get("claude_code"):
+        L.append("\n  Claude Code tokens by source:")
+        for src, d in sorted(agg["claude_code"].items(), key=lambda kv: -kv[1]["cost_usd"]):
+            L.append(f"    {src:<18} {d['calls']:>4} calls   ${d['cost_usd']}")
+    if agg.get("cost_by_loop"):
+        L.append("\n  Cost by loop:")
+        for name, d in sorted(agg["cost_by_loop"].items(), key=lambda kv: -kv[1]["cost_usd"]):
+            L.append(f"    {name:<20} ${d['cost_usd']}  ({d['calls']} calls)")
+
+    verdict = agg.get("verdict") or {}
+    if verdict:
+        L.append("\n  Validation verdicts (worst first — demote-candidates need action):")
+        L.append(f"    {'VALIDATION':<22}{'RUNS':>5}{'CAUGHT':>7}{'COST':>10}{'$/CATCH':>10}   VERDICT")
+        L.append("    " + "─" * 70)
+        rows = sorted(verdict.items(),
+                      key=lambda kv: (_VERDICT_ORDER.get(kv[1]["verdict"], 9), -kv[1]["cost_usd"]))
+        for name, v in rows:
+            cost = f"${v['cost_usd']:.2f}"
+            cpc = f"${v['cost_per_catch']:.3f}" if v["cost_per_catch"] is not None else "—"
+            L.append(f"    {name:<22}{v['runs']:>5}{v['caught']:>7}{cost:>10}{cpc:>10}   {v['verdict']}")
+    return "\n".join(L)
 
 
 def main() -> int:
@@ -359,7 +397,8 @@ def main() -> int:
         return 0
     if args.cmd == "aggregate":
         agg = aggregate(read_log(), repo=args.repo)
-        print(json.dumps(agg, indent=2))
+        print(render_report(agg, repo=args.repo) if args.format == "text"
+              else json.dumps(agg, indent=2))
         return 0
     return 2
 

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -156,6 +156,28 @@ def test_ingest_claude_code_folds_api_requests(tmp_path, monkeypatch):
     assert agg["cost_usd_total"] == 0.02  # end-to-end (no consults here)
 
 
+def test_verdict_excludes_pure_cost_build_loops():
+    # `implement` has cost but no gate events -> it's build cost, not a validation
+    v = factory_log.cost_value_verdict(
+        {"code-review": {"runs": 2, "caught": 3}},
+        {"code-review": {"calls": 2, "cost_usd": 0.6}, "implement": {"calls": 5, "cost_usd": 3.0}})
+    assert "implement" not in v and "code-review" in v
+
+
+def test_render_report_shows_verdict_and_cost():
+    agg = factory_log.aggregate([
+        {"event": "gate", "name": "browser-validate", "result": "pass", "caught": 0, "repo": "r"},
+        {"event": "gate", "name": "browser-validate", "result": "pass", "caught": 0, "repo": "r"},
+        {"event": "gate", "name": "browser-validate", "result": "pass", "caught": 0, "repo": "r"},
+        {"event": "claude_code", "cost_usd": 0.15, "query_source": "subagent", "skill": "browser-validate", "repo": "r"},
+        {"event": "gate", "name": "code-review", "result": "fail", "caught": 4, "repo": "r"},
+    ], repo="r")
+    report = factory_log.render_report(agg, repo="r")
+    assert "Factory cost/value report — r" in report
+    assert "demote-candidate" in report and "browser-validate" in report
+    assert "VALIDATION" in report and "$/CATCH" in report
+
+
 def test_cost_value_verdict():
     """Every validation costed + its value quantified into a keep/demote verdict."""
     gates = {


### PR DESCRIPTION
`render_report()` turns the telemetry aggregate into a readable report — end-to-end cost, Claude Code tokens by source, cost by loop, and the **verdict table** (worst-first) with runs/caught/cost/$-per-catch. Also fixes the verdict to cover only *validations* (names that emit gate events): the build loop (`implement`) has cost but isn't a validation, so it's shown in cost-by-loop, not judged as catching nothing. +2 tests, make lint + make test green.