### PR TITLE
feat(tracker): issue-tracking abstraction with github + local backends (#158)

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -65,21 +65,38 @@ Show the user the full issue markdown and ask:
 
 ### Step 4: Create the issue
 
+Resolve the issue ref via `tracker.py` instead of calling `gh issue` directly —
+this is what makes the workflow backend-agnostic (GitHub today, `local` or
+others per `docs/cw/tracker.json` in the target repo). See `docs/tracker.md`
+for the full interface.
+
 ```bash
-gh issue create \
-  --repo "$owner_repo" \
+ref=$(python3 "$CW_HOME/scripts/tracker.py" create "$owner_repo" \
   --title "$title" \
   --body "$body" \
-  --label "$labels"
+  --label "$label1" --label "$label2")
 ```
 
-If a milestone was specified:
+If a milestone/epic was specified, pass it at creation time (the backend maps
+it to a GitHub milestone or a local frontmatter `epic` field as appropriate):
+
 ```bash
-gh issue edit "$issue_number" --repo "$owner_repo" --milestone "$milestone"
+ref=$(python3 "$CW_HOME/scripts/tracker.py" create "$owner_repo" \
+  --title "$title" \
+  --body "$body" \
+  --label "$label1" --label "$label2" \
+  --epic "$milestone")
 ```
 
 ### Step 5: Report
 
-Show the created issue URL and number. Ask if the user wants to:
+Fetch the created issue back to show its URL/path and confirm the fields landed:
+
+```bash
+python3 "$CW_HOME/scripts/tracker.py" get "$ref"
+```
+
+Show the created issue's `url_or_path` and ref. Ask if the user wants to:
 - Create another issue
-- Start implementing this one (`/implement owner/repo#N`)
+- Start implementing this one (`/implement owner/repo#N` for the `github`
+  backend; `/implement "$ref"` otherwise)

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -13,12 +13,19 @@ Create a well-structured GitHub issue with clear title, description, acceptance 
 
 ## Workflow
 
-### Step 0: Resolve CW_HOME
+### Step 0: Resolve CW_HOME and the target repo root
 
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+target_root=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
+
+`$target_root` is the local checkout of the target repo. Every `tracker.py`
+call below passes `--repo-root "$target_root"` — that is how the target repo's
+`docs/cw/tracker.json` backend config is honored (and where the `local`
+backend stores issue files). Without it, tracker.py would resolve config from
+the current working directory instead of the target repo.
 
 ### Step 1: Gather requirements
 
@@ -70,22 +77,23 @@ this is what makes the workflow backend-agnostic (GitHub today, `local` or
 others per `docs/cw/tracker.json` in the target repo). See `docs/tracker.md`
 for the full interface.
 
+Create the issue exactly **once**:
+
 ```bash
-ref=$(python3 "$CW_HOME/scripts/tracker.py" create "$owner_repo" \
+ref=$(python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" create "$owner_repo" \
   --title "$title" \
   --body "$body" \
   --label "$label1" --label "$label2")
 ```
 
-If a milestone/epic was specified, pass it at creation time (the backend maps
-it to a GitHub milestone or a local frontmatter `epic` field as appropriate):
+If a milestone/epic was specified, set it on the issue you just created — do
+**not** run a second create (the backend maps `epic` to a GitHub milestone or
+a local frontmatter `epic` field as appropriate):
 
 ```bash
-ref=$(python3 "$CW_HOME/scripts/tracker.py" create "$owner_repo" \
-  --title "$title" \
-  --body "$body" \
-  --label "$label1" --label "$label2" \
-  --epic "$milestone")
+if [ -n "$milestone" ]; then
+  python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" update "$ref" --set "epic=$milestone"
+fi
 ```
 
 ### Step 5: Report
@@ -93,7 +101,7 @@ ref=$(python3 "$CW_HOME/scripts/tracker.py" create "$owner_repo" \
 Fetch the created issue back to show its URL/path and confirm the fields landed:
 
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" get "$ref"
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" get "$ref"
 ```
 
 Show the created issue's `url_or_path` and ref. Ask if the user wants to:

--- a/.claude/commands/plan-epic.md
+++ b/.claude/commands/plan-epic.md
@@ -13,34 +13,47 @@ Group related issues into a coherent epic with a dependency graph, integration r
 
 ## Workflow
 
-### Step 0: Resolve CW_HOME
+### Step 0: Resolve CW_HOME, the target repo root, and the tracker backend
 
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+target_root=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+backend=$(python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" backend)
 ```
+
+`$target_root` is the local checkout of the target repo; every `tracker.py`
+call below passes `--repo-root "$target_root"` so the target repo's
+`docs/cw/tracker.json` backend config is honored regardless of the current
+working directory. `$backend` (`github`, `local`, ...) gates the
+GitHub-specific milestone plumbing below — when the repo is configured
+`local`, this workflow must never mutate GitHub.
 
 ### Step 1: Load the backlog
 
 Resolve the backlog via `tracker.py` instead of calling `gh issue` directly —
-this is what makes the workflow backend-agnostic (GitHub today, `local` or
-others per `docs/cw/tracker.json` in the target repo). See `docs/tracker.md`
-for the full interface.
+this is what makes the workflow backend-agnostic. See `docs/tracker.md` for
+the full interface.
 
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" list "$owner_repo"
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" list "$owner_repo"
 ```
 
 This returns every issue (any state) with full metadata (`ref`, `title`,
 `body`, `state`, `labels`, `assignee`, `epic`, `url_or_path`). Derive the
 open/closed/assigned views you need from this single JSON list client-side
-(filter on `state`/`assignee`) rather than issuing separate queries.
+(filter on `state`/`assignee`) rather than issuing separate queries. Keep the
+`ref` values — they are what Step 6 groups (`gh:owner/repo#N` for the
+`github` backend, `local:docs/issues/NNNN.md` for `local`).
 
-Also fetch milestones to see if there's existing epic-level organisation
-(milestones are GitHub-specific metadata, not part of the tracker-agnostic
-`Issue` shape, so this stays a direct `gh api` call):
+For the `github` backend only, also fetch milestones to see if there's
+existing epic-level organisation (milestones are GitHub-specific metadata,
+not part of the tracker-agnostic `Issue` shape). For other backends the
+`epic` field on each issue already carries the grouping.
 ```bash
-gh api repos/$owner_repo/milestones --jq '.[] | {title, description, open_issues, closed_issues}'
+if [ "$backend" = "github" ]; then
+  gh api repos/$owner_repo/milestones --jq '.[] | {title, description, open_issues, closed_issues}'
+fi
 ```
 
 ### Step 2: Identify the epic
@@ -128,28 +141,60 @@ Present the full epic plan:
 
 Ask the user to confirm. Adjust if needed.
 
-### Step 6: Create the GitHub milestone
+### Step 6: Record the epic (grouping + dependency graph)
 
-Create a milestone to track the epic. The milestone description **must** include a machine-readable dependency block so that `/implement-wave` can parse the DAG without brittle markdown parsing.
+The epic needs two durable artifacts: the **grouping** (which issues belong to
+it) and the **dependency graph** (a machine-readable block `/implement-wave`
+parses to compute waves, without brittle markdown parsing).
 
-Generate the `<!-- DEPENDENCIES -->` block from a JSON adjacency map with the tested formatter (it de-dupes and sorts deps so the output always matches the parser), then embed it in the milestone description:
+First generate the `<!-- DEPENDENCIES -->` block from a JSON adjacency map
+with the tested formatter (it de-dupes and sorts deps so the output always
+matches the parser). This is backend-independent:
 
 ```bash
 DEPS=$(python3 "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43], "45": [43], "46": [42]}')
-gh api repos/$owner_repo/milestones -f title="Epic: [Name]" -f description="$(cat <<EOF
+```
+
+The block is an HTML comment (invisible in rendered markdown) with one line per ticket in the format `#N: [#dep1, #dep2]`; empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph. Do not hand-write it; always generate it with `format-deps` so it round-trips through the parser.
+
+**Where the block is stored depends on the backend.** For `github` it lives in
+a milestone description (as today); for any other backend it lives in
+`docs/epics/<slug>/epic.md` in the target repo, committed to git, so
+`/implement-wave` has a storage path with no GitHub dependency. Never run the
+`gh api` milestone mutation when the repo is configured with a non-github
+backend:
+
+```bash
+if [ "$backend" = "github" ]; then
+  gh api repos/$owner_repo/milestones -f title="Epic: [Name]" -f description="$(cat <<EOF
 [Goal]
 
 $DEPS
 EOF
 )"
+else
+  EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "Epic: [Name]")
+  mkdir -p "$target_root/docs/epics/$EPIC_SLUG"
+  cat > "$target_root/docs/epics/$EPIC_SLUG/epic.md" <<EOF
+# Epic: [Name]
+
+[Goal]
+
+$DEPS
+EOF
+  git -C "$target_root" add "docs/epics/$EPIC_SLUG/epic.md"
+  git -C "$target_root" commit -m "docs: record epic plan for Epic: [Name]"
+fi
 ```
 
-The block is an HTML comment (invisible in rendered markdown) with one line per ticket in the format `#N: [#dep1, #dep2]`; empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph — `/implement-wave` parses it to compute waves. Do not hand-write it; always generate it with `format-deps` so it round-trips through the parser.
+Then assign all epic tickets to the epic via `tracker.py group`, using the
+`ref` values captured in Step 1 (`gh:owner/repo#N` refs for `github` — the
+milestone above already exists, so this only assigns issues to it;
+`local:docs/issues/NNNN.md` refs for `local`, where grouping is a frontmatter
+`epic` field):
 
-Add all epic tickets to the milestone via `tracker.py group` (the milestone
-already exists from the step above, so this only assigns each issue to it):
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" group "Epic: [Name]" "gh:$owner_repo#42" "gh:$owner_repo#43" "gh:$owner_repo#44"
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" group "Epic: [Name]" "$ref1" "$ref2" "$ref3"
 ```
 
 ### Step 7: Offer next steps

--- a/.claude/commands/plan-epic.md
+++ b/.claude/commands/plan-epic.md
@@ -13,17 +13,32 @@ Group related issues into a coherent epic with a dependency graph, integration r
 
 ## Workflow
 
-### Step 1: Load the backlog
-
-Fetch all open issues and recent context:
+### Step 0: Resolve CW_HOME
 
 ```bash
-gh issue list --repo "$owner_repo" --state open --limit 200 --json number,title,labels,assignees,milestone,createdAt,updatedAt,body
-gh issue list --repo "$owner_repo" --state open --limit 50 --json number,title,labels,assignees --jq '.[] | select(.assignees | length > 0)'
-gh issue list --repo "$owner_repo" --state closed --limit 10 --json number,title,closedAt,labels
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 ```
 
-Also fetch milestones to see if there's existing epic-level organisation:
+### Step 1: Load the backlog
+
+Resolve the backlog via `tracker.py` instead of calling `gh issue` directly —
+this is what makes the workflow backend-agnostic (GitHub today, `local` or
+others per `docs/cw/tracker.json` in the target repo). See `docs/tracker.md`
+for the full interface.
+
+```bash
+python3 "$CW_HOME/scripts/tracker.py" list "$owner_repo"
+```
+
+This returns every issue (any state) with full metadata (`ref`, `title`,
+`body`, `state`, `labels`, `assignee`, `epic`, `url_or_path`). Derive the
+open/closed/assigned views you need from this single JSON list client-side
+(filter on `state`/`assignee`) rather than issuing separate queries.
+
+Also fetch milestones to see if there's existing epic-level organisation
+(milestones are GitHub-specific metadata, not part of the tracker-agnostic
+`Issue` shape, so this stays a direct `gh api` call):
 ```bash
 gh api repos/$owner_repo/milestones --jq '.[] | {title, description, open_issues, closed_issues}'
 ```
@@ -131,9 +146,10 @@ EOF
 
 The block is an HTML comment (invisible in rendered markdown) with one line per ticket in the format `#N: [#dep1, #dep2]`; empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph — `/implement-wave` parses it to compute waves. Do not hand-write it; always generate it with `format-deps` so it round-trips through the parser.
 
-Add all epic tickets to the milestone:
+Add all epic tickets to the milestone via `tracker.py group` (the milestone
+already exists from the step above, so this only assigns each issue to it):
 ```bash
-gh issue edit $issue_number --repo "$owner_repo" --milestone "Epic: [Name]"
+python3 "$CW_HOME/scripts/tracker.py" group "Epic: [Name]" "gh:$owner_repo#42" "gh:$owner_repo#43" "gh:$owner_repo#44"
 ```
 
 ### Step 7: Offer next steps

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -1,0 +1,172 @@
+# tracker.py: a tracker-agnostic issue interface
+
+Every workflow that touches issues (`/create-issue`, `/plan-epic`, `/implement`,
+`/implement-wave`, `/close-epic`) used to call the `gh` CLI directly, hard-coupling
+issue tracking to GitHub Issues: no offline/local use, no client projects that
+live somewhere else, no way to test issue-driven workflows without a network.
+
+`scripts/tracker.py` is a small, pluggable interface over issue tracking,
+mirroring the existing `repo.py` / provider-role patterns. This ticket ships two
+backends — `github` (the reference implementation) and `local` (a git-committed
+markdown backend, and the offline test double for every issue-driven workflow).
+
+## The interface
+
+```python
+from tracker import GithubBackend, LocalBackend, IssueDraft, get_tracker
+
+backend = get_tracker("acme/app")  # -> GithubBackend unless configured otherwise
+ref = backend.create(IssueDraft(title="Fix bug", body="...", labels=["bug"]))
+issue = backend.get(ref)
+backend.update(ref, {"state": "closed"})
+backend.comment(ref, "Shipped in #45")
+backend.group([ref], "Epic: Widgets")
+members = backend.members("Epic: Widgets")
+```
+
+Every backend implements the same five verbs plus epic grouping:
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get` | `get(ref) -> Issue` | Fetch one issue by ref. |
+| `list` | `list(query=None) -> list[Issue]` | `query` is a substring (matched against title/body) or a `dict` of exact-match filters (e.g. `{"epic": "Epic: Name"}`). |
+| `create` | `create(draft: IssueDraft) -> ref` | Returns the new issue's canonical ref. |
+| `update` | `update(ref, fields: dict) -> Issue` | `fields` may set `title`, `body`, `state` (`"open"`/`"closed"`), `labels` (replaces the set), `assignee`, `epic`. |
+| `comment` | `comment(ref, body) -> None` | Adds a comment. Not part of `Issue.body` — verify per-backend (see `tests/test_tracker.py`). |
+| `group` | `group(refs: list[str], epic_name) -> None` | Assigns every ref to an epic. |
+| `members` | `members(epic_name) -> list[Issue]` | All issues currently in that epic. |
+
+`Issue` is a dataclass: `ref`, `title`, `body`, `state`, `labels`, `assignee`,
+`epic` (the grouping key), `url_or_path` (a GitHub URL or a local file path).
+`IssueDraft` is the create-time input: `title`, `body`, `labels`, `assignee`,
+`epic`.
+
+## Issue refs are URIs
+
+- `gh:owner/repo#42` — GitHub, explicit.
+- `local:docs/issues/0042.md` — the local backend, path relative to the target
+  repo root.
+- Bare `owner/repo#42` (no scheme) **keeps meaning GitHub** — zero breakage for
+  existing usage and docs.
+- `obsidian:<vault-rel-path>` and `jira:PROJ-42` are recognized by the ref
+  grammar (`parse_ref`) for forward compatibility, but neither backend is
+  wired up yet — constructing one raises `NotImplementedError`. See
+  [Out of scope](#out-of-scope-this-ticket) below.
+
+`tracker.parse_ref(ref) -> (scheme, identifier)` is the pure function behind
+this; it never touches the network or filesystem.
+
+## Backend resolution
+
+Given a target repo, which backend applies is resolved in this order:
+
+1. `docs/cw/tracker.json` **in the target repo**:
+   ```json
+   { "backend": "local" }
+   ```
+2. CW-side fallback, `~/.chief-wiggum/config.json`:
+   ```json
+   { "tracker": { "backend": "local" } }
+   ```
+3. Default: `"github"` — today's behavior, unconfigured repos are unaffected.
+
+`tracker.resolve_backend_name(repo_root)` is the pure function; `get_tracker(target,
+repo_root=...)` builds the actual backend (a `GithubBackend` bound to `target`
+as `owner/repo`, or a `LocalBackend` bound to `repo_root`).
+
+Ref-addressed operations (`get`/`update`/`comment`/`group`) don't need config
+resolution at all — the ref's scheme says which backend to build directly
+(`gh:` -> `GithubBackend`, `local:` -> `LocalBackend` rooted at `--repo-root`
+or cwd). Only repo-addressed operations without an existing ref (`list`,
+`create`, `members`) consult `docs/cw/tracker.json` / the CW-side fallback.
+
+## Backends
+
+### `github` — the reference implementation
+
+Wraps `gh issue create/view/list/edit/close/reopen/comment` and `gh api
+.../milestones`. Epic grouping maps onto a GitHub milestone, exactly as
+`/plan-epic` does today. `state` maps to `gh issue close`/`reopen`; `labels`
+updates diff the current set against the requested set and issue the minimal
+`--add-label`/`--remove-label` pair.
+
+The `gh` transport is injectable (`GithubBackend(repo, runner=...)`), matching
+the existing `chief_wiggum/github.py` convention — this is what makes the
+conformance suite (see below) testable without a network.
+
+### `local` — one markdown file per issue
+
+One file per issue, `docs/issues/NNNN.md` (4-digit, zero-padded), **committed
+to git** in the target repo. Format:
+
+```markdown
+---
+id: 42
+title: "Fix crash on empty form"
+state: "open"
+labels: ["bug", "urgent"]
+epic: "Epic: Widgets"
+assignee: "alice"
+---
+
+Body markdown goes here. Comments are appended below a `---` divider by
+`comment()`; they are not folded into the frontmatter.
+```
+
+Every frontmatter value is written with `json.dumps` — JSON is a valid subset
+of YAML, so the file is real, parseable YAML frontmatter (openable by any
+YAML-aware tool, e.g. Obsidian) without pulling in a `pyyaml` dependency.
+
+IDs auto-increment from the highest existing numeric filename in `docs/issues/`.
+
+## Adding a backend
+
+1. Implement the seven methods above (`get`, `list`, `create`, `update`,
+   `comment`, `group`, `members`) against `Issue`/`IssueDraft`.
+2. Register the ref scheme in `KNOWN_SCHEMES` if it's new, and wire it into
+   `get_tracker()` / `_backend_for_ref()`.
+3. Add it to the conformance suite in `tests/test_tracker.py`
+   (`backend_and_verify` fixture) — a backend only ships once it passes the
+   *same* parameterized suite as `github` and `local`
+   (create → list → group → update → comment round-trip).
+4. Document the URI scheme and config value here.
+
+## Out of scope (this ticket)
+
+- **Obsidian**: a config variant of `local` — same file format, pointed at a
+  vault-relative path instead of `docs/issues/`. Wiki-links in bodies pass
+  through untouched (the local backend never parses body content). Documented
+  here only; no code ships in this ticket.
+- **Jira**: REST via an API token from the system keyring (`chief-wiggum`
+  service — never an env var, per the repo's secret-management convention).
+  Deferred to a real client need. Only `title`/`body`/`state`/`labels`/`epic`
+  would map — no custom fields or workflows.
+- **Two-way sync between backends** — a ref lives in exactly one backend.
+- **Migrating existing GitHub issues** anywhere.
+
+## CLI
+
+```bash
+python3 scripts/tracker.py get gh:acme/app#42
+python3 scripts/tracker.py get acme/app#42                      # bare = same as gh:
+python3 scripts/tracker.py list acme/app --epic "Epic: Name"
+python3 scripts/tracker.py create acme/app --title "Fix bug" --body "..." --label bug
+python3 scripts/tracker.py update gh:acme/app#42 --set state=closed
+python3 scripts/tracker.py comment gh:acme/app#42 "Looks good"
+python3 scripts/tracker.py group "Epic: Name" gh:acme/app#42 gh:acme/app#43
+python3 scripts/tracker.py members acme/app "Epic: Name"
+
+# local backend, operating against a target repo checkout:
+python3 scripts/tracker.py --repo-root "$TARGET_REPO" list acme/app
+python3 scripts/tracker.py --repo-root "$TARGET_REPO" get local:docs/issues/0001.md
+```
+
+Output is JSON (an `Issue` dict, or a list of them) for every command that
+returns data, matching sibling scripts like `epic_metadata.py`.
+
+## Command migration
+
+`/create-issue` and `/plan-epic` resolve issue refs via `tracker.py` instead of
+calling `gh issue`/`gh api` directly (see their command markdown). The
+remaining `gh`-calling commands (`/seed`, `/implement`, `/implement-wave`,
+`/close-epic`) are a later ticket.

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -31,8 +31,8 @@ Every backend implements the same five verbs plus epic grouping:
 | `get` | `get(ref) -> Issue` | Fetch one issue by ref. |
 | `list` | `list(query=None) -> list[Issue]` | `query` is a substring (matched against title/body) or a `dict` of exact-match filters (e.g. `{"epic": "Epic: Name"}`). |
 | `create` | `create(draft: IssueDraft) -> ref` | Returns the new issue's canonical ref. |
-| `update` | `update(ref, fields: dict) -> Issue` | `fields` may set `title`, `body`, `state` (`"open"`/`"closed"`), `labels` (replaces the set), `assignee`, `epic`. |
-| `comment` | `comment(ref, body) -> None` | Adds a comment. Not part of `Issue.body` — verify per-backend (see `tests/test_tracker.py`). |
+| `update` | `update(ref, fields: dict) -> Issue` | `fields` may set `title`, `body`, `state`, `labels` (replaces the set), `assignee`, `epic`. `state` is validated **before dispatch** on every backend: anything other than `"open"`/`"closed"` raises `ValueError` and nothing is mutated. |
+| `comment` | `comment(ref, body) -> None` | Adds a comment. Comments are never part of `Issue.body` on any backend (GitHub: a separate resource; local: a delimited `## cw-comments` section) — so `list()` substring queries never match comment text. |
 | `group` | `group(refs: list[str], epic_name) -> None` | Assigns every ref to an epic. |
 | `members` | `members(epic_name) -> list[Issue]` | All issues currently in that epic. |
 
@@ -45,7 +45,9 @@ Every backend implements the same five verbs plus epic grouping:
 
 - `gh:owner/repo#42` — GitHub, explicit.
 - `local:docs/issues/0042.md` — the local backend, path relative to the target
-  repo root.
+  repo root. The path is containment-checked: absolute paths and any ref that
+  resolves outside the repo's `docs/issues/` directory (e.g.
+  `local:../other.md`, `local:/tmp/x.md`) are rejected with `ValueError`.
 - Bare `owner/repo#42` (no scheme) **keeps meaning GitHub** — zero breakage for
   existing usage and docs.
 - `obsidian:<vault-rel-path>` and `jira:PROJ-42` are recognized by the ref
@@ -109,9 +111,23 @@ epic: "Epic: Widgets"
 assignee: "alice"
 ---
 
-Body markdown goes here. Comments are appended below a `---` divider by
-`comment()`; they are not folded into the frontmatter.
+Body markdown goes here.
+
+## cw-comments
+
+---
+First comment text.
+
+---
+Second comment text.
 ```
+
+Comments are appended by `comment()` under a `## cw-comments` heading at the
+end of the file. Everything from that heading onward is **excluded** from
+`Issue.body`, so body semantics match the GitHub backend (where comments are
+a separate resource) and `list()` substring queries never match comment text.
+`update(ref, {"body": ...})` replaces only the body and preserves the
+comments section.
 
 Every frontmatter value is written with `json.dumps` — JSON is a valid subset
 of YAML, so the file is real, parseable YAML frontmatter (openable by any
@@ -147,26 +163,41 @@ IDs auto-increment from the highest existing numeric filename in `docs/issues/`.
 ## CLI
 
 ```bash
+python3 scripts/tracker.py --repo-root "$target_root" backend    # print resolved backend name
 python3 scripts/tracker.py get gh:acme/app#42
 python3 scripts/tracker.py get acme/app#42                      # bare = same as gh:
-python3 scripts/tracker.py list acme/app --epic "Epic: Name"
-python3 scripts/tracker.py create acme/app --title "Fix bug" --body "..." --label bug
+python3 scripts/tracker.py --repo-root "$target_root" list acme/app --epic "Epic: Name"
+python3 scripts/tracker.py --repo-root "$target_root" create acme/app --title "Fix bug" --body "..." --label bug
 python3 scripts/tracker.py update gh:acme/app#42 --set state=closed
 python3 scripts/tracker.py comment gh:acme/app#42 "Looks good"
 python3 scripts/tracker.py group "Epic: Name" gh:acme/app#42 gh:acme/app#43
 python3 scripts/tracker.py members acme/app "Epic: Name"
 
 # local backend, operating against a target repo checkout:
-python3 scripts/tracker.py --repo-root "$TARGET_REPO" list acme/app
-python3 scripts/tracker.py --repo-root "$TARGET_REPO" get local:docs/issues/0001.md
+python3 scripts/tracker.py --repo-root "$target_root" get local:docs/issues/0001.md
+python3 scripts/tracker.py --repo-root "$target_root" group "Epic: Name" local:docs/issues/0001.md
 ```
 
 Output is JSON (an `Issue` dict, or a list of them) for every command that
 returns data, matching sibling scripts like `epic_metadata.py`.
 
+**Always pass `--repo-root`** when calling from a workflow: `--repo-root`
+defaults to the current working directory, and workflows run from arbitrary
+cwds. Resolve the target checkout first (`target_root=$(python3
+"$CW_HOME/scripts/repo.py" resolve "$owner_repo")`) and pass it on every
+call — that is what makes the target repo's `docs/cw/tracker.json` config
+(and the local backend's storage location) take effect. The `backend`
+subcommand prints the resolved backend name so command prompts can gate
+GitHub-specific plumbing (e.g. milestone descriptions) on `backend == github`.
+
 ## Command migration
 
 `/create-issue` and `/plan-epic` resolve issue refs via `tracker.py` instead of
-calling `gh issue`/`gh api` directly (see their command markdown). The
-remaining `gh`-calling commands (`/seed`, `/implement`, `/implement-wave`,
+calling `gh issue`/`gh api` directly (see their command markdown). In
+`/plan-epic`, the GitHub milestone plumbing is conditional on the resolved
+backend: for `github` the dependency-graph block lives in the milestone
+description (as today); for other backends it is written to
+`docs/epics/<slug>/epic.md` in the target repo, and epic membership is the
+frontmatter `epic` field set by `tracker.py group`. The remaining
+`gh`-calling commands (`/seed`, `/implement`, `/implement-wave`,
 `/close-epic`) are a later ticket.

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+"""
+Tracker-agnostic issue interface for chief-wiggum.
+
+Every workflow that touches issues (``/create-issue``, ``/plan-epic``, ...)
+used to call the ``gh`` CLI directly, hard-coupling issue tracking to GitHub.
+This module gives them a small, backend-pluggable interface instead, mirroring
+the existing ``repo.py`` / provider-role patterns.
+
+Issue refs are URIs: ``gh:owner/repo#42``, ``local:docs/issues/0042.md``. A
+bare ``owner/repo#42`` keeps meaning GitHub, so existing usage/docs don't
+break. ``obsidian:`` and ``jira:`` prefixes are recognized by the ref grammar
+for forward compatibility but have no backend wired up yet (see
+docs/tracker.md).
+
+Backends (this ticket): ``github`` (wraps ``gh``, the reference
+implementation) and ``local`` (one markdown file per issue with YAML
+frontmatter under ``docs/issues/`` in the target repo).
+
+Backend resolution is per-target-repo: ``docs/cw/tracker.json`` in the target
+repo (``{"backend": "github"}``); if absent, ``~/.chief-wiggum/config.json``'s
+``tracker.backend``; if that's absent too, ``github`` (today's behavior).
+
+As a module::
+
+    from tracker import GithubBackend, LocalBackend, IssueDraft, get_tracker
+
+    backend = get_tracker("acme/app")  # -> GithubBackend unless configured otherwise
+    ref = backend.create(IssueDraft(title="Fix bug", body="...", labels=["bug"]))
+    issue = backend.get(ref)
+
+As a CLI::
+
+    python3 tracker.py get gh:acme/app#42
+    python3 tracker.py list acme/app --epic "Epic: Name"
+    python3 tracker.py create acme/app --title "Fix bug" --body "..." --label bug
+    python3 tracker.py update gh:acme/app#42 --set state=closed
+    python3 tracker.py comment gh:acme/app#42 "Looks good"
+    python3 tracker.py group "Epic: Name" gh:acme/app#42 gh:acme/app#43
+    python3 tracker.py members acme/app "Epic: Name"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum import github as gh_meta  # noqa: E402
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+ISSUES_SUBDIR = Path("docs") / "issues"
+
+
+# --- data model --------------------------------------------------------------
+
+
+@dataclass
+class Issue:
+    ref: str
+    title: str
+    body: str = ""
+    state: str = "open"
+    labels: list[str] = field(default_factory=list)
+    assignee: str | None = None
+    epic: str | None = None
+    url_or_path: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "ref": self.ref,
+            "title": self.title,
+            "body": self.body,
+            "state": self.state,
+            "labels": list(self.labels),
+            "assignee": self.assignee,
+            "epic": self.epic,
+            "url_or_path": self.url_or_path,
+        }
+
+
+@dataclass
+class IssueDraft:
+    title: str
+    body: str = ""
+    labels: list[str] = field(default_factory=list)
+    assignee: str | None = None
+    epic: str | None = None
+
+
+def _matches_query(issue: Issue, query: str | dict[str, Any] | None) -> bool:
+    """Client-side filter shared by every backend's ``list()``."""
+    if query is None:
+        return True
+    if isinstance(query, str):
+        haystack = f"{issue.title}\n{issue.body}".lower()
+        return query.lower() in haystack
+    if isinstance(query, dict):
+        for key, value in query.items():
+            if key == "labels":
+                if value not in issue.labels:
+                    return False
+            elif getattr(issue, key, None) != value:
+                return False
+        return True
+    raise TypeError(f"unsupported query type: {type(query)!r}")
+
+
+# --- ref parsing ---------------------------------------------------------------
+
+KNOWN_SCHEMES = ("gh", "local", "obsidian", "jira")
+
+_SCHEME_RE = re.compile(r"^(" + "|".join(KNOWN_SCHEMES) + r"):(.+)$")
+_BARE_GH_RE = re.compile(r"^[\w.-]+/[\w.-]+#\d+$")
+
+
+def parse_ref(ref: str) -> tuple[str, str]:
+    """Split an issue ref into ``(scheme, identifier)``.
+
+    Bare ``owner/repo#42`` (no scheme prefix) is treated as ``("gh", ref)`` so
+    existing GitHub-only usage keeps working unchanged.
+    """
+    match = _SCHEME_RE.match(ref)
+    if match:
+        return match.group(1), match.group(2)
+    if _BARE_GH_RE.match(ref):
+        return "gh", ref
+    raise ValueError(f"unrecognized issue ref: {ref!r}")
+
+
+# --- local frontmatter (a valid subset of YAML, no new dependency) -----------
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n?(.*)\Z", re.DOTALL)
+
+
+def _dump_frontmatter(data: dict[str, Any]) -> str:
+    lines = ["---"]
+    for key, value in data.items():
+        # json.dumps produces valid YAML scalars/flow-sequences, so this
+        # round-trips through both our own parser and a real YAML parser
+        # (e.g. Obsidian's), without pulling in a YAML dependency.
+        lines.append(f"{key}: {json.dumps(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        raise ValueError("missing YAML frontmatter block")
+    raw_frontmatter, body = match.group(1), match.group(2)
+    data: dict[str, Any] = {}
+    for line in raw_frontmatter.splitlines():
+        if not line.strip():
+            continue
+        key, _, raw_value = line.partition(":")
+        data[key.strip()] = json.loads(raw_value.strip())
+    return data, body.lstrip("\n")
+
+
+# --- github backend ------------------------------------------------------------
+
+
+class GithubBackend:
+    """Reference-implementation backend: wraps ``gh issue``/``gh api``."""
+
+    def __init__(self, repo: str, *, runner: Runner | None = None):
+        self.repo = repo
+        # Resolved at construction time (not bound as a parameter default) so
+        # tests can monkeypatch subprocess.run before a backend is built.
+        self.runner = runner or subprocess.run
+
+    def _run(self, args: list[str]) -> str:
+        result = self.runner(
+            ["gh", *args], capture_output=True, text=True, check=True, timeout=60
+        )
+        return result.stdout
+
+    @staticmethod
+    def _parse_ident(ident: str) -> tuple[str, int]:
+        owner_repo, sep, number = ident.rpartition("#")
+        if not sep or not owner_repo or not number.isdigit():
+            raise ValueError(f"malformed github issue ref identifier: {ident!r}")
+        return owner_repo, int(number)
+
+    @staticmethod
+    def _number_from_url(url: str) -> int:
+        match = re.search(r"/issues/(\d+)\s*$", url)
+        if not match:
+            raise ValueError(f"could not parse issue number from gh output: {url!r}")
+        return int(match.group(1))
+
+    @staticmethod
+    def _issue_from_json(owner_repo: str, data: dict[str, Any]) -> Issue:
+        labels = [
+            lbl["name"] if isinstance(lbl, dict) else str(lbl)
+            for lbl in (data.get("labels") or [])
+        ]
+        assignees = data.get("assignees") or []
+        assignee: str | None = None
+        if assignees:
+            first = assignees[0]
+            assignee = first.get("login") if isinstance(first, dict) else str(first)
+        milestone = data.get("milestone")
+        epic = milestone.get("title") if isinstance(milestone, dict) else milestone
+        number = int(data["number"])
+        return Issue(
+            ref=f"gh:{owner_repo}#{number}",
+            title=data.get("title", ""),
+            body=data.get("body") or "",
+            state=str(data.get("state", "open")).lower(),
+            labels=labels,
+            assignee=assignee,
+            epic=epic,
+            url_or_path=data.get("url") or f"https://github.com/{owner_repo}/issues/{number}",
+        )
+
+    def _view(self, owner_repo: str, number: int) -> Issue:
+        out = self._run(
+            [
+                "issue", "view", str(number), "--repo", owner_repo,
+                "--json", "number,title,body,state,labels,assignees,milestone,url",
+            ]
+        )
+        return self._issue_from_json(owner_repo, json.loads(out))
+
+    def get(self, ref: str) -> Issue:
+        scheme, ident = parse_ref(ref)
+        if scheme != "gh":
+            raise ValueError(f"GithubBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
+        owner_repo, number = self._parse_ident(ident)
+        return self._view(owner_repo, number)
+
+    def list(self, query: str | dict[str, Any] | None = None) -> list[Issue]:
+        args = [
+            "issue", "list", "--repo", self.repo, "--state", "all", "--limit", "200",
+            "--json", "number,title,body,state,labels,assignees,milestone,url",
+        ]
+        if isinstance(query, dict) and query.get("epic"):
+            args += ["--milestone", query["epic"]]
+        out = self._run(args)
+        issues = [self._issue_from_json(self.repo, d) for d in json.loads(out or "[]")]
+        return [issue for issue in issues if _matches_query(issue, query)]
+
+    def create(self, draft: IssueDraft) -> str:
+        args = [
+            "issue", "create", "--repo", self.repo,
+            "--title", draft.title, "--body", draft.body or "",
+        ]
+        for label in draft.labels:
+            args += ["--label", label]
+        if draft.assignee:
+            args += ["--assignee", draft.assignee]
+        out = self._run(args)
+        number = self._number_from_url(out.strip())
+        ref = f"gh:{self.repo}#{number}"
+        if draft.epic:
+            self.group([ref], draft.epic)
+        return ref
+
+    def update(self, ref: str, fields: dict[str, Any]) -> Issue:
+        scheme, ident = parse_ref(ref)
+        if scheme != "gh":
+            raise ValueError(f"GithubBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
+        owner_repo, number = self._parse_ident(ident)
+
+        if "state" in fields:
+            current = self._view(owner_repo, number)
+            if fields["state"] != current.state:
+                cmd = "close" if fields["state"] == "closed" else "reopen"
+                self._run(["issue", cmd, str(number), "--repo", owner_repo])
+
+        edit_args: list[str] = []
+        if "title" in fields:
+            edit_args += ["--title", fields["title"]]
+        if "body" in fields:
+            edit_args += ["--body", fields["body"]]
+        if "assignee" in fields and fields["assignee"]:
+            edit_args += ["--add-assignee", fields["assignee"]]
+        if "epic" in fields:
+            if fields["epic"]:
+                edit_args += ["--milestone", fields["epic"]]
+            else:
+                edit_args += ["--remove-milestone"]
+        if "labels" in fields:
+            current = self._view(owner_repo, number)
+            new_labels = set(fields["labels"])
+            old_labels = set(current.labels)
+            for label in sorted(old_labels - new_labels):
+                edit_args += ["--remove-label", label]
+            for label in sorted(new_labels - old_labels):
+                edit_args += ["--add-label", label]
+
+        if edit_args:
+            self._run(["issue", "edit", str(number), "--repo", owner_repo, *edit_args])
+        return self._view(owner_repo, number)
+
+    def comment(self, ref: str, body: str) -> None:
+        scheme, ident = parse_ref(ref)
+        if scheme != "gh":
+            raise ValueError(f"GithubBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
+        owner_repo, number = self._parse_ident(ident)
+        self._run(["issue", "comment", str(number), "--repo", owner_repo, "--body", body])
+
+    def group(self, refs: list[str], epic_name: str) -> None:
+        """Map epic grouping onto a GitHub milestone (as today)."""
+        owner_repos = {self._parse_ident(parse_ref(ref)[1])[0] for ref in refs}
+        for owner_repo in owner_repos:
+            if gh_meta.find_milestone(owner_repo, epic_name, runner=self.runner) is None:
+                self._run(["api", f"repos/{owner_repo}/milestones", "-f", f"title={epic_name}"])
+        for ref in refs:
+            self.update(ref, {"epic": epic_name})
+
+    def members(self, epic_name: str) -> list[Issue]:
+        return self.list(query={"epic": epic_name})
+
+
+# --- local backend ---------------------------------------------------------
+
+
+class LocalBackend:
+    """One markdown file per issue, YAML frontmatter, under docs/issues/."""
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+        self.issues_dir = self.root / ISSUES_SUBDIR
+
+    def _path_for_id(self, issue_id: int) -> Path:
+        return self.issues_dir / f"{issue_id:04d}.md"
+
+    def _ref_for_id(self, issue_id: int) -> str:
+        rel = (ISSUES_SUBDIR / f"{issue_id:04d}.md").as_posix()
+        return f"local:{rel}"
+
+    def _resolve_path(self, ref: str) -> Path:
+        scheme, ident = parse_ref(ref)
+        if scheme != "local":
+            raise ValueError(f"LocalBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
+        return self.root / ident
+
+    def _read(self, path: Path) -> Issue:
+        if not path.is_file():
+            raise FileNotFoundError(f"no local issue at {path}")
+        data, body = _parse_frontmatter(path.read_text())
+        rel = path.relative_to(self.root).as_posix()
+        return Issue(
+            ref=f"local:{rel}",
+            title=data.get("title", ""),
+            body=body.rstrip("\n"),
+            state=data.get("state", "open"),
+            labels=list(data.get("labels") or []),
+            assignee=data.get("assignee"),
+            epic=data.get("epic"),
+            url_or_path=str(path),
+        )
+
+    def get(self, ref: str) -> Issue:
+        return self._read(self._resolve_path(ref))
+
+    def list(self, query: str | dict[str, Any] | None = None) -> list[Issue]:
+        if not self.issues_dir.is_dir():
+            return []
+        issues = [self._read(path) for path in sorted(self.issues_dir.glob("*.md"))]
+        return [issue for issue in issues if _matches_query(issue, query)]
+
+    def _next_id(self) -> int:
+        if not self.issues_dir.is_dir():
+            return 1
+        ids = [int(p.stem) for p in self.issues_dir.glob("*.md") if p.stem.isdigit()]
+        return max(ids, default=0) + 1
+
+    def create(self, draft: IssueDraft) -> str:
+        self.issues_dir.mkdir(parents=True, exist_ok=True)
+        issue_id = self._next_id()
+        path = self._path_for_id(issue_id)
+        frontmatter = {
+            "id": issue_id,
+            "title": draft.title,
+            "state": "open",
+            "labels": list(draft.labels),
+            "epic": draft.epic,
+            "assignee": draft.assignee,
+        }
+        path.write_text(_dump_frontmatter(frontmatter) + "\n\n" + (draft.body or "") + "\n")
+        return self._ref_for_id(issue_id)
+
+    def update(self, ref: str, fields: dict[str, Any]) -> Issue:
+        fields = dict(fields)
+        path = self._resolve_path(ref)
+        data, body = _parse_frontmatter(path.read_text())
+        if "body" in fields:
+            body = fields.pop("body")
+        for key in ("title", "state", "labels", "epic", "assignee"):
+            if key in fields:
+                data[key] = fields[key]
+        path.write_text(_dump_frontmatter(data) + "\n\n" + body.rstrip("\n") + "\n")
+        return self._read(path)
+
+    def comment(self, ref: str, body: str) -> None:
+        path = self._resolve_path(ref)
+        data, existing_body = _parse_frontmatter(path.read_text())
+        appended = existing_body.rstrip("\n") + f"\n\n---\n**Comment:** {body}\n"
+        path.write_text(_dump_frontmatter(data) + "\n\n" + appended.rstrip("\n") + "\n")
+
+    def group(self, refs: list[str], epic_name: str) -> None:
+        for ref in refs:
+            self.update(ref, {"epic": epic_name})
+
+    def members(self, epic_name: str) -> list[Issue]:
+        return [issue for issue in self.list() if issue.epic == epic_name]
+
+
+Backend = GithubBackend | LocalBackend
+
+
+# --- backend resolution ------------------------------------------------------
+
+
+DEFAULT_CW_CONFIG = Path.home() / ".chief-wiggum" / "config.json"
+
+
+def resolve_backend_name(repo_root: Path | str, *, cw_config: Path | None = None) -> str:
+    """Resolve which backend a target repo uses.
+
+    1. ``<repo_root>/docs/cw/tracker.json``'s ``"backend"`` key.
+    2. CW-side fallback: ``~/.chief-wiggum/config.json``'s ``tracker.backend``.
+    3. Default: ``"github"`` (today's behavior).
+    """
+    config_path = Path(repo_root) / "docs" / "cw" / "tracker.json"
+    if config_path.is_file():
+        try:
+            data = json.loads(config_path.read_text())
+            name = data.get("backend")
+            if name:
+                return name
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    cw_config = cw_config if cw_config is not None else DEFAULT_CW_CONFIG
+    if cw_config.is_file():
+        try:
+            data = json.loads(cw_config.read_text())
+            name = (data.get("tracker") or {}).get("backend")
+            if name:
+                return name
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return "github"
+
+
+def get_tracker(
+    target: str, *, repo_root: Path | str | None = None, runner: Runner | None = None
+) -> Backend:
+    """Build the resolved backend for a target repo.
+
+    ``target`` is the ``owner/repo`` string used for GitHub operations.
+    ``repo_root`` is the local checkout used to read ``docs/cw/tracker.json``
+    and (for the local backend) to store issue files; defaults to cwd.
+    """
+    root = Path(repo_root).resolve() if repo_root else Path.cwd()
+    backend_name = resolve_backend_name(root)
+    if backend_name == "github":
+        return GithubBackend(target, runner=runner)
+    if backend_name == "local":
+        return LocalBackend(root)
+    raise NotImplementedError(
+        f"tracker backend {backend_name!r} is not implemented yet "
+        "(only 'github' and 'local' ship in this ticket; see docs/tracker.md)"
+    )
+
+
+def _backend_for_ref(
+    scheme: str, ident: str, repo_root: str | None, *, runner: Runner | None = None
+) -> Backend:
+    """Build the backend a fully-qualified ref names, without config resolution."""
+    if scheme == "gh":
+        owner_repo, _ = GithubBackend._parse_ident(ident)
+        return GithubBackend(owner_repo, runner=runner)
+    if scheme == "local":
+        root = Path(repo_root).resolve() if repo_root else Path.cwd()
+        return LocalBackend(root)
+    raise NotImplementedError(
+        f"backend for scheme {scheme!r} is not implemented yet (see docs/tracker.md)"
+    )
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Tracker-agnostic issue interface")
+    parser.add_argument(
+        "--repo-root",
+        help="Local target-repo root for backend config/storage (default: cwd)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_get = sub.add_parser("get", help="Fetch a single issue by ref")
+    p_get.add_argument("ref")
+
+    p_list = sub.add_parser("list", help="List issues for a target repo")
+    p_list.add_argument("target", help="owner/repo (github) or local repo path")
+    p_list.add_argument("--query", help="Substring filter over title/body")
+    p_list.add_argument("--epic", help="Filter to issues in this epic")
+
+    p_create = sub.add_parser("create", help="Create a new issue")
+    p_create.add_argument("target")
+    p_create.add_argument("--title", required=True)
+    p_create.add_argument("--body", default="")
+    p_create.add_argument("--label", action="append", default=[], dest="labels")
+    p_create.add_argument("--assignee")
+    p_create.add_argument("--epic")
+
+    p_update = sub.add_parser("update", help="Update fields on an issue")
+    p_update.add_argument("ref")
+    p_update.add_argument(
+        "--set", action="append", default=[], dest="sets", metavar="KEY=VALUE",
+        help="e.g. --set state=closed (repeatable); labels value is comma-separated",
+    )
+
+    p_comment = sub.add_parser("comment", help="Add a comment to an issue")
+    p_comment.add_argument("ref")
+    p_comment.add_argument("body")
+
+    p_group = sub.add_parser("group", help="Assign refs to an epic")
+    p_group.add_argument("epic")
+    p_group.add_argument("refs", nargs="+")
+
+    p_members = sub.add_parser("members", help="List issues in an epic")
+    p_members.add_argument("target")
+    p_members.add_argument("epic")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo_root = args.repo_root
+
+    try:
+        if args.command == "get":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            print(json.dumps(backend.get(args.ref).to_dict(), indent=2))
+
+        elif args.command == "list":
+            backend = get_tracker(args.target, repo_root=repo_root)
+            query: str | dict[str, Any] | None = args.query
+            if args.epic:
+                query = {"epic": args.epic}
+            issues = backend.list(query)
+            print(json.dumps([i.to_dict() for i in issues], indent=2))
+
+        elif args.command == "create":
+            backend = get_tracker(args.target, repo_root=repo_root)
+            draft = IssueDraft(
+                title=args.title, body=args.body, labels=args.labels,
+                assignee=args.assignee, epic=args.epic,
+            )
+            print(backend.create(draft))
+
+        elif args.command == "update":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            fields: dict[str, Any] = {}
+            for kv in args.sets:
+                key, _, value = kv.partition("=")
+                fields[key] = value.split(",") if key == "labels" else value
+            print(json.dumps(backend.update(args.ref, fields).to_dict(), indent=2))
+
+        elif args.command == "comment":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            backend.comment(args.ref, args.body)
+
+        elif args.command == "group":
+            scheme, ident = parse_ref(args.refs[0])
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            backend.group(args.refs, args.epic)
+
+        elif args.command == "members":
+            backend = get_tracker(args.target, repo_root=repo_root)
+            issues = backend.members(args.epic)
+            print(json.dumps([i.to_dict() for i in issues], indent=2))
+
+        else:  # pragma: no cover - argparse enforces valid subcommands
+            print(f"Unknown command: {args.command}", file=sys.stderr)
+            return 1
+
+    except (ValueError, FileNotFoundError, NotImplementedError, TypeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"Error: gh command failed: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -31,6 +31,7 @@ As a module::
 
 As a CLI::
 
+    python3 tracker.py --repo-root /path/to/checkout backend
     python3 tracker.py get gh:acme/app#42
     python3 tracker.py list acme/app --epic "Epic: Name"
     python3 tracker.py create acme/app --title "Fix bug" --body "..." --label bug
@@ -95,6 +96,17 @@ class IssueDraft:
     labels: list[str] = field(default_factory=list)
     assignee: str | None = None
     epic: str | None = None
+
+
+VALID_STATES = ("open", "closed")
+
+
+def _validate_update_fields(fields: dict[str, Any]) -> None:
+    """Shared pre-dispatch validation for ``update()`` across all backends."""
+    if "state" in fields and fields["state"] not in VALID_STATES:
+        raise ValueError(
+            f"invalid state {fields['state']!r}: must be one of {', '.join(VALID_STATES)}"
+        )
 
 
 def _matches_query(issue: Issue, query: str | dict[str, Any] | None) -> bool:
@@ -269,6 +281,7 @@ class GithubBackend:
         return ref
 
     def update(self, ref: str, fields: dict[str, Any]) -> Issue:
+        _validate_update_fields(fields)
         scheme, ident = parse_ref(ref)
         if scheme != "gh":
             raise ValueError(f"GithubBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
@@ -328,11 +341,28 @@ class GithubBackend:
 # --- local backend ---------------------------------------------------------
 
 
+_COMMENTS_HEADER = "## cw-comments"
+_COMMENTS_RE = re.compile(rf"^{re.escape(_COMMENTS_HEADER)}\s*$", re.MULTILINE)
+
+
+def _split_comments(full_body: str) -> tuple[str, str | None]:
+    """Split a stored issue body into (body, comments-section-or-None).
+
+    Comments live under a ``## cw-comments`` heading at the end of the file so
+    they never leak into ``Issue.body`` (keeping body semantics identical to
+    the GitHub backend, where comments are a separate resource).
+    """
+    match = _COMMENTS_RE.search(full_body)
+    if not match:
+        return full_body, None
+    return full_body[: match.start()], full_body[match.start():]
+
+
 class LocalBackend:
     """One markdown file per issue, YAML frontmatter, under docs/issues/."""
 
     def __init__(self, root: Path | str):
-        self.root = Path(root)
+        self.root = Path(root).resolve()
         self.issues_dir = self.root / ISSUES_SUBDIR
 
     def _path_for_id(self, issue_id: int) -> Path:
@@ -346,12 +376,22 @@ class LocalBackend:
         scheme, ident = parse_ref(ref)
         if scheme != "local":
             raise ValueError(f"LocalBackend cannot resolve ref with scheme {scheme!r}: {ref!r}")
-        return self.root / ident
+        ident_path = Path(ident)
+        if ident_path.is_absolute():
+            raise ValueError(f"local ref must be repo-relative, got absolute path: {ref!r}")
+        resolved = (self.root / ident_path).resolve()
+        issues_root = self.issues_dir.resolve()
+        if not resolved.is_relative_to(issues_root):
+            raise ValueError(
+                f"local ref escapes {ISSUES_SUBDIR.as_posix()}/: {ref!r}"
+            )
+        return resolved
 
     def _read(self, path: Path) -> Issue:
         if not path.is_file():
             raise FileNotFoundError(f"no local issue at {path}")
-        data, body = _parse_frontmatter(path.read_text())
+        data, full_body = _parse_frontmatter(path.read_text())
+        body, _ = _split_comments(full_body)
         rel = path.relative_to(self.root).as_posix()
         return Issue(
             ref=f"local:{rel}",
@@ -395,22 +435,30 @@ class LocalBackend:
         return self._ref_for_id(issue_id)
 
     def update(self, ref: str, fields: dict[str, Any]) -> Issue:
+        _validate_update_fields(fields)
         fields = dict(fields)
         path = self._resolve_path(ref)
-        data, body = _parse_frontmatter(path.read_text())
+        data, full_body = _parse_frontmatter(path.read_text())
+        body, comments = _split_comments(full_body)
         if "body" in fields:
             body = fields.pop("body")
         for key in ("title", "state", "labels", "epic", "assignee"):
             if key in fields:
                 data[key] = fields[key]
-        path.write_text(_dump_frontmatter(data) + "\n\n" + body.rstrip("\n") + "\n")
+        new_full = body.rstrip("\n")
+        if comments:
+            new_full += "\n\n" + comments.rstrip("\n")
+        path.write_text(_dump_frontmatter(data) + "\n\n" + new_full + "\n")
         return self._read(path)
 
     def comment(self, ref: str, body: str) -> None:
         path = self._resolve_path(ref)
-        data, existing_body = _parse_frontmatter(path.read_text())
-        appended = existing_body.rstrip("\n") + f"\n\n---\n**Comment:** {body}\n"
-        path.write_text(_dump_frontmatter(data) + "\n\n" + appended.rstrip("\n") + "\n")
+        data, full_body = _parse_frontmatter(path.read_text())
+        existing_body, comments = _split_comments(full_body)
+        comments = (comments or _COMMENTS_HEADER).rstrip("\n")
+        comments += f"\n\n---\n{body}"
+        new_full = existing_body.rstrip("\n") + "\n\n" + comments
+        path.write_text(_dump_frontmatter(data) + "\n\n" + new_full + "\n")
 
     def group(self, refs: list[str], epic_name: str) -> None:
         for ref in refs:
@@ -506,6 +554,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
+    sub.add_parser(
+        "backend",
+        help="Print the resolved backend name for --repo-root (github/local/...)",
+    )
+
     p_get = sub.add_parser("get", help="Fetch a single issue by ref")
     p_get.add_argument("ref")
 
@@ -549,7 +602,11 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = args.repo_root
 
     try:
-        if args.command == "get":
+        if args.command == "backend":
+            root = Path(repo_root).resolve() if repo_root else Path.cwd()
+            print(resolve_backend_name(root))
+
+        elif args.command == "get":
             scheme, ident = parse_ref(args.ref)
             backend = _backend_for_ref(scheme, ident, repo_root)
             print(json.dumps(backend.get(args.ref).to_dict(), indent=2))

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,455 @@
+"""Conformance suite + unit tests for tracker.py (#158)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import tracker
+from tracker import (
+    GithubBackend,
+    IssueDraft,
+    LocalBackend,
+    _dump_frontmatter,
+    _parse_frontmatter,
+    parse_ref,
+    resolve_backend_name,
+)
+
+# --- fake gh CLI (statefully mocks the subprocess boundary) ------------------
+
+
+def _cp(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _split_positional_and_flags(args: list[str]) -> tuple[list[str], dict[str, list[str]]]:
+    positional: list[str] = []
+    flags: dict[str, list[str]] = {}
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token.startswith("--"):
+            flags.setdefault(token, []).append(args[i + 1])
+            i += 2
+        else:
+            positional.append(token)
+            i += 1
+    return positional, flags
+
+
+class FakeGh:
+    """A tiny in-memory stand-in for the ``gh`` CLI.
+
+    Implements just enough of ``gh issue`` / ``gh api .../milestones`` to
+    exercise GithubBackend's create/get/list/update/comment/group/members
+    without touching the network. Raises CalledProcessError the same way a
+    real ``check=True`` subprocess.run would on failure.
+    """
+
+    def __init__(self):
+        self.issues: dict[str, dict[int, dict]] = {}
+        self._next_number: dict[str, int] = {}
+        self.milestones: dict[str, set[str]] = {}
+        self.comments: dict[tuple[str, int], list[str]] = {}
+
+    def __call__(self, args: list[str], **kwargs) -> subprocess.CompletedProcess:
+        assert args[0] == "gh"
+        if args[1] == "issue":
+            return self._issue(args[2], args[3:])
+        if args[1] == "api":
+            return self._api(args[2:])
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    def _issue(self, sub: str, args: list[str]) -> subprocess.CompletedProcess:
+        if sub == "create":
+            return self._create(args)
+        if sub == "view":
+            return self._view(args)
+        if sub == "list":
+            return self._list(args)
+        if sub == "edit":
+            return self._edit(args)
+        if sub in ("close", "reopen"):
+            return self._set_state(sub, args)
+        if sub == "comment":
+            return self._comment(args)
+        raise AssertionError(f"unexpected gh issue subcommand: {sub}")
+
+    def _create(self, args: list[str]) -> subprocess.CompletedProcess:
+        _, flags = _split_positional_and_flags(args)
+        repo = flags["--repo"][0]
+        title = flags["--title"][0]
+        body = flags.get("--body", [""])[0]
+        labels = flags.get("--label", [])
+        assignee = flags.get("--assignee", [None])[0]
+        number = self._next_number.get(repo, 1)
+        self._next_number[repo] = number + 1
+        self.issues.setdefault(repo, {})[number] = {
+            "number": number,
+            "title": title,
+            "body": body,
+            "state": "open",
+            "labels": [{"name": lbl} for lbl in labels],
+            "assignees": [{"login": assignee}] if assignee else [],
+            "milestone": None,
+            "url": f"https://github.com/{repo}/issues/{number}",
+        }
+        return _cp(f"https://github.com/{repo}/issues/{number}\n")
+
+    def _find(self, repo: str, number: int) -> dict:
+        data = self.issues.get(repo, {}).get(number)
+        if data is None:
+            raise subprocess.CalledProcessError(1, ["gh", "issue"], output="", stderr="not found")
+        return data
+
+    def _view(self, args: list[str]) -> subprocess.CompletedProcess:
+        positional, flags = _split_positional_and_flags(args)
+        number = int(positional[0])
+        repo = flags["--repo"][0]
+        return _cp(json.dumps(self._find(repo, number)))
+
+    def _list(self, args: list[str]) -> subprocess.CompletedProcess:
+        _, flags = _split_positional_and_flags(args)
+        repo = flags["--repo"][0]
+        milestone = flags.get("--milestone", [None])[0]
+        items = list(self.issues.get(repo, {}).values())
+        if milestone:
+            items = [d for d in items if (d.get("milestone") or {}).get("title") == milestone]
+        return _cp(json.dumps(items))
+
+    def _edit(self, args: list[str]) -> subprocess.CompletedProcess:
+        positional, flags = _split_positional_and_flags(args)
+        number = int(positional[0])
+        repo = flags["--repo"][0]
+        data = self._find(repo, number)
+        if "--title" in flags:
+            data["title"] = flags["--title"][0]
+        if "--body" in flags:
+            data["body"] = flags["--body"][0]
+        if "--add-assignee" in flags:
+            data["assignees"] = [{"login": flags["--add-assignee"][0]}]
+        if "--milestone" in flags:
+            data["milestone"] = {"title": flags["--milestone"][0]}
+        if "--remove-milestone" in flags:
+            data["milestone"] = None
+        if "--remove-label" in flags or "--add-label" in flags:
+            current = {lbl["name"] for lbl in data.get("labels", [])}
+            for lbl in flags.get("--remove-label", []):
+                current.discard(lbl)
+            for lbl in flags.get("--add-label", []):
+                current.add(lbl)
+            data["labels"] = [{"name": lbl} for lbl in sorted(current)]
+        return _cp(f"https://github.com/{repo}/issues/{number}\n")
+
+    def _set_state(self, sub: str, args: list[str]) -> subprocess.CompletedProcess:
+        positional, flags = _split_positional_and_flags(args)
+        number = int(positional[0])
+        repo = flags["--repo"][0]
+        self._find(repo, number)["state"] = "closed" if sub == "close" else "open"
+        return _cp("")
+
+    def _comment(self, args: list[str]) -> subprocess.CompletedProcess:
+        positional, flags = _split_positional_and_flags(args)
+        number = int(positional[0])
+        repo = flags["--repo"][0]
+        body = flags["--body"][0]
+        self.comments.setdefault((repo, number), []).append(body)
+        return _cp(f"https://github.com/{repo}/issues/{number}#issuecomment-1\n")
+
+    def _api(self, args: list[str]) -> subprocess.CompletedProcess:
+        endpoint = args[0]
+        repo = endpoint.split("/milestones")[0].removeprefix("repos/")
+        if "-f" in args:
+            kv = args[args.index("-f") + 1]
+            key, _, value = kv.partition("=")
+            if key == "title":
+                self.milestones.setdefault(repo, set()).add(value)
+            return _cp("{}")
+        titles = self.milestones.get(repo, set())
+        payload = [
+            {"title": t, "description": "", "number": i, "open_issues": 0, "closed_issues": 0}
+            for i, t in enumerate(sorted(titles), start=1)
+        ]
+        return _cp(json.dumps(payload))
+
+
+# --- parameterized conformance fixtures --------------------------------------
+
+
+def _make_github_backend():
+    fake = FakeGh()
+    backend = GithubBackend("acme/widget", runner=fake)
+
+    def verify_comment(ref: str, text: str) -> None:
+        owner_repo, number = GithubBackend._parse_ident(parse_ref(ref)[1])
+        assert fake.comments[(owner_repo, number)][-1] == text
+
+    return backend, verify_comment
+
+
+def _make_local_backend(root: Path):
+    backend = LocalBackend(root)
+
+    def verify_comment(ref: str, text: str) -> None:
+        assert text in backend.get(ref).body
+
+    return backend, verify_comment
+
+
+@pytest.fixture(params=["github", "local"])
+def backend_and_verify(request, tmp_path):
+    if request.param == "github":
+        return _make_github_backend()
+    return _make_local_backend(tmp_path)
+
+
+class TestConformance:
+    """The same suite runs against every backend: create -> list -> group -> update -> comment."""
+
+    def test_create_then_get_roundtrips(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        draft = IssueDraft(title="Fix bug", body="Details here", labels=["bug"])
+        ref = backend.create(draft)
+        issue = backend.get(ref)
+        assert issue.ref == ref
+        assert issue.title == "Fix bug"
+        assert issue.body == "Details here"
+        assert issue.labels == ["bug"]
+        assert issue.state == "open"
+
+    def test_list_includes_created_issues(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        ref = backend.create(IssueDraft(title="Alpha"))
+        backend.create(IssueDraft(title="Beta"))
+        issues = backend.list()
+        assert {i.title for i in issues} == {"Alpha", "Beta"}
+        assert any(i.ref == ref for i in issues)
+
+    def test_list_query_filters_by_substring(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        backend.create(IssueDraft(title="Alpha", body="mentions widgets"))
+        backend.create(IssueDraft(title="Beta", body="mentions gadgets"))
+        issues = backend.list("widgets")
+        assert [i.title for i in issues] == ["Alpha"]
+
+    def test_group_and_members_round_trip(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        ref1 = backend.create(IssueDraft(title="One"))
+        ref2 = backend.create(IssueDraft(title="Two"))
+        backend.create(IssueDraft(title="Unrelated"))
+        backend.group([ref1, ref2], "Epic: Widgets")
+
+        members = backend.members("Epic: Widgets")
+        assert {m.ref for m in members} == {ref1, ref2}
+        assert all(m.epic == "Epic: Widgets" for m in members)
+
+        # get() reflects the grouping too.
+        assert backend.get(ref1).epic == "Epic: Widgets"
+
+    def test_update_replaces_fields(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        ref = backend.create(IssueDraft(title="Original", labels=["a"]))
+        updated = backend.update(
+            ref, {"title": "Updated", "labels": ["b", "c"], "state": "closed"}
+        )
+        assert updated.title == "Updated"
+        assert set(updated.labels) == {"b", "c"}
+        assert updated.state == "closed"
+
+        refetched = backend.get(ref)
+        assert refetched.title == "Updated"
+        assert set(refetched.labels) == {"b", "c"}
+        assert refetched.state == "closed"
+
+    def test_comment_is_recorded(self, backend_and_verify):
+        backend, verify_comment = backend_and_verify
+        ref = backend.create(IssueDraft(title="Commentable"))
+        backend.comment(ref, "This is a comment")
+        verify_comment(ref, "This is a comment")
+
+
+# --- ref parsing --------------------------------------------------------------
+
+
+class TestParseRef:
+    def test_bare_owner_repo_hash_number_is_github(self):
+        assert parse_ref("acme/widget-api#42") == ("gh", "acme/widget-api#42")
+
+    def test_gh_scheme(self):
+        assert parse_ref("gh:acme/app#7") == ("gh", "acme/app#7")
+
+    def test_local_scheme(self):
+        assert parse_ref("local:docs/issues/0042.md") == ("local", "docs/issues/0042.md")
+
+    @pytest.mark.parametrize("scheme", ["obsidian", "jira"])
+    def test_recognizes_future_schemes_syntactically(self, scheme):
+        # Not implemented yet, but the grammar recognizes the prefix so a
+        # NotImplementedError (not a parse error) is what callers see.
+        assert parse_ref(f"{scheme}:whatever") == (scheme, "whatever")
+
+    @pytest.mark.parametrize(
+        "bad", ["not-a-ref", "owner/repo", "owner/repo#", "unknownscheme:x", "#42"]
+    )
+    def test_rejects_malformed_refs(self, bad):
+        with pytest.raises(ValueError):
+            parse_ref(bad)
+
+
+# --- backend resolution -------------------------------------------------------
+
+
+class TestResolveBackendName:
+    def test_absent_config_defaults_to_github(self, tmp_path):
+        missing_cw_config = tmp_path / "no-such-config.json"
+        assert resolve_backend_name(tmp_path, cw_config=missing_cw_config) == "github"
+
+    def test_per_repo_config_wins(self, tmp_path):
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        missing_cw_config = tmp_path / "no-such-config.json"
+        assert resolve_backend_name(tmp_path, cw_config=missing_cw_config) == "local"
+
+    def test_cw_side_fallback_used_when_no_per_repo_config(self, tmp_path):
+        cw_config = tmp_path / "cw-config.json"
+        cw_config.write_text(json.dumps({"tracker": {"backend": "local"}}))
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        assert resolve_backend_name(repo_root, cw_config=cw_config) == "local"
+
+    def test_malformed_per_repo_config_falls_through(self, tmp_path):
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text("{not json")
+        missing_cw_config = tmp_path / "no-such-config.json"
+        assert resolve_backend_name(tmp_path, cw_config=missing_cw_config) == "github"
+
+
+class TestGetTracker:
+    def test_defaults_to_github_backend(self, tmp_path):
+        backend = tracker.get_tracker("acme/app", repo_root=tmp_path)
+        assert isinstance(backend, GithubBackend)
+        assert backend.repo == "acme/app"
+
+    def test_local_config_selects_local_backend(self, tmp_path):
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        backend = tracker.get_tracker("acme/app", repo_root=tmp_path)
+        assert isinstance(backend, LocalBackend)
+        assert backend.root == tmp_path.resolve()
+
+    def test_unimplemented_backend_raises(self, tmp_path):
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "jira"}))
+        with pytest.raises(NotImplementedError):
+            tracker.get_tracker("acme/app", repo_root=tmp_path)
+
+
+# --- local backend frontmatter format -----------------------------------------
+
+
+class TestLocalFrontmatter:
+    def test_frontmatter_round_trips(self):
+        text = _dump_frontmatter(
+            {"id": 1, "title": "Hi", "state": "open", "labels": ["a", "b"], "epic": None}
+        )
+        data, body = _parse_frontmatter(text + "\n\nBody text\n")
+        assert data == {"id": 1, "title": "Hi", "state": "open", "labels": ["a", "b"], "epic": None}
+        assert body == "Body text\n"
+
+    def test_missing_frontmatter_raises(self):
+        with pytest.raises(ValueError):
+            _parse_frontmatter("no frontmatter here")
+
+    def test_create_writes_expected_file_layout(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="First", body="hello", labels=["x"]))
+        assert ref == "local:docs/issues/0001.md"
+        path = tmp_path / "docs" / "issues" / "0001.md"
+        assert path.is_file()
+        data, body = _parse_frontmatter(path.read_text())
+        assert data["id"] == 1
+        assert data["state"] == "open"
+        assert data["labels"] == ["x"]
+        assert "hello" in body
+
+    def test_ids_increment_across_files(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref1 = backend.create(IssueDraft(title="A"))
+        ref2 = backend.create(IssueDraft(title="B"))
+        assert ref1 == "local:docs/issues/0001.md"
+        assert ref2 == "local:docs/issues/0002.md"
+
+    def test_get_missing_issue_raises(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            backend.get("local:docs/issues/0099.md")
+
+    def test_wrong_scheme_rejected(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        with pytest.raises(ValueError):
+            backend.get("gh:acme/app#1")
+
+
+class TestGithubBackendRefHandling:
+    def test_wrong_scheme_rejected(self):
+        fake = FakeGh()
+        backend = GithubBackend("acme/app", runner=fake)
+        with pytest.raises(ValueError):
+            backend.get("local:docs/issues/0001.md")
+
+    def test_malformed_ident_rejected(self):
+        with pytest.raises(ValueError):
+            GithubBackend._parse_ident("not-a-valid-ident")
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_create_get_list_via_cli_local_backend(self, tmp_path, capsys):
+        # Select the local backend for this repo_root BEFORE creating, so
+        # `create` never falls through to the (unmocked) real `gh` CLI.
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        exit_code = tracker.main(
+            ["--repo-root", str(tmp_path), "create", "acme/app", "--title", "CLI issue"]
+        )
+        assert exit_code == 0
+        ref = capsys.readouterr().out.strip()
+        assert ref == "local:docs/issues/0001.md"
+
+        exit_code = tracker.main(["--repo-root", str(tmp_path), "get", ref])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert json.loads(out)["title"] == "CLI issue"
+
+        exit_code = tracker.main(["--repo-root", str(tmp_path), "list", "acme/app"])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert json.loads(out)[0]["title"] == "CLI issue"
+
+    def test_get_via_cli_github_backend(self, tmp_path, monkeypatch, capsys):
+        fake = FakeGh()
+        fake.issues.setdefault("acme/app", {})[42] = {
+            "number": 42, "title": "From gh", "body": "b", "state": "open",
+            "labels": [], "assignees": [], "milestone": None,
+            "url": "https://github.com/acme/app/issues/42",
+        }
+        monkeypatch.setattr(subprocess, "run", fake)
+        exit_code = tracker.main(["get", "gh:acme/app#42"])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert json.loads(out)["title"] == "From gh"
+
+    def test_unrecognized_ref_reports_error_exit_code(self, capsys):
+        exit_code = tracker.main(["get", "not-a-ref"])
+        assert exit_code == 1
+        assert "Error" in capsys.readouterr().err

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from tracker import (
     parse_ref,
     resolve_backend_name,
 )
+
+CW_ROOT = Path(__file__).resolve().parents[1]
 
 # --- fake gh CLI (statefully mocks the subprocess boundary) ------------------
 
@@ -194,7 +197,12 @@ def _make_local_backend(root: Path):
     backend = LocalBackend(root)
 
     def verify_comment(ref: str, text: str) -> None:
-        assert text in backend.get(ref).body
+        # Comments are stored in the file's ## cw-comments section, which is
+        # deliberately NOT part of Issue.body (same semantics as GitHub, where
+        # comments are a separate resource).
+        raw = backend._resolve_path(ref).read_text()
+        assert text in raw
+        assert text not in backend.get(ref).body
 
     return backend, verify_comment
 
@@ -269,6 +277,14 @@ class TestConformance:
         ref = backend.create(IssueDraft(title="Commentable"))
         backend.comment(ref, "This is a comment")
         verify_comment(ref, "This is a comment")
+
+    def test_update_rejects_invalid_state(self, backend_and_verify):
+        backend, _ = backend_and_verify
+        ref = backend.create(IssueDraft(title="Stateful"))
+        with pytest.raises(ValueError, match="invalid state"):
+            backend.update(ref, {"state": "bogus"})
+        # Validation happens before dispatch: nothing was mutated.
+        assert backend.get(ref).state == "open"
 
 
 # --- ref parsing --------------------------------------------------------------
@@ -396,6 +412,67 @@ class TestLocalFrontmatter:
             backend.get("gh:acme/app#1")
 
 
+class TestLocalPathContainment:
+    @pytest.mark.parametrize(
+        "bad_ref",
+        [
+            "local:/tmp/x.md",
+            "local:../other.md",
+            "local:docs/issues/../../secret.md",
+            "local:docs/other/0001.md",
+            "local:docs/issues/../cw/tracker.json",
+        ],
+    )
+    def test_refs_outside_docs_issues_are_rejected(self, tmp_path, bad_ref):
+        backend = LocalBackend(tmp_path)
+        with pytest.raises(ValueError):
+            backend.get(bad_ref)
+        with pytest.raises(ValueError):
+            backend.update(bad_ref, {"title": "x"})
+        with pytest.raises(ValueError):
+            backend.comment(bad_ref, "x")
+
+    def test_contained_ref_still_resolves(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="In bounds"))
+        assert backend.get(ref).title == "In bounds"
+
+
+class TestLocalComments:
+    def test_comment_excluded_from_body_and_list(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="T", body="original body"))
+        backend.comment(ref, "zzyzx unique comment")
+        issue = backend.get(ref)
+        assert issue.body == "original body"
+        # list()'s substring match must not see comment text either.
+        assert backend.list("zzyzx") == []
+        # But the comment IS persisted, under the cw-comments delimiter.
+        raw = backend._resolve_path(ref).read_text()
+        assert "## cw-comments" in raw
+        assert "zzyzx unique comment" in raw
+
+    def test_multiple_comments_accumulate_under_one_section(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="T", body="b"))
+        backend.comment(ref, "first")
+        backend.comment(ref, "second")
+        raw = backend._resolve_path(ref).read_text()
+        assert raw.count("## cw-comments") == 1
+        assert raw.index("first") < raw.index("second")
+        assert backend.get(ref).body == "b"
+
+    def test_update_body_preserves_comments(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="T", body="old body"))
+        backend.comment(ref, "keep me")
+        updated = backend.update(ref, {"body": "new body"})
+        assert updated.body == "new body"
+        raw = backend._resolve_path(ref).read_text()
+        assert "keep me" in raw
+        assert "old body" not in raw
+
+
 class TestGithubBackendRefHandling:
     def test_wrong_scheme_rejected(self):
         fake = FakeGh()
@@ -453,3 +530,104 @@ class TestCLI:
         exit_code = tracker.main(["get", "not-a-ref"])
         assert exit_code == 1
         assert "Error" in capsys.readouterr().err
+
+    def test_repo_root_honored_from_foreign_cwd(self, tmp_path, monkeypatch, capsys):
+        # The commands run from arbitrary cwds; --repo-root must be what
+        # selects the TARGET repo's docs/cw/tracker.json, not the cwd.
+        repo = tmp_path / "target"
+        (repo / "docs" / "cw").mkdir(parents=True)
+        (repo / "docs" / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        exit_code = tracker.main(
+            ["--repo-root", str(repo), "create", "acme/app", "--title", "Foreign cwd"]
+        )
+        assert exit_code == 0
+        assert capsys.readouterr().out.strip() == "local:docs/issues/0001.md"
+        assert (repo / "docs" / "issues" / "0001.md").is_file()
+        assert not (elsewhere / "docs").exists()
+
+    def test_backend_subcommand_prints_resolved_backend(self, tmp_path, monkeypatch, capsys):
+        # Hermetic: don't let a real ~/.chief-wiggum/config.json leak in.
+        monkeypatch.setattr(tracker, "DEFAULT_CW_CONFIG", tmp_path / "no-such-config.json")
+
+        exit_code = tracker.main(["--repo-root", str(tmp_path), "backend"])
+        assert exit_code == 0
+        assert capsys.readouterr().out.strip() == "github"
+
+        (tmp_path / "docs" / "cw").mkdir(parents=True)
+        (tmp_path / "docs" / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        exit_code = tracker.main(["--repo-root", str(tmp_path), "backend"])
+        assert exit_code == 0
+        assert capsys.readouterr().out.strip() == "local"
+
+    def test_plan_epic_flow_against_local_backend(self, tmp_path, monkeypatch, capsys):
+        """The /plan-epic sequence (list -> group -> members -> update) on a
+        local-configured scratch repo, driven entirely through the CLI, from a
+        foreign cwd — no GitHub mutation path is ever reachable."""
+        repo = tmp_path / "scratch-repo"
+        (repo / "docs" / "cw").mkdir(parents=True)
+        (repo / "docs" / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        run = lambda *a: tracker.main(["--repo-root", str(repo), *a])  # noqa: E731
+
+        refs = []
+        for title in ("Data model", "API endpoints", "Unrelated chore"):
+            assert run("create", "acme/app", "--title", title) == 0
+            refs.append(capsys.readouterr().out.strip())
+
+        assert run("group", "Epic: Orders", refs[0], refs[1]) == 0
+        capsys.readouterr()
+
+        assert run("members", "acme/app", "Epic: Orders") == 0
+        members = json.loads(capsys.readouterr().out)
+        assert {m["title"] for m in members} == {"Data model", "API endpoints"}
+        assert all(m["epic"] == "Epic: Orders" for m in members)
+
+        assert run("update", refs[0], "--set", "state=closed") == 0
+        assert json.loads(capsys.readouterr().out)["state"] == "closed"
+
+        # Epic membership is durable frontmatter in the repo, not GitHub state.
+        raw = (repo / "docs" / "issues" / "0001.md").read_text()
+        assert '"Epic: Orders"' in raw
+
+
+# --- command markdown migration (doc contracts) -------------------------------
+
+
+class TestCommandMarkdownMigration:
+    def test_create_issue_command_uses_tracker_and_creates_once(self):
+        text = (CW_ROOT / ".claude" / "commands" / "create-issue.md").read_text()
+        assert "gh issue create" not in text
+        assert "gh issue edit" not in text
+        # Exactly ONE create invocation (regression: a milestone used to
+        # trigger a second full create).
+        creates = re.findall(r'tracker\.py"[^\n]*[^-]\bcreate\b', text)
+        assert len(creates) == 1
+        # Every tracker call passes the resolved target repo root.
+        assert '--repo-root "$target_root"' in creates[0]
+        assert "scripts/repo.py" in text
+
+    def test_plan_epic_command_is_backend_conditional(self):
+        text = (CW_ROOT / ".claude" / "commands" / "plan-epic.md").read_text()
+        assert "gh issue list" not in text
+        assert "gh issue edit" not in text
+        # Target repo root is resolved and passed on tracker calls.
+        assert "scripts/repo.py" in text
+        assert '--repo-root "$target_root"' in text
+        # Milestone plumbing is conditional on the resolved backend...
+        assert '"$backend" = "github"' in text
+        # ...and the local backend has a storage path for the dependency graph.
+        assert "epic.md" in text
+
+    def test_no_unconditional_gh_milestone_mutation_in_plan_epic(self):
+        text = (CW_ROOT / ".claude" / "commands" / "plan-epic.md").read_text()
+        for line_block in re.findall(r"```bash\n(.*?)```", text, re.DOTALL):
+            if "gh api" in line_block and "milestones" in line_block and "-f" in line_block:
+                # every milestone-mutating gh api call must live in a
+                # backend=github conditional block
+                assert 'if [ "$backend" = "github" ]' in line_block


### PR DESCRIPTION
## Summary

- Adds `scripts/tracker.py`: a tracker-agnostic issue interface (`get`, `list`, `create`, `update`, `comment`, plus `group`/`members` for epic grouping) over an `Issue`/`IssueDraft` dataclass pair, mirroring the existing `repo.py` / provider-role patterns.
- Issue refs are URIs — `gh:owner/repo#42`, `local:docs/issues/0042.md` — and a bare `owner/repo#42` keeps meaning GitHub, so existing usage/docs don't break.
- Ships two backends (as scoped): `github` (wraps `gh issue`/`gh api .../milestones`, the reference implementation — epic grouping maps onto a milestone, as today) and `local` (one markdown file per issue with YAML frontmatter under `docs/issues/` in the target repo — also the offline test double for issue-driven workflows). Frontmatter values are written with `json.dumps`, which is valid YAML, so files stay real YAML frontmatter without a new `pyyaml` dependency.
- Backend resolution is per-target-repo: `docs/cw/tracker.json` (`{"backend": "..."}`), falling back to `~/.chief-wiggum/config.json`'s `tracker.backend`, defaulting to `github` (today's behavior) if neither exists.
- CLI entry point (`python3 scripts/tracker.py get/list/create/update/comment/group/members ...`) with JSON output, consistent with sibling scripts like `epic_metadata.py`.
- Migrates `.claude/commands/create-issue.md` and `.claude/commands/plan-epic.md` off direct `gh issue`/`gh issue edit --milestone` calls onto `tracker.py`. `gh api .../milestones` calls that manage GitHub-specific milestone metadata (listing existing epics, embedding the `<!-- DEPENDENCIES -->` block) are intentionally left as direct `gh` calls — that's GitHub-specific plumbing outside the tracker-agnostic `Issue` shape, not an issue-tracking call the ticket scoped for migration. Other `gh`-calling commands (`/seed`, `/implement`, `/implement-wave`, `/close-epic`) are a later ticket, per the issue.
- Adds `docs/tracker.md`: URI scheme, config resolution order, file format, and how to add a backend.
- Obsidian (documented as a `local` config variant) and Jira are explicitly out of this ticket, as scoped — `parse_ref` recognizes both prefixes syntactically for forward compatibility, but building either raises `NotImplementedError`.

## Test plan

- [x] TDD: `tests/test_tracker.py` written alongside the implementation — one parameterized conformance suite (`create → list → group → update → comment` round-trip) run against both backends via a `backend_and_verify` fixture.
- [x] GitHub backend is tested against a `FakeGh` in-memory double that intercepts the `subprocess.run` boundary (issue create/view/list/edit/close/reopen/comment, plus `gh api .../milestones` list/create) — **no network calls in tests**.
- [x] Local backend is tested against a `tmp_path` repo (file layout, frontmatter round-trip, ID auto-increment).
- [x] Additional unit tests: `parse_ref` (bare/`gh:`/`local:`/`obsidian:`/`jira:`/malformed), `resolve_backend_name` (absent config, per-repo config, CW-side fallback, malformed JSON), `get_tracker` dispatch, and CLI smoke tests (local backend end-to-end; github backend via a monkeypatched `subprocess.run`).
- [x] `python3 -m pytest tests/ -x -q` → **816 passed, 4 skipped** (4 skips are pre-existing, unrelated to this change).
- [x] `python3 -m ruff check scripts/tracker.py tests/test_tracker.py` → clean.
- [x] `python3 scripts/check_cw_standards.py` and `python3 scripts/check_portability.py` → both pass.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF