### PR TITLE
feat(system): infra single-writer — terraform drift as sanctioned-writer enforcement (#165)

### DIFF
--- a/docs/single-writer.md
+++ b/docs/single-writer.md
@@ -120,3 +120,141 @@ internal/admin/handlers.go:     func ChangePlan(...)      { p.StripePlan = ... }
 ```
 
 and exits `1` — the exact regression that shipped silently before this check.
+
+## Infra extension: terraform drift as sanctioned-writer enforcement (#165)
+
+The single-writer idiom above inventories *code* writers of a field. Some
+invariants declare a single writer of *infrastructure* instead: "terraform owns
+env/secrets; CI only pushes images." That rule lived only in a memory file until
+the Dogeared deploy's `enable_cicd` footgun made the gap concrete — a CI run
+silently applied an infra change out-of-band, and nothing flagged it, because no
+check inventories *live* infra writers the way `check_single_writer.py`
+inventories code writers.
+
+`scripts/check_infra_writer.py` closes that gap by treating `terraform plan` as
+the writer-inventory tool: if the live state ever diverges from the declared
+(terraform) state, exactly one thing could have written it out-of-band, and
+`terraform plan -detailed-exitcode` already knows how to detect that.
+
+### Declaration
+
+An infra invariant lives in a JSON config (default
+`docs/system/infra-invariants.json`):
+
+```json
+[
+  {
+    "id": "INV-infra-001",
+    "controls_field": "infra.env-secrets",
+    "sanctioned_writers": ["terraform"],
+    "terraform_root": "infra/",
+    "schedule_note": "run nightly via cron"
+  }
+]
+```
+
+- **`id`** — an `INV-` stable ID (same grammar as `check_traceability.py` /
+  `check_single_writer.py`; validated against the shared ID grammar
+  (`scripts/chief_wiggum/trace_ids.py`) when it exists on the branch, else a
+  local regex — the import is optional/guarded so this checker works standalone).
+- **`controls_field`** — the scope name (e.g. `infra.env-secrets`), matched
+  against exemption `scope` for break-glass downgrade.
+- **`sanctioned_writers`** — the only authorized writer(s) (normally `["terraform"]`).
+- **`terraform_root`** — the directory `terraform plan` runs in for this invariant.
+- **`schedule_note`** — optional free text (e.g. "nightly cron", "on every close-epic run").
+
+### The check
+
+For each declared invariant, `check_infra_writer.py` runs (via `subprocess`, never a
+shell):
+
+```
+terraform plan -detailed-exitcode -input=false -lock=false -no-color
+```
+
+in `terraform_root`, and maps terraform's own exit-code contract:
+
+| Exit code | Meaning | Status |
+| --- | --- | --- |
+| `0` | declared state matches live state | `clean` |
+| `2` | live state diverges from declared state — an unsanctioned write happened out-of-band | `drift` (or `exempted`, see below) |
+| `1` | terraform itself errored (auth/network/config) | `error` — **never conflated with drift** |
+| other | unexpected | `error` |
+
+`terraform` missing entirely degrades gracefully: `{"available": false, ...}`,
+exit `0` — mirroring `lsp_query.py`'s missing-language-server path. A missing
+`terraform_root` directory is an `error`, not a `drift`.
+
+### Drift is an event, not just a state
+
+Every detected drift (`drift` or `exempted`) appends an **append-only** JSONL
+record to `docs/quality/infra-drift.jsonl`:
+
+```json
+{"ts": 1752921600.0, "invariant": "INV-infra-001", "root": "infra/", "plan_summary_first_40_lines": ["~ update in place", "..."]}
+```
+
+A later clean plan (someone reconciled the drift, or terraform re-applied) does
+**not** erase this record — convergence is not innocence. The journal is the
+durable evidence that an out-of-band write occurred, independent of whether it
+was later fixed.
+
+### Break-glass: committed exemption records
+
+An incident sometimes requires a deliberate, temporary out-of-band change (the
+break-glass case GitOps assumes exists). Rather than silently accepting drift,
+`check_infra_writer.py` looks for committed exemption records in
+`docs/system/exemptions/*.json`:
+
+```json
+{
+  "scope": "infra.env-secrets",
+  "reason": "emergency secret rotation during INC-42",
+  "expiry": "2026-08-01",
+  "approver": "pat",
+  "incident_ref": "INC-42"
+}
+```
+
+- An **active** exemption (`scope` matches the invariant's `controls_field`, and
+  `expiry` has not passed) downgrades a `drift` finding to `exempted` — it is
+  still journaled (see above), just not gate-failing.
+- An **expired** exemption is itself a finding: the break-glass window closed
+  and nobody re-declared or cleaned it up. Expired exemptions gate-fail
+  independently of whether any current drift matches their scope.
+
+Creating an exemption is a single JSON file commit — frictionless by design, so
+it happens *during* an incident, not as after-the-fact paperwork.
+
+### Authority boundary
+
+Every report — text or JSON — states the same authority line:
+
+> proves declared state matches live state at scan time for scanned roots; does
+> not prove no out-of-band write occurred between scans
+
+This is the same class of caveat the code-level checker states for its regex
+lens: the tool proves what it can observe, not everything that could have
+happened. Audit-log integration (proving *no* out-of-band write happened
+*between* scans, not just checking whether one has left a live trace) is a
+deferred trigger item.
+
+### Running it
+
+```bash
+# report-only (default): prints findings, exit 0
+python3 scripts/check_infra_writer.py --config docs/system/infra-invariants.json
+
+# JSON output
+python3 scripts/check_infra_writer.py --format json
+
+# blocking: exit 1 on unexempted drift or an expired exemption
+python3 scripts/check_infra_writer.py --gate
+```
+
+Per `docs/gate-rollout.md`: this gate ships **report-only**. Validate it against
+a real repo's terraform (a clean-plan run, and a seeded drift caught in a
+sandbox workspace) before wiring `--gate` into `/close-epic` for repos that
+declare infra invariants.
+
+Exit codes: `0` ok / report-only, `1` gate violation, `2` usage error.

--- a/docs/single-writer.md
+++ b/docs/single-writer.md
@@ -160,7 +160,13 @@ An infra invariant lives in a JSON config (default
 - **`controls_field`** — the scope name (e.g. `infra.env-secrets`), matched
   against exemption `scope` for break-glass downgrade.
 - **`sanctioned_writers`** — the only authorized writer(s) (normally `["terraform"]`).
-- **`terraform_root`** — the directory `terraform plan` runs in for this invariant.
+- **`terraform_root`** — the directory `terraform plan` runs in for this
+  invariant, **repo-relative**. It resolves against the target repo's root — an
+  explicit `--repo`, else the nearest ancestor of the config file containing
+  `.git`, else the config file's directory — never the caller's CWD. Roots that
+  escape the repo boundary (absolute paths, `..` traversal) are rejected as
+  errors: the config is committed data and must not be able to point the
+  scanner (or the journal) outside the repo it lives in.
 - **`schedule_note`** — optional free text (e.g. "nightly cron", "on every close-epic run").
 
 ### The check
@@ -182,13 +188,20 @@ in `terraform_root`, and maps terraform's own exit-code contract:
 | other | unexpected | `error` |
 
 `terraform` missing entirely degrades gracefully: `{"available": false, ...}`,
-exit `0` — mirroring `lsp_query.py`'s missing-language-server path. A missing
-`terraform_root` directory is an `error`, not a `drift`.
+exit `0` — mirroring `lsp_query.py`'s missing-language-server path. This is the
+**one** graceful-degradation exception (intended rollout behavior). Every other
+failure to evaluate — terraform exit `1`, a missing or repo-escaping
+`terraform_root`, an unparseable/malformed declaration, a failed journal write —
+is an `error`/`malformed` finding that **fails `--gate`**: a blocking gate must
+fail when it could not actually evaluate the invariant, otherwise "terraform is
+broken" silently reads as "no drift". None of these are ever conflated with
+`drift` in the report.
 
 ### Drift is an event, not just a state
 
 Every detected drift (`drift` or `exempted`) appends an **append-only** JSONL
-record to `docs/quality/infra-drift.jsonl`:
+record to `docs/quality/infra-drift.jsonl` **in the target repo** (resolved
+against the same repo root as `terraform_root`, never the caller's CWD):
 
 ```json
 {"ts": 1752921600.0, "invariant": "INV-infra-001", "root": "infra/", "plan_summary_first_40_lines": ["~ update in place", "..."]}
@@ -198,6 +211,11 @@ A later clean plan (someone reconciled the drift, or terraform re-applied) does
 **not** erase this record — convergence is not innocence. The journal is the
 durable evidence that an out-of-band write occurred, independent of whether it
 was later fixed.
+
+The drift **finding is recorded before** the journal write, so a failed write
+can never swallow it: a journal-write failure is reported as an explicit
+(gate-failing) `error` finding alongside the drift, and report-only mode still
+renders the full report instead of crashing.
 
 ### Break-glass: committed exemption records
 
@@ -248,7 +266,11 @@ python3 scripts/check_infra_writer.py --config docs/system/infra-invariants.json
 # JSON output
 python3 scripts/check_infra_writer.py --format json
 
-# blocking: exit 1 on unexempted drift or an expired exemption
+# explicit repo root (otherwise derived from the config file's location)
+python3 scripts/check_infra_writer.py --repo /path/to/target-repo
+
+# blocking: exit 1 on unexempted drift, an expired exemption, or any
+# error/malformed finding that prevented evaluating an invariant
 python3 scripts/check_infra_writer.py --gate
 ```
 

--- a/scripts/check_infra_writer.py
+++ b/scripts/check_infra_writer.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Infra single-writer checker (#165): terraform drift as sanctioned-writer enforcement.
+
+Extends the single-writer idiom (``check_single_writer.py``) to infrastructure.
+"Terraform owns env/secrets; CI only pushes images" is a memory-file rule until
+it's declared and checked mechanically. An **infra invariant** names a
+``controls_field`` (e.g. ``infra.env-secrets``), its ``sanctioned_writers``
+(e.g. ``["terraform"]``), and the ``terraform_root`` whose declared state must
+match live state.
+
+Pilot incident this targets: the Dogeared deploy's ``enable_cicd`` footgun — a
+CI run that silently applied infra changes out-of-band, bypassing the
+terraform-owns-infra contract. Nothing flagged it because no check inventories
+*live* infra writers the way ``check_single_writer.py`` inventories *code*
+writers of a field.
+
+How it works:
+
+1. Load declared infra invariants from a JSON config (default
+   ``docs/system/infra-invariants.json``)::
+
+       [{"id": "INV-infra-001",
+         "controls_field": "infra.env-secrets",
+         "sanctioned_writers": ["terraform"],
+         "terraform_root": "infra/",
+         "schedule_note": "run nightly via cron"}]
+
+2. For each invariant, run ``terraform plan -detailed-exitcode`` (subprocess,
+   ``-input=false -lock=false -no-color``) in its ``terraform_root``:
+
+   - exit ``0``  -> clean, declared state matches live state.
+   - exit ``2``  -> DRIFT: an unsanctioned write happened out-of-band.
+   - exit ``1``  -> terraform ERROR (config/auth/network) — reported as
+     ``error``, never conflated with drift.
+   - ``terraform`` missing entirely -> ``{"available": false, ...}``, graceful
+     degradation, exit 0 (mirrors ``lsp_query.py``'s missing-LSP-server path).
+
+3. **Drift is an event, not just a state.** Every detected drift (exempted or
+   not) appends an append-only JSONL record to ``docs/quality/infra-drift.jsonl``
+   — ``{ts, invariant, root, plan_summary_first_40_lines}``. A later clean plan
+   does NOT erase the journal entry; convergence is not innocence.
+
+4. **Break-glass = committed exemption records.** ``docs/system/exemptions/*.json``
+   — ``{scope, reason, expiry, approver, incident_ref}``. An ACTIVE exemption
+   (``scope`` matches the invariant's ``controls_field`` and ``expiry`` hasn't
+   passed) downgrades a drift finding to ``exempted`` (still journaled). An
+   EXPIRED exemption is itself a finding — the break-glass window closed and
+   nobody re-declared or cleaned it up.
+
+Authority boundary (always stated in the report): this proves declared state
+matches live state **at scan time**, for **scanned roots**; it does not prove
+no out-of-band write occurred *between* scans (audit-log integration is a
+deferred trigger item, same caveat ``docs/single-writer.md`` states for the
+code-level checker's regex lens).
+
+Report-only by default (prints findings, exit 0); ``--gate`` hard-fails (exit 1)
+on any unexempted drift or expired exemption — per ``docs/gate-rollout.md``,
+validate report-only on a real repo before wiring ``--gate`` into a workflow.
+
+Exit codes: 0 = ok / report-only, 1 = gate violation, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from pathlib import Path
+
+DEFAULT_CONFIG = Path("docs/system/infra-invariants.json")
+DEFAULT_JOURNAL = Path("docs/quality/infra-drift.jsonl")
+
+AUTHORITY = (
+    "proves declared state matches live state at scan time for scanned roots; "
+    "does not prove no out-of-band write occurred between scans"
+)
+
+TERRAFORM_PLAN_ARGS = ["terraform", "plan", "-detailed-exitcode", "-input=false", "-lock=false", "-no-color"]
+
+# Same id-body shape as check_single_writer.py / check_traceability.py, anchored
+# to validate a whole id field (not embedded in prose): INV-<slug>-<NNN>.
+_LOCAL_ID_BODY = r"INV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}"
+
+# Optional/guarded: use the shared id-body grammar (single source of truth for
+# the stable-ID shape, #166) if it exists on this branch, else fall back to the
+# local regex above. Keeps this checker working standalone off a `main` that
+# predates scripts/chief_wiggum/trace_ids.py, while adopting the shared grammar
+# automatically once it lands — we still only accept the INV kind here (infra
+# invariants are INV-only), just delegate the <slug>-<NNN> suffix shape.
+try:
+    from chief_wiggum.trace_ids import ID_BODY as _SHARED_ID_BODY  # type: ignore
+except ImportError:
+    _SHARED_ID_BODY = None
+
+_VALID_INV_ID_RE = re.compile(rf"^{_SHARED_ID_BODY or _LOCAL_ID_BODY}$", re.IGNORECASE)
+
+
+def _valid_inv_id(node_id: str) -> bool:
+    # The shared ID_BODY matches ANY declared kind (BR|CTR|INV|ARC|...); infra
+    # invariants must specifically be INV, so require that prefix ourselves.
+    return node_id.upper().startswith("INV-") and bool(_VALID_INV_ID_RE.match(node_id))
+
+
+# --- data model --------------------------------------------------------------
+
+
+@dataclass
+class InfraInvariant:
+    id: str
+    controls_field: str
+    sanctioned_writers: list[str]
+    terraform_root: str
+    schedule_note: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Exemption:
+    scope: str
+    reason: str
+    expiry: str  # ISO date (YYYY-MM-DD)
+    approver: str
+    incident_ref: str
+    source: str  # file path, for reporting
+
+    def is_expired(self, today: date) -> bool:
+        try:
+            return date.fromisoformat(self.expiry) < today
+        except ValueError:
+            return True  # unparseable expiry is treated as expired (a finding, not a pass)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class InfraDriftReport:
+    available: bool = True
+    config: str = ""
+    checked: list[dict] = field(default_factory=list)     # every invariant that ran cleanly
+    drift: list[dict] = field(default_factory=list)        # unexempted drift (violations)
+    exempted: list[dict] = field(default_factory=list)     # drift downgraded by an active exemption
+    errors: list[dict] = field(default_factory=list)       # terraform errors / missing roots
+    malformed: list[dict] = field(default_factory=list)    # bad invariant/exemption declarations
+    expired_exemptions: list[dict] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    authority: str = AUTHORITY
+
+    @property
+    def counts(self) -> dict:
+        return {
+            "checked": len(self.checked),
+            "drift": len(self.drift),
+            "exempted": len(self.exempted),
+            "errors": len(self.errors),
+            "malformed": len(self.malformed),
+            "expired_exemptions": len(self.expired_exemptions),
+        }
+
+    @property
+    def gate_ok(self) -> bool:
+        # --gate hard-fails on unexempted drift or an expired (lapsed) exemption —
+        # the break-glass window closed and nobody re-declared or cleaned it up.
+        return not self.drift and not self.expired_exemptions
+
+    def to_dict(self) -> dict:
+        return {
+            "available": self.available,
+            "config": self.config,
+            "counts": self.counts,
+            "gate_ok": self.gate_ok,
+            "checked": self.checked,
+            "drift": self.drift,
+            "exempted": self.exempted,
+            "errors": self.errors,
+            "malformed": self.malformed,
+            "expired_exemptions": self.expired_exemptions,
+            "warnings": self.warnings,
+            "authority": self.authority,
+        }
+
+
+# --- parsing declarations ----------------------------------------------------
+
+
+def _parse_invariants(raw: list) -> tuple[list[InfraInvariant], list[dict]]:
+    invariants: list[InfraInvariant] = []
+    malformed: list[dict] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            malformed.append({"index": i, "reason": "entry is not a JSON object"})
+            continue
+        node_id = str(entry.get("id", ""))
+        controls_field = entry.get("controls_field")
+        sanctioned_writers = entry.get("sanctioned_writers")
+        terraform_root = entry.get("terraform_root")
+
+        reasons: list[str] = []
+        if not _valid_inv_id(node_id):
+            reasons.append(f"invalid or missing id {node_id!r} (expected INV-<slug>-<NNN>)")
+        if not controls_field or not isinstance(controls_field, str):
+            reasons.append("controls_field must be a non-empty string")
+        if not sanctioned_writers or not isinstance(sanctioned_writers, list):
+            reasons.append("sanctioned_writers must be a non-empty array")
+        if not terraform_root or not isinstance(terraform_root, str):
+            reasons.append("terraform_root must be a non-empty string")
+        if reasons:
+            malformed.append({"id": node_id or f"<index {i}>", "reason": "; ".join(reasons)})
+            continue
+
+        invariants.append(InfraInvariant(
+            id=node_id,
+            controls_field=str(controls_field),
+            sanctioned_writers=[str(w) for w in sanctioned_writers],
+            terraform_root=str(terraform_root),
+            schedule_note=(str(entry["schedule_note"]) if entry.get("schedule_note") else None),
+        ))
+    return invariants, malformed
+
+
+def load_invariants(config_path: str | Path) -> tuple[list[InfraInvariant], list[dict]]:
+    path = Path(config_path)
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, list):
+        raise ValueError(f"config {path} must be a JSON array of invariants")
+    return _parse_invariants(raw)
+
+
+# --- exemptions ---------------------------------------------------------------
+
+
+_REQUIRED_EXEMPTION_FIELDS = ("scope", "reason", "expiry", "approver", "incident_ref")
+
+
+def load_exemptions(exemptions_dir: str | Path) -> tuple[list[Exemption], list[dict]]:
+    """Load committed break-glass exemption records from ``exemptions_dir/*.json``.
+
+    Missing directory degrades gracefully (no exemptions declared). A malformed
+    record (not an object, or missing a required field) is reported, not raised.
+    """
+    root = Path(exemptions_dir)
+    exemptions: list[Exemption] = []
+    malformed: list[dict] = []
+    if not root.exists():
+        return exemptions, malformed
+    for path in sorted(root.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            malformed.append({"source": str(path), "reason": f"cannot parse exemption: {exc}"})
+            continue
+        if not isinstance(data, dict):
+            malformed.append({"source": str(path), "reason": "exemption must be a JSON object"})
+            continue
+        missing = [k for k in _REQUIRED_EXEMPTION_FIELDS if not data.get(k)]
+        if missing:
+            malformed.append({"source": str(path), "reason": f"missing field(s): {', '.join(missing)}"})
+            continue
+        exemptions.append(Exemption(
+            scope=str(data["scope"]),
+            reason=str(data["reason"]),
+            expiry=str(data["expiry"]),
+            approver=str(data["approver"]),
+            incident_ref=str(data["incident_ref"]),
+            source=str(path),
+        ))
+    return exemptions, malformed
+
+
+def _find_active_exemption(exemptions: list[Exemption], scope: str, today: date) -> Exemption | None:
+    for exemption in exemptions:
+        if exemption.scope == scope and not exemption.is_expired(today):
+            return exemption
+    return None
+
+
+# --- journal (drift is an event) ----------------------------------------------
+
+
+def append_drift_journal(journal_path: str | Path, invariant_id: str, root: str, plan_output: str) -> None:
+    """Append-only JSONL record — a later clean plan does NOT erase this entry."""
+    path = Path(journal_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "ts": time.time(),
+        "invariant": invariant_id,
+        "root": root,
+        "plan_summary_first_40_lines": plan_output.splitlines()[:40],
+    }
+    with path.open("a") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+# --- running terraform ---------------------------------------------------------
+
+
+def _default_runner(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        TERRAFORM_PLAN_ARGS,
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+Runner = Callable[[Path], subprocess.CompletedProcess]
+
+
+def terraform_available() -> bool:
+    return shutil.which("terraform") is not None
+
+
+# --- top-level check -----------------------------------------------------------
+
+
+def check(
+    config_path: str | Path = DEFAULT_CONFIG,
+    *,
+    exemptions_dir: str | Path | None = None,
+    journal_path: str | Path | None = None,
+    runner: Runner | None = None,
+    today: date | None = None,
+    available: bool | None = None,
+) -> InfraDriftReport:
+    """Run the infra single-writer check.
+
+    ``runner``/``today``/``available`` are injectable seams for tests (mock
+    subprocess, freeze the exemption-expiry clock, force the missing-terraform
+    path) — production callers leave them ``None`` and get the real behavior.
+    """
+    config_path = Path(config_path)
+    report = InfraDriftReport(config=str(config_path))
+
+    is_available = terraform_available() if available is None else available
+    report.available = is_available
+    if not is_available:
+        # Graceful degradation, exactly like lsp_query.py's missing-server path:
+        # never block the workflow because the tool isn't installed here.
+        report.warnings.append("terraform not installed; skipping infra-writer check (graceful degradation)")
+        return report
+
+    if not config_path.exists():
+        report.warnings.append(f"no infra invariants declared (config not found: {config_path})")
+        return report
+
+    try:
+        raw = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        report.warnings.append(f"cannot parse config {config_path}: {exc}")
+        return report
+    if not isinstance(raw, list):
+        report.warnings.append(f"config {config_path} must be a JSON array of invariants")
+        return report
+
+    invariants, malformed = _parse_invariants(raw)
+    report.malformed = malformed
+    if not invariants:
+        report.warnings.append("no valid infra invariants found; nothing to check")
+        return report
+
+    exemptions_root = Path(exemptions_dir) if exemptions_dir is not None else config_path.parent / "exemptions"
+    exemptions, exemption_malformed = load_exemptions(exemptions_root)
+    report.malformed += exemption_malformed
+
+    check_today = today or date.today()
+    report.expired_exemptions = [
+        {**e.to_dict(), "reason": "exemption expired"} for e in exemptions if e.is_expired(check_today)
+    ]
+
+    journal = Path(journal_path) if journal_path is not None else DEFAULT_JOURNAL
+    run = runner or _default_runner
+
+    for inv in invariants:
+        root = Path(inv.terraform_root)
+        if not root.is_dir():
+            report.errors.append({
+                "invariant_id": inv.id,
+                "controls_field": inv.controls_field,
+                "terraform_root": inv.terraform_root,
+                "status": "error",
+                "reason": f"terraform_root not found: {inv.terraform_root}",
+            })
+            continue
+
+        try:
+            proc = run(root)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            report.errors.append({
+                "invariant_id": inv.id,
+                "controls_field": inv.controls_field,
+                "terraform_root": inv.terraform_root,
+                "status": "error",
+                "reason": f"terraform plan failed to run: {exc}",
+            })
+            continue
+
+        exit_code = proc.returncode
+        stdout = proc.stdout or ""
+        base = {
+            "invariant_id": inv.id,
+            "controls_field": inv.controls_field,
+            "terraform_root": inv.terraform_root,
+            "sanctioned_writers": inv.sanctioned_writers,
+            "exit_code": exit_code,
+        }
+
+        if exit_code == 0:
+            report.checked.append({**base, "status": "clean"})
+        elif exit_code == 2:
+            # DRIFT: an unsanctioned write happened out-of-band. This is an EVENT —
+            # journal it before anything else, so a later clean plan (convergence)
+            # never erases evidence the drift occurred.
+            append_drift_journal(journal, inv.id, inv.terraform_root, stdout)
+            plan_excerpt = stdout.splitlines()[:10]
+            active = _find_active_exemption(exemptions, inv.controls_field, check_today)
+            if active:
+                report.exempted.append({
+                    **base, "status": "exempted", "plan_excerpt": plan_excerpt,
+                    "exemption": active.to_dict(),
+                })
+            else:
+                report.drift.append({**base, "status": "drift", "plan_excerpt": plan_excerpt})
+        elif exit_code == 1:
+            # terraform ERROR — never conflate with drift.
+            report.errors.append({
+                **base, "status": "error",
+                "reason": (proc.stderr or "terraform plan exited 1").strip()[:2000],
+            })
+        else:
+            report.errors.append({
+                **base, "status": "error",
+                "reason": f"unexpected terraform exit code {exit_code}",
+            })
+
+    return report
+
+
+# --- rendering / CLI -----------------------------------------------------------
+
+
+def render_text(report: InfraDriftReport) -> str:
+    c = report.counts
+    lines = [
+        "# Infra Single-Writer Audit (terraform drift)",
+        "",
+        f"Authority: {report.authority}",
+        "",
+    ]
+    if not report.available:
+        lines.append("terraform: NOT AVAILABLE — check skipped (graceful degradation)")
+        lines += [f"- {w}" for w in report.warnings]
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"Config: {report.config}")
+    lines.append(
+        f"Checked: {c['checked']}  |  Drift: {c['drift']}  |  Exempted: {c['exempted']}  |  "
+        f"Errors: {c['errors']}  |  Malformed: {c['malformed']}  |  Expired exemptions: {c['expired_exemptions']}"
+    )
+    lines.append(f"Gate: {'OK' if report.gate_ok else 'FINDINGS'}")
+
+    if report.drift:
+        lines += ["", "## Drift (unsanctioned out-of-band write)", ""]
+        for d in report.drift:
+            lines.append(f"- {d['invariant_id']} `{d['controls_field']}` root={d['terraform_root']}")
+            lines += [f"    {ln}" for ln in d.get("plan_excerpt", [])]
+    if report.exempted:
+        lines += ["", "## Exempted drift (active break-glass exemption)", ""]
+        for d in report.exempted:
+            ex = d["exemption"]
+            lines.append(
+                f"- {d['invariant_id']} `{d['controls_field']}` root={d['terraform_root']} "
+                f"exempted by {ex['source']} (expiry {ex['expiry']}, incident {ex['incident_ref']})"
+            )
+    if report.expired_exemptions:
+        lines += ["", "## Expired exemptions (findings on their own)", ""]
+        for e in report.expired_exemptions:
+            lines.append(f"- {e['source']} scope=`{e['scope']}` expired {e['expiry']} (approver {e['approver']})")
+    if report.errors:
+        lines += ["", "## Errors (terraform failed to run — not drift)", ""]
+        for e in report.errors:
+            lines.append(f"- {e['invariant_id']} root={e['terraform_root']}: {e.get('reason', '')}")
+    if report.malformed:
+        lines += ["", "## Malformed declarations", ""]
+        for m in report.malformed:
+            lines.append(f"- {m.get('id', m.get('source', '?'))}: {m['reason']}")
+    if report.checked and not report.drift:
+        lines += ["", "## Clean", ""]
+        for chk in report.checked:
+            lines.append(f"- {chk['invariant_id']} `{chk['controls_field']}` root={chk['terraform_root']}: clean")
+    if report.warnings:
+        lines += ["", "## Warnings", ""] + [f"- {w}" for w in report.warnings]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Infra single-writer checker — terraform drift as sanctioned-writer enforcement"
+    )
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to infra-invariants JSON config")
+    parser.add_argument(
+        "--gate", action="store_true",
+        help="Fail (exit 1) on unexempted drift or an expired exemption; default is report-only",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    report = check(args.config)
+
+    if args.format == "json":
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(render_text(report))
+
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+        caught = len(report.drift) + len(report.expired_exemptions)
+        emit_gate(
+            "check_infra_writer",
+            "fail" if caught else "pass",
+            caught=caught,
+            repo=os.path.basename(os.getcwd()),
+        )
+    except Exception:
+        pass
+
+    if args.gate and not report.gate_ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_infra_writer.py
+++ b/scripts/check_infra_writer.py
@@ -54,8 +54,18 @@ deferred trigger item, same caveat ``docs/single-writer.md`` states for the
 code-level checker's regex lens).
 
 Report-only by default (prints findings, exit 0); ``--gate`` hard-fails (exit 1)
-on any unexempted drift or expired exemption — per ``docs/gate-rollout.md``,
-validate report-only on a real repo before wiring ``--gate`` into a workflow.
+on any unexempted drift, expired exemption, ERROR (terraform exit 1, a missing
+or repo-escaping ``terraform_root``, a failed journal write), or MALFORMED
+declaration — a blocking gate must fail when it could not actually evaluate the
+invariant. The single graceful-degradation exception is terraform not being
+installed at all. Per ``docs/gate-rollout.md``, validate report-only on a real
+repo before wiring ``--gate`` into a workflow.
+
+Path resolution: each ``terraform_root`` is resolved relative to the **repo
+root** — an explicit ``--repo``, else the nearest ancestor of the config file
+containing ``.git``, else the config file's directory — never the caller's CWD.
+Roots that escape that boundary (absolute paths, ``..``) are rejected. The
+drift journal likewise lands in the target repo's ``docs/quality/``, not CWD.
 
 Exit codes: 0 = ok / report-only, 1 = gate violation, 2 = usage error.
 """
@@ -75,7 +85,9 @@ from datetime import date
 from pathlib import Path
 
 DEFAULT_CONFIG = Path("docs/system/infra-invariants.json")
-DEFAULT_JOURNAL = Path("docs/quality/infra-drift.jsonl")
+# Repo-relative: resolved against the target repo's root (see _find_repo_root),
+# never the caller's CWD.
+DEFAULT_JOURNAL_REL = Path("docs/quality/infra-drift.jsonl")
 
 AUTHORITY = (
     "proves declared state matches live state at scan time for scanned roots; "
@@ -168,9 +180,18 @@ class InfraDriftReport:
 
     @property
     def gate_ok(self) -> bool:
-        # --gate hard-fails on unexempted drift or an expired (lapsed) exemption —
-        # the break-glass window closed and nobody re-declared or cleaned it up.
-        return not self.drift and not self.expired_exemptions
+        # --gate hard-fails on:
+        #   - unexempted drift;
+        #   - an expired (lapsed) exemption — the break-glass window closed and
+        #     nobody re-declared or cleaned it up;
+        #   - any ERROR (terraform exit 1, missing/escaping root, journal write
+        #     failure) or MALFORMED declaration — a blocking gate must fail when
+        #     it could not actually evaluate the invariant, otherwise "terraform
+        #     is broken" silently reads as "no drift".
+        # The single graceful-degradation exception is terraform not being
+        # installed at all (available=False): that path returns before any
+        # findings exist, by design (rollout behavior, mirrors lsp_query.py).
+        return not (self.drift or self.expired_exemptions or self.errors or self.malformed)
 
     def to_dict(self) -> dict:
         return {
@@ -300,6 +321,39 @@ def append_drift_journal(journal_path: str | Path, invariant_id: str, root: str,
         fh.write(json.dumps(record, sort_keys=True) + "\n")
 
 
+# --- path resolution -----------------------------------------------------------
+
+
+def _find_repo_root(config_path: Path) -> Path:
+    """The repo root that ``terraform_root`` entries and the drift journal
+    resolve against: the nearest ancestor of the config file containing
+    ``.git``, else the config file's own directory. Never the caller's CWD —
+    the check must behave identically wherever it is invoked from."""
+    resolved = config_path.resolve()
+    for parent in resolved.parents:
+        if (parent / ".git").exists():
+            return parent
+    return resolved.parent
+
+
+def _resolve_terraform_root(repo_root: Path, declared: str) -> Path | None:
+    """Resolve a declared ``terraform_root`` inside ``repo_root``.
+
+    Returns ``None`` for roots that escape the repo boundary — absolute paths
+    and ``..`` traversal are rejected: the config is committed data, and a
+    declared root must not be able to point the scanner (or the journal)
+    outside the repo it lives in.
+    """
+    declared_path = Path(declared)
+    if declared_path.is_absolute():
+        return None
+    base = repo_root.resolve()
+    resolved = (base / declared_path).resolve()
+    if not resolved.is_relative_to(base):
+        return None
+    return resolved
+
+
 # --- running terraform ---------------------------------------------------------
 
 
@@ -326,6 +380,7 @@ def terraform_available() -> bool:
 def check(
     config_path: str | Path = DEFAULT_CONFIG,
     *,
+    repo_root: str | Path | None = None,
     exemptions_dir: str | Path | None = None,
     journal_path: str | Path | None = None,
     runner: Runner | None = None,
@@ -334,6 +389,9 @@ def check(
 ) -> InfraDriftReport:
     """Run the infra single-writer check.
 
+    ``repo_root`` (CLI ``--repo``) overrides the boundary that ``terraform_root``
+    entries and the drift journal resolve against; by default it is derived from
+    the config file's location (see ``_find_repo_root``) — never the caller's CWD.
     ``runner``/``today``/``available`` are injectable seams for tests (mock
     subprocess, freeze the exemption-expiry clock, force the missing-terraform
     path) — production callers leave them ``None`` and get the real behavior.
@@ -344,8 +402,10 @@ def check(
     is_available = terraform_available() if available is None else available
     report.available = is_available
     if not is_available:
-        # Graceful degradation, exactly like lsp_query.py's missing-server path:
-        # never block the workflow because the tool isn't installed here.
+        # The ONE graceful-degradation path (intended rollout behavior, mirrors
+        # lsp_query.py's missing-server path): terraform isn't installed here,
+        # so nothing was evaluated and nothing gates. Every other failure to
+        # evaluate below is an error/malformed finding and DOES gate.
         report.warnings.append("terraform not installed; skipping infra-writer check (graceful degradation)")
         return report
 
@@ -353,20 +413,29 @@ def check(
         report.warnings.append(f"no infra invariants declared (config not found: {config_path})")
         return report
 
+    # From here on the repo HAS declared infra invariants — failing to read or
+    # understand the declaration means the gate could not evaluate them, which
+    # must be a gate-failing finding (malformed), not a warning.
     try:
         raw = json.loads(config_path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
-        report.warnings.append(f"cannot parse config {config_path}: {exc}")
+        report.malformed.append({"source": str(config_path), "reason": f"cannot parse config: {exc}"})
         return report
     if not isinstance(raw, list):
-        report.warnings.append(f"config {config_path} must be a JSON array of invariants")
+        report.malformed.append({
+            "source": str(config_path),
+            "reason": "config must be a JSON array of invariants",
+        })
         return report
 
     invariants, malformed = _parse_invariants(raw)
     report.malformed = malformed
     if not invariants:
-        report.warnings.append("no valid infra invariants found; nothing to check")
+        if not raw:
+            report.warnings.append("config declares no invariants; nothing to check")
         return report
+
+    base_root = Path(repo_root).resolve() if repo_root is not None else _find_repo_root(config_path)
 
     exemptions_root = Path(exemptions_dir) if exemptions_dir is not None else config_path.parent / "exemptions"
     exemptions, exemption_malformed = load_exemptions(exemptions_root)
@@ -377,18 +446,29 @@ def check(
         {**e.to_dict(), "reason": "exemption expired"} for e in exemptions if e.is_expired(check_today)
     ]
 
-    journal = Path(journal_path) if journal_path is not None else DEFAULT_JOURNAL
+    # The journal lands in the target repo's docs/quality/, not the caller's CWD.
+    journal = Path(journal_path) if journal_path is not None else base_root / DEFAULT_JOURNAL_REL
     run = runner or _default_runner
 
     for inv in invariants:
-        root = Path(inv.terraform_root)
+        base = {
+            "invariant_id": inv.id,
+            "controls_field": inv.controls_field,
+            "terraform_root": inv.terraform_root,
+        }
+
+        root = _resolve_terraform_root(base_root, inv.terraform_root)
+        if root is None:
+            report.errors.append({
+                **base, "status": "error",
+                "reason": f"terraform_root escapes repo root {base_root} "
+                          "(absolute paths and .. traversal are rejected)",
+            })
+            continue
         if not root.is_dir():
             report.errors.append({
-                "invariant_id": inv.id,
-                "controls_field": inv.controls_field,
-                "terraform_root": inv.terraform_root,
-                "status": "error",
-                "reason": f"terraform_root not found: {inv.terraform_root}",
+                **base, "status": "error",
+                "reason": f"terraform_root not found: {root}",
             })
             continue
 
@@ -396,31 +476,20 @@ def check(
             proc = run(root)
         except (OSError, subprocess.TimeoutExpired) as exc:
             report.errors.append({
-                "invariant_id": inv.id,
-                "controls_field": inv.controls_field,
-                "terraform_root": inv.terraform_root,
-                "status": "error",
+                **base, "status": "error",
                 "reason": f"terraform plan failed to run: {exc}",
             })
             continue
 
         exit_code = proc.returncode
         stdout = proc.stdout or ""
-        base = {
-            "invariant_id": inv.id,
-            "controls_field": inv.controls_field,
-            "terraform_root": inv.terraform_root,
-            "sanctioned_writers": inv.sanctioned_writers,
-            "exit_code": exit_code,
-        }
+        base = {**base, "sanctioned_writers": inv.sanctioned_writers, "exit_code": exit_code}
 
         if exit_code == 0:
             report.checked.append({**base, "status": "clean"})
         elif exit_code == 2:
-            # DRIFT: an unsanctioned write happened out-of-band. This is an EVENT —
-            # journal it before anything else, so a later clean plan (convergence)
-            # never erases evidence the drift occurred.
-            append_drift_journal(journal, inv.id, inv.terraform_root, stdout)
+            # DRIFT: an unsanctioned write happened out-of-band. Record the
+            # FINDING first — a journal-write failure must never swallow it.
             plan_excerpt = stdout.splitlines()[:10]
             active = _find_active_exemption(exemptions, inv.controls_field, check_today)
             if active:
@@ -430,6 +499,18 @@ def check(
                 })
             else:
                 report.drift.append({**base, "status": "drift", "plan_excerpt": plan_excerpt})
+            # Drift is an EVENT — journal it so a later clean plan (convergence)
+            # never erases the evidence. A failed write is an explicit error
+            # finding (gate-failing): silently losing the event would defeat
+            # the append-only journal's purpose. It must not crash report-only
+            # mode either — the full report still renders.
+            try:
+                append_drift_journal(journal, inv.id, inv.terraform_root, stdout)
+            except OSError as exc:
+                report.errors.append({
+                    **base, "status": "error",
+                    "reason": f"drift detected but journal write failed ({journal}): {exc}",
+                })
         elif exit_code == 1:
             # terraform ERROR — never conflate with drift.
             report.errors.append({
@@ -486,7 +567,7 @@ def render_text(report: InfraDriftReport) -> str:
         for e in report.expired_exemptions:
             lines.append(f"- {e['source']} scope=`{e['scope']}` expired {e['expiry']} (approver {e['approver']})")
     if report.errors:
-        lines += ["", "## Errors (terraform failed to run — not drift)", ""]
+        lines += ["", "## Errors (could not evaluate — gate-failing, but not drift)", ""]
         for e in report.errors:
             lines.append(f"- {e['invariant_id']} root={e['terraform_root']}: {e.get('reason', '')}")
     if report.malformed:
@@ -508,13 +589,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to infra-invariants JSON config")
     parser.add_argument(
+        "--repo",
+        help="Target repo root that terraform_root entries and the drift journal resolve "
+        "against (default: derived from the config file's location, never CWD)",
+    )
+    parser.add_argument(
         "--gate", action="store_true",
-        help="Fail (exit 1) on unexempted drift or an expired exemption; default is report-only",
+        help="Fail (exit 1) on unexempted drift, an expired exemption, or any error/malformed "
+        "finding that prevented evaluating an invariant (terraform exit 1, missing/escaping "
+        "root, failed journal write, bad declaration); default is report-only. Terraform not "
+        "being installed at all remains graceful degradation (exit 0)",
     )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
 
-    report = check(args.config)
+    report = check(args.config, repo_root=args.repo)
 
     if args.format == "json":
         print(json.dumps(report.to_dict(), indent=2))
@@ -527,7 +616,8 @@ def main(argv: list[str] | None = None) -> int:
         if _here not in sys.path:
             sys.path.insert(0, _here)
         from factory_log import emit_gate
-        caught = len(report.drift) + len(report.expired_exemptions)
+        caught = (len(report.drift) + len(report.expired_exemptions)
+                  + len(report.errors) + len(report.malformed))
         emit_gate(
             "check_infra_writer",
             "fail" if caught else "pass",

--- a/tests/test_check_infra_writer.py
+++ b/tests/test_check_infra_writer.py
@@ -23,15 +23,21 @@ def _write_config(tmp_path, entries):
     return config
 
 
-def _basic_invariant(root_dir, **overrides) -> dict:
+def _basic_invariant(terraform_root: str = "infra", **overrides) -> dict:
     entry = {
         "id": "INV-infra-001",
         "controls_field": "infra.env-secrets",
         "sanctioned_writers": ["terraform"],
-        "terraform_root": str(root_dir),
+        "terraform_root": terraform_root,
     }
     entry.update(overrides)
     return entry
+
+
+def _setup_repo(tmp_path, entries=None):
+    """A minimal 'repo': config at tmp_path, terraform root at tmp_path/infra."""
+    (tmp_path / "infra").mkdir()
+    return _write_config(tmp_path, entries if entries is not None else [_basic_invariant()])
 
 
 # --- invariant declaration parsing -------------------------------------------
@@ -85,11 +91,10 @@ def test_parse_non_object_entry_is_malformed():
 
 
 def test_exit_code_0_is_clean(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+    config = _setup_repo(tmp_path)
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         runner=lambda r: _fake_proc(0, stdout="No changes."),
         journal_path=tmp_path / "journal.jsonl",
         available=True,
@@ -102,11 +107,10 @@ def test_exit_code_0_is_clean(tmp_path):
 
 
 def test_exit_code_2_is_drift(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+    config = _setup_repo(tmp_path)
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         runner=lambda r: _fake_proc(2, stdout="~ update in place\n" * 3),
         journal_path=tmp_path / "journal.jsonl",
         available=True,
@@ -119,89 +123,201 @@ def test_exit_code_2_is_drift(tmp_path):
     assert report.errors == []
 
 
-def test_exit_code_1_is_error_not_drift(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+def test_exit_code_1_is_error_not_drift_and_fails_gate(tmp_path):
+    config = _setup_repo(tmp_path)
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         runner=lambda r: _fake_proc(1, stderr="Error: no valid credential source found"),
         journal_path=tmp_path / "journal.jsonl",
         available=True,
     )
-    # A terraform error must not be conflated with drift, and does not gate-fail.
-    assert report.gate_ok
+    # A terraform error must not be conflated with drift, but the gate could not
+    # evaluate the invariant — so it must FAIL the gate, not silently pass.
+    assert not report.gate_ok
     assert report.drift == []
     assert len(report.errors) == 1
     assert report.errors[0]["status"] == "error"
     assert "credential" in report.errors[0]["reason"]
 
 
-def test_unexpected_exit_code_is_error(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+def test_unexpected_exit_code_is_error_and_fails_gate(tmp_path):
+    config = _setup_repo(tmp_path)
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         runner=lambda r: _fake_proc(3),
         journal_path=tmp_path / "journal.jsonl",
         available=True,
     )
-    assert report.gate_ok
+    assert not report.gate_ok
     assert report.drift == []
     assert len(report.errors) == 1
     assert "unexpected terraform exit code 3" in report.errors[0]["reason"]
 
 
-def test_terraform_root_missing_is_error(tmp_path):
-    config = _write_config(tmp_path, [_basic_invariant(tmp_path / "does-not-exist")])
+def test_terraform_root_missing_is_error_and_fails_gate(tmp_path):
+    config = _write_config(tmp_path, [_basic_invariant("does-not-exist")])
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         runner=lambda r: _fake_proc(0),
         journal_path=tmp_path / "journal.jsonl",
         available=True,
     )
-    assert report.gate_ok  # errors don't gate, only drift/expired exemptions do
+    assert not report.gate_ok  # could not evaluate -> gate fails
     assert len(report.errors) == 1
     assert "not found" in report.errors[0]["reason"]
+
+
+def test_malformed_declaration_fails_gate(tmp_path):
+    config = _write_config(tmp_path, [{"id": "not-an-id"}])
+    report = ciw.check(config, repo_root=tmp_path, runner=lambda r: _fake_proc(0), available=True)
+    assert not report.gate_ok
+    assert report.malformed
+
+
+def test_unparseable_config_is_malformed_and_fails_gate(tmp_path):
+    config = tmp_path / "infra-invariants.json"
+    config.write_text("{not json")
+    report = ciw.check(config, repo_root=tmp_path, available=True)
+    assert not report.gate_ok
+    assert report.malformed and "cannot parse config" in report.malformed[0]["reason"]
+
+
+def test_non_array_config_is_malformed_and_fails_gate(tmp_path):
+    config = tmp_path / "infra-invariants.json"
+    config.write_text(json.dumps({"id": "INV-infra-001"}))
+    report = ciw.check(config, repo_root=tmp_path, available=True)
+    assert not report.gate_ok
+    assert report.malformed and "JSON array" in report.malformed[0]["reason"]
+
+
+def test_empty_config_array_is_ok(tmp_path):
+    config = _write_config(tmp_path, [])
+    report = ciw.check(config, repo_root=tmp_path, available=True)
+    assert report.gate_ok
+    assert any("no invariants" in w for w in report.warnings)
+
+
+# --- terraform_root resolution: repo-rooted, never CWD -------------------------
+
+
+def test_terraform_root_resolves_from_repo_root_not_cwd(tmp_path, monkeypatch):
+    """The declared root must resolve against the repo root (derived from the
+    config file's location), regardless of the directory the check runs from."""
+    config = _setup_repo(tmp_path)
+    elsewhere = tmp_path / "unrelated-cwd"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    seen_roots = []
+
+    def runner(root):
+        seen_roots.append(root)
+        return _fake_proc(0)
+
+    # No explicit repo_root: derived from the config's location (tmp_path).
+    report = ciw.check(config, runner=runner, journal_path=tmp_path / "j.jsonl", available=True)
+    assert report.gate_ok
+    assert len(report.checked) == 1
+    assert seen_roots == [(tmp_path / "infra").resolve()]
+
+
+def test_absolute_terraform_root_is_rejected(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(str(outside))])
+    report = ciw.check(config, repo_root=tmp_path, runner=lambda r: _fake_proc(0), available=True)
+    assert not report.gate_ok
+    assert len(report.errors) == 1
+    assert "escapes repo root" in report.errors[0]["reason"]
+
+
+def test_dotdot_terraform_root_is_rejected(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "sibling").mkdir()
+    config = _write_config(repo, [_basic_invariant("../sibling")])
+    report = ciw.check(config, repo_root=repo, runner=lambda r: _fake_proc(0), available=True)
+    assert not report.gate_ok
+    assert len(report.errors) == 1
+    assert "escapes repo root" in report.errors[0]["reason"]
+
+
+def test_default_journal_lands_in_repo_root(tmp_path, monkeypatch):
+    config = _setup_repo(tmp_path)
+    elsewhere = tmp_path / "unrelated-cwd"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    ciw.check(config, repo_root=tmp_path, runner=lambda r: _fake_proc(2, stdout="drift"), available=True)
+
+    assert (tmp_path / "docs" / "quality" / "infra-drift.jsonl").exists()
+    assert not (elsewhere / "docs").exists()  # nothing written relative to CWD
 
 
 # --- journaling: drift is an event, not just a state --------------------------
 
 
 def test_drift_appends_journal_record(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+    config = _setup_repo(tmp_path)
     journal = tmp_path / "journal.jsonl"
     plan_output = "\n".join(f"line {i}" for i in range(60))  # more than 40 lines
-    ciw.check(config, runner=lambda r: _fake_proc(2, stdout=plan_output), journal_path=journal, available=True)
+    ciw.check(
+        config, repo_root=tmp_path,
+        runner=lambda r: _fake_proc(2, stdout=plan_output),
+        journal_path=journal, available=True,
+    )
 
     assert journal.exists()
     records = [json.loads(line) for line in journal.read_text().splitlines()]
     assert len(records) == 1
     rec = records[0]
     assert rec["invariant"] == "INV-infra-001"
-    assert rec["root"] == str(root)
+    assert rec["root"] == "infra"
     assert len(rec["plan_summary_first_40_lines"]) == 40
     assert rec["plan_summary_first_40_lines"][0] == "line 0"
     assert "ts" in rec
 
 
 def test_journal_is_append_only_across_runs(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+    config = _setup_repo(tmp_path)
     journal = tmp_path / "journal.jsonl"
 
     # First run: drift.
-    ciw.check(config, runner=lambda r: _fake_proc(2, stdout="drift #1"), journal_path=journal, available=True)
+    ciw.check(config, repo_root=tmp_path, runner=lambda r: _fake_proc(2, stdout="drift #1"),
+              journal_path=journal, available=True)
     # Second run: clean (convergence) — must NOT erase the earlier drift record.
-    ciw.check(config, runner=lambda r: _fake_proc(0), journal_path=journal, available=True)
+    ciw.check(config, repo_root=tmp_path, runner=lambda r: _fake_proc(0),
+              journal_path=journal, available=True)
 
     records = [json.loads(line) for line in journal.read_text().splitlines()]
     assert len(records) == 1  # only the drift run journaled; the clean run added nothing
     assert records[0]["plan_summary_first_40_lines"] == ["drift #1"]
+
+
+def test_unwritable_journal_still_reports_drift(tmp_path):
+    """A journal-write failure must not crash report-only mode or swallow the
+    drift finding: the drift is recorded FIRST, and the failed write becomes an
+    explicit (gate-failing) error finding."""
+    config = _setup_repo(tmp_path)
+    blocker = tmp_path / "blocked"
+    blocker.write_text("a file where the journal's parent dir should be")
+    journal = blocker / "journal.jsonl"  # parent is a file -> mkdir/open raises OSError
+
+    report = ciw.check(
+        config, repo_root=tmp_path,
+        runner=lambda r: _fake_proc(2, stdout="drift"),
+        journal_path=journal, available=True,
+    )
+    assert len(report.drift) == 1  # the finding survived the failed journal write
+    assert len(report.errors) == 1
+    assert "journal write failed" in report.errors[0]["reason"]
+    assert not report.gate_ok
+    # Report-only mode still renders the full report without raising.
+    rendered = ciw.render_text(report)
+    assert "Drift" in rendered and "journal write failed" in rendered
 
 
 # --- exemption lifecycle: active / expired -----------------------------------
@@ -221,14 +337,13 @@ def _write_exemption(exemptions_dir, name="exempt.json", **overrides) -> None:
 
 
 def test_active_exemption_downgrades_drift(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
+    config = _setup_repo(tmp_path)
     exemptions_dir = tmp_path / "exemptions"
     _write_exemption(exemptions_dir, expiry="2099-01-01")
-    config = _write_config(tmp_path, [_basic_invariant(root)])
 
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         exemptions_dir=exemptions_dir,
         runner=lambda r: _fake_proc(2, stdout="drift"),
         journal_path=tmp_path / "journal.jsonl",
@@ -245,14 +360,13 @@ def test_active_exemption_downgrades_drift(tmp_path):
 
 
 def test_expired_exemption_does_not_downgrade_and_is_itself_a_finding(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
+    config = _setup_repo(tmp_path)
     exemptions_dir = tmp_path / "exemptions"
     _write_exemption(exemptions_dir, expiry="2020-01-01")
-    config = _write_config(tmp_path, [_basic_invariant(root)])
 
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         exemptions_dir=exemptions_dir,
         runner=lambda r: _fake_proc(2, stdout="drift"),
         journal_path=tmp_path / "journal.jsonl",
@@ -267,14 +381,13 @@ def test_expired_exemption_does_not_downgrade_and_is_itself_a_finding(tmp_path):
 
 
 def test_exemption_scope_mismatch_does_not_apply(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
+    config = _setup_repo(tmp_path)
     exemptions_dir = tmp_path / "exemptions"
     _write_exemption(exemptions_dir, scope="infra.other-scope", expiry="2099-01-01")
-    config = _write_config(tmp_path, [_basic_invariant(root)])
 
     report = ciw.check(
         config,
+        repo_root=tmp_path,
         exemptions_dir=exemptions_dir,
         runner=lambda r: _fake_proc(2, stdout="drift"),
         journal_path=tmp_path / "journal.jsonl",
@@ -286,17 +399,22 @@ def test_exemption_scope_mismatch_does_not_apply(tmp_path):
     assert report.exempted == []
 
 
-def test_malformed_exemption_is_reported():
-    exemptions_dir_content = {"scope": "x"}  # missing required fields
-    # exercised via load_exemptions directly for a focused unit test
-    import tempfile
-    from pathlib import Path
-    with tempfile.TemporaryDirectory() as d:
-        p = Path(d) / "bad.json"
-        p.write_text(json.dumps(exemptions_dir_content))
-        exemptions, malformed = ciw.load_exemptions(Path(d))
-        assert exemptions == []
-        assert malformed and "missing field" in malformed[0]["reason"]
+def test_malformed_exemption_is_reported_and_fails_gate(tmp_path):
+    config = _setup_repo(tmp_path)
+    exemptions_dir = tmp_path / "exemptions"
+    exemptions_dir.mkdir()
+    (exemptions_dir / "bad.json").write_text(json.dumps({"scope": "x"}))  # missing fields
+
+    report = ciw.check(
+        config,
+        repo_root=tmp_path,
+        exemptions_dir=exemptions_dir,
+        runner=lambda r: _fake_proc(0),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    assert not report.gate_ok
+    assert report.malformed and "missing field" in report.malformed[0]["reason"]
 
 
 def test_missing_exemptions_dir_degrades_gracefully(tmp_path):
@@ -309,15 +427,14 @@ def test_missing_exemptions_dir_degrades_gracefully(tmp_path):
 
 
 def test_terraform_unavailable_degrades_gracefully(tmp_path):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+    config = _setup_repo(tmp_path)
 
     def _boom(r):
         raise AssertionError("runner must not be called when terraform is unavailable")
 
-    report = ciw.check(config, runner=_boom, available=False)
+    report = ciw.check(config, repo_root=tmp_path, runner=_boom, available=False)
     assert report.available is False
+    assert report.gate_ok  # the ONE graceful-degradation exception
     assert report.checked == []
     assert report.drift == []
     assert any("not installed" in w for w in report.warnings)
@@ -343,53 +460,52 @@ def test_authority_line_present_in_report_and_text(tmp_path):
 # --- CLI: gate behavior --------------------------------------------------------
 
 
-def test_cli_report_only_exits_0_on_drift(tmp_path, monkeypatch, capsys):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
+def _cli_setup(tmp_path, monkeypatch, returncode: int, entries=None, stdout: str = "", stderr: str = ""):
+    config = _setup_repo(tmp_path, entries)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(ciw, "terraform_available", lambda: True)
-    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(2, stdout="drift"))
+    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(returncode, stdout=stdout, stderr=stderr))
+    return config
 
-    rc = ciw.main(["--config", str(config)])
+
+def test_cli_report_only_exits_0_on_drift(tmp_path, monkeypatch, capsys):
+    config = _cli_setup(tmp_path, monkeypatch, 2, stdout="drift")
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path)])
     assert rc == 0
     out = capsys.readouterr().out
     assert "Drift" in out
 
 
 def test_cli_gate_exits_1_on_unexempted_drift(tmp_path, monkeypatch, capsys):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
-    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(2, stdout="drift"))
+    config = _cli_setup(tmp_path, monkeypatch, 2, stdout="drift")
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path), "--gate"])
+    assert rc == 1
 
-    rc = ciw.main(["--config", str(config), "--gate"])
+
+def test_cli_gate_exits_1_on_terraform_error(tmp_path, monkeypatch, capsys):
+    config = _cli_setup(tmp_path, monkeypatch, 1, stderr="Error: backend init failed")
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path), "--gate"])
+    assert rc == 1
+    # ...but report-only still exits 0 on the same error.
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path)])
+    assert rc == 0
+
+
+def test_cli_gate_exits_1_on_malformed_config(tmp_path, monkeypatch, capsys):
+    config = _cli_setup(tmp_path, monkeypatch, 0, entries=[{"id": "not-an-id"}])
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path), "--gate"])
     assert rc == 1
 
 
 def test_cli_gate_passes_on_clean_plan(tmp_path, monkeypatch, capsys):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
-    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(0))
-
-    rc = ciw.main(["--config", str(config), "--gate"])
+    config = _cli_setup(tmp_path, monkeypatch, 0)
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path), "--gate"])
     assert rc == 0
 
 
 def test_cli_json_format(tmp_path, monkeypatch, capsys):
-    root = tmp_path / "infra"
-    root.mkdir()
-    config = _write_config(tmp_path, [_basic_invariant(root)])
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
-    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(0))
-
-    rc = ciw.main(["--config", str(config), "--format", "json"])
+    config = _cli_setup(tmp_path, monkeypatch, 0)
+    rc = ciw.main(["--config", str(config), "--repo", str(tmp_path), "--format", "json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["available"] is True

--- a/tests/test_check_infra_writer.py
+++ b/tests/test_check_infra_writer.py
@@ -1,0 +1,415 @@
+"""Tests for the infra single-writer / terraform-drift checker (#165).
+
+Subprocess (``terraform plan``) is always mocked via the ``runner`` seam —
+these tests never shell out to a real terraform binary.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import date
+
+import check_infra_writer as ciw
+
+
+def _fake_proc(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=ciw.TERRAFORM_PLAN_ARGS, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_config(tmp_path, entries):
+    config = tmp_path / "infra-invariants.json"
+    config.write_text(json.dumps(entries))
+    return config
+
+
+def _basic_invariant(root_dir, **overrides) -> dict:
+    entry = {
+        "id": "INV-infra-001",
+        "controls_field": "infra.env-secrets",
+        "sanctioned_writers": ["terraform"],
+        "terraform_root": str(root_dir),
+    }
+    entry.update(overrides)
+    return entry
+
+
+# --- invariant declaration parsing -------------------------------------------
+
+
+def test_parse_valid_invariant():
+    invs, malformed = ciw._parse_invariants([
+        {
+            "id": "INV-infra-001",
+            "controls_field": "infra.env-secrets",
+            "sanctioned_writers": ["terraform"],
+            "terraform_root": "infra/",
+            "schedule_note": "nightly cron",
+        }
+    ])
+    assert malformed == []
+    assert len(invs) == 1
+    inv = invs[0]
+    assert inv.id == "INV-infra-001"
+    assert inv.controls_field == "infra.env-secrets"
+    assert inv.sanctioned_writers == ["terraform"]
+    assert inv.terraform_root == "infra/"
+    assert inv.schedule_note == "nightly cron"
+
+
+def test_parse_invalid_id_is_malformed():
+    invs, malformed = ciw._parse_invariants([
+        {"id": "not-an-id", "controls_field": "infra.x", "sanctioned_writers": ["terraform"], "terraform_root": "infra/"}
+    ])
+    assert invs == []
+    assert malformed and "invalid or missing id" in malformed[0]["reason"]
+
+
+def test_parse_missing_fields_is_malformed():
+    invs, malformed = ciw._parse_invariants([{"id": "INV-infra-001"}])
+    assert invs == []
+    assert malformed
+    reason = malformed[0]["reason"]
+    assert "controls_field" in reason
+    assert "sanctioned_writers" in reason
+    assert "terraform_root" in reason
+
+
+def test_parse_non_object_entry_is_malformed():
+    invs, malformed = ciw._parse_invariants(["oops"])
+    assert invs == []
+    assert malformed and malformed[0]["index"] == 0
+
+
+# --- exit-code mapping (0/1/2) ------------------------------------------------
+
+
+def test_exit_code_0_is_clean(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    report = ciw.check(
+        config,
+        runner=lambda r: _fake_proc(0, stdout="No changes."),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    assert report.gate_ok
+    assert len(report.checked) == 1
+    assert report.checked[0]["status"] == "clean"
+    assert report.drift == []
+    assert not (tmp_path / "journal.jsonl").exists()
+
+
+def test_exit_code_2_is_drift(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    report = ciw.check(
+        config,
+        runner=lambda r: _fake_proc(2, stdout="~ update in place\n" * 3),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    assert not report.gate_ok
+    assert len(report.drift) == 1
+    assert report.drift[0]["invariant_id"] == "INV-infra-001"
+    assert report.drift[0]["status"] == "drift"
+    assert report.exempted == []
+    assert report.errors == []
+
+
+def test_exit_code_1_is_error_not_drift(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    report = ciw.check(
+        config,
+        runner=lambda r: _fake_proc(1, stderr="Error: no valid credential source found"),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    # A terraform error must not be conflated with drift, and does not gate-fail.
+    assert report.gate_ok
+    assert report.drift == []
+    assert len(report.errors) == 1
+    assert report.errors[0]["status"] == "error"
+    assert "credential" in report.errors[0]["reason"]
+
+
+def test_unexpected_exit_code_is_error(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    report = ciw.check(
+        config,
+        runner=lambda r: _fake_proc(3),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    assert report.gate_ok
+    assert report.drift == []
+    assert len(report.errors) == 1
+    assert "unexpected terraform exit code 3" in report.errors[0]["reason"]
+
+
+def test_terraform_root_missing_is_error(tmp_path):
+    config = _write_config(tmp_path, [_basic_invariant(tmp_path / "does-not-exist")])
+    report = ciw.check(
+        config,
+        runner=lambda r: _fake_proc(0),
+        journal_path=tmp_path / "journal.jsonl",
+        available=True,
+    )
+    assert report.gate_ok  # errors don't gate, only drift/expired exemptions do
+    assert len(report.errors) == 1
+    assert "not found" in report.errors[0]["reason"]
+
+
+# --- journaling: drift is an event, not just a state --------------------------
+
+
+def test_drift_appends_journal_record(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    journal = tmp_path / "journal.jsonl"
+    plan_output = "\n".join(f"line {i}" for i in range(60))  # more than 40 lines
+    ciw.check(config, runner=lambda r: _fake_proc(2, stdout=plan_output), journal_path=journal, available=True)
+
+    assert journal.exists()
+    records = [json.loads(line) for line in journal.read_text().splitlines()]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["invariant"] == "INV-infra-001"
+    assert rec["root"] == str(root)
+    assert len(rec["plan_summary_first_40_lines"]) == 40
+    assert rec["plan_summary_first_40_lines"][0] == "line 0"
+    assert "ts" in rec
+
+
+def test_journal_is_append_only_across_runs(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    journal = tmp_path / "journal.jsonl"
+
+    # First run: drift.
+    ciw.check(config, runner=lambda r: _fake_proc(2, stdout="drift #1"), journal_path=journal, available=True)
+    # Second run: clean (convergence) — must NOT erase the earlier drift record.
+    ciw.check(config, runner=lambda r: _fake_proc(0), journal_path=journal, available=True)
+
+    records = [json.loads(line) for line in journal.read_text().splitlines()]
+    assert len(records) == 1  # only the drift run journaled; the clean run added nothing
+    assert records[0]["plan_summary_first_40_lines"] == ["drift #1"]
+
+
+# --- exemption lifecycle: active / expired -----------------------------------
+
+
+def _write_exemption(exemptions_dir, name="exempt.json", **overrides) -> None:
+    exemptions_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "scope": "infra.env-secrets",
+        "reason": "planned migration",
+        "expiry": "2099-01-01",
+        "approver": "pat",
+        "incident_ref": "INC-42",
+    }
+    record.update(overrides)
+    (exemptions_dir / name).write_text(json.dumps(record))
+
+
+def test_active_exemption_downgrades_drift(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    exemptions_dir = tmp_path / "exemptions"
+    _write_exemption(exemptions_dir, expiry="2099-01-01")
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+
+    report = ciw.check(
+        config,
+        exemptions_dir=exemptions_dir,
+        runner=lambda r: _fake_proc(2, stdout="drift"),
+        journal_path=tmp_path / "journal.jsonl",
+        today=date(2026, 7, 19),
+        available=True,
+    )
+    assert report.gate_ok  # exempted drift does not gate-fail
+    assert report.drift == []
+    assert len(report.exempted) == 1
+    assert report.exempted[0]["exemption"]["incident_ref"] == "INC-42"
+    # Still journaled even though exempted — break-glass doesn't erase the event.
+    journal_records = [json.loads(line) for line in (tmp_path / "journal.jsonl").read_text().splitlines()]
+    assert len(journal_records) == 1
+
+
+def test_expired_exemption_does_not_downgrade_and_is_itself_a_finding(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    exemptions_dir = tmp_path / "exemptions"
+    _write_exemption(exemptions_dir, expiry="2020-01-01")
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+
+    report = ciw.check(
+        config,
+        exemptions_dir=exemptions_dir,
+        runner=lambda r: _fake_proc(2, stdout="drift"),
+        journal_path=tmp_path / "journal.jsonl",
+        today=date(2026, 7, 19),
+        available=True,
+    )
+    assert not report.gate_ok
+    assert len(report.drift) == 1  # expired exemption does NOT downgrade
+    assert report.exempted == []
+    assert len(report.expired_exemptions) == 1
+    assert report.expired_exemptions[0]["scope"] == "infra.env-secrets"
+
+
+def test_exemption_scope_mismatch_does_not_apply(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    exemptions_dir = tmp_path / "exemptions"
+    _write_exemption(exemptions_dir, scope="infra.other-scope", expiry="2099-01-01")
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+
+    report = ciw.check(
+        config,
+        exemptions_dir=exemptions_dir,
+        runner=lambda r: _fake_proc(2, stdout="drift"),
+        journal_path=tmp_path / "journal.jsonl",
+        today=date(2026, 7, 19),
+        available=True,
+    )
+    assert not report.gate_ok
+    assert len(report.drift) == 1
+    assert report.exempted == []
+
+
+def test_malformed_exemption_is_reported():
+    exemptions_dir_content = {"scope": "x"}  # missing required fields
+    # exercised via load_exemptions directly for a focused unit test
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "bad.json"
+        p.write_text(json.dumps(exemptions_dir_content))
+        exemptions, malformed = ciw.load_exemptions(Path(d))
+        assert exemptions == []
+        assert malformed and "missing field" in malformed[0]["reason"]
+
+
+def test_missing_exemptions_dir_degrades_gracefully(tmp_path):
+    exemptions, malformed = ciw.load_exemptions(tmp_path / "nope")
+    assert exemptions == []
+    assert malformed == []
+
+
+# --- terraform availability degradation --------------------------------------
+
+
+def test_terraform_unavailable_degrades_gracefully(tmp_path):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+
+    def _boom(r):
+        raise AssertionError("runner must not be called when terraform is unavailable")
+
+    report = ciw.check(config, runner=_boom, available=False)
+    assert report.available is False
+    assert report.checked == []
+    assert report.drift == []
+    assert any("not installed" in w for w in report.warnings)
+
+
+def test_missing_config_degrades_gracefully(tmp_path):
+    report = ciw.check(tmp_path / "no-such-config.json", available=True)
+    assert report.gate_ok
+    assert report.checked == []
+    assert any("not found" in w or "no infra invariants" in w for w in report.warnings)
+
+
+# --- authority line always present --------------------------------------------
+
+
+def test_authority_line_present_in_report_and_text(tmp_path):
+    report = ciw.check(tmp_path / "nope.json", available=True)
+    assert ciw.AUTHORITY in report.authority
+    rendered = ciw.render_text(report)
+    assert ciw.AUTHORITY in rendered
+
+
+# --- CLI: gate behavior --------------------------------------------------------
+
+
+def test_cli_report_only_exits_0_on_drift(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
+    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(2, stdout="drift"))
+
+    rc = ciw.main(["--config", str(config)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Drift" in out
+
+
+def test_cli_gate_exits_1_on_unexempted_drift(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
+    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(2, stdout="drift"))
+
+    rc = ciw.main(["--config", str(config), "--gate"])
+    assert rc == 1
+
+
+def test_cli_gate_passes_on_clean_plan(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
+    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(0))
+
+    rc = ciw.main(["--config", str(config), "--gate"])
+    assert rc == 0
+
+
+def test_cli_json_format(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "infra"
+    root.mkdir()
+    config = _write_config(tmp_path, [_basic_invariant(root)])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ciw, "terraform_available", lambda: True)
+    monkeypatch.setattr(ciw, "_default_runner", lambda r: _fake_proc(0))
+
+    rc = ciw.main(["--config", str(config), "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["available"] is True
+    assert payload["gate_ok"] is True
+    assert payload["authority"] == ciw.AUTHORITY
+
+
+def test_cli_terraform_missing_exits_0(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(ciw, "terraform_available", lambda: False)
+    rc = ciw.main(["--config", str(tmp_path / "irrelevant.json"), "--gate"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "NOT AVAILABLE" in out
+
+
+# --- ID validation guarded import ---------------------------------------------
+
+
+def test_valid_inv_id_accepts_shared_shape():
+    assert ciw._valid_inv_id("INV-infra-001")
+    assert ciw._valid_inv_id("INV-INFRA-001")
+    assert not ciw._valid_inv_id("INV-infra-1")
+    assert not ciw._valid_inv_id("not-an-id")


### PR DESCRIPTION
## Summary

Closes #165. Extends the single-writer invariant idiom (`check_single_writer.py`) to infrastructure: "terraform owns env/secrets; CI only pushes images" becomes a declared, checked contract instead of a memory-file rule. Pilot target: the Dogeared deploy's `enable_cicd` footgun.

- **Declaration**: infra invariants (`INV-*`) in a JSON config (default `docs/system/infra-invariants.json`): `controls_field`, `sanctioned_writers`, `terraform_root`, optional `schedule_note`. ID validated against the shared grammar (`scripts/chief_wiggum/trace_ids.py`, landed on `main` via #172) when present, guarded/optional so the checker still works standalone.
- **Check**: `terraform plan -detailed-exitcode -input=false -lock=false -no-color` per declared root via `subprocess` (never a shell). Exit `0` = clean, `2` = drift, `1` = terraform error (never conflated with drift). Missing `terraform` binary degrades gracefully — `{"available": false, ...}`, exit 0, mirroring `lsp_query.py`.
- **Drift is an event**: every detected drift (exempted or not) appends an append-only JSONL record to `docs/quality/infra-drift.jsonl` — convergence later does not erase it.
- **Break-glass**: committed exemption records in `docs/system/exemptions/*.json` (`scope`, `reason`, `expiry`, `approver`, `incident_ref`). An active exemption downgrades drift to `exempted` (still journaled); an expired exemption is itself a finding.
- **CLI**: `check_infra_writer.py [--config path] [--gate] [--format text|json]`. Report-only by default (per `docs/gate-rollout.md`); `--gate` hard-fails on unexempted drift or an expired exemption. Every report states the authority boundary: "proves declared state matches live state at scan time for scanned roots; does not prove no out-of-band write occurred between scans."
- `docs/single-writer.md` updated with the infra extension section.

## Test plan

- [x] 25 new tests in `tests/test_check_infra_writer.py` — exit-code mapping (0/1/2), journaling (including append-only across runs), exemption active/expired/scope-mismatch, malformed declarations/exemptions, terraform-unavailable and missing-config graceful degradation, CLI report-only vs `--gate` behavior, JSON output, guarded shared-ID-grammar validation. All subprocess calls mocked via an injectable `runner` seam — no real terraform is invoked.
- [x] Full suite: `python3 -m pytest tests/ -q` → 815 passed, 4 skipped (pre-existing skips unrelated to this change).
- [x] `ruff check` clean on both new files.
- [x] Manual smoke test of a seeded-drift scenario end-to-end (fake `terraform plan` exit 2 → journal record written, `--gate` semantics verified).

## Deviations

None — implemented per the issue's settled design decisions.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF