### PR TITLE
feat(consult): review lenses + robustness fixes (#163)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -84,7 +84,7 @@ Prepare a consultation prompt at `$CW_TMP/architect-prompt.md` including:
   5. Where are the integration risks and how should we test them?
   6. What could go wrong between tickets? (dual sources of truth, race conditions, inconsistent reads)
 
-Fire the `architecture_critic` quorum (codex + gemini in parallel, with retries + output validation):
+Fire the `architecture_critic` quorum (codex + gemini in parallel, with retries + output validation). Every provider gets the **identical** prompt above — the value is in natural divergence, not roleplay — but `config/providers.json` may additionally assign each provider a bounded **review lens** (`role.lenses`, e.g. `codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`; charters live in `config/lenses.json`). When a lens is assigned, `consult_ai.py` appends that provider's charter as a clearly-delimited `## Your charter` section — the shared prompt itself never changes. This decorrelates the reviewers on purpose: a soundness-refuter and a completeness-checker reading the *same* context reliably surface disjoint findings instead of converging on the same top issue three times:
 
 ```bash
 python3 "$CW_HOME/scripts/consult_ai.py" --role architecture_critic $CW_TMP/architect-prompt.md \
@@ -98,6 +98,8 @@ Responses land at `$CW_TMP/architect-consult/architecture_critic-<provider>.md` 
 ### Step 4: Synthesise into architectural artifacts
 
 Launch a **synthesis worker** (contract: `docs/worker-contracts.md#synthesis-worker`) to reconcile all three consultations into **structured formal models** (JSON) plus supporting prose artifacts. Each artifact is a separate file in `$CW_TMP/`.
+
+**Reconciliation expects disjoint findings, not convergence.** When the quorum is lensed (Step 3), agreement across providers is the exception, not the confirmation signal — each reviewer was scoped to look for something different. Reconcile by **union, then cross-verify contested items**: fold in every finding from every provider (a soundness issue the refuter caught is not weaker for being unique to it), and only for items where providers actively *disagree* on a fact (not merely "only one mentioned it") should the synthesis worker re-check against the codebase before deciding which side is right. Do not discard a lensed provider's finding for lacking a second vote — that would defeat the reason lenses were assigned.
 
 **The worker MUST produce structured JSON models first.** The prose markdown is then generated mechanically from the JSON — never the other way around. This ensures the machine-readable and human-readable artifacts stay in sync.
 
@@ -372,7 +374,7 @@ Prepare a validation prompt at `$CW_TMP/validate-artifacts-prompt.md` containing
   6. Does every precondition have a corresponding error case? (REQUIRES without an ERROR CASE means a silent failure)
   7. Are the `expression` fields in preconditions/postconditions/invariants reasonable and implementable?
 
-Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation):
+Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation). As in Step 3, `reviewer` may carry a lens assignment in `config/providers.json` — check its `lenses` map before assuming two providers scoped alike:
 
 ```bash
 python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/validate-artifacts-prompt.md \
@@ -381,7 +383,7 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/validate-artifa
 
 Responses land at `$CW_TMP/validate-artifacts/reviewer-<provider>.md` (status in `reviewer-manifest.json`).
 
-Review both responses. Apply clear improvements to the JSON models. Regenerate prose if models changed:
+Review both responses. **Union the findings rather than looking for agreement** — a lensed quorum is expected to produce disjoint findings; only cross-verify against the models when two providers make contested/contradictory claims about the same fact. Apply clear improvements to the JSON models. Regenerate prose if models changed:
 ```bash
 python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
 python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -312,7 +312,7 @@ The worker should:
    git diff "$DEFAULT_BRANCH"...HEAD > $TICKET_TMP/impl-diff.txt
    ```
 
-2. Run the review pipeline in one call. It captures the `base...HEAD` diff, assembles the review prompt from `templates/review-prompt.md` + `review-checklist.md` (plus any epic artifacts you pass), runs the `reviewer` quorum (parallel, retries, output validation), and writes the synthesis prompt + a manifest. Pass a `ticket.json` with the title/body/acceptance criteria, and optionally epic artifacts:
+2. Run the review pipeline in one call. It captures the `base...HEAD` diff, assembles the review prompt from `templates/review-prompt.md` + `review-checklist.md` (plus any epic artifacts you pass), runs the `reviewer` quorum (parallel, retries, output validation), and writes the synthesis prompt + a manifest. Every provider gets the **identical** assembled prompt — but check `config/providers.json`'s `reviewer.lenses` map first: providers may be assigned a bounded review lens (e.g. `codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`; charters in `config/lenses.json`), in which case `run_review.py` appends each provider's charter as a `## Your charter` section before calling it — the shared diff/context every provider sees never changes. Pass a `ticket.json` with the title/body/acceptance criteria, and optionally epic artifacts:
    ```bash
    python3 "$CW_HOME/scripts/run_review.py" \
      --ticket-context "$TICKET_TMP/ticket.json" \
@@ -329,6 +329,7 @@ The worker should:
    ```bash
    python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/reviews/reviewer-codex.md $TICKET_TMP/reviews/reviewer-gemini.md
    ```
+   **When `reviewer` is lensed, expect disjoint findings, not convergence** — each provider was scoped to a different concern over the same diff, so agreement across reviewers is the exception, not the confirmation signal. `synthesize_reviews.py` reconciles by **union, then cross-verifies only contested items**: every concrete finding is retained regardless of whether one reviewer raised it or several (a soundness issue only the refuter caught is not weaker for being unique to it), and cross-verification against the diff is reserved for cases where two reviewers make genuinely *contradictory* claims about the same fact — not merely where one mentions something the other didn't. Do not fall back to majority-vote reasoning when reconciling a lensed quorum; it defeats the reason the lenses were assigned.
 
 5. Return a concise summary categorising each piece of feedback:
    - **High-confidence fixes**: Concrete bugs/regressions with clear failure scenarios. Apply automatically.

--- a/config/lenses.json
+++ b/config/lenses.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "lenses": {
+    "refute-soundness": {
+      "goal": "Your goal is to find the strongest reason this proposal is WRONG. Actively try to break the core reasoning: identify any assumption that does not hold, any edge case the logic silently mishandles, any place where a stated invariant does not actually follow from the design. If you cannot find a soundness problem after genuinely trying, say so plainly rather than manufacturing a weak one to have something to report.",
+      "exclusions": [
+        "Do NOT evaluate adoption cost, migration effort, or how disruptive the change is to existing users.",
+        "Do NOT evaluate completeness (whether every case is covered) except where an omitted case would itself make the core reasoning unsound.",
+        "Do NOT comment on naming, style, or documentation quality."
+      ]
+    },
+    "adoption-cost": {
+      "goal": "Your goal is to assess how expensive and risky this proposal is to adopt: migration effort, backward compatibility, operational burden, rollout/rollback risk, and the cost of getting it wrong in production. Assume the core design is sound — you are pricing the change, not refuting the reasoning behind it.",
+      "exclusions": [
+        "Do NOT re-litigate whether the underlying design is logically correct — assume it is.",
+        "Do NOT evaluate whether every edge case or actor is enumerated.",
+        "Do NOT comment on code style or naming."
+      ]
+    },
+    "completeness": {
+      "goal": "Your goal is to check coverage: does the proposal address every case, actor, and failure mode implied by the stated goal? List anything missing — an unhandled state, an unaddressed error path, a class of user or input the design does not mention — without arguing about whether the covered cases are handled correctly.",
+      "exclusions": [
+        "Do NOT evaluate whether the reasoning for the cases that ARE covered is sound — assume it is.",
+        "Do NOT evaluate adoption cost or migration effort.",
+        "Do NOT comment on code style or naming."
+      ]
+    },
+    "security": {
+      "goal": "Your goal is to find security and data-exposure problems: authentication/authorization gaps, injection or deserialization risks, secrets handling, tenant/data isolation failures, and any place untrusted input reaches a sensitive sink. Treat functional correctness outside the security surface as someone else's job.",
+      "exclusions": [
+        "Do NOT evaluate general code quality, style, or naming.",
+        "Do NOT evaluate adoption cost or migration effort.",
+        "Do NOT evaluate completeness of non-security functionality."
+      ]
+    }
+  }
+}

--- a/config/providers.json
+++ b/config/providers.json
@@ -38,11 +38,21 @@
     },
     "reviewer": {
       "required": ["codex", "gemini"],
-      "optional": ["claude-interactive"]
+      "optional": ["claude-interactive"],
+      "lenses": {
+        "codex": "refute-soundness",
+        "gemini": "completeness",
+        "claude-interactive": "adoption-cost"
+      }
     },
     "architecture_critic": {
       "required": ["codex"],
-      "optional": ["gemini", "claude-interactive"]
+      "optional": ["gemini", "claude-interactive"],
+      "lenses": {
+        "codex": "refute-soundness",
+        "gemini": "completeness",
+        "claude-interactive": "adoption-cost"
+      }
     },
     "design_critic": {
       "required": ["gemini"],

--- a/scripts/chief_wiggum/review.py
+++ b/scripts/chief_wiggum/review.py
@@ -108,7 +108,12 @@ def build_synthesis_prompt(response_paths: list[str]) -> str:
     return (
         "Synthesize the independent code reviews below into one actionable report.\n"
         "Categorize each finding as high-confidence (apply), medium (verify first), "
-        "or low/architectural (flag for user). Note consensus vs single-reviewer findings.\n\n"
+        "or low/architectural (flag for user).\n"
+        "Reviewers may have been assigned disjoint review lenses over the same "
+        "diff, so expect disjoint findings, not convergence. Combine by union: a "
+        "finding raised by a single reviewer is not weaker for lacking consensus "
+        "— do not downgrade it. Cross-verify against the diff only where "
+        "reviewers make contradictory claims about the same fact.\n\n"
         f"Reviewer responses:\n{listing}\n"
     )
 
@@ -218,6 +223,14 @@ def run_review(
 
     if lenses is None:
         lenses = providers.load_lenses()
+
+    # Fail fast on a malformed lens map — a lens assigned to a provider not in
+    # the role would otherwise silently no-op, and an unknown lens on an
+    # optional provider would degrade to a provider "failure" while the run
+    # still reported success. Matches consult_ai --role behavior.
+    lens_errors = providers.validate_role_lenses(plan.role, lenses)
+    if lens_errors:
+        raise ReviewError("; ".join(lens_errors))
 
     # The quorum calls execute(provider); bind the assembled prompt here. A
     # provider mapped to a lens on this role gets its charter appended; the

--- a/scripts/chief_wiggum/review.py
+++ b/scripts/chief_wiggum/review.py
@@ -177,6 +177,7 @@ def run_review(
     epic_sections: Iterable[tuple[str, str]] = (),
     role: str = "reviewer",
     config: dict | None = None,
+    lenses: dict | None = None,
     execute: Callable[[providers.Provider, str], str] | None = None,
     runner: Runner = subprocess.run,
     max_diff_bytes: int = DEFAULT_MAX_DIFF_BYTES,
@@ -185,6 +186,11 @@ def run_review(
 
     Refuses to run outside a git repo or when ``base`` cannot be resolved.
     ``execute`` (the provider call) is injected so the pipeline is testable.
+
+    Every provider gets the identical assembled prompt. If ``role`` maps a
+    provider to a lens (``config/providers.json`` role.lenses), that provider's
+    charter (``config/lenses.json``, or ``lenses`` if supplied) is appended —
+    the shared prompt itself is never altered (chief-wiggum#163).
     """
     assert_git_repo(worktree, runner=runner)
     out = Path(output_dir)
@@ -210,8 +216,17 @@ def run_review(
     if execute is None:
         raise ReviewError("an execute callable is required to run the reviewer quorum")
 
-    # The quorum calls execute(provider); bind the assembled prompt here.
-    quorum = providers.run_role_quorum(plan, lambda p: execute(p, prompt), out)
+    if lenses is None:
+        lenses = providers.load_lenses()
+
+    # The quorum calls execute(provider); bind the assembled prompt here. A
+    # provider mapped to a lens on this role gets its charter appended; the
+    # shared prompt every provider starts from is identical either way.
+    quorum = providers.run_role_quorum(
+        plan,
+        lambda p: execute(p, providers.prompt_for_provider(plan.role, p.name, prompt, lenses)),
+        out,
+    )
     response_paths = [r.path for r in quorum.results if r.path]
 
     synthesis = build_synthesis_prompt(response_paths)

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -333,21 +333,24 @@ def main():
 
     prompt = prompt_path.read_text()
 
-    prompt_bytes = len(prompt.strip().encode("utf-8"))
-    if prompt_bytes < MIN_PROMPT_BYTES:
-        print(
-            f"Error: prompt file {prompt_path} is only {prompt_bytes} bytes "
-            f"(minimum {MIN_PROMPT_BYTES}) — refusing to consult. This is the "
-            "signature of a truncated or empty prompt; fix the prompt before "
-            "spending a provider call on it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     if args.context:
         ctx_path = Path(args.context)
         if ctx_path.exists():
             prompt += f"\n\n---\nContext:\n{ctx_path.read_text()}"
+
+    # Guard the FINAL assembled prompt (prompt file + any --context), so a
+    # legitimately small prompt file paired with substantive context is
+    # accepted — but always BEFORE any provider is called.
+    prompt_bytes = len(prompt.strip().encode("utf-8"))
+    if prompt_bytes < MIN_PROMPT_BYTES:
+        print(
+            f"Error: assembled prompt from {prompt_path} is only {prompt_bytes} "
+            f"bytes (minimum {MIN_PROMPT_BYTES}) — refusing to consult. This is "
+            "the signature of a truncated or empty prompt; fix the prompt before "
+            "spending a provider call on it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if args.role:
         config = load_config(Path(args.config))

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -29,11 +29,15 @@ sys.path.insert(0, str(Path(__file__).parent))
 from keychain import get_secret
 from providers import (
     DEFAULT_CONFIG,
+    DEFAULT_LENSES,
     Provider,
     load_config,
+    load_lenses,
     plan_role,
+    prompt_for_provider,
     run_role_quorum,
     validate_config,
+    validate_lenses,
 )
 
 # Per-tool timeouts (seconds). These are generous — better to wait than to
@@ -54,6 +58,14 @@ HEARTBEAT_INTERVAL = 30
 
 # Default model for Vertex AI path (override with --model)
 DEFAULT_VERTEX_MODEL = "gemini-3.1-pro-preview"
+
+# A prompt file smaller than this is almost never intentional — it's the
+# signature of a truncated write (a template substitution that silently
+# produced nothing, an interrupted heredoc, etc). Live use burned a codex
+# call and an opus agent run on exactly this (chief-wiggum#163); refuse
+# before any provider is called rather than spend a slow, expensive
+# consultation on a prompt that was never meant to be submitted.
+MIN_PROMPT_BYTES = 200
 
 
 def _kill_group(proc: subprocess.Popen) -> None:
@@ -289,6 +301,10 @@ def main():
     parser.add_argument("--cwd", help="Working directory for the AI tool (e.g., target repo path)")
     parser.add_argument("--role", help="Provider role to consult from config/providers.json")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Provider config path")
+    parser.add_argument(
+        "--lenses-config", default=str(DEFAULT_LENSES),
+        help="Review-lens charter config path (config/lenses.json)",
+    )
     parser.add_argument("--enable-provider", action="append", default=[], help="Force-enable provider by name")
     parser.add_argument("--disable-provider", action="append", default=[], help="Disable provider by name")
     parser.add_argument("--max-attempts", type=int, default=2, help="Total attempts for required providers in --role mode (incl. first try)")
@@ -317,6 +333,17 @@ def main():
 
     prompt = prompt_path.read_text()
 
+    prompt_bytes = len(prompt.strip().encode("utf-8"))
+    if prompt_bytes < MIN_PROMPT_BYTES:
+        print(
+            f"Error: prompt file {prompt_path} is only {prompt_bytes} bytes "
+            f"(minimum {MIN_PROMPT_BYTES}) — refusing to consult. This is the "
+            "signature of a truncated or empty prompt; fix the prompt before "
+            "spending a provider call on it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if args.context:
         ctx_path = Path(args.context)
         if ctx_path.exists():
@@ -331,6 +358,12 @@ def main():
         )
         if errors:
             for error in errors:
+                print(f"Config error: {error}", file=sys.stderr)
+            sys.exit(1)
+        lenses = load_lenses(Path(args.lenses_config))
+        lens_errors = validate_lenses(config, lenses)
+        if lens_errors:
+            for error in lens_errors:
                 print(f"Config error: {error}", file=sys.stderr)
             sys.exit(1)
         try:
@@ -350,10 +383,17 @@ def main():
             )
             sys.exit(1)
         # Run the quorum in parallel with retries + output validation, and write
-        # a manifest. Required providers must produce substantive output.
+        # a manifest. Required providers must produce substantive output. Every
+        # provider gets the identical shared prompt; a provider mapped to a lens
+        # (config/providers.json role.lenses) additionally gets its charter
+        # appended (chief-wiggum#163) — the shared body itself never changes.
+        def execute(provider: Provider) -> str:
+            provider_prompt = prompt_for_provider(plan.role, provider.name, prompt, lenses)
+            return consult_provider(provider, provider_prompt, args.model, args.cwd)
+
         manifest = run_role_quorum(
             plan,
-            lambda provider: consult_provider(provider, prompt, args.model, args.cwd),
+            execute,
             args.output_dir,
             max_attempts=args.max_attempts,
             min_bytes=args.min_bytes,
@@ -376,31 +416,34 @@ def main():
     assert target is not None
     fn = TOOLS[target]
     tool_timeout = TOOL_TIMEOUTS.get(target, TIMEOUT)
+    out_path = Path(args.output) if args.output else None
+    if out_path:
+        # Create missing parent directories up front so writing the response —
+        # success OR failure message — never fails with FileNotFoundError.
+        out_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         output = fn(prompt, model=args.model, cwd=args.cwd)
-        if args.output:
-            out_path = Path(args.output)
-            out_path.parent.mkdir(parents=True, exist_ok=True)
+        if out_path:
             out_path.write_text(output)
             print(f"OK: {target} response written to {args.output}")
         else:
             print(output)
     except subprocess.TimeoutExpired:
         msg = f"Timeout: {target} did not respond within {tool_timeout}s"
-        if args.output:
-            Path(args.output).write_text(msg)
+        if out_path:
+            out_path.write_text(msg)
         print(msg, file=sys.stderr)
         sys.exit(1)
     except subprocess.CalledProcessError as e:
         msg = f"Error calling {target}: {e.stderr or e}"
-        if args.output:
-            Path(args.output).write_text(msg)
+        if out_path:
+            out_path.write_text(msg)
         print(msg, file=sys.stderr)
         sys.exit(1)
     except Exception as e:
         msg = f"Error: {e}"
-        if args.output:
-            Path(args.output).write_text(msg)
+        if out_path:
+            out_path.write_text(msg)
         print(msg, file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -221,26 +221,33 @@ def validate_config(
     return errors
 
 
-def validate_lenses(config: dict[str, Any], lenses: dict[str, Any]) -> list[str]:
-    """Validate role -> lens assignments before any provider is called.
+def validate_role_lenses(role: Role, lenses: dict[str, Any]) -> list[str]:
+    """Validate one role's lens assignments before any provider is called.
 
-    Catches two mistakes that would otherwise surface mid-quorum: a lens
-    assigned to a provider that isn't actually in the role, and a lens name
-    with no matching charter in ``config/lenses.json``.
+    Catches two mistakes that would otherwise surface mid-quorum (or worse,
+    silently no-op): a lens assigned to a provider that isn't actually in the
+    role, and a lens name with no matching charter in ``config/lenses.json``.
     """
     errors: list[str] = []
-    for role_name, role in roles_from_config(config).items():
-        members = set(role.required) | set(role.optional)
-        for provider_name, lens_name in role.lenses.items():
-            if provider_name not in members:
-                errors.append(
-                    f"role {role_name} assigns a lens to {provider_name!r}, "
-                    "which is not a required or optional provider of that role"
-                )
-            if lens_name not in lenses:
-                errors.append(
-                    f"role {role_name} references unknown lens {lens_name!r}"
-                )
+    members = set(role.required) | set(role.optional)
+    for provider_name, lens_name in role.lenses.items():
+        if provider_name not in members:
+            errors.append(
+                f"role {role.name} assigns a lens to {provider_name!r}, "
+                "which is not a required or optional provider of that role"
+            )
+        if lens_name not in lenses:
+            errors.append(
+                f"role {role.name} references unknown lens {lens_name!r}"
+            )
+    return errors
+
+
+def validate_lenses(config: dict[str, Any], lenses: dict[str, Any]) -> list[str]:
+    """Validate every role's lens assignments in ``config``."""
+    errors: list[str] = []
+    for role in roles_from_config(config).values():
+        errors.extend(validate_role_lenses(role, lenses))
     return errors
 
 

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_CONFIG = Path(__file__).resolve().parents[1] / "config" / "providers.json"
+DEFAULT_LENSES = Path(__file__).resolve().parents[1] / "config" / "lenses.json"
 
 
 @dataclass(frozen=True)
@@ -27,6 +28,10 @@ class Role:
     name: str
     required: tuple[str, ...]
     optional: tuple[str, ...]
+    # Optional provider -> lens name mapping (chief-wiggum#163). When a provider
+    # is mapped, its charter (from config/lenses.json) is appended to the shared
+    # prompt for that provider only — the shared prompt itself never changes.
+    lenses: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -50,6 +55,54 @@ def load_config(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
     return json.loads(path.expanduser().read_text())
 
 
+def load_lenses(path: Path = DEFAULT_LENSES) -> dict[str, Any]:
+    """Load named review-lens charters from ``config/lenses.json``.
+
+    Returns an empty mapping if the file does not exist — lenses are an
+    opt-in review-quorum feature (chief-wiggum#163), not a hard dependency.
+    """
+    path = path.expanduser()
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text()).get("lenses", {})
+
+
+def render_charter(lens: dict[str, Any]) -> str:
+    """Render a lens as the markdown section appended to a provider's prompt."""
+    goal = str(lens.get("goal", "")).strip()
+    exclusions = lens.get("exclusions") or []
+    lines = ["## Your charter", "", goal]
+    if exclusions:
+        lines.append("")
+        lines.append("Do NOT evaluate:")
+        for item in exclusions:
+            lines.append(f"- {item}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def prompt_for_provider(
+    role: Role,
+    provider_name: str,
+    shared_prompt: str,
+    lenses: dict[str, Any] | None,
+) -> str:
+    """Return the prompt to send ``provider_name`` for ``role``.
+
+    Every provider in a role quorum gets identical context — the value is in
+    natural divergence, not roleplay. When ``role`` maps ``provider_name`` to a
+    lens, that lens's charter is appended after a clearly delimited section so
+    the shared body stays byte-identical across every provider in the role;
+    an unmapped provider's prompt is returned completely unchanged.
+    """
+    lens_name = role.lenses.get(provider_name)
+    if not lens_name:
+        return shared_prompt
+    lenses = lenses or {}
+    if lens_name not in lenses:
+        raise KeyError(f"role {role.name!r} references unknown lens {lens_name!r}")
+    return f"{shared_prompt}\n\n---\n\n{render_charter(lenses[lens_name])}"
+
+
 def providers_from_config(config: dict[str, Any]) -> dict[str, Provider]:
     providers: dict[str, Provider] = {}
     for name, raw in config.get("providers", {}).items():
@@ -70,6 +123,7 @@ def roles_from_config(config: dict[str, Any]) -> dict[str, Role]:
             name=name,
             required=tuple(raw.get("required", [])),
             optional=tuple(raw.get("optional", [])),
+            lenses=dict(raw.get("lenses", {})),
         )
     return roles
 
@@ -164,6 +218,29 @@ def validate_config(
             )
         if provider.type not in {"tool", "delegate"}:
             errors.append(f"provider {provider.name} has unsupported type {provider.type}")
+    return errors
+
+
+def validate_lenses(config: dict[str, Any], lenses: dict[str, Any]) -> list[str]:
+    """Validate role -> lens assignments before any provider is called.
+
+    Catches two mistakes that would otherwise surface mid-quorum: a lens
+    assigned to a provider that isn't actually in the role, and a lens name
+    with no matching charter in ``config/lenses.json``.
+    """
+    errors: list[str] = []
+    for role_name, role in roles_from_config(config).items():
+        members = set(role.required) | set(role.optional)
+        for provider_name, lens_name in role.lenses.items():
+            if provider_name not in members:
+                errors.append(
+                    f"role {role_name} assigns a lens to {provider_name!r}, "
+                    "which is not a required or optional provider of that role"
+                )
+            if lens_name not in lenses:
+                errors.append(
+                    f"role {role_name} references unknown lens {lens_name!r}"
+                )
     return errors
 
 

--- a/scripts/synthesize_reviews.py
+++ b/scripts/synthesize_reviews.py
@@ -50,16 +50,35 @@ def synthesize(reviews: list[dict]) -> str:
     parts.append("")
     parts.append("Merge the above reviews into a single actionable list:")
     parts.append("")
+    parts.append(
+        "If these reviewers were run under **review lenses** (chief-wiggum#163 — "
+        "config/providers.json `role.lenses`, charters in config/lenses.json), each "
+        "was deliberately scoped to a different concern (e.g. one refutes soundness, "
+        "one checks completeness, one prices adoption cost) over the SAME diff. "
+        "Expect disjoint findings, not convergence — a lensed quorum working correctly "
+        "looks like three different top findings, not three reviewers agreeing."
+    )
+    parts.append("")
+    parts.append(
+        "**Combine by union, then cross-verify only contested items — do not "
+        "majority-vote.** A finding raised by exactly one reviewer is not weaker for "
+        "being unique; under lenses it is often the point (the reviewer scoped to look "
+        "for that class of problem is the one who should have found it). Reserve "
+        "cross-verification for cases where two reviewers make CONTRADICTORY claims "
+        "about the same fact — not merely where one mentions something the other "
+        "didn't."
+    )
+    parts.append("")
     parts.append("Use a bug-first standard. Ignore nits, praise, and generic style commentary unless they point to a real defect.")
     parts.append("")
     parts.append("### High Confidence")
-    parts.append("Items that 2+ reviewers flagged, or one reviewer supported with a concrete failure scenario from the diff.")
+    parts.append("Every concrete, verifiable finding — whether raised by one reviewer or several. A single lensed reviewer's finding is retained on the same footing as one two reviewers happened to converge on.")
     parts.append("")
     parts.append("### Needs Verification")
     parts.append("Plausible issues that are worth testing locally before applying a fix.")
     parts.append("")
     parts.append("### Disputed / Low Confidence")
-    parts.append("Speculative or conflicting feedback. Present only if it could materially affect correctness or scope.")
+    parts.append("Findings that directly CONTRADICT another reviewer on the same fact, or speculative concerns with no concrete failure scenario. Being unique to one reviewer is NOT, by itself, a reason to downgrade a finding into this bucket.")
     parts.append("")
     parts.append("For each retained item, include file references if available and explain the likely failure mode briefly.")
     parts.append("")

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -496,6 +496,55 @@ def test_single_tool_consult_accepts_prompt_at_the_floor(tmp_path, monkeypatch):
     consult_ai.main()  # must not raise
 
 
+def test_short_prompt_with_substantive_context_is_accepted(tmp_path, monkeypatch):
+    # The guard applies to the FINAL assembled prompt (prompt file + --context),
+    # so a legitimately small prompt file paired with substantive context must
+    # not be rejected.
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Review the attached context.")
+    context = tmp_path / "context.md"
+    context.write_text(PROMPT_TEXT)
+
+    sent = {}
+
+    def fake_tool(prompt, model=None, cwd=None):
+        sent["prompt"] = prompt
+        return "ok response"
+
+    monkeypatch.setitem(consult_ai.TOOLS, "codex", fake_tool)
+    monkeypatch.setattr(
+        sys, "argv", ["consult_ai.py", "codex", str(prompt), "--context", str(context)]
+    )
+
+    consult_ai.main()  # must not raise
+
+    assert "Review the attached context." in sent["prompt"]
+    assert PROMPT_TEXT in sent["prompt"]
+
+
+def test_short_prompt_with_short_context_is_still_refused(tmp_path, monkeypatch):
+    # Context counts toward the size check, but if prompt + context together
+    # are still under the floor, the refusal must still fire before any call.
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("tiny")
+    context = tmp_path / "context.md"
+    context.write_text("also tiny")
+    called: list[str] = []
+
+    monkeypatch.setitem(
+        consult_ai.TOOLS, "codex", lambda prompt, model=None, cwd=None: called.append("codex") or "x"
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["consult_ai.py", "codex", str(prompt), "--context", str(context)]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+    assert called == []
+
+
 # --- robustness: -o creates missing parent directories (chief-wiggum#163) --
 
 

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -7,6 +7,17 @@ import sys
 import consult_ai
 import pytest
 
+# A realistic-length prompt (>= consult_ai.MIN_PROMPT_BYTES) so tests that
+# exercise the role-quorum machinery don't trip the short-prompt guard
+# (chief-wiggum#163) — that guard has its own dedicated tests below.
+PROMPT_TEXT = (
+    "Review this change for correctness, safety, and completeness before "
+    "merging. Consider edge cases, error handling, and how it interacts "
+    "with existing code paths in the surrounding module. Call out anything "
+    "that looks unsound or incomplete."
+)
+assert len(PROMPT_TEXT.encode("utf-8")) >= consult_ai.MIN_PROMPT_BYTES
+
 
 def write_config(path, *, optional_enabled=True):
     path.write_text(
@@ -22,9 +33,54 @@ def write_config(path, *, optional_enabled=True):
     )
 
 
+def write_config_with_lenses(path, *, lenses=None):
+    path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "codex": {"type": "tool", "tool": "codex", "enabled": True},
+                    "gemini": {"type": "tool", "tool": "gemini", "enabled": True},
+                },
+                "roles": {
+                    "reviewer": {
+                        "required": ["codex", "gemini"],
+                        "optional": [],
+                        "lenses": lenses
+                        if lenses is not None
+                        else {"codex": "refute-soundness", "gemini": "completeness"},
+                    }
+                },
+            }
+        )
+    )
+
+
+def write_lenses(path):
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "lenses": {
+                    "refute-soundness": {
+                        "goal": "Find the strongest reason this proposal is wrong.",
+                        "exclusions": [
+                            "Do NOT evaluate adoption cost.",
+                            "Do NOT evaluate style or naming.",
+                        ],
+                    },
+                    "completeness": {
+                        "goal": "Check whether every case and actor is covered.",
+                        "exclusions": ["Do NOT evaluate whether covered cases are correct."],
+                    },
+                },
+            }
+        )
+    )
+
+
 def test_role_consult_writes_required_and_optional_outputs(tmp_path, monkeypatch):
     prompt = tmp_path / "prompt.md"
-    prompt.write_text("Review this.")
+    prompt.write_text(PROMPT_TEXT)
     config = tmp_path / "providers.json"
     output_dir = tmp_path / "out"
     write_config(config)
@@ -52,13 +108,13 @@ def test_role_consult_writes_required_and_optional_outputs(tmp_path, monkeypatch
 
     consult_ai.main()
 
-    assert (output_dir / "reviewer-codex.md").read_text() == "codex: Review this."
-    assert (output_dir / "reviewer-gemini.md").read_text() == "gemini: Review this."
+    assert (output_dir / "reviewer-codex.md").read_text() == f"codex: {PROMPT_TEXT}"
+    assert (output_dir / "reviewer-gemini.md").read_text() == f"gemini: {PROMPT_TEXT}"
 
 
 def test_role_consult_does_not_fail_when_optional_provider_is_disabled(tmp_path, monkeypatch):
     prompt = tmp_path / "prompt.md"
-    prompt.write_text("Review this.")
+    prompt.write_text(PROMPT_TEXT)
     config = tmp_path / "providers.json"
     output_dir = tmp_path / "out"
     write_config(config, optional_enabled=False)
@@ -95,7 +151,7 @@ def test_role_consult_does_not_fail_when_optional_provider_is_disabled(tmp_path,
 
 def test_role_consult_fails_when_required_provider_is_disabled(tmp_path, monkeypatch):
     prompt = tmp_path / "prompt.md"
-    prompt.write_text("Review this.")
+    prompt.write_text(PROMPT_TEXT)
     config = tmp_path / "providers.json"
     output_dir = tmp_path / "out"
     write_config(config)
@@ -124,7 +180,7 @@ def test_role_consult_fails_when_required_provider_is_disabled(tmp_path, monkeyp
 
 def test_role_consult_fails_cleanly_for_unknown_role(tmp_path, monkeypatch):
     prompt = tmp_path / "prompt.md"
-    prompt.write_text("Review this.")
+    prompt.write_text(PROMPT_TEXT)
     config = tmp_path / "providers.json"
     output_dir = tmp_path / "out"
     write_config(config)
@@ -235,3 +291,246 @@ def test_run_capture_timeout_does_not_hang_on_surviving_grandchild():
         )
     elapsed = _time.monotonic() - start
     assert elapsed < 15, f"timeout did not return promptly ({elapsed:.1f}s) — pipe hang not fixed"
+
+
+# --- review lenses: bounded charters per provider (chief-wiggum#163) --------
+
+
+def test_role_consult_appends_lens_charter_with_byte_identical_shared_body(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    config = tmp_path / "providers.json"
+    lenses = tmp_path / "lenses.json"
+    output_dir = tmp_path / "out"
+    write_config_with_lenses(config)
+    write_lenses(lenses)
+
+    captured: dict[str, str] = {}
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        captured[provider.name] = prompt_text
+        return f"{provider.name} response: {prompt_text}"
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--lenses-config",
+            str(lenses),
+            "--output-dir",
+            str(output_dir),
+            "--min-bytes",
+            "1",
+        ],
+    )
+
+    consult_ai.main()
+
+    codex_prompt = captured["codex"]
+    gemini_prompt = captured["gemini"]
+
+    # Both charters are appended, clearly delimited.
+    assert "## Your charter" in codex_prompt
+    assert "## Your charter" in gemini_prompt
+    assert "Find the strongest reason this proposal is wrong." in codex_prompt
+    assert "Check whether every case and actor is covered." in gemini_prompt
+    # Each provider's own charter, not the other's.
+    assert "Find the strongest reason" not in gemini_prompt
+    assert "Check whether every case" not in codex_prompt
+
+    # The shared body (everything before the charter section) is
+    # byte-identical across every provider in the role.
+    shared_codex = codex_prompt.split("## Your charter")[0]
+    shared_gemini = gemini_prompt.split("## Your charter")[0]
+    assert shared_codex == shared_gemini
+    assert shared_codex == f"{PROMPT_TEXT}\n\n---\n\n"
+
+
+def test_role_consult_leaves_unlensed_provider_prompt_unchanged(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    config = tmp_path / "providers.json"
+    lenses = tmp_path / "lenses.json"
+    output_dir = tmp_path / "out"
+    # Only codex is mapped to a lens; gemini is unmapped and must be untouched.
+    write_config_with_lenses(config, lenses={"codex": "refute-soundness"})
+    write_lenses(lenses)
+
+    captured: dict[str, str] = {}
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        captured[provider.name] = prompt_text
+        return f"{provider.name} response: {prompt_text}"
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--lenses-config",
+            str(lenses),
+            "--output-dir",
+            str(output_dir),
+            "--min-bytes",
+            "1",
+        ],
+    )
+
+    consult_ai.main()
+
+    assert captured["gemini"] == PROMPT_TEXT
+    assert captured["codex"] != PROMPT_TEXT
+    assert "## Your charter" in captured["codex"]
+
+
+def test_role_consult_fails_cleanly_for_unknown_lens(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    config = tmp_path / "providers.json"
+    lenses = tmp_path / "lenses.json"
+    output_dir = tmp_path / "out"
+    write_config_with_lenses(config, lenses={"codex": "no-such-lens"})
+    write_lenses(lenses)
+    called: list[str] = []
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        called.append(provider.name)
+        return "should never run"
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--lenses-config",
+            str(lenses),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+    assert called == []
+
+
+# --- robustness: short-prompt refusal (chief-wiggum#163) --------------------
+
+
+def test_role_consult_refuses_short_prompt_before_any_provider_call(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("too short")
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config)
+    called: list[str] = []
+
+    def fake_consult_provider(provider, prompt_text, model, cwd):
+        called.append(provider.name)
+        return "should never run"
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py",
+            "--role",
+            "reviewer",
+            str(prompt),
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+    assert called == []
+    assert not output_dir.exists()
+
+
+def test_single_tool_consult_refuses_empty_prompt(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("")
+    monkeypatch.setattr(sys, "argv", ["consult_ai.py", "codex", str(prompt)])
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+
+
+def test_single_tool_consult_accepts_prompt_at_the_floor(tmp_path, monkeypatch):
+    # A prompt exactly at MIN_PROMPT_BYTES must be accepted, not rejected.
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("x" * consult_ai.MIN_PROMPT_BYTES)
+
+    monkeypatch.setitem(consult_ai.TOOLS, "codex", lambda prompt, model=None, cwd=None: "ok response")
+    monkeypatch.setattr(sys, "argv", ["consult_ai.py", "codex", str(prompt)])
+
+    consult_ai.main()  # must not raise
+
+
+# --- robustness: -o creates missing parent directories (chief-wiggum#163) --
+
+
+def test_output_flag_creates_missing_parent_directories_on_success(tmp_path, monkeypatch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    out_path = tmp_path / "nested" / "deep" / "response.md"
+
+    monkeypatch.setitem(
+        consult_ai.TOOLS, "codex", lambda prompt, model=None, cwd=None: "a substantive response"
+    )
+    monkeypatch.setattr(sys, "argv", ["consult_ai.py", "codex", str(prompt), "-o", str(out_path)])
+
+    consult_ai.main()
+
+    assert out_path.read_text() == "a substantive response"
+
+
+def test_output_flag_creates_missing_parent_directories_on_provider_error(tmp_path, monkeypatch):
+    # This is the actual bug (chief-wiggum#163): previously the parent directory
+    # was only created on the success path, so a provider failure with a missing
+    # -o parent crashed with an unhandled FileNotFoundError instead of exiting
+    # cleanly with the error message written to the requested path.
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    out_path = tmp_path / "nested" / "response.md"
+
+    def failing_tool(prompt, model=None, cwd=None):
+        raise subprocess.CalledProcessError(1, ["codex"], stderr="boom")
+
+    monkeypatch.setitem(consult_ai.TOOLS, "codex", failing_tool)
+    monkeypatch.setattr(sys, "argv", ["consult_ai.py", "codex", str(prompt), "-o", str(out_path)])
+
+    with pytest.raises(SystemExit) as exc:
+        consult_ai.main()
+
+    assert exc.value.code == 1
+    assert "boom" in out_path.read_text()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 import providers
+import pytest
 
 
 def test_default_provider_config_is_valid():
@@ -95,3 +96,79 @@ def test_config_round_trips_from_json_file(tmp_path):
     )
 
     assert providers.load_config(path)["roles"]["reviewer"]["required"] == ["codex"]
+
+
+# --- review lenses (chief-wiggum#163) ---------------------------------------
+
+
+def test_default_lenses_config_is_valid():
+    lenses = providers.load_lenses()
+    assert {"refute-soundness", "adoption-cost", "completeness", "security"} <= set(lenses)
+    for name, lens in lenses.items():
+        assert lens.get("goal"), f"lens {name} has no goal"
+        assert lens.get("exclusions"), f"lens {name} has no exclusions"
+
+
+def test_load_lenses_missing_file_returns_empty_mapping(tmp_path):
+    assert providers.load_lenses(tmp_path / "does-not-exist.json") == {}
+
+
+def test_render_charter_includes_goal_and_exclusions():
+    charter = providers.render_charter(
+        {"goal": "Break the reasoning.", "exclusions": ["Do NOT evaluate style."]}
+    )
+    assert charter.startswith("## Your charter")
+    assert "Break the reasoning." in charter
+    assert "- Do NOT evaluate style." in charter
+
+
+def test_prompt_for_provider_returns_shared_prompt_unchanged_when_unmapped():
+    role = providers.Role(name="reviewer", required=("codex",), optional=())
+    assert providers.prompt_for_provider(role, "codex", "shared body", {}) == "shared body"
+
+
+def test_prompt_for_provider_appends_charter_for_mapped_provider():
+    role = providers.Role(
+        name="reviewer", required=("codex",), optional=(), lenses={"codex": "refute-soundness"}
+    )
+    lenses = {"refute-soundness": {"goal": "Break it.", "exclusions": ["Do NOT nitpick style."]}}
+
+    result = providers.prompt_for_provider(role, "codex", "shared body", lenses)
+
+    assert result.startswith("shared body")
+    assert "## Your charter" in result
+    assert "Break it." in result
+
+
+def test_prompt_for_provider_raises_for_unknown_lens():
+    role = providers.Role(
+        name="reviewer", required=("codex",), optional=(), lenses={"codex": "no-such-lens"}
+    )
+    with pytest.raises(KeyError):
+        providers.prompt_for_provider(role, "codex", "shared body", {})
+
+
+def test_validate_lenses_flags_unknown_lens_name():
+    config = {
+        "providers": {"codex": {"type": "tool", "tool": "codex"}},
+        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"codex": "missing-lens"}}},
+    }
+    errors = providers.validate_lenses(config, {"refute-soundness": {}})
+    assert any("unknown lens" in e for e in errors)
+
+
+def test_validate_lenses_flags_provider_not_in_role():
+    config = {
+        "providers": {"codex": {"type": "tool", "tool": "codex"}},
+        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"gemini": "refute-soundness"}}},
+    }
+    errors = providers.validate_lenses(config, {"refute-soundness": {}})
+    assert any("not a required or optional provider" in e for e in errors)
+
+
+def test_validate_lenses_passes_for_well_formed_role():
+    config = {
+        "providers": {"codex": {"type": "tool", "tool": "codex"}},
+        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"codex": "refute-soundness"}}},
+    }
+    assert providers.validate_lenses(config, {"refute-soundness": {}}) == []

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -183,6 +183,54 @@ def test_run_review_end_to_end(tmp_path, monkeypatch):
     assert "- AC one" in captured["prompt"]
 
 
+def test_run_review_applies_lens_charter_per_provider(tmp_path, monkeypatch):
+    # reviewer.lenses maps codex -> refute-soundness; gemini is unmapped.
+    role = Role(
+        name="reviewer",
+        required=("codex",),
+        optional=("gemini",),
+        lenses={"codex": "refute-soundness"},
+    )
+    plan = RolePlan(
+        role=role,
+        required=(Provider("codex", "tool", True, tool="codex"),),
+        optional=(Provider("gemini", "tool", True, tool="gemini"),),
+        missing_required=(),
+        skipped_optional=(),
+    )
+    runner = _runner(
+        {
+            "rev-parse --show-toplevel": (0, str(tmp_path)),
+            "rev-parse --verify": (0, "abc"),
+            "diff": (0, "diff --git a b\n+added line"),
+        }
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: plan)
+
+    captured = {}
+
+    def execute(provider, prompt):
+        captured[provider.name] = prompt
+        return "A substantive review with findings to report here."
+
+    out = tmp_path / "reviews"
+    lenses = {"refute-soundness": {"goal": "Break the reasoning.", "exclusions": ["Do NOT nitpick style."]}}
+
+    review.run_review(
+        _ticket(), tmp_path, "main", out,
+        template=TEMPLATE, checklist="# Checklist\n- item",
+        config={}, lenses=lenses, execute=execute, runner=runner,
+    )
+
+    assert "## Your charter" in captured["codex"]
+    assert "Break the reasoning." in captured["codex"]
+    assert "## Your charter" not in captured["gemini"]
+    # The shared body reaching every provider is identical — codex's prompt is
+    # the unlensed gemini prompt plus the delimiter and charter, nothing else.
+    shared_codex = captured["codex"].split("## Your charter")[0]
+    assert shared_codex == f"{captured['gemini']}\n\n---\n\n"
+
+
 def test_run_review_refuses_without_execute(tmp_path, monkeypatch):
     runner = _runner(
         {"rev-parse --show-toplevel": (0, str(tmp_path)), "rev-parse --verify": (0, "abc"), "diff": (0, "d")}

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -131,6 +131,17 @@ def test_synthesis_prompt_lists_responses():
     assert "reviewer-codex.md" in p and "reviewer-gemini.md" in p
 
 
+def test_synthesis_prompt_instructs_union_not_consensus():
+    # Reconciliation of a (possibly lensed) quorum is union + cross-verify
+    # contested items — a unique finding must not be downgraded for lacking
+    # consensus (chief-wiggum#163).
+    p = review.build_synthesis_prompt(["a/reviewer-codex.md"])
+    assert "Combine by union" in p
+    assert "not weaker for lacking consensus" in p
+    assert "contradictory claims" in p
+    assert "consensus vs single-reviewer" not in p
+
+
 # --- full run (mocked git + provider) ---------------------------------------
 
 
@@ -229,6 +240,81 @@ def test_run_review_applies_lens_charter_per_provider(tmp_path, monkeypatch):
     # the unlensed gemini prompt plus the delimiter and charter, nothing else.
     shared_codex = captured["codex"].split("## Your charter")[0]
     assert shared_codex == f"{captured['gemini']}\n\n---\n\n"
+
+
+def _lens_runner(tmp_path):
+    return _runner(
+        {
+            "rev-parse --show-toplevel": (0, str(tmp_path)),
+            "rev-parse --verify": (0, "abc"),
+            "diff": (0, "diff --git a b\n+added line"),
+        }
+    )
+
+
+def test_run_review_fails_fast_on_lens_for_provider_not_in_role(tmp_path, monkeypatch):
+    # A lens assigned to a provider that is not in the role must be a hard,
+    # pre-quorum error — not a silent no-op.
+    role = Role(
+        name="reviewer",
+        required=("codex",),
+        optional=(),
+        lenses={"gemini": "refute-soundness"},
+    )
+    plan = RolePlan(
+        role=role,
+        required=(Provider("codex", "tool", True, tool="codex"),),
+        optional=(),
+        missing_required=(),
+        skipped_optional=(),
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: plan)
+    called: list[str] = []
+
+    def execute(provider, prompt):
+        called.append(provider.name)
+        return "A substantive review with findings to report here."
+
+    lenses = {"refute-soundness": {"goal": "Break it.", "exclusions": []}}
+    with pytest.raises(review.ReviewError, match="not a required or optional provider"):
+        review.run_review(
+            _ticket(), tmp_path, "main", tmp_path / "o",
+            template=TEMPLATE, config={}, lenses=lenses, execute=execute,
+            runner=_lens_runner(tmp_path),
+        )
+    assert called == []
+
+
+def test_run_review_fails_fast_on_unknown_lens_even_for_optional_provider(tmp_path, monkeypatch):
+    # Previously an unknown lens on an OPTIONAL provider degraded to a provider
+    # "failure" while the run still reported success. It must fail fast instead.
+    role = Role(
+        name="reviewer",
+        required=("codex",),
+        optional=("gemini",),
+        lenses={"gemini": "no-such-lens"},
+    )
+    plan = RolePlan(
+        role=role,
+        required=(Provider("codex", "tool", True, tool="codex"),),
+        optional=(Provider("gemini", "tool", True, tool="gemini"),),
+        missing_required=(),
+        skipped_optional=(),
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: plan)
+    called: list[str] = []
+
+    def execute(provider, prompt):
+        called.append(provider.name)
+        return "A substantive review with findings to report here."
+
+    with pytest.raises(review.ReviewError, match="unknown lens"):
+        review.run_review(
+            _ticket(), tmp_path, "main", tmp_path / "o",
+            template=TEMPLATE, config={}, lenses={}, execute=execute,
+            runner=_lens_runner(tmp_path),
+        )
+    assert called == []
 
 
 def test_run_review_refuses_without_execute(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Implements #163 exactly as specified: bounded review-lens charters for the AI review quorum, plus two consult_ai.py robustness fixes found in live use.

- **`config/lenses.json`** (new): named charters — `refute-soundness`, `adoption-cost`, `completeness`, `security` — each a goal paragraph plus explicit "do NOT evaluate X" exclusions.
- **`scripts/providers.py`**: `Role` gains an optional `lenses` map (provider → lens name), parsed from `config/providers.json`. New `load_lenses()`, `render_charter()`, `prompt_for_provider()`, `validate_lenses()`.
- **`scripts/consult_ai.py`**: when a role's `lenses` map assigns a provider a lens, its charter is appended to the shared prompt as a clearly-delimited `## Your charter` section — the shared body itself is never altered, so it stays byte-identical across every provider in the quorum (asserted directly in tests). Lens config is validated before any provider is called (unknown lens name, or a lens assigned to a provider not in the role → clean error, non-zero exit, nothing dispatched).
- **`scripts/chief_wiggum/review.py`**: `run_review()` (the pipeline `/implement`'s code-review step actually uses) threads the same `prompt_for_provider` mechanism, so a lensed `reviewer` role applies here too, not just via the raw CLI.
- **Robustness fixes** (both bit in live use):
  - `-o`/`--output-dir` now create missing parent directories on *every* exit path. Previously the parent was only created on the success branch — a provider timeout/error with a missing `-o` parent crashed with an unhandled `FileNotFoundError` instead of exiting cleanly with the error message written to the requested path.
  - Prompt files under 200 bytes (`MIN_PROMPT_BYTES`) are refused with a clear error and non-zero exit **before any provider is called** — an accidentally-truncated prompt previously burned a live codex call and an opus agent run.
- **`config/providers.json`**: wires the `reviewer` and `architecture_critic` roles with an example lens assignment (`codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`), matching the evidence in the issue (soundness-refuter caught a bug nobody else found).
- **Docs**: `.claude/commands/architect.md` (Step 3 architecture-critic quorum, Step "validate artifacts" reviewer quorum) and `.claude/commands/implement.md` (Step 7 code review) now describe lens assignment from role config, and reconciliation instructions are updated to expect **disjoint** findings from a lensed quorum — union then cross-verify only contested/contradictory items, not majority vote. `scripts/synthesize_reviews.py`'s actual synthesis prompt text was updated to match (this is the concrete artifact the review worker uses to reconcile, not just prose).

## Test plan

- [x] TDD: extended `tests/test_consult_ai.py`, `tests/test_providers.py`, `tests/test_review_pipeline.py` first, then implemented.
- [x] `python3 -m pytest tests/ -x -q` → **794 passed, 4 skipped** (0 failed).
- [x] New tests directly assert: charter appended only for a mapped provider, shared body byte-identical across providers (`shared_codex == shared_gemini`), unknown-lens config error refuses before any provider call, short/empty prompt refusal before any provider call, prompt exactly at the 200-byte floor is accepted, `-o` creates missing parent dirs on both success and provider-error branches, and `review.run_review()` applies the same lens mechanism.
- [x] Manual smoke test of the CLI end-to-end (mocked provider calls) confirms real charter text renders correctly and the shared prefix is byte-identical.

No deviations from the issue spec.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF