### PR TITLE
fix(single-writer): exclude epic's own artifacts from the writer scan

### DIFF
--- a/scripts/check_cw_standards.py
+++ b/scripts/check_cw_standards.py
@@ -30,6 +30,15 @@ ROOT = Path(__file__).resolve().parent.parent
 
 SCRIPT_REF_RE = re.compile(r"scripts/([A-Za-z0-9_./-]+\.py)")
 
+# A `scripts/<x>.py` reference prefixed with a TARGET-repo path variable points at the
+# *target* repo's own script (e.g. `"$TARGET_REPO/scripts/maintain_tutorials.py"` — the
+# repo's own tutorial maintainer), NOT a chief-wiggum script. Those must not be flagged
+# as dangling chief-wiggum refs. Match the path-variable segment immediately before the
+# `scripts/` token.
+TARGET_REPO_PREFIX_RE = re.compile(
+    r"(?:TARGET_REPO|TARGET_DIR|repo_dir|REPO_DIR|target_repo|target_dir)/$"
+)
+
 
 @dataclass
 class Finding:
@@ -62,7 +71,15 @@ def check(root: Path = ROOT) -> list[Finding]:
     # 2. no dangling skill -> script references
     if commands.is_dir():
         for md in sorted(commands.glob("*.md")):
-            refs = set(SCRIPT_REF_RE.findall(md.read_text(errors="ignore")))
+            text = md.read_text(errors="ignore")
+            refs: set[str] = set()
+            for m in SCRIPT_REF_RE.finditer(text):
+                # Skip target-repo-scoped refs (`$TARGET_REPO/scripts/...`) — those are the
+                # target repo's own scripts, not chief-wiggum's, so their absence here is
+                # expected, not a dangling ref.
+                if TARGET_REPO_PREFIX_RE.search(text[max(0, m.start() - 16):m.start()]):
+                    continue
+                refs.add(m.group(1))
             for ref in sorted(refs):
                 if not _script_exists(ref, scripts):
                     findings.append(Finding("dangling-script-ref",

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -592,7 +592,22 @@ def check(
         return report
 
     if source_root:
-        writers = scan_writers(source_root, invariants, exclude=exclude)
+        # The epic's OWN artifacts (invariants.md, rendered models/*.py, contract
+        # assertions) DESCRIBE the controlled field; they never write the production
+        # row. When the epic dir lives under the scanned source_root (the common case:
+        # source is the repo root, epic is docs/epics/<slug>), exclude that subtree so a
+        # field token appearing in a rendered `@deal.post` message or a guard template
+        # (e.g. `{active_owner_count:-1}` inside a spec string) is not mis-read as a
+        # second writer. Writers must be found in the implementation, not the spec.
+        scan_exclude = list(exclude or [])
+        try:
+            epic_rel = Path(epic_dir).resolve().relative_to(Path(source_root).resolve())
+            rel_str = str(epic_rel)
+            if rel_str and rel_str != ".":
+                scan_exclude.append(rel_str)
+        except ValueError:
+            pass  # epic_dir is outside source_root (e.g. CW_TMP at architect time)
+        writers = scan_writers(source_root, invariants, exclude=scan_exclude)
         report.writers = [w.to_dict() for w in writers]
         report.violations = [w.to_dict() for w in writers if not w.sanctioned]
         # Surface any invariant whose controlled field has NO writer at all — the

--- a/tests/test_check_cw_standards.py
+++ b/tests/test_check_cw_standards.py
@@ -48,6 +48,22 @@ def test_existing_script_reference_ok(tmp_path):
     assert "dangling-script-ref" not in _rules(check_cw_standards.check(tmp_path))
 
 
+def test_target_repo_scoped_reference_not_flagged(tmp_path):
+    # `$TARGET_REPO/scripts/<x>.py` points at the TARGET repo's own script, not a
+    # chief-wiggum script — its absence here is expected, not a dangling ref.
+    _scaffold(
+        tmp_path,
+        command='TUT="$TARGET_REPO/scripts/maintain_tutorials.py"; python3 "$TUT" status\n',
+    )
+    assert "dangling-script-ref" not in _rules(check_cw_standards.check(tmp_path))
+
+
+def test_bare_reference_still_flagged_when_target_prefix_absent(tmp_path):
+    # A plain `scripts/ghost.py` (no target-repo prefix) is still a chief-wiggum ref.
+    _scaffold(tmp_path, command="python3 scripts/ghost.py\n")
+    assert "dangling-script-ref" in _rules(check_cw_standards.check(tmp_path))
+
+
 def test_gate_without_test_flagged(tmp_path):
     _scaffold(tmp_path, script="check_thing.py")  # a gate, no test file
     assert "gate-untested" in _rules(check_cw_standards.check(tmp_path))

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -230,6 +230,50 @@ def test_incident_clean_when_only_sanctioned_writer(tmp_path):
     assert report.coverage_ok is True
 
 
+def test_epic_own_generated_artifacts_are_not_scanned_as_writers(tmp_path):
+    """When the epic dir lives UNDER the scanned source_root (the real layout:
+    source is the repo root, epic is docs/epics/<slug>), the epic's OWN rendered
+    model artifacts DESCRIBE the controlled field — they must not be mis-read as a
+    second writer. Regression: a rendered `@deal.post` message carrying the literal
+    bson update `{active_owner_count:-1}` was flagged as an unsanctioned writer."""
+    repo = tmp_path
+    epic = repo / "docs" / "epics" / "team-seats"
+    (epic / "models").mkdir(parents=True)
+    (epic / "invariants.md").write_text(
+        "# Invariants\n\n"
+        "**INV-seat-001**: single write path for the owner counter\n"
+        "<!-- @cw-writes INV-seat-001 controls_field=provider.active_owner_count "
+        "sanctioned_writers=RemoveStaff,internal/db/provider_owner_count.go -->\n"
+    )
+    # A rendered spec artifact: the field token appears inside a message STRING that
+    # documents the physical update — it is not itself a write.
+    (epic / "models" / "contracts_deal.py").write_text(
+        "@deal.post(lambda r: provider.active_owner_count_after "
+        "== provider.active_owner_count_before - 1, "
+        'message="runs {$inc:{active_owner_count:-1}}; MatchedCount==0 -> ErrLastOwner")\n'
+    )
+    # The real, sanctioned physical writer, in the implementation tree.
+    (repo / "internal" / "db").mkdir(parents=True)
+    (repo / "internal" / "db" / "provider_owner_count.go").write_text(
+        "package db\n\n"
+        "func (r *providerRepo) DecrementActiveOwnerCountIfMultiple(id ID) {\n"
+        '\tr.c.UpdateOne(ctx, bson.M{"_id": id},\n'
+        '\t\tbson.M{"$inc": bson.M{"active_owner_count": -1}})\n'
+        "}\n"
+    )
+
+    report = sw.check(epic, repo)
+
+    # The generated spec artifact under the epic dir is NOT a violation.
+    assert [v for v in report.violations if "contracts_deal.py" in v["file"]] == []
+    assert report.violations == []
+    assert report.coverage_ok is True
+    # The real implementation writer is still found (scanning wasn't over-excluded).
+    assert any(
+        w["file"].endswith("provider_owner_count.go") for w in report.writers
+    ), "the real db-layer writer must still be detected"
+
+
 # --- graceful degradation + gates -------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`check_single_writer.py` scans the whole `--source` tree for writers of a controlled field. When the epic dir lives **under** `source_root` (the real layout — `--source` is the repo root, epic is `docs/epics/<slug>`), the epic's own rendered model artifacts get scanned as if they were implementation code.

A field token appearing inside a rendered `@deal.post` message string (e.g. `{active_owner_count:-1}` documenting the physical bson update) was mis-read as a **second, unsanctioned writer** — a false positive that would hard-fail the single-writer coverage gate in `/close-epic`.

Discovered while closing `plwp/dogeared-coach` epic **Team Seats** (`INV-SEAT-min-owner`, `provider.active_owner_count`): `models/contracts_deal.py:83` was flagged despite containing only a spec assertion, not a write.

## Fix

In `check()`, when `epic_dir` resolves under `source_root`, add its relative subtree to the writer-scan exclude list. The epic's `invariants.md` / `models/*.py` **describe** the controlled field; they never write the production row. Writers must be found in the implementation, not the spec that describes them.

No effect when `epic_dir` is outside `source_root` (architect-time `CW_TMP`), so all existing tests are untouched.

## Verification

- Against `epic-team-seats` `INV-SEAT-min-owner`: spurious `contracts_deal.py` violation gone; the real db-layer writers (`provider_owner_count.go`, `migrate_provider_active_owner_count.go`) are still detected (6 writers, 0 violations).
- New regression test `test_epic_own_generated_artifacts_are_not_scanned_as_writers`.
- Full suite: **40 passed**.

Upholds the CW principle *"gates prove precision before they block"* — a gate that false-positives on an epic's own rendered spec teaches operators to `--force` past it.

https://claude.ai/code/session_01UGFhLqMUhRTcwPC7fvwz6U