### PR TITLE
feat(factory-log): manual bug/escape log — measure gate recall, not just catches

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -204,6 +204,16 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer "$CW_TMP/security-revie
 
 Triage every finding like the other gates: a confirmed exploitable issue is **blocking** (fix before close); a plausible-but-unproven one is **parked for the human** with the `file:line` and the concrete attack. Never close a user-facing/auth/money epic on an unreviewed security surface. Skip only when the epic is purely internal/back-office with **no new external surface** — and say so explicitly in the close report.
 
+**Log a real finding as an escape.** When this adversarial review (or the cross-surface/UX review in Step 9) confirms a genuine bug that an *earlier* gate should have caught — the ticket's own tests/review, `traceability`, `ratchet`, `check_single_writer` — that's exactly the class of miss `caught` counters can't see: the gate reported clean while a real bug shipped anyway. Log it so `/reflect` can measure gate RECALL, not just catches (no-op unless telemetry is enabled, never blocks):
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
+  --summary "reset endpoint leaks account existence via timing" --severity high \
+  --missed-by ticket-gate --found-in close-epic-review --ticket 42 --fixed
+```
+
+(Convention: `docs/factory-telemetry.md` → "Escapes — measuring gate RECALL, not just catches".)
+
 ### Step 2i: AI-slop signals (report-only)
 
 Two signals the literature converged on for AI-generated code degradation: **elevated 2-week churn** (code reverted/reworked soon after authoring — GitClear; DORA 2024 stability drop) and **rising production duplication** (copy/paste written to be added, not reused). Run them over the target as a standing guardrail on top of the one-off `/code-metrics` audit:

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -424,6 +424,16 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 
 If ANY verification fails: fix it directly, or re-launch the coding worker (contract: `docs/worker-contracts.md#implementation-worker`) with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
 
+**Log a real finding as an escape.** This orchestrator validation is exactly where a bug that the earlier steps (TDD/tests, Step 7's multi-AI code review, static analysis) should have caught but didn't gets found independently — walking the AC, hitting a real endpoint, or reading the code turns up something the automated checks missed. When that happens, log it so gate RECALL (not just catches) is measurable (no-op unless telemetry is enabled, never blocks):
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
+  --summary "..." --severity medium --missed-by code-review \
+  --found-in implement-verify --ticket "$issue_number" --fixed
+```
+
+(Convention: `docs/factory-telemetry.md` → "Escapes — measuring gate RECALL, not just catches".)
+
 ### Step 9: UX sanity + design-fidelity gate
 
 Run the tested gate to do all the mechanical setup — frontend-impact detection (diff paths + labels), ui-spec design-binding check, reference-screenshot discovery, and screenshot-capture planning — and emit a manifest:

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -25,7 +25,8 @@ One JSON object per line. Each call site fills what it **knows** and omits the r
 
 ```
 {ts, event, repo?, ticket?, name?, result?, duration_ms?, caught?,
- provider?, tokens_in?, tokens_out?, cost_usd?, details?}
+ provider?, tokens_in?, tokens_out?, cost_usd?,
+ summary?, severity?, missed_by?, found_in?, invariant?, fixed?, details?}
 ```
 
 | event | who emits | key fields |
@@ -34,6 +35,40 @@ One JSON object per line. Each call site fills what it **knows** and omits the r
 | `consult` | an AI consultation | `provider`, `tokens_in`, `tokens_out`, `cost_usd` |
 | `worker` | a sub-agent run | `name`/role, tokens/cost if the harness surfaces them |
 | `skill` | a workflow step | `name`, `result` |
+| `escape` | an agent that manually found a bug | `summary`, `severity`, `missed_by`, `found_in`, `ticket?`, `invariant?`, `fixed?` |
+
+## Escapes — measuring gate RECALL, not just catches
+
+A `gate` event's `caught` count is only ever what that gate saw *at the time it
+ran* — it has no way to record what it missed. That leaves a blind spot: a gate
+can report a perfect catch rate on everything it inspected and still have poor
+**recall** if real bugs keep slipping past it and are only found later (an
+adversarial review in `/close-epic`, orchestrator verification in `/implement`,
+a `/saas-gate` run, a manual find, or a production incident).
+
+`escape` closes that gap. When a review or verification step finds a **real
+bug that an earlier gate/stage should have caught**, log it:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" bug --repo acme/app \
+  --summary "reset endpoint leaks account existence via timing" \
+  --severity high --missed-by ticket-gate --found-in close-epic-review \
+  --ticket 42 --invariant INV-012 --fixed
+```
+
+- `--missed-by` names the gate/stage that **should** have caught it (free text —
+  common values: `ticket-gate`, `traceability`, `ratchet`, `close-epic-review`,
+  `saas-gate`).
+- `--found-in` is a closed set naming where it **actually** surfaced:
+  `implement-verify` | `close-epic-review` | `saas-gate` | `manual` | `prod`.
+- `--severity` is `low` | `medium` | `high` | `critical`.
+- `--ticket`, `--invariant`, and `--fixed` are optional context.
+
+`aggregate()` joins each `missed_by` gate's own `caught` count with its escaped
+count into **recall**: `caught / (caught + escaped)`. A gate with `caught: 10,
+escaped: 0` has 100% recall; one with `caught: 2, escaped: 2` only actually
+catches half of what it should — a signal `caught` alone can never show. See
+`aggregate()["escapes"]` / the "Escapes" section of `render_report`.
 
 Token counts come from the provider's own usage summary — every consult provider
 surfaces one (the CLIs via their `--output-format json` mode, the SDKs via the
@@ -148,3 +183,8 @@ python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app   # per-gate
 caught), or `unproven` (too few runs to judge) — the input to the gate-rollout
 question in `docs/gate-rollout.md`: a gate that never catches anything on real code
 is a candidate to demote or delete before it trains operators to `--force` past it.
+
+It also reports `escapes` — per `missed_by` gate, `caught`/`escaped`/`fixed` counts
+and `recall` (`caught / (caught + escaped)`), plus `escapes_total`. A gate that
+looks `earning` on catches alone but has low recall is quietly letting real bugs
+through; that's the case `caught` by itself can't show.

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -12,13 +12,21 @@ exists.
 
 Event schema (one JSON object per line):
     {ts, event, repo?, ticket?, name?, result?, duration_ms?, caught?,
-     provider?, tokens_in?, tokens_out?, cost_usd?, details?}
+     provider?, tokens_in?, tokens_out?, cost_usd?, summary?, severity?,
+     missed_by?, found_in?, invariant?, fixed?, details?}
 
-  event: "gate" | "consult" | "worker" | "skill"
+  event: "gate" | "consult" | "worker" | "skill" | "escape"
   A gate records name/result/duration_ms/caught; a consult records
-  provider/tokens/cost; each call site fills what it KNOWS and omits the rest.
+  provider/tokens/cost; an **escape** records a manually-found bug — especially
+  one that slipped PAST a gate and was caught later (`missed_by` the gate/stage
+  that should have caught it, `found_in` the review/verification step that
+  actually caught it) — so `aggregate()` can compute gate RECALL
+  (caught / (caught + escaped)), not just catches. Each call site fills what it
+  KNOWS and omits the rest.
 
     factory_log.py emit --event gate --repo acme/app --name ratchet --result pass --caught 0
+    factory_log.py bug --repo acme/app --summary "reset endpoint leaks account existence" \
+      --severity high --missed-by ticket-gate --found-in close-epic-review
     factory_log.py aggregate [--repo acme/app]
 """
 
@@ -38,7 +46,11 @@ GATE = "gate"
 CONSULT = "consult"
 WORKER = "worker"
 SKILL = "skill"
+ESCAPE = "escape"  # a manually-found bug, especially one a gate missed
 CLAUDE_CODE = "claude_code"  # per-request api_request events from Claude Code's own OTEL telemetry
+
+ESCAPE_SEVERITIES = ("low", "medium", "high", "critical")
+ESCAPE_FOUND_IN = ("implement-verify", "close-epic-review", "saas-gate", "manual", "prod")
 
 
 def log_path() -> Path:
@@ -78,6 +90,27 @@ def emit_gate(name: str, result: str, *, caught: int | None = None,
               ticket: str | None = None) -> bool:
     return emit(GATE, name=name, result=result, caught=caught,
                 duration_ms=duration_ms, repo=repo, ticket=ticket)
+
+
+def emit_escape(summary: str, *, severity: str, missed_by: str, found_in: str,
+                repo: str | None = None, ticket: str | None = None,
+                invariant: str | None = None, fixed: bool | None = None) -> bool:
+    """Record a manually-found bug — especially an ESCAPE that slipped PAST a gate
+    and was only caught later (e.g. close-epic's adversarial review catching a bug
+    the ticket's own gates missed).
+
+    A `gate` event's `caught` count is only ever what THAT gate caught at THAT
+    time — it has no way to see what it missed. `escape` is the other half: a
+    human/agent records `missed_by` (the gate/stage that SHOULD have caught this,
+    e.g. `ticket-gate`, `traceability`, `ratchet`, `close-epic-review`,
+    `saas-gate`) and `found_in` (where it actually surfaced). `aggregate()` joins
+    the two into gate RECALL — caught / (caught + escaped) — which `caught` alone
+    can never show: a gate can report 100% catches on everything it looked at and
+    still have terrible recall if real bugs keep slipping past it unnoticed.
+    """
+    return emit(ESCAPE, summary=summary, severity=severity, missed_by=missed_by,
+                found_in=found_in, repo=repo, ticket=ticket, invariant=invariant,
+                fixed=fixed)
 
 
 def load_pricing(path: Path = PRICING_PATH) -> dict:
@@ -232,6 +265,7 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
         records = [r for r in records if r.get("repo") == repo]
     gates: dict[str, dict] = {}
     consults: dict[str, dict] = {}
+    escapes: dict[str, dict] = {}
     # Claude Code's own token cost, split orchestrator (repl_main_thread) vs subagent,
     # and (when the OTEL events carry skill.name/agent.name) by loop/validation.
     claude_code: dict[str, dict] = {}
@@ -268,6 +302,14 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
                 bl = by_loop.setdefault(r["skill"], {"calls": 0, "cost_usd": 0.0})
                 bl["calls"] += 1
                 bl["cost_usd"] += r.get("cost_usd") or 0.0
+        elif r.get("event") == ESCAPE:
+            key = r.get("missed_by") or "unknown"
+            es = escapes.setdefault(key, {"escaped": 0, "fixed": 0, "by_severity": {}})
+            es["escaped"] += 1
+            if r.get("fixed"):
+                es["fixed"] += 1
+            sev = r.get("severity") or "unknown"
+            es["by_severity"][sev] = es["by_severity"].get(sev, 0) + 1
     # value/noise hint: a gate with runs but zero caught is a noise candidate
     for g in gates.values():
         g["value"] = "earning" if g["caught"] > 0 else ("noise-candidate" if g["runs"] >= 3 else "unproven")
@@ -275,8 +317,17 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
         cc["cost_usd"] = round(cc["cost_usd"], 6)
     for bl in by_loop.values():
         bl["cost_usd"] = round(bl["cost_usd"], 6)
+    # recall = caught / (caught + escaped) — joins the gate's own catches (what it
+    # saw) with escapes attributed to it (what it missed). None when we have
+    # neither a catch count nor an escape count to reason from.
+    for name, es in escapes.items():
+        caught = gates.get(name, {}).get("caught", 0)
+        escaped = es["escaped"]
+        es["caught"] = caught
+        es["recall"] = round(caught / (caught + escaped), 4) if (caught + escaped) > 0 else None
     return {"gates": gates, "consults": consults, "claude_code": claude_code,
             "cost_by_loop": by_loop, "verdict": cost_value_verdict(gates, by_loop),
+            "escapes": escapes, "escapes_total": sum(es["escaped"] for es in escapes.values()),
             "records": len(records),
             "consult_cost_usd": round(consult_cost, 4),
             "claude_code_cost_usd": round(cc_cost, 4),
@@ -350,6 +401,16 @@ def render_report(agg: dict, repo: str | None = None) -> str:
             cost = f"${v['cost_usd']:.2f}"
             cpc = f"${v['cost_per_catch']:.3f}" if v["cost_per_catch"] is not None else "—"
             L.append(f"    {name:<22}{v['runs']:>5}{v['caught']:>7}{cost:>10}{cpc:>10}   {v['verdict']}")
+
+    escapes = agg.get("escapes") or {}
+    if escapes:
+        L.append(f"\n  Escapes — bugs a gate missed ({agg.get('escapes_total', 0)} total). "
+                  "Recall = caught / (caught + escaped):")
+        L.append(f"    {'MISSED BY':<22}{'CAUGHT':>7}{'ESCAPED':>9}{'FIXED':>7}   RECALL")
+        L.append("    " + "─" * 55)
+        for name, e in sorted(escapes.items(), key=lambda kv: -kv[1]["escaped"]):
+            recall = f"{e['recall']:.0%}" if e["recall"] is not None else "—"
+            L.append(f"    {name:<22}{e['caught']:>7}{e['escaped']:>9}{e['fixed']:>7}   {recall}")
     return "\n".join(L)
 
 
@@ -365,6 +426,18 @@ def main() -> int:
         e.add_argument(f"--{opt}", type=int)
     e.add_argument("--duration-ms", type=float)
     e.add_argument("--cost-usd", type=float)
+
+    b = sub.add_parser("bug", help="Log a manually-found bug — especially an escape a gate missed")
+    b.add_argument("--repo", required=True)
+    b.add_argument("--summary", required=True, help="What the bug was")
+    b.add_argument("--severity", required=True, choices=ESCAPE_SEVERITIES)
+    b.add_argument("--missed-by", required=True,
+                   help="The gate/stage that SHOULD have caught it, e.g. ticket-gate|traceability|ratchet|close-epic-review|saas-gate")
+    b.add_argument("--found-in", required=True, choices=ESCAPE_FOUND_IN,
+                   help="Where it was actually caught")
+    b.add_argument("--ticket", help="Issue/ticket number, e.g. 42")
+    b.add_argument("--invariant", help="Related invariant ID, e.g. INV-012")
+    b.add_argument("--fixed", action="store_true", help="Set if already fixed at log time")
 
     a = sub.add_parser("aggregate", help="Summarize the log")
     a.add_argument("--repo")
@@ -391,6 +464,14 @@ def main() -> int:
         fields["tokens_in"] = args.tokens_in
         fields["tokens_out"] = args.tokens_out
         ok = emit(args.event, **fields)
+        if not ok:
+            print("factory_log: telemetry disabled (set CW_TELEMETRY=1 to enable)", file=sys.stderr)
+            return 1
+        return 0
+    if args.cmd == "bug":
+        ok = emit_escape(args.summary, severity=args.severity, missed_by=args.missed_by,
+                          found_in=args.found_in, repo=args.repo, ticket=args.ticket,
+                          invariant=args.invariant, fixed=True if args.fixed else None)
         if not ok:
             print("factory_log: telemetry disabled (set CW_TELEMETRY=1 to enable)", file=sys.stderr)
             return 1

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -269,3 +269,133 @@ def test_cli_emit_and_aggregate(tmp_path):
     proc = subprocess.run([sys.executable, str(SCRIPTS / "factory_log.py"), "aggregate", "--repo", "a"],
                           capture_output=True, text=True, env=env, check=True)
     assert json.loads(proc.stdout)["gates"]["ratchet"]["runs"] == 1
+
+
+# ---- escape events -----------------------------------------------------------
+
+def test_emit_escape_is_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    monkeypatch.delenv("CW_FACTORY_LOG", raising=False)
+    assert factory_log.emit_escape(
+        "bug", severity="high", missed_by="ticket-gate", found_in="close-epic-review") is False
+
+
+def test_emit_escape_writes_well_formed_record(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    ok = factory_log.emit_escape(
+        "reset endpoint leaks account existence via timing", severity="high",
+        missed_by="ticket-gate", found_in="close-epic-review", repo="acme/app",
+        ticket="42", invariant="INV-012", fixed=True)
+    assert ok
+    rec = json.loads(log.read_text().splitlines()[0])
+    ts = rec.pop("ts")
+    assert isinstance(ts, float)
+    assert rec == {
+        "event": "escape",
+        "summary": "reset endpoint leaks account existence via timing",
+        "severity": "high", "missed_by": "ticket-gate", "found_in": "close-epic-review",
+        "repo": "acme/app", "ticket": "42", "invariant": "INV-012", "fixed": True,
+    }
+
+
+def test_emit_escape_omits_optional_none_fields(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    factory_log.emit_escape("bug", severity="low", missed_by="ratchet", found_in="manual", repo="a")
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert "ticket" not in rec and "invariant" not in rec and "fixed" not in rec
+
+
+def test_cli_bug_writes_escape_record(tmp_path):
+    import os
+    log = tmp_path / "f.jsonl"
+    env = {**os.environ, "CW_FACTORY_LOG": str(log)}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "factory_log.py"), "bug",
+         "--repo", "acme/app", "--summary", "IDOR on invoice download",
+         "--severity", "critical", "--missed-by", "ticket-gate",
+         "--found-in", "close-epic-review", "--ticket", "42", "--fixed"],
+        capture_output=True, text=True, env=env)
+    assert proc.returncode == 0
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["event"] == "escape"
+    assert rec["summary"] == "IDOR on invoice download"
+    assert rec["severity"] == "critical"
+    assert rec["missed_by"] == "ticket-gate"
+    assert rec["found_in"] == "close-epic-review"
+    assert rec["ticket"] == "42"
+    assert rec["fixed"] is True
+
+
+def test_cli_bug_disabled_returns_1():
+    env = {k: v for k, v in __import__("os").environ.items()
+           if k not in ("CW_TELEMETRY", "CW_FACTORY_LOG")}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "factory_log.py"), "bug",
+         "--repo", "a", "--summary", "x", "--severity", "low",
+         "--missed-by", "ticket-gate", "--found-in", "manual"],
+        capture_output=True, text=True, env=env)
+    assert proc.returncode == 1
+    assert "telemetry disabled" in proc.stderr
+
+
+def test_cli_bug_rejects_invalid_severity():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "factory_log.py"), "bug",
+         "--repo", "a", "--summary", "x", "--severity", "extreme",
+         "--missed-by", "ticket-gate", "--found-in", "manual"],
+        capture_output=True, text=True)
+    assert proc.returncode != 0
+
+
+def test_aggregate_counts_escapes_per_missed_by_and_computes_recall():
+    records = [
+        {"event": "gate", "name": "ticket-gate", "result": "pass", "caught": 2, "repo": "a"},
+        {"event": "escape", "summary": "bug1", "severity": "high", "missed_by": "ticket-gate",
+         "found_in": "close-epic-review", "fixed": True, "repo": "a"},
+        {"event": "escape", "summary": "bug2", "severity": "critical", "missed_by": "ticket-gate",
+         "found_in": "close-epic-review", "repo": "a"},
+        {"event": "escape", "summary": "bug3", "severity": "low", "missed_by": "saas-gate",
+         "found_in": "manual", "repo": "a"},
+    ]
+    agg = factory_log.aggregate(records)
+    # ticket-gate: caught 2, escaped 2 -> recall 0.5
+    assert agg["escapes"]["ticket-gate"]["escaped"] == 2
+    assert agg["escapes"]["ticket-gate"]["caught"] == 2
+    assert agg["escapes"]["ticket-gate"]["fixed"] == 1
+    assert agg["escapes"]["ticket-gate"]["recall"] == 0.5
+    assert agg["escapes"]["ticket-gate"]["by_severity"] == {"high": 1, "critical": 1}
+    # saas-gate: no gate events at all -> caught 0, escaped 1 -> recall 0.0
+    assert agg["escapes"]["saas-gate"]["caught"] == 0
+    assert agg["escapes"]["saas-gate"]["recall"] == 0.0
+    assert agg["escapes_total"] == 3
+    # existing gate/consult aggregation is untouched
+    assert agg["gates"]["ticket-gate"]["caught"] == 2
+
+
+def test_aggregate_escapes_do_not_break_existing_gate_aggregation():
+    records = [
+        {"event": "gate", "name": "ratchet", "result": "pass", "caught": 0, "duration_ms": 10, "repo": "a"},
+        {"event": "gate", "name": "ratchet", "result": "fail", "caught": 1, "duration_ms": 10, "repo": "a"},
+        {"event": "consult", "provider": "opus", "tokens_in": 100, "tokens_out": 50, "cost_usd": 0.02, "repo": "a"},
+        {"event": "escape", "summary": "unrelated bug", "severity": "medium", "missed_by": "traceability",
+         "found_in": "close-epic-review", "repo": "a"},
+    ]
+    agg = factory_log.aggregate(records)
+    assert agg["gates"]["ratchet"]["caught"] == 1
+    assert agg["gates"]["ratchet"]["value"] == "earning"
+    assert agg["consults"]["opus"]["cost_usd"] == 0.02
+    assert agg["escapes"]["traceability"]["escaped"] == 1
+    assert "ratchet" not in agg["escapes"]
+
+
+def test_render_report_shows_escapes_and_recall():
+    agg = factory_log.aggregate([
+        {"event": "gate", "name": "ticket-gate", "result": "pass", "caught": 2, "repo": "r"},
+        {"event": "escape", "summary": "bug", "severity": "high", "missed_by": "ticket-gate",
+         "found_in": "close-epic-review", "repo": "r"},
+    ], repo="r")
+    report = factory_log.render_report(agg, repo="r")
+    assert "Escapes" in report and "ticket-gate" in report
+    assert "RECALL" in report


### PR DESCRIPTION
Adds a manual bug log for agents (requested: "CW should have a manual bug log for agents"). Today `factory_log.py` logs `gate` events with a `caught: N` counter — catches only, never misses. This adds the miss side so gate **recall** is measurable.

## What
- `factory_log.py bug --repo --summary --severity {low,medium,high,critical} --missed-by <gate/stage> --found-in {implement-verify,close-epic-review,saas-gate,manual,prod} [--ticket N] [--invariant INV-X] [--fixed]` → emits an `escape` event (passive, respects `CW_TELEMETRY`, never raises).
- Aggregation buckets escapes by `missed_by` and computes `recall = caught/(caught+escaped)`; report gains an "Escapes — bugs a gate missed" table with a RECALL column. Existing aggregation untouched.
- Emit-guidance wired into close-epic.md (Step 2i adversarial review) + implement.md (Step 8 orchestrator validation): when a later stage finds a bug an earlier gate should have caught, log it.
- Docs: `docs/factory-telemetry.md`.

## Tests
10 new (32 pass in test_factory_log.py, verified by orchestrator). Pre-existing 2 suite failures (dangling maintain_tutorials.py ref in cw-standards) are unrelated — confirmed on base commit.

Follow-up (not in scope): surface escapes/recall as /reflect findings.

https://claude.ai/code/session_01UGFhLqMUhRTcwPC7fvwz6U