### PR TITLE
feat(system): check_budget_tree.py — typed NFR budget trees with union-bound tail arithmetic (#164)

### DIFF
--- a/docs/budget-trees.md
+++ b/docs/budget-trees.md
@@ -39,6 +39,18 @@ true union bound, not a sum of the underlying random variables. A tree may
 opt into `arithmetic: "naive"` (plain sum-of-bounds, ignoring alpha), but that
 mode is **WARN-only and can never gate a workflow**, regardless of `--gate`.
 
+Two structural preconditions keep the sound check sound:
+
+- **Alphas must be declared.** In a union-bound tree, a non-leaf node without
+  its own `alpha`, or any child/residual without `alpha`, is a **structure
+  finding** — missing alphas must never silently degrade the union-bound
+  check into a naive sum-of-bounds. (Naive trees don't use alpha, so they
+  don't require it.)
+- **Kind/unit homogeneity.** Every child and residual must carry the same
+  `kind` and `unit` as its parent — a ms parent must not sum usd/tokens
+  children. A mismatch is a **structure finding** and the meaningless mixed
+  sums are skipped.
+
 ## Coverage: the residual bucket
 
 Every node that declares `children` **must** also declare a `residual` child
@@ -66,18 +78,20 @@ worst-case occupancy beyond what a single-hop timeout chain models.
 
 ## Two modes
 
-- **static** (default): well-formedness + arithmetic + monotonicity.
-  `--gate` fails (exit 1) on **structure/arithmetic findings only** —
-  monotonicity and naive-arithmetic are advisory and never gate.
+- **static** (default): schema validation + well-formedness + arithmetic +
+  monotonicity. `--gate` fails (exit 1) on **schema/structure/arithmetic
+  findings only** — monotonicity and naive-arithmetic are advisory and never
+  gate.
 - **`--measured <file>`**: evaluate declared bounds against a k6 summary
   export (`{"metrics": {name: {...p95...}}}`) or a flat `{metric: {p95:
-  ...}}` export. Every node gets a three-way status:
+  ...}}` export. Every node gets a status:
 
   | Status | Meaning |
   | --- | --- |
   | `held` | an observation exists and satisfies the declared bound |
-  | `unbound` | no `telemetry_ref` declared, OR an observation exists but **breaches** the bound |
-  | `no_observations` | the metric was never observed — missing from the export, or present with an explicit zero count. **A finding, never a pass.** |
+  | `breached` | an observation exists and **exceeds** the declared bound |
+  | `no_observations` | a `telemetry_ref` is declared but the metric was never observed — missing from the export, or present with an explicit zero count. A measurement gap: **a finding, never a pass.** |
+  | `unbound` | no `telemetry_ref` declared — the node is not bound to any metric. A spec gap, deliberately distinct from `no_observations`, and never a pass. |
 
   Measured mode is **evidence-only, permanently**: it never exits non-zero,
   even with `--gate` — environment variance means a measured latency claim
@@ -100,6 +114,12 @@ Neither mode ever claims to prove runtime behavior holds in production.
 nodes: `{id, kind: latency|throughput|spend, unit, bound, alpha, headroom,
 telemetry_ref, children, residual, asm_refs}`. Same tree arithmetic applies to
 all three `kind`s.
+
+The schema is **enforced, not just documentation**: the checker walks the
+schema's `required`/`enum`/`pattern`/`minimum`/`maximum`/`additionalProperties`
+keywords against the document (stdlib, no jsonschema dependency) and reports
+violations as `schema`-category findings — gateable in static mode like any
+other structure finding.
 
 ## The checker
 

--- a/docs/budget-trees.md
+++ b/docs/budget-trees.md
@@ -1,0 +1,118 @@
+# Budget trees: typed NFR budgets with sound tail arithmetic
+
+Chief Wiggum can check that a latency/throughput/spend budget decomposition is
+internally consistent — mechanically, instead of trusting a prose diagram that
+adds up percentiles like they were plain numbers. This is the first
+system-layer gate (#164): a **budget tree**.
+
+Pilot use case: a ~800ms mouth-to-ear voice-agent budget, decomposed into
+endpointing / LLM TTFT / TTS TTFB / transport — metrics LiveKit/pipecat already
+emit.
+
+## Why not just sum the numbers?
+
+**Percentiles do not sum.** `P(A > 300ms) = 5%` and `P(B > 300ms) = 5%` does
+NOT imply `P(A+B > 700ms) <= 10%`, and it does NOT imply the reverse either —
+summing p95s is neither sound nor complete. The correlated-tails
+counterexample (from the issue, encoded as
+`test_correlated_tails_counterexample_naive_passes_union_bound_flags` in
+`tests/test_check_budget_tree.py`): two children each bounded at p95=300ms
+against a 700ms parent — a naive `sum(bound) <= parent.bound` check
+(300+300=600<=700) reports PASS and looks safe, while the same children's own
+tail-probability budgets (`alpha=0.05` each) sum to `0.10`, twice the parent's
+declared `alpha=0.05` — the union bound shows the parent's own tail guarantee
+is oversubscribed, something the naive sum can never see.
+
+## The construction
+
+Each budget node is a tail-probability allocation: `P(node's observed value >
+node.bound) <= node.alpha`. A child set is consistent with its parent under
+the default **union-bound** arithmetic iff:
+
+```
+sum(child.alpha) <= parent.alpha
+sum(child.bound) + parent.headroom <= parent.bound
+```
+
+This is coherent **without assuming independence** between children — it's a
+true union bound, not a sum of the underlying random variables. A tree may
+opt into `arithmetic: "naive"` (plain sum-of-bounds, ignoring alpha), but that
+mode is **WARN-only and can never gate a workflow**, regardless of `--gate`.
+
+## Coverage: the residual bucket
+
+Every node that declares `children` **must** also declare a `residual` child
+— an explicit unaccounted-budget bucket. Omitting it is a structure finding.
+This makes the accounting exhaustive: a budget tree can't silently drop the
+gap between what's declared and what's allocated.
+
+## Assumption references
+
+Vendor-stage children can cite `asm_refs`: `{id: ASM-..., evidence, ref}`.
+`evidence: sla-doc` or `live-probe` renders as **covered**; `evidence:
+justified` renders as a **documented waiver** — a distinct, non-finding
+status, not silently equal to "covered". Missing or invalid evidence is a
+finding.
+
+## Timeout monotonicity
+
+Optional `chains: [{id, hops: [{caller, callee, timeout_ms}]}]` declare
+cross-service timeout chains, ordered outermost to innermost. The check:
+`hop[i].timeout_ms > hop[i+1].timeout_ms` for every adjacent pair — an outer
+caller's timeout must exceed its nested callee's, else the callee can still be
+in flight when the caller has already given up. Violations are **WARN-only**
+(never gateable) and always carry a note that retries/hedging multiply
+worst-case occupancy beyond what a single-hop timeout chain models.
+
+## Two modes
+
+- **static** (default): well-formedness + arithmetic + monotonicity.
+  `--gate` fails (exit 1) on **structure/arithmetic findings only** —
+  monotonicity and naive-arithmetic are advisory and never gate.
+- **`--measured <file>`**: evaluate declared bounds against a k6 summary
+  export (`{"metrics": {name: {...p95...}}}`) or a flat `{metric: {p95:
+  ...}}` export. Every node gets a three-way status:
+
+  | Status | Meaning |
+  | --- | --- |
+  | `held` | an observation exists and satisfies the declared bound |
+  | `unbound` | no `telemetry_ref` declared, OR an observation exists but **breaches** the bound |
+  | `no_observations` | the metric was never observed — missing from the export, or present with an explicit zero count. **A finding, never a pass.** |
+
+  Measured mode is **evidence-only, permanently**: it never exits non-zero,
+  even with `--gate` — environment variance means a measured latency claim
+  should never hard-block CI (see `docs/gate-rollout.md`).
+
+## Authority boundary
+
+Every report — text or JSON — states exactly what was proven:
+
+```
+static:   "static mode proves budget-declaration consistency, not runtime latency"
+measured: "measured mode reports observations from <source>; not a proof of runtime behaviour"
+```
+
+Neither mode ever claims to prove runtime behavior holds in production.
+
+## Schema
+
+`templates/formal-models/system-contracts-schema.json` — `BUD-` stable-ID
+nodes: `{id, kind: latency|throughput|spend, unit, bound, alpha, headroom,
+telemetry_ref, children, residual, asm_refs}`. Same tree arithmetic applies to
+all three `kind`s.
+
+## The checker
+
+```bash
+# static mode: structure + union-bound arithmetic + monotonicity
+python3 scripts/check_budget_tree.py docs/system/system-contracts.json --format json
+python3 scripts/check_budget_tree.py docs/system/system-contracts.json --gate   # hard-fail on findings
+
+# measured mode: evaluate against k6/telemetry export (never gates)
+python3 scripts/check_budget_tree.py docs/system/system-contracts.json --measured k6-summary.json
+```
+
+Exit codes: `0` ok/report-only, `1` `--gate` violation (static mode only), `2`
+usage error. Ships **report-only** per the gate-rollout doctrine
+(`docs/gate-rollout.md`) — not yet wired as a blocker into `/architect` or
+`/close-epic`.

--- a/scripts/check_budget_tree.py
+++ b/scripts/check_budget_tree.py
@@ -23,6 +23,19 @@ each bounded at p95=300ms comfortably "pass" a naive 700ms parent by simple
 addition, while the union-bound check on their tail-probability budgets can
 still show the parent's own alpha is oversubscribed).
 
+Union-bound arithmetic requires alphas to be DECLARED: a non-leaf union-bound
+node missing its own ``alpha``, or any child/residual missing ``alpha``, is a
+structure finding — missing alphas must never silently degrade the sound check
+into a naive sum-of-bounds. Likewise every child and residual must carry the
+same ``kind`` and ``unit`` as its parent (a ms parent must not sum usd/tokens
+children); a mismatch is a structure finding and the mismatched sums are
+skipped.
+
+The document is also validated structurally against the schema
+(``required`` fields, ``enum`` values, ``pattern``-ed IDs, numeric bounds,
+unknown fields) — violations are ``schema``-category findings, gateable in
+static mode like any other structure finding.
+
 **Coverage.** Every node that declares ``children`` MUST also declare a
 ``residual`` child (an explicit unaccounted-budget bucket) — a missing residual
 is a structure finding.
@@ -46,15 +59,19 @@ invalid evidence is a finding.
   naive-arithmetic are WARN-only and never gate.
 - ``--measured <file>`` — evaluate declared bounds against a k6 summary export
   (``{"metrics": {name: {...p95...}}}``) or a flat ``{metric: {p95: ...}}``
-  export. Each telemetry-bound node gets a three-way status:
+  export. Each node gets a status:
 
-    - ``unbound``       — no ``telemetry_ref`` declared, OR the referenced
-                          metric has an observation whose value BREACHES the
-                          declared bound (the bound does not hold in practice).
-    - ``no_observations`` — the metric was never observed (missing from the
-                          export, or present with an explicit zero count).
-                          This is a FINDING, never a pass.
+    - ``unbound``       — the node declares NO ``telemetry_ref``: it is not
+                          bound to any metric. A coverage finding, never a pass.
+    - ``no_observations`` — a ``telemetry_ref`` is declared but the metric was
+                          never observed (missing from the export, or present
+                          with an explicit zero count). A FINDING, never a pass.
     - ``held``          — an observation exists and satisfies the bound.
+    - ``breached``      — an observation exists and EXCEEDS the declared bound.
+
+  ``unbound`` vs ``no_observations`` is a deliberate distinction (a missing
+  binding is a spec gap; a bound metric with no data is a measurement gap);
+  ``held`` vs ``breached`` is the bound evaluation for nodes that have data.
 
   Measured mode is EVIDENCE-ONLY, permanently: it never exits non-zero,
   regardless of ``--gate`` (environment variance means a measured latency claim
@@ -74,6 +91,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -102,7 +120,7 @@ def measured_authority(source: str) -> str:
 
 @dataclass
 class Finding:
-    category: str  # "structure" | "arithmetic"
+    category: str  # "structure" | "arithmetic" | "schema"
     id: str
     message: str
 
@@ -138,7 +156,7 @@ class MeasuredResult:
     telemetry_ref: str | None
     bound: float | None
     observed: float | None
-    status: str  # "held" | "no_observations" | "unbound"
+    status: str  # "held" | "breached" | "no_observations" | "unbound"
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -163,6 +181,7 @@ class BudgetTreeReport:
             "asm_missing": sum(1 for a in self.asm_statuses if a.status == "missing"),
             "asm_waived": sum(1 for a in self.asm_statuses if a.status == "waived"),
             "measured_held": sum(1 for m in self.measured if m.status == "held"),
+            "measured_breached": sum(1 for m in self.measured if m.status == "breached"),
             "measured_no_observations": sum(1 for m in self.measured if m.status == "no_observations"),
             "measured_unbound": sum(1 for m in self.measured if m.status == "unbound"),
         }
@@ -226,11 +245,95 @@ def load_measured(path: str | Path) -> dict[str, dict]:
     return out
 
 
+# --- schema validation --------------------------------------------------------
+#
+# The schema (templates/formal-models/system-contracts-schema.json) is ENFORCED,
+# not just documentation: a small stdlib structural validator walks the schema's
+# $ref/type/required/properties/additionalProperties/enum/pattern/min/max/items
+# keywords against the document. Violations are "schema"-category findings —
+# gateable in static mode like any other structure finding. (No jsonschema
+# dependency: gate scripts are stdlib-only.)
+
+
+def _resolve_ref(schema_node: dict, root_schema: dict) -> dict:
+    while isinstance(schema_node, dict) and "$ref" in schema_node:
+        target: object = root_schema
+        for part in schema_node["$ref"].lstrip("#/").split("/"):
+            target = target[part]  # type: ignore[index]
+        schema_node = target  # type: ignore[assignment]
+    return schema_node
+
+
+def _validate_value(value, schema_node: dict, path: str, root_schema: dict, errors: list[tuple[str, str]]) -> None:
+    schema_node = _resolve_ref(schema_node, root_schema)
+    expected = schema_node.get("type")
+
+    if "enum" in schema_node and value not in schema_node["enum"]:
+        errors.append((path, f"value {value!r} not in allowed set {schema_node['enum']}"))
+        return
+
+    if expected == "object":
+        if not isinstance(value, dict):
+            errors.append((path, f"expected object, got {type(value).__name__}"))
+            return
+        for req in schema_node.get("required", []):
+            if req not in value:
+                errors.append((path, f"missing required field '{req}'"))
+        props = schema_node.get("properties", {})
+        if schema_node.get("additionalProperties") is False:
+            for key in value:
+                if key not in props:
+                    errors.append((path, f"unknown field '{key}'"))
+        for key, sub in value.items():
+            if key in props:
+                _validate_value(sub, props[key], f"{path}.{key}", root_schema, errors)
+    elif expected == "array":
+        if not isinstance(value, list):
+            errors.append((path, f"expected array, got {type(value).__name__}"))
+            return
+        min_items = schema_node.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            errors.append((path, f"expected at least {min_items} item(s), got {len(value)}"))
+        item_schema = schema_node.get("items")
+        if item_schema:
+            for i, item in enumerate(value):
+                _validate_value(item, item_schema, f"{path}[{i}]", root_schema, errors)
+    elif expected == "string":
+        if not isinstance(value, str):
+            errors.append((path, f"expected string, got {type(value).__name__}"))
+            return
+        pattern = schema_node.get("pattern")
+        if pattern and not re.search(pattern, value):
+            errors.append((path, f"value {value!r} does not match pattern {pattern}"))
+    elif expected == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            errors.append((path, f"expected number, got {type(value).__name__}"))
+            return
+        minimum, maximum = schema_node.get("minimum"), schema_node.get("maximum")
+        if minimum is not None and value < minimum:
+            errors.append((path, f"value {value} below minimum {minimum}"))
+        if maximum is not None and value > maximum:
+            errors.append((path, f"value {value} above maximum {maximum}"))
+
+
+def validate_doc(doc: dict, schema: dict) -> list[Finding]:
+    """Structurally validate a budget-tree document against the JSON schema.
+
+    Returns ``schema``-category findings for every violation (missing required
+    fields, enum violations like a bad ``arithmetic`` or ``evidence`` value,
+    malformed ``BUD-``/``ASM-`` IDs, out-of-range ``alpha``, unknown fields).
+    """
+    errors: list[tuple[str, str]] = []
+    _validate_value(doc, schema, "$", schema, errors)
+    return [Finding("schema", path, f"{path}: {msg}") for path, msg in errors]
+
+
 # --- static mode --------------------------------------------------------------
 
 
-def check_static(doc: dict) -> BudgetTreeReport:
+def check_static(doc: dict, schema: dict | None = None) -> BudgetTreeReport:
     report = BudgetTreeReport(mode="static")
+    report.findings.extend(validate_doc(doc, schema if schema is not None else load_schema()))
     for idx, tree in enumerate(doc.get("trees") or []):
         root = tree.get("root") or {}
         arithmetic = tree.get("arithmetic", "union-bound")
@@ -261,46 +364,91 @@ def _check_node(node: dict, arithmetic: str, report: BudgetTreeReport) -> None:
             )
         effective = list(children) + ([residual] if residual else [])
 
+        # Kind/unit compatibility precedes ANY arithmetic: a ms parent must not
+        # sum usd/tokens children. Mismatched nodes are structure findings and
+        # the (meaningless) mixed sums are skipped.
+        compatible = True
+        for c in effective:
+            if c.get("kind") != node.get("kind") or c.get("unit") != node.get("unit"):
+                compatible = False
+                report.findings.append(
+                    Finding(
+                        "structure",
+                        node_id,
+                        f"{node_id}: child {c.get('id', '<node>')} has kind/unit "
+                        f"{c.get('kind')}/{c.get('unit')} incompatible with parent's "
+                        f"{node.get('kind')}/{node.get('unit')} — budget arithmetic "
+                        "requires a homogeneous kind and unit per tree level",
+                    )
+                )
+
         if arithmetic == "naive":
-            total_bound = sum(c.get("bound", 0) or 0 for c in effective)
-            parent_bound = node.get("bound")
-            verdict = (
-                "would PASS" if parent_bound is None or total_bound <= parent_bound + _ALPHA_TOL else "would FAIL"
-            )
-            report.warnings.append(
-                Note(
-                    "naive-arithmetic",
-                    node_id,
-                    f"{node_id}: naive sum-of-bounds check {verdict} "
-                    f"(sum(children)={total_bound} vs parent bound={parent_bound}) — "
-                    "advisory only; percentiles do not sum, this mode is unsound for "
-                    "correlated tails and can never gate a workflow",
+            if compatible:
+                total_bound = sum(c.get("bound", 0) or 0 for c in effective)
+                parent_bound = node.get("bound")
+                verdict = (
+                    "would PASS" if parent_bound is None or total_bound <= parent_bound + _ALPHA_TOL else "would FAIL"
                 )
-            )
+                report.warnings.append(
+                    Note(
+                        "naive-arithmetic",
+                        node_id,
+                        f"{node_id}: naive sum-of-bounds check {verdict} "
+                        f"(sum(children)={total_bound} vs parent bound={parent_bound}) — "
+                        "advisory only; percentiles do not sum, this mode is unsound for "
+                        "correlated tails and can never gate a workflow",
+                    )
+                )
         else:  # union-bound (default, sound, gateable)
-            sum_alpha = sum(c.get("alpha") or 0 for c in effective)
-            sum_bound = sum(c.get("bound", 0) or 0 for c in effective)
-            headroom = node.get("headroom") or 0
+            # Missing alphas must NEVER silently degrade the sound check into a
+            # naive sum-of-bounds: a non-leaf union-bound node without alpha, or
+            # any child/residual without alpha, is a structure finding.
             parent_alpha = node.get("alpha")
-            parent_bound = node.get("bound")
-            if parent_alpha is not None and sum_alpha > parent_alpha + _ALPHA_TOL:
+            missing_alpha = [c.get("id", "<node>") for c in effective if c.get("alpha") is None]
+            if parent_alpha is None:
                 report.findings.append(
                     Finding(
-                        "arithmetic",
+                        "structure",
                         node_id,
-                        f"{node_id}: children's tail-probability budget sums to {sum_alpha} "
-                        f"which exceeds parent alpha {parent_alpha} (union bound violated)",
+                        f"{node_id}: non-leaf union-bound node has no alpha — the "
+                        "tail-probability half of the union-bound check cannot run; "
+                        "declare alpha or the tree silently degrades to a naive sum",
                     )
                 )
-            if parent_bound is not None and sum_bound + headroom > parent_bound + _ALPHA_TOL:
+            if missing_alpha:
                 report.findings.append(
                     Finding(
-                        "arithmetic",
+                        "structure",
                         node_id,
-                        f"{node_id}: sum(children.bound)={sum_bound} + headroom={headroom} "
-                        f"exceeds parent bound {parent_bound}",
+                        f"{node_id}: children missing alpha: {', '.join(missing_alpha)} — "
+                        "every child and residual in a union-bound tree must declare its "
+                        "tail-probability allocation",
                     )
                 )
+            if compatible and parent_alpha is not None and not missing_alpha:
+                sum_alpha = sum(c["alpha"] for c in effective)
+                if sum_alpha > parent_alpha + _ALPHA_TOL:
+                    report.findings.append(
+                        Finding(
+                            "arithmetic",
+                            node_id,
+                            f"{node_id}: children's tail-probability budget sums to {sum_alpha} "
+                            f"which exceeds parent alpha {parent_alpha} (union bound violated)",
+                        )
+                    )
+            if compatible:
+                sum_bound = sum(c.get("bound", 0) or 0 for c in effective)
+                headroom = node.get("headroom") or 0
+                parent_bound = node.get("bound")
+                if parent_bound is not None and sum_bound + headroom > parent_bound + _ALPHA_TOL:
+                    report.findings.append(
+                        Finding(
+                            "arithmetic",
+                            node_id,
+                            f"{node_id}: sum(children.bound)={sum_bound} + headroom={headroom} "
+                            f"exceeds parent bound {parent_bound}",
+                        )
+                    )
 
         for child in children:
             _check_node(child, arithmetic, report)
@@ -357,8 +505,9 @@ def _check_chains(chains: list[dict], report: BudgetTreeReport) -> None:
 # --- measured mode --------------------------------------------------------------
 
 
-def check_measured(doc: dict, measured: dict[str, dict], source: str) -> BudgetTreeReport:
+def check_measured(doc: dict, measured: dict[str, dict], source: str, schema: dict | None = None) -> BudgetTreeReport:
     report = BudgetTreeReport(mode="measured", source=source)
+    report.findings.extend(validate_doc(doc, schema if schema is not None else load_schema()))
     for idx, tree in enumerate(doc.get("trees") or []):
         root = tree.get("root") or {}
         report.trees.append(root.get("id", f"tree[{idx}]"))
@@ -375,10 +524,15 @@ def _measure_node(node: dict, measured: dict[str, dict], report: BudgetTreeRepor
     observed = stats.get("p95") if stats else None
     count = stats.get("count") if stats else None
 
-    if not telemetry_ref or stats is None or observed is None or count == 0:
+    # unbound (no binding declared) vs no_observations (binding declared but no
+    # data) is a deliberate distinction: the first is a spec gap, the second a
+    # measurement gap. Neither is EVER a pass.
+    if not telemetry_ref:
+        status = "unbound"
+    elif stats is None or observed is None or count == 0:
         status = "no_observations"
     elif bound is not None and observed > bound:
-        status = "unbound"
+        status = "breached"
     else:
         status = "held"
 
@@ -411,6 +565,9 @@ def render_text(report: BudgetTreeReport) -> str:
                 lines.append(f"- {a.id} (on {a.node}): {a.status} [{a.evidence or '?'}] {a.ref or ''}")
     else:
         lines.append(f"Source: {report.source}")
+        if report.findings:
+            lines += ["", "## Findings (informational — measured mode never gates)"]
+            lines += [f"- [{f.category}] {f.message}" for f in report.findings]
         if report.measured:
             lines += ["", "## Measured bindings"]
             for m in report.measured:
@@ -445,7 +602,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        load_schema(Path(args.schema))
+        schema = load_schema(Path(args.schema))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"Error: cannot load schema: {exc}", file=sys.stderr)
         return 2
@@ -462,9 +619,9 @@ def main(argv: list[str] | None = None) -> int:
         except (OSError, json.JSONDecodeError) as exc:
             print(f"Error: cannot load measured data: {exc}", file=sys.stderr)
             return 2
-        report = check_measured(doc, measured_data, source=args.measured)
+        report = check_measured(doc, measured_data, source=args.measured, schema=schema)
     else:
-        report = check_static(doc)
+        report = check_static(doc, schema=schema)
 
     print(json.dumps(report.to_dict(), indent=2) if args.format == "json" else render_text(report))
 

--- a/scripts/check_budget_tree.py
+++ b/scripts/check_budget_tree.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Budget tree checker (#164): typed NFR budget trees with sound tail arithmetic.
+
+The first system-layer gate: latency/throughput/spend budgets as checked
+contracts, not prose. Pilot use case: a ~800ms mouth-to-ear voice-agent budget
+decomposed into endpointing / LLM TTFT / TTS TTFB / transport.
+
+Schema: ``templates/formal-models/system-contracts-schema.json``. Nodes carry a
+stable ``BUD-`` ID, ``{kind, unit, bound, alpha, telemetry_ref, children,
+residual, asm_refs}``.
+
+**Sound tail arithmetic (the core).** Percentiles do NOT sum. A child set is
+consistent with its parent under the default ``union-bound`` arithmetic iff::
+
+    sum(child.alpha) <= parent.alpha                       (tail-probability budget)
+    sum(child.bound) + parent.headroom <= parent.bound      (union bound)
+
+This is coherent WITHOUT assuming child latencies are independent. A tree may
+opt into ``arithmetic: "naive"`` (plain sum-of-bounds, ignoring alpha) but that
+mode is WARN-only and can never gate a workflow — it is unsound for correlated
+tails (see the correlated-tails counterexample in the test suite: two children
+each bounded at p95=300ms comfortably "pass" a naive 700ms parent by simple
+addition, while the union-bound check on their tail-probability budgets can
+still show the parent's own alpha is oversubscribed).
+
+**Coverage.** Every node that declares ``children`` MUST also declare a
+``residual`` child (an explicit unaccounted-budget bucket) — a missing residual
+is a structure finding.
+
+**Timeout monotonicity** (optional ``chains``): each chain's hops (outermost to
+innermost) must have strictly decreasing ``timeout_ms`` — an outer caller's
+timeout must exceed its nested callee's, else the callee can still be in
+flight when the caller has already given up. Violations are WARN-only (never
+gateable) and always come with a note that retries/hedging multiply worst-case
+occupancy beyond what a single-hop timeout chain models.
+
+**Assumption refs** (``asm_refs``): each entry is ``{id, evidence, ref}``.
+``evidence in {sla-doc, live-probe}`` renders "covered"; ``evidence: justified``
+renders as a documented WAIVER (a distinct, non-finding status); missing or
+invalid evidence is a finding.
+
+**Two modes:**
+
+- ``static`` (default) — well-formedness + arithmetic + monotonicity. Supports
+  ``--gate`` (exit 1) on structure/arithmetic findings only — monotonicity and
+  naive-arithmetic are WARN-only and never gate.
+- ``--measured <file>`` — evaluate declared bounds against a k6 summary export
+  (``{"metrics": {name: {...p95...}}}``) or a flat ``{metric: {p95: ...}}``
+  export. Each telemetry-bound node gets a three-way status:
+
+    - ``unbound``       — no ``telemetry_ref`` declared, OR the referenced
+                          metric has an observation whose value BREACHES the
+                          declared bound (the bound does not hold in practice).
+    - ``no_observations`` — the metric was never observed (missing from the
+                          export, or present with an explicit zero count).
+                          This is a FINDING, never a pass.
+    - ``held``          — an observation exists and satisfies the bound.
+
+  Measured mode is EVIDENCE-ONLY, permanently: it never exits non-zero,
+  regardless of ``--gate`` (environment variance means a measured latency claim
+  should never hard-block CI — see docs/gate-rollout.md).
+
+Every report (text and JSON) carries an ``authority`` line stating exactly what
+was proven:
+
+    static:   "static mode proves budget-declaration consistency, not runtime latency"
+    measured: "measured mode reports observations from <source>; not a proof of runtime behaviour"
+
+Mirrors ``check_traceability.py``'s shape (dataclasses, report object with
+counts/ok, argparse, best-effort factory_log emit). Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+DEFAULT_SCHEMA = (
+    Path(__file__).resolve().parents[1] / "templates" / "formal-models" / "system-contracts-schema.json"
+)
+
+ARITHMETIC_CHOICES = ("union-bound", "naive")
+EVIDENCE_CHOICES = ("sla-doc", "live-probe", "justified")
+_ALPHA_TOL = 1e-9
+
+STATIC_AUTHORITY = "static mode proves budget-declaration consistency, not runtime latency"
+MONOTONICITY_NOTE = (
+    "timeout monotonicity checks a single-hop chain only; retries/hedging multiply "
+    "worst-case occupancy beyond what this check models"
+)
+
+
+def measured_authority(source: str) -> str:
+    return f"measured mode reports observations from {source}; not a proof of runtime behaviour"
+
+
+# --- report data model -------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    category: str  # "structure" | "arithmetic"
+    id: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Note:
+    category: str  # "naive-arithmetic" | "monotonicity"
+    id: str | None
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class AsmStatus:
+    id: str
+    node: str
+    status: str  # "covered" | "waived" | "missing"
+    evidence: str | None
+    ref: str | None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class MeasuredResult:
+    id: str
+    telemetry_ref: str | None
+    bound: float | None
+    observed: float | None
+    status: str  # "held" | "no_observations" | "unbound"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class BudgetTreeReport:
+    mode: str  # "static" | "measured"
+    source: str | None = None
+    trees: list[str] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+    warnings: list[Note] = field(default_factory=list)
+    asm_statuses: list[AsmStatus] = field(default_factory=list)
+    measured: list[MeasuredResult] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict:
+        return {
+            "trees": len(self.trees),
+            "findings": len(self.findings),
+            "warnings": len(self.warnings),
+            "asm_missing": sum(1 for a in self.asm_statuses if a.status == "missing"),
+            "asm_waived": sum(1 for a in self.asm_statuses if a.status == "waived"),
+            "measured_held": sum(1 for m in self.measured if m.status == "held"),
+            "measured_no_observations": sum(1 for m in self.measured if m.status == "no_observations"),
+            "measured_unbound": sum(1 for m in self.measured if m.status == "unbound"),
+        }
+
+    @property
+    def ok(self) -> bool:
+        """Gateable status. Measured mode is evidence-only and is ALWAYS ok — it
+        never blocks a workflow, regardless of what it observed."""
+        if self.mode == "measured":
+            return True
+        return not self.findings
+
+    @property
+    def authority(self) -> str:
+        return STATIC_AUTHORITY if self.mode == "static" else measured_authority(self.source or "<unknown>")
+
+    def to_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "authority": self.authority,
+            "trees": self.trees,
+            "counts": self.counts,
+            "ok": self.ok,
+            "findings": [f.to_dict() for f in self.findings],
+            "warnings": [w.to_dict() for w in self.warnings],
+            "asm_statuses": [a.to_dict() for a in self.asm_statuses],
+            "measured": [m.to_dict() for m in self.measured],
+        }
+
+
+# --- loading ------------------------------------------------------------------
+
+
+def load_schema(path: Path = DEFAULT_SCHEMA) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def load_doc(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def load_measured(path: str | Path) -> dict[str, dict]:
+    """Normalize a k6 summary export (``{"metrics": {name: {...}}}``) or a flat
+    ``{metric: {p95: ...}}`` export into ``{metric: {"p95": float|None, "count": int|None}}``.
+
+    Tolerant of the several shapes k6 has shipped: ``values`` may be nested
+    (``{"values": {"p(95)": ...}}``) or flat on the metric itself; the p95 key
+    may be ``p95``, ``p(95)``, or ``P95``; an observation count may be
+    ``count``, ``len``, or ``Count``.
+    """
+    raw = json.loads(Path(path).read_text())
+    metrics = raw.get("metrics") if isinstance(raw, dict) and "metrics" in raw else raw
+    out: dict[str, dict] = {}
+    for name, stats in (metrics or {}).items():
+        if not isinstance(stats, dict):
+            continue
+        values = stats.get("values") if isinstance(stats.get("values"), dict) else stats
+        p95 = next((values[k] for k in ("p95", "p(95)", "P95") if values.get(k) is not None), None)
+        count = next((values[k] for k in ("count", "len", "Count") if values.get(k) is not None), None)
+        out[name] = {"p95": p95, "count": count}
+    return out
+
+
+# --- static mode --------------------------------------------------------------
+
+
+def check_static(doc: dict) -> BudgetTreeReport:
+    report = BudgetTreeReport(mode="static")
+    for idx, tree in enumerate(doc.get("trees") or []):
+        root = tree.get("root") or {}
+        arithmetic = tree.get("arithmetic", "union-bound")
+        report.trees.append(root.get("id", f"tree[{idx}]"))
+        _check_node(root, arithmetic, report)
+    _check_chains(doc.get("chains") or [], report)
+    return report
+
+
+def _check_node(node: dict, arithmetic: str, report: BudgetTreeReport) -> None:
+    node_id = node.get("id", "<node>")
+
+    for asm in node.get("asm_refs") or []:
+        _check_asm(asm, node_id, report)
+
+    children = node.get("children") or []
+    residual = node.get("residual")
+
+    if children:
+        if not residual:
+            report.findings.append(
+                Finding(
+                    "structure",
+                    node_id,
+                    f"{node_id}: has children but no residual budget declared "
+                    "(every non-leaf node must account for unallocated budget)",
+                )
+            )
+        effective = list(children) + ([residual] if residual else [])
+
+        if arithmetic == "naive":
+            total_bound = sum(c.get("bound", 0) or 0 for c in effective)
+            parent_bound = node.get("bound")
+            verdict = (
+                "would PASS" if parent_bound is None or total_bound <= parent_bound + _ALPHA_TOL else "would FAIL"
+            )
+            report.warnings.append(
+                Note(
+                    "naive-arithmetic",
+                    node_id,
+                    f"{node_id}: naive sum-of-bounds check {verdict} "
+                    f"(sum(children)={total_bound} vs parent bound={parent_bound}) — "
+                    "advisory only; percentiles do not sum, this mode is unsound for "
+                    "correlated tails and can never gate a workflow",
+                )
+            )
+        else:  # union-bound (default, sound, gateable)
+            sum_alpha = sum(c.get("alpha") or 0 for c in effective)
+            sum_bound = sum(c.get("bound", 0) or 0 for c in effective)
+            headroom = node.get("headroom") or 0
+            parent_alpha = node.get("alpha")
+            parent_bound = node.get("bound")
+            if parent_alpha is not None and sum_alpha > parent_alpha + _ALPHA_TOL:
+                report.findings.append(
+                    Finding(
+                        "arithmetic",
+                        node_id,
+                        f"{node_id}: children's tail-probability budget sums to {sum_alpha} "
+                        f"which exceeds parent alpha {parent_alpha} (union bound violated)",
+                    )
+                )
+            if parent_bound is not None and sum_bound + headroom > parent_bound + _ALPHA_TOL:
+                report.findings.append(
+                    Finding(
+                        "arithmetic",
+                        node_id,
+                        f"{node_id}: sum(children.bound)={sum_bound} + headroom={headroom} "
+                        f"exceeds parent bound {parent_bound}",
+                    )
+                )
+
+        for child in children:
+            _check_node(child, arithmetic, report)
+        if residual:
+            _check_node(residual, arithmetic, report)
+
+
+def _check_asm(asm: dict, node_id: str, report: BudgetTreeReport) -> None:
+    asm_id = asm.get("id", "<unnamed-asm>")
+    evidence = asm.get("evidence")
+    ref = asm.get("ref")
+    if evidence not in EVIDENCE_CHOICES or not ref:
+        report.findings.append(
+            Finding(
+                "structure",
+                asm_id,
+                f"{asm_id} (on {node_id}): missing/invalid evidence or ref — "
+                f"asm_refs require evidence in {EVIDENCE_CHOICES} and a non-empty ref",
+            )
+        )
+        report.asm_statuses.append(AsmStatus(asm_id, node_id, "missing", evidence, ref))
+    elif evidence == "justified":
+        report.asm_statuses.append(AsmStatus(asm_id, node_id, "waived", evidence, ref))
+    else:
+        report.asm_statuses.append(AsmStatus(asm_id, node_id, "covered", evidence, ref))
+
+
+def _check_chains(chains: list[dict], report: BudgetTreeReport) -> None:
+    noted = False
+    for chain in chains:
+        chain_id = chain.get("id", "<chain>")
+        hops = chain.get("hops") or []
+        for i in range(len(hops) - 1):
+            outer, inner = hops[i], hops[i + 1]
+            outer_t, inner_t = outer.get("timeout_ms"), inner.get("timeout_ms")
+            if outer_t is None or inner_t is None:
+                continue
+            if not (outer_t > inner_t):
+                report.warnings.append(
+                    Note(
+                        "monotonicity",
+                        chain_id,
+                        f"{chain_id}: hop {outer.get('caller')}->{outer.get('callee')} "
+                        f"timeout={outer_t}ms is not greater than nested hop "
+                        f"{inner.get('caller')}->{inner.get('callee')} timeout={inner_t}ms "
+                        f"({MONOTONICITY_NOTE})",
+                    )
+                )
+                noted = True
+    if chains and not noted:
+        report.warnings.append(Note("monotonicity", None, f"all chains monotonic. ({MONOTONICITY_NOTE})"))
+
+
+# --- measured mode --------------------------------------------------------------
+
+
+def check_measured(doc: dict, measured: dict[str, dict], source: str) -> BudgetTreeReport:
+    report = BudgetTreeReport(mode="measured", source=source)
+    for idx, tree in enumerate(doc.get("trees") or []):
+        root = tree.get("root") or {}
+        report.trees.append(root.get("id", f"tree[{idx}]"))
+        _measure_node(root, measured, report)
+    return report
+
+
+def _measure_node(node: dict, measured: dict[str, dict], report: BudgetTreeReport) -> None:
+    node_id = node.get("id", "<node>")
+    telemetry_ref = node.get("telemetry_ref")
+    bound = node.get("bound")
+
+    stats = measured.get(telemetry_ref) if telemetry_ref else None
+    observed = stats.get("p95") if stats else None
+    count = stats.get("count") if stats else None
+
+    if not telemetry_ref or stats is None or observed is None or count == 0:
+        status = "no_observations"
+    elif bound is not None and observed > bound:
+        status = "unbound"
+    else:
+        status = "held"
+
+    report.measured.append(MeasuredResult(node_id, telemetry_ref, bound, observed, status))
+
+    for child in node.get("children") or []:
+        _measure_node(child, measured, report)
+    if node.get("residual"):
+        _measure_node(node["residual"], measured, report)
+
+
+# --- rendering ------------------------------------------------------------------
+
+
+def render_text(report: BudgetTreeReport) -> str:
+    lines = [f"# Budget Tree Report ({report.mode})", "", f"Authority: {report.authority}", ""]
+    lines.append(f"Trees checked: {', '.join(report.trees) if report.trees else '(none)'}")
+
+    if report.mode == "static":
+        lines.append(f"Status: {'OK' if report.ok else 'FINDINGS'}")
+        if report.findings:
+            lines += ["", "## Findings (gateable under --gate)"]
+            lines += [f"- [{f.category}] {f.message}" for f in report.findings]
+        if report.warnings:
+            lines += ["", "## Warnings (advisory, never gateable)"]
+            lines += [f"- [{w.category}] {w.message}" for w in report.warnings]
+        if report.asm_statuses:
+            lines += ["", "## Assumption references"]
+            for a in report.asm_statuses:
+                lines.append(f"- {a.id} (on {a.node}): {a.status} [{a.evidence or '?'}] {a.ref or ''}")
+    else:
+        lines.append(f"Source: {report.source}")
+        if report.measured:
+            lines += ["", "## Measured bindings"]
+            for m in report.measured:
+                obs = m.observed if m.observed is not None else "—"
+                lines.append(
+                    f"- {m.id} ref={m.telemetry_ref or '(none)'} bound={m.bound} observed={obs} -> {m.status}"
+                )
+
+    return "\n".join(lines) + "\n"
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Budget tree checker: typed NFR budget trees with union-bound tail arithmetic (#164)"
+    )
+    parser.add_argument("budget_file", help="Path to a system-contracts.json budget tree document")
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    parser.add_argument(
+        "--measured",
+        help="k6 summary JSON or flat {metric: {p95: ...}} export; switches to measured mode "
+        "(evidence-only, never gates)",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Static mode only: exit 1 on structure/arithmetic findings. No-op (measured mode never gates).",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    try:
+        load_schema(Path(args.schema))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error: cannot load schema: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        doc = load_doc(args.budget_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error: cannot load budget tree file: {exc}", file=sys.stderr)
+        return 2
+
+    if args.measured:
+        try:
+            measured_data = load_measured(args.measured)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Error: cannot load measured data: {exc}", file=sys.stderr)
+            return 2
+        report = check_measured(doc, measured_data, source=args.measured)
+    else:
+        report = check_static(doc)
+
+    print(json.dumps(report.to_dict(), indent=2) if args.format == "json" else render_text(report))
+
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+
+        caught = len(report.findings) if report.mode == "static" else 0
+        emit_gate("check_budget_tree", "fail" if (report.mode == "static" and not report.ok) else "pass", caught=caught)
+    except Exception:
+        pass
+
+    if report.mode == "static" and args.gate and not report.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/formal-models/system-contracts-schema.json
+++ b/templates/formal-models/system-contracts-schema.json
@@ -65,7 +65,7 @@
           "type": "number",
           "minimum": 0,
           "maximum": 1,
-          "description": "Tail probability: P(this node's observed value > bound) <= alpha. Required to run the union-bound consistency check meaningfully; a node without alpha is skipped in the alpha half of that check."
+          "description": "Tail probability: P(this node's observed value > bound) <= alpha. In a union-bound tree, alpha is effectively mandatory: a non-leaf node without alpha, or any child/residual without alpha, is a structure finding — missing alphas must never silently degrade the sound check into a naive sum-of-bounds. Naive trees do not use alpha."
         },
         "headroom": {
           "type": "number",
@@ -79,7 +79,7 @@
         },
         "children": {
           "type": "array",
-          "description": "Sub-allocations of this node's budget. If non-empty, 'residual' is REQUIRED on this node.",
+          "description": "Sub-allocations of this node's budget. If non-empty, 'residual' is REQUIRED on this node. Every child (and the residual) must carry the same kind and unit as this node — the checker rejects mixed-kind/unit arithmetic as a structure finding.",
           "items": { "$ref": "#/$defs/node" }
         },
         "residual": {

--- a/templates/formal-models/system-contracts-schema.json
+++ b/templates/formal-models/system-contracts-schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/system-contracts.json",
+  "title": "System Budget Trees",
+  "description": "Typed NFR (latency/throughput/spend) budget trees, checked by scripts/check_budget_tree.py (#164). A tree decomposes a top-level budget (e.g. ~800ms mouth-to-ear for a voice agent) into child allocations that must be consistent with their parent under UNION-BOUND tail arithmetic (percentiles do not sum — see docs/budget-trees.md). Every non-leaf node must declare an explicit 'residual' child accounting for unallocated budget. Optional 'chains' declare cross-service timeout hops for monotonicity checking (caller timeout must exceed nested callee timeout).",
+  "type": "object",
+  "required": ["trees"],
+  "additionalProperties": false,
+  "properties": {
+    "trees": {
+      "type": "array",
+      "description": "One or more independent budget trees (e.g. one per user-facing flow)",
+      "items": { "$ref": "#/$defs/tree" },
+      "minItems": 1
+    },
+    "chains": {
+      "type": "array",
+      "description": "Optional cross-service timeout chains, checked for monotonicity (caller > callee per hop)",
+      "items": { "$ref": "#/$defs/chain" }
+    },
+    "derived_from": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/provenance" }
+    }
+  },
+  "$defs": {
+    "tree": {
+      "type": "object",
+      "required": ["root"],
+      "additionalProperties": false,
+      "properties": {
+        "root": { "$ref": "#/$defs/node" },
+        "arithmetic": {
+          "type": "string",
+          "enum": ["union-bound", "naive"],
+          "default": "union-bound",
+          "description": "'union-bound' (default) is the sound, gateable check: sum(child.alpha) <= parent.alpha AND sum(child.bound) + headroom <= parent.bound — coherent without assuming independence. 'naive' (sum-of-bounds only, ignoring alpha) is UNSOUND for tail percentiles and is WARN-only — it can never gate a workflow, regardless of --gate."
+        }
+      }
+    },
+    "node": {
+      "type": "object",
+      "required": ["id", "kind", "unit", "bound"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^BUD-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$",
+          "description": "Stable ID, e.g. BUD-voice-agent-001"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["latency", "throughput", "spend"],
+          "description": "Budget type. Union-bound tree arithmetic is identical across all three kinds."
+        },
+        "unit": {
+          "type": "string",
+          "description": "e.g. 'ms', 'req/s', 'usd/day'"
+        },
+        "bound": {
+          "type": "number",
+          "description": "The allocated budget value (e.g. a p95 latency bound in ms)"
+        },
+        "alpha": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Tail probability: P(this node's observed value > bound) <= alpha. Required to run the union-bound consistency check meaningfully; a node without alpha is skipped in the alpha half of that check."
+        },
+        "headroom": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Explicit slack this node reserves beyond what it allocates to children+residual. Counted on the PARENT side of the union-bound bound check: sum(child.bound) + headroom <= parent.bound."
+        },
+        "telemetry_ref": {
+          "type": "string",
+          "description": "OTel span name / k6 metric name this node's observed value is measured from (used only in --measured mode)"
+        },
+        "children": {
+          "type": "array",
+          "description": "Sub-allocations of this node's budget. If non-empty, 'residual' is REQUIRED on this node.",
+          "items": { "$ref": "#/$defs/node" }
+        },
+        "residual": {
+          "description": "Explicit unaccounted-budget bucket. REQUIRED on any node that declares children (a non-leaf node) — makes coverage accounting exhaustive instead of silently dropping unallocated budget.",
+          "$ref": "#/$defs/node"
+        },
+        "asm_refs": {
+          "type": "array",
+          "description": "Assumptions this node's bound rests on (e.g. a vendor SLA claim)",
+          "items": { "$ref": "#/$defs/asm_ref" }
+        }
+      }
+    },
+    "asm_ref": {
+      "type": "object",
+      "required": ["id", "evidence", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ASM-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$",
+          "description": "Stable ID, e.g. ASM-elevenlabs-ttfb-001"
+        },
+        "evidence": {
+          "type": "string",
+          "enum": ["sla-doc", "live-probe", "justified"],
+          "description": "How this assumption is backed. 'sla-doc'/'live-probe' render as covered; 'justified' renders as a DOCUMENTED WAIVER (a distinct status, not silently equal to covered). Missing/invalid evidence is a finding."
+        },
+        "ref": {
+          "type": "string",
+          "description": "Pointer to the evidence (doc URL, probe script/run, or waiver rationale)"
+        }
+      }
+    },
+    "chain": {
+      "type": "object",
+      "required": ["id", "hops"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "hops": {
+          "type": "array",
+          "description": "Ordered outermost-to-innermost. Monotonicity requires hop[i].timeout_ms > hop[i+1].timeout_ms (an outer caller's timeout must exceed its nested callee's timeout, else the callee can still be in flight when the caller has already given up).",
+          "items": { "$ref": "#/$defs/hop" },
+          "minItems": 1
+        }
+      }
+    },
+    "hop": {
+      "type": "object",
+      "required": ["caller", "callee", "timeout_ms"],
+      "additionalProperties": false,
+      "properties": {
+        "caller": { "type": "string" },
+        "callee": { "type": "string" },
+        "timeout_ms": { "type": "number" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["type", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+        },
+        "ref": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/test_check_budget_tree.py
+++ b/tests/test_check_budget_tree.py
@@ -223,6 +223,252 @@ def test_leaf_node_does_not_require_residual():
     assert report.findings == []
 
 
+# --- missing alpha must not silently degrade union-bound to a naive sum ------
+
+
+def test_union_bound_missing_child_alpha_is_structure_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-ma-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [
+                        _leaf("BUD-ma-002", 300, 0.02),
+                        _leaf("BUD-ma-003", 300),  # NO alpha
+                    ],
+                    "residual": _residual("BUD-ma-004", 100, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(
+        f.category == "structure" and "missing alpha" in f.message and "BUD-ma-003" in f.message
+        for f in report.findings
+    )
+
+
+def test_union_bound_missing_parent_alpha_is_structure_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-ma-005",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    # NO alpha on a non-leaf union-bound node
+                    "children": [_leaf("BUD-ma-006", 300, 0.02)],
+                    "residual": _residual("BUD-ma-007", 100, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(
+        f.category == "structure" and "no alpha" in f.message and "BUD-ma-005" in f.message
+        for f in report.findings
+    )
+
+
+def test_naive_mode_does_not_require_alphas():
+    # Alphas are unused by naive arithmetic; their absence is not a finding there
+    # (the mode itself already carries the unsound-and-never-gateable warning).
+    doc = {
+        "trees": [
+            {
+                "arithmetic": "naive",
+                "root": {
+                    "id": "BUD-ma-008",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [_leaf("BUD-ma-009", 300)],
+                    "residual": _residual("BUD-ma-010", 100),
+                },
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert report.ok
+    assert not any("alpha" in f.message for f in report.findings)
+
+
+# --- kind/unit compatibility --------------------------------------------------
+
+
+def test_mixed_unit_child_is_structure_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-mix-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [
+                        _leaf("BUD-mix-002", 300, 0.02),
+                        {"id": "BUD-mix-003", "kind": "latency", "unit": "s", "bound": 0.3, "alpha": 0.02},
+                    ],
+                    "residual": _residual("BUD-mix-004", 100, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(
+        f.category == "structure" and "incompatible" in f.message and "BUD-mix-003" in f.message
+        for f in report.findings
+    )
+
+
+def test_mixed_kind_child_is_structure_finding_and_arithmetic_is_skipped():
+    # A ms parent must not sum usd children — and the meaningless mixed sum must
+    # not produce a bogus arithmetic finding on top of the structure finding.
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-mix-005",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 100,
+                    "alpha": 0.05,
+                    "children": [
+                        {"id": "BUD-mix-006", "kind": "spend", "unit": "usd", "bound": 5000, "alpha": 0.02},
+                    ],
+                    "residual": _residual("BUD-mix-007", 10, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "structure" and "incompatible" in f.message for f in report.findings)
+    assert not any(f.category == "arithmetic" for f in report.findings)
+
+
+def test_matching_kind_and_unit_produces_no_compatibility_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-mix-008",
+                    "kind": "spend",
+                    "unit": "usd/day",
+                    "bound": 100,
+                    "alpha": 0.05,
+                    "children": [{"id": "BUD-mix-009", "kind": "spend", "unit": "usd/day", "bound": 60, "alpha": 0.02}],
+                    "residual": {"id": "BUD-mix-010", "kind": "spend", "unit": "usd/day", "bound": 30, "alpha": 0.02},
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert report.ok
+
+
+# --- schema enforcement --------------------------------------------------------
+
+
+def test_schema_unknown_field_is_finding():
+    doc = {"trees": [{"root": _leaf("BUD-sch-001", 100, 0.05, bogus_field=True)}]}
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "schema" and "bogus_field" in f.message for f in report.findings)
+
+
+def test_schema_invalid_arithmetic_enum_is_finding():
+    doc = {"trees": [{"arithmetic": "vibes", "root": _leaf("BUD-sch-002", 100, 0.05)}]}
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "schema" and "arithmetic" in f.id for f in report.findings)
+
+
+def test_schema_bad_bud_id_pattern_is_finding():
+    doc = {"trees": [{"root": _leaf("BUDGET-001", 100, 0.05)}]}
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "schema" and "pattern" in f.message for f in report.findings)
+
+
+def test_schema_alpha_out_of_range_is_finding():
+    doc = {"trees": [{"root": _leaf("BUD-sch-003", 100, 1.5)}]}
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "schema" and "maximum" in f.message for f in report.findings)
+
+
+def test_schema_missing_required_asm_evidence_is_finding():
+    doc = {
+        "trees": [
+            {"root": _leaf("BUD-sch-004", 100, 0.05, asm_refs=[{"id": "ASM-sch-001", "ref": "somewhere"}])}
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(
+        f.category == "schema" and "evidence" in f.message and "asm_refs" in f.id for f in report.findings
+    )
+
+
+def test_schema_missing_required_node_fields_is_finding():
+    doc = {"trees": [{"root": {"id": "BUD-sch-005"}}]}  # no kind/unit/bound
+    report = cbt.check_static(doc)
+    assert not report.ok
+    msgs = [f.message for f in report.findings if f.category == "schema"]
+    assert any("kind" in m for m in msgs)
+    assert any("unit" in m for m in msgs)
+    assert any("bound" in m for m in msgs)
+
+
+def test_schema_valid_doc_has_no_schema_findings():
+    doc = {
+        "trees": [
+            {
+                "arithmetic": "union-bound",
+                "root": {
+                    "id": "BUD-sch-006",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "telemetry_ref": "e2e_latency",
+                    "children": [
+                        _leaf(
+                            "BUD-sch-007",
+                            300,
+                            0.02,
+                            asm_refs=[{"id": "ASM-sch-002", "evidence": "sla-doc", "ref": "https://x.example/sla"}],
+                        )
+                    ],
+                    "residual": _residual("BUD-sch-008", 100, 0.01),
+                },
+            }
+        ],
+        "chains": [{"id": "c1", "hops": [{"caller": "a", "callee": "b", "timeout_ms": 100}]}],
+    }
+    report = cbt.check_static(doc)
+    assert not any(f.category == "schema" for f in report.findings)
+    assert report.ok
+
+
+def test_schema_findings_are_gateable_in_static_mode(tmp_path):
+    doc = {"trees": [{"root": {"id": "BUD-sch-009", "kind": "latency", "unit": "ms", "bound": 100, "oops": 1}}]}
+    p = tmp_path / "budget.json"
+    p.write_text(json.dumps(doc))
+    assert cbt.main([str(p)]) == 0  # report-only by default
+    assert cbt.main([str(p), "--gate"]) == 1  # schema findings gate like structure findings
+
+
 # --- timeout monotonicity -----------------------------------------------------
 
 
@@ -315,7 +561,7 @@ def test_asm_ref_missing_ref_is_finding():
     assert not report.ok
 
 
-# --- measured mode: three-way status -------------------------------------------
+# --- measured mode: binding statuses ------------------------------------------
 
 
 def test_measured_held_when_observation_within_bound():
@@ -326,12 +572,13 @@ def test_measured_held_when_observation_within_bound():
     assert report.measured[0].status == "held"
 
 
-def test_measured_unbound_when_observation_breaches_bound():
+def test_measured_breached_when_observation_exceeds_bound():
     doc = {"trees": [{"root": _leaf("BUD-meas-002", 300, telemetry_ref="asr_latency")}]}
     measured = {"asr_latency": {"p95": 450, "count": 500}}
     report = cbt.check_measured(doc, measured, source="k6-summary.json")
     assert report.ok  # still never gates, evidence-only
-    assert report.measured[0].status == "unbound"
+    assert report.measured[0].status == "breached"
+    assert report.counts["measured_breached"] == 1
 
 
 def test_measured_no_observations_when_zero_count_is_a_finding_signal():
@@ -350,10 +597,48 @@ def test_measured_no_observations_when_metric_absent_from_export():
     assert report.measured[0].status == "no_observations"
 
 
-def test_measured_no_observations_when_node_has_no_telemetry_ref():
+def test_measured_unbound_when_node_has_no_telemetry_ref():
+    # No telemetry_ref = the node is not bound to any metric: "unbound" — a spec
+    # gap, DISTINCT from "no_observations" (a declared binding with no data — a
+    # measurement gap). Neither is ever a pass.
     doc = {"trees": [{"root": _leaf("BUD-meas-005", 300)}]}  # no telemetry_ref at all
     report = cbt.check_measured(doc, {"asr_latency": {"p95": 100, "count": 10}}, source="k6-summary.json")
-    assert report.measured[0].status == "no_observations"
+    assert report.measured[0].status == "unbound"
+    assert report.counts["measured_unbound"] == 1
+
+
+def test_measured_all_four_statuses_are_distinct():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-meas-010",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [
+                        _leaf("BUD-meas-011", 300, telemetry_ref="m_held"),
+                        _leaf("BUD-meas-012", 300, telemetry_ref="m_breached"),
+                        _leaf("BUD-meas-013", 300, telemetry_ref="m_nodata"),
+                    ],
+                    "residual": _residual("BUD-meas-014", 100),  # no telemetry_ref
+                }
+            }
+        ]
+    }
+    measured = {
+        "m_held": {"p95": 250, "count": 100},
+        "m_breached": {"p95": 999, "count": 100},
+        "m_nodata": {"p95": None, "count": 0},
+    }
+    report = cbt.check_measured(doc, measured, source="k6-summary.json")
+    statuses = {m.id: m.status for m in report.measured}
+    assert statuses["BUD-meas-011"] == "held"
+    assert statuses["BUD-meas-012"] == "breached"
+    assert statuses["BUD-meas-013"] == "no_observations"
+    assert statuses["BUD-meas-014"] == "unbound"  # residual: no binding declared
+    assert statuses["BUD-meas-010"] == "unbound"  # root: no binding declared
+    assert report.ok  # measured mode is evidence-only, always ok
 
 
 def test_measured_recurses_into_children_and_residual():
@@ -374,9 +659,9 @@ def test_measured_recurses_into_children_and_residual():
     measured = {"child_metric": {"p95": 250, "count": 10}}
     report = cbt.check_measured(doc, measured, source="k6-summary.json")
     ids = {m.id: m.status for m in report.measured}
-    assert ids["BUD-meas-006"] == "no_observations"  # root has no telemetry_ref
+    assert ids["BUD-meas-006"] == "unbound"  # root has no telemetry_ref
     assert ids["BUD-meas-007"] == "held"
-    assert ids["BUD-meas-008"] == "no_observations"  # residual has no telemetry_ref
+    assert ids["BUD-meas-008"] == "unbound"  # residual has no telemetry_ref
 
 
 # --- load_measured: k6 summary + flat export shapes ---------------------------
@@ -515,7 +800,17 @@ def test_cli_measured_never_exits_nonzero_even_with_gate(tmp_path, capsys):
     rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--gate"])
     assert rc == 0  # measured mode is evidence-only, permanently
     out = capsys.readouterr().out
-    assert "unbound" in out
+    assert "breached" in out
+
+
+def test_cli_measured_with_schema_findings_still_exits_zero_even_with_gate(tmp_path):
+    # Even a schema-invalid document cannot make measured mode exit non-zero:
+    # findings are reported as evidence, --gate has no effect.
+    doc = {"trees": [{"root": _leaf("BUD-cli-008", 100, telemetry_ref="m1", bogus_field=True)}]}
+    budget_path = _write(tmp_path, "budget.json", doc)
+    measured_path = _write(tmp_path, "measured.json", {"m1": {"p95": 50, "count": 5}})
+    rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--gate"])
+    assert rc == 0
 
 
 def test_cli_json_format_includes_authority_and_counts(tmp_path, capsys):

--- a/tests/test_check_budget_tree.py
+++ b/tests/test_check_budget_tree.py
@@ -1,0 +1,541 @@
+"""Tests for the budget tree checker (#164)."""
+
+from __future__ import annotations
+
+import json
+
+import check_budget_tree as cbt
+
+
+def _leaf(id_, bound, alpha=None, telemetry_ref=None, **extra):
+    node = {"id": id_, "kind": "latency", "unit": "ms", "bound": bound}
+    if alpha is not None:
+        node["alpha"] = alpha
+    if telemetry_ref is not None:
+        node["telemetry_ref"] = telemetry_ref
+    node.update(extra)
+    return node
+
+
+def _residual(id_, bound, alpha=None):
+    return _leaf(id_, bound, alpha)
+
+
+# --- union-bound arithmetic ---------------------------------------------------
+
+
+def test_union_bound_consistent_tree_has_no_findings():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-voice-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [
+                        _leaf("BUD-voice-002", 300, 0.02),
+                        _leaf("BUD-voice-003", 300, 0.02),
+                    ],
+                    "residual": _residual("BUD-voice-004", 150, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert report.ok
+    assert report.findings == []
+
+
+def test_union_bound_alpha_oversubscribed_is_arithmetic_finding():
+    # sum(bound) fits (300+300+150=750<=800) but sum(alpha) does NOT (0.03+0.03+0.03=0.09 > 0.05)
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-x-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [
+                        _leaf("BUD-x-002", 300, 0.03),
+                        _leaf("BUD-x-003", 300, 0.03),
+                    ],
+                    "residual": _residual("BUD-x-004", 150, 0.03),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "arithmetic" and "alpha" in f.message for f in report.findings)
+
+
+def test_union_bound_bound_oversubscribed_is_arithmetic_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-y-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 500,
+                    "alpha": 0.1,
+                    "children": [
+                        _leaf("BUD-y-002", 300, 0.02),
+                        _leaf("BUD-y-003", 300, 0.02),
+                    ],
+                    "residual": _residual("BUD-y-004", 50, 0.02),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "arithmetic" and "bound" in f.message.lower() for f in report.findings)
+
+
+def test_headroom_counts_against_parent_bound():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-h-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 700,
+                    "alpha": 0.1,
+                    "headroom": 200,
+                    "children": [_leaf("BUD-h-002", 300, 0.03)],
+                    "residual": _residual("BUD-h-003", 150, 0.03),
+                }
+            }
+        ]
+    }
+    # 300 + 150 + headroom(200) = 650 <= 700 -> fine
+    report = cbt.check_static(doc)
+    assert report.ok
+
+    doc["trees"][0]["root"]["headroom"] = 300
+    # 300 + 150 + headroom(300) = 750 > 700 -> violation
+    report2 = cbt.check_static(doc)
+    assert not report2.ok
+
+
+# --- the correlated-tails counterexample (refuter finding #1) ----------------
+
+
+def test_correlated_tails_counterexample_naive_passes_union_bound_flags():
+    """Two children each p95=300ms, parent bound=700ms.
+
+    Naive sum-of-bounds (300+300=600 <= 700) PASSES and looks safe. But each
+    child's own tail-probability budget (alpha=0.05) sums to 0.10 against a
+    parent alpha of 0.05 — the union bound shows the parent's own tail
+    guarantee is oversubscribed, something the naive sum can never see because
+    percentiles do not sum. This is the load-bearing counterexample from the
+    issue: naive arithmetic is unsound for correlated tails.
+    """
+    root = {
+        "id": "BUD-tail-001",
+        "kind": "latency",
+        "unit": "ms",
+        "bound": 700,
+        "alpha": 0.05,
+        "children": [
+            _leaf("BUD-tail-002", 300, 0.05),
+            _leaf("BUD-tail-003", 300, 0.05),
+        ],
+        "residual": _residual("BUD-tail-004", 0, 0.0),
+    }
+
+    naive_doc = {"trees": [{"root": root, "arithmetic": "naive"}]}
+    naive_report = cbt.check_static(naive_doc)
+    assert naive_report.ok  # naive mode never gates -> reports as ok
+    assert any(
+        w.category == "naive-arithmetic" and "would PASS" in w.message for w in naive_report.warnings
+    )
+
+    union_doc = {"trees": [{"root": root, "arithmetic": "union-bound"}]}
+    union_report = cbt.check_static(union_doc)
+    assert not union_report.ok
+    assert any(f.category == "arithmetic" and "alpha" in f.message for f in union_report.findings)
+
+
+def test_naive_mode_warning_is_never_a_finding():
+    doc = {
+        "trees": [
+            {
+                "arithmetic": "naive",
+                "root": {
+                    "id": "BUD-n-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 100,
+                    "children": [_leaf("BUD-n-002", 200)],
+                    "residual": _residual("BUD-n-003", 0),
+                },
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    # naive would-FAIL is reported, but only as a warning, never a finding, never blocking
+    assert report.ok
+    assert report.findings == []
+    assert any("would FAIL" in w.message for w in report.warnings)
+
+
+# --- residual enforcement -----------------------------------------------------
+
+
+def test_missing_residual_on_nonleaf_is_structure_finding():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-r-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [_leaf("BUD-r-002", 300, 0.02)],
+                    # no residual!
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert not report.ok
+    assert any(f.category == "structure" and "residual" in f.message for f in report.findings)
+
+
+def test_leaf_node_does_not_require_residual():
+    doc = {
+        "trees": [
+            {
+                "root": _leaf("BUD-l-001", 100, 0.05),
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    assert report.ok
+    assert report.findings == []
+
+
+# --- timeout monotonicity -----------------------------------------------------
+
+
+def test_monotonic_chain_has_no_violation_warning():
+    doc = {
+        "trees": [{"root": _leaf("BUD-m-001", 100)}],
+        "chains": [
+            {
+                "id": "chain-1",
+                "hops": [
+                    {"caller": "gateway", "callee": "asr", "timeout_ms": 500},
+                    {"caller": "asr", "callee": "llm", "timeout_ms": 300},
+                    {"caller": "llm", "callee": "tts", "timeout_ms": 150},
+                ],
+            }
+        ],
+    }
+    report = cbt.check_static(doc)
+    assert report.ok
+    violations = [w for w in report.warnings if w.category == "monotonicity" and "not greater than" in w.message]
+    assert violations == []
+
+
+def test_nonmonotonic_chain_is_warning_not_finding():
+    doc = {
+        "trees": [{"root": _leaf("BUD-m2-001", 100)}],
+        "chains": [
+            {
+                "id": "chain-2",
+                "hops": [
+                    {"caller": "gateway", "callee": "asr", "timeout_ms": 200},
+                    {"caller": "asr", "callee": "llm", "timeout_ms": 300},  # violation: 200 !> 300
+                ],
+            }
+        ],
+    }
+    report = cbt.check_static(doc)
+    assert report.ok  # WARN only, never gateable
+    assert report.findings == []
+    violations = [w for w in report.warnings if w.category == "monotonicity" and "not greater than" in w.message]
+    assert len(violations) == 1
+    assert "retries/hedging" in violations[0].message
+
+
+# --- ASM evidence statuses -----------------------------------------------------
+
+
+def test_asm_ref_sla_doc_is_covered():
+    node = _leaf("BUD-a-001", 100, asm_refs=[{"id": "ASM-vendor-001", "evidence": "sla-doc", "ref": "https://vendor.example/sla"}])
+    doc = {"trees": [{"root": node}]}
+    report = cbt.check_static(doc)
+    assert report.ok
+    assert report.asm_statuses[0].status == "covered"
+
+
+def test_asm_ref_live_probe_is_covered():
+    node = _leaf("BUD-a-002", 100, asm_refs=[{"id": "ASM-vendor-002", "evidence": "live-probe", "ref": "probes/vendor.py"}])
+    report = cbt.check_static({"trees": [{"root": node}]})
+    assert report.asm_statuses[0].status == "covered"
+
+
+def test_asm_ref_justified_renders_as_waiver_not_covered():
+    node = _leaf(
+        "BUD-a-003", 100, asm_refs=[{"id": "ASM-vendor-003", "evidence": "justified", "ref": "no SLA published; accepted risk per ADR-12"}]
+    )
+    report = cbt.check_static({"trees": [{"root": node}]})
+    assert report.ok
+    assert report.asm_statuses[0].status == "waived"
+    assert report.asm_statuses[0].status != "covered"
+
+
+def test_asm_ref_missing_evidence_is_finding():
+    node = _leaf("BUD-a-004", 100, asm_refs=[{"id": "ASM-vendor-004", "ref": "somewhere"}])
+    report = cbt.check_static({"trees": [{"root": node}]})
+    assert not report.ok
+    assert any(f.category == "structure" and "ASM-vendor-004" in f.message for f in report.findings)
+    assert report.asm_statuses[0].status == "missing"
+
+
+def test_asm_ref_invalid_evidence_value_is_finding():
+    node = _leaf("BUD-a-005", 100, asm_refs=[{"id": "ASM-vendor-005", "evidence": "vibes", "ref": "somewhere"}])
+    report = cbt.check_static({"trees": [{"root": node}]})
+    assert not report.ok
+    assert report.asm_statuses[0].status == "missing"
+
+
+def test_asm_ref_missing_ref_is_finding():
+    node = _leaf("BUD-a-006", 100, asm_refs=[{"id": "ASM-vendor-006", "evidence": "sla-doc"}])
+    report = cbt.check_static({"trees": [{"root": node}]})
+    assert not report.ok
+
+
+# --- measured mode: three-way status -------------------------------------------
+
+
+def test_measured_held_when_observation_within_bound():
+    doc = {"trees": [{"root": _leaf("BUD-meas-001", 300, telemetry_ref="asr_latency")}]}
+    measured = {"asr_latency": {"p95": 250, "count": 500}}
+    report = cbt.check_measured(doc, measured, source="k6-summary.json")
+    assert report.ok  # measured mode never gates
+    assert report.measured[0].status == "held"
+
+
+def test_measured_unbound_when_observation_breaches_bound():
+    doc = {"trees": [{"root": _leaf("BUD-meas-002", 300, telemetry_ref="asr_latency")}]}
+    measured = {"asr_latency": {"p95": 450, "count": 500}}
+    report = cbt.check_measured(doc, measured, source="k6-summary.json")
+    assert report.ok  # still never gates, evidence-only
+    assert report.measured[0].status == "unbound"
+
+
+def test_measured_no_observations_when_zero_count_is_a_finding_signal():
+    doc = {"trees": [{"root": _leaf("BUD-meas-003", 300, telemetry_ref="asr_latency")}]}
+    measured = {"asr_latency": {"p95": None, "count": 0}}
+    report = cbt.check_measured(doc, measured, source="k6-summary.json")
+    assert report.measured[0].status == "no_observations"
+    assert report.counts["measured_no_observations"] == 1
+    # zero observations is never reported as a pass
+    assert report.measured[0].status != "held"
+
+
+def test_measured_no_observations_when_metric_absent_from_export():
+    doc = {"trees": [{"root": _leaf("BUD-meas-004", 300, telemetry_ref="nonexistent_metric")}]}
+    report = cbt.check_measured(doc, {}, source="k6-summary.json")
+    assert report.measured[0].status == "no_observations"
+
+
+def test_measured_no_observations_when_node_has_no_telemetry_ref():
+    doc = {"trees": [{"root": _leaf("BUD-meas-005", 300)}]}  # no telemetry_ref at all
+    report = cbt.check_measured(doc, {"asr_latency": {"p95": 100, "count": 10}}, source="k6-summary.json")
+    assert report.measured[0].status == "no_observations"
+
+
+def test_measured_recurses_into_children_and_residual():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-meas-006",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [_leaf("BUD-meas-007", 300, telemetry_ref="child_metric")],
+                    "residual": _residual("BUD-meas-008", 100),
+                }
+            }
+        ]
+    }
+    measured = {"child_metric": {"p95": 250, "count": 10}}
+    report = cbt.check_measured(doc, measured, source="k6-summary.json")
+    ids = {m.id: m.status for m in report.measured}
+    assert ids["BUD-meas-006"] == "no_observations"  # root has no telemetry_ref
+    assert ids["BUD-meas-007"] == "held"
+    assert ids["BUD-meas-008"] == "no_observations"  # residual has no telemetry_ref
+
+
+# --- load_measured: k6 summary + flat export shapes ---------------------------
+
+
+def test_load_measured_flat_export(tmp_path):
+    p = tmp_path / "flat.json"
+    p.write_text(json.dumps({"asr_latency": {"p95": 250, "count": 10}}))
+    data = cbt.load_measured(p)
+    assert data["asr_latency"] == {"p95": 250, "count": 10}
+
+
+def test_load_measured_k6_summary_export(tmp_path):
+    p = tmp_path / "k6-summary.json"
+    p.write_text(
+        json.dumps(
+            {
+                "metrics": {
+                    "http_req_duration": {"values": {"p(95)": 320.5, "count": 1000}},
+                    "unused_metric": {"values": {"count": 0}},
+                }
+            }
+        )
+    )
+    data = cbt.load_measured(p)
+    assert data["http_req_duration"]["p95"] == 320.5
+    assert data["http_req_duration"]["count"] == 1000
+    assert data["unused_metric"]["count"] == 0
+    assert data["unused_metric"]["p95"] is None
+
+
+# --- authority line ------------------------------------------------------------
+
+
+def test_static_authority_line():
+    report = cbt.check_static({"trees": [{"root": _leaf("BUD-auth-001", 100)}]})
+    assert report.authority == "static mode proves budget-declaration consistency, not runtime latency"
+    assert "authority" in report.to_dict()
+
+
+def test_measured_authority_line_includes_source():
+    report = cbt.check_measured({"trees": [{"root": _leaf("BUD-auth-002", 100)}]}, {}, source="k6-summary.json")
+    assert report.authority == "measured mode reports observations from k6-summary.json; not a proof of runtime behaviour"
+
+
+def test_render_text_includes_authority_line():
+    report = cbt.check_static({"trees": [{"root": _leaf("BUD-auth-003", 100)}]})
+    text = cbt.render_text(report)
+    assert "Authority:" in text
+    assert report.authority in text
+
+
+# --- report shape: counts/ok/to_dict -------------------------------------------
+
+
+def test_report_json_serializable():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-json-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "alpha": 0.05,
+                    "children": [_leaf("BUD-json-002", 300, 0.02)],
+                    "residual": _residual("BUD-json-003", 150, 0.01),
+                }
+            }
+        ]
+    }
+    report = cbt.check_static(doc)
+    json.dumps(report.to_dict())  # must not raise
+
+
+# --- CLI: exit codes + gating ---------------------------------------------------
+
+
+def _write(tmp_path, name, doc):
+    p = tmp_path / name
+    p.write_text(json.dumps(doc))
+    return p
+
+
+def test_cli_static_default_is_report_only_even_with_findings(tmp_path, capsys):
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-cli-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [_leaf("BUD-cli-002", 300)],
+                    # missing residual -> a finding
+                }
+            }
+        ]
+    }
+    p = _write(tmp_path, "budget.json", doc)
+    rc = cbt.main([str(p)])
+    assert rc == 0  # report-only by default even with findings present
+    assert "FINDINGS" in capsys.readouterr().out
+
+
+def test_cli_static_gate_fails_on_findings(tmp_path, capsys):
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-cli-003",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [_leaf("BUD-cli-004", 300)],
+                }
+            }
+        ]
+    }
+    p = _write(tmp_path, "budget.json", doc)
+    rc = cbt.main([str(p), "--gate"])
+    assert rc == 1
+
+
+def test_cli_static_gate_passes_clean_tree(tmp_path):
+    doc = {"trees": [{"root": _leaf("BUD-cli-005", 100, 0.05)}]}
+    p = _write(tmp_path, "budget.json", doc)
+    rc = cbt.main([str(p), "--gate"])
+    assert rc == 0
+
+
+def test_cli_measured_never_exits_nonzero_even_with_gate(tmp_path, capsys):
+    doc = {"trees": [{"root": _leaf("BUD-cli-006", 100, telemetry_ref="m1")}]}
+    budget_path = _write(tmp_path, "budget.json", doc)
+    measured_path = _write(tmp_path, "measured.json", {"m1": {"p95": 500, "count": 5}})  # breaches bound
+    rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--gate"])
+    assert rc == 0  # measured mode is evidence-only, permanently
+    out = capsys.readouterr().out
+    assert "unbound" in out
+
+
+def test_cli_json_format_includes_authority_and_counts(tmp_path, capsys):
+    doc = {"trees": [{"root": _leaf("BUD-cli-007", 100, 0.05)}]}
+    p = _write(tmp_path, "budget.json", doc)
+    rc = cbt.main([str(p), "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["authority"] == cbt.STATIC_AUTHORITY
+    assert "counts" in data and "findings" in data["counts"]
+
+
+def test_cli_missing_file_is_usage_error(tmp_path, capsys):
+    rc = cbt.main([str(tmp_path / "nope.json")])
+    assert rc == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_cli_malformed_json_is_usage_error(tmp_path, capsys):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    rc = cbt.main([str(p)])
+    assert rc == 2


### PR DESCRIPTION
## Summary

Implements #164: the first system-layer gate — typed NFR budget trees
(latency/throughput/spend) checked as machine-readable contracts, not prose.
Pilot use case: the ~800ms mouth-to-ear voice-agent budget decomposed into
endpointing / LLM TTFT / TTS TTFB / transport.

New files only (no existing scanner modified):
- `templates/formal-models/system-contracts-schema.json` — documented JSON
  Schema for `BUD-` stable-ID budget trees: `{id, kind: latency|throughput|spend,
  unit, bound, alpha, headroom, telemetry_ref, children, residual, asm_refs}`,
  plus optional `chains` for timeout-monotonicity checks.
- `scripts/check_budget_tree.py` — the checker, stdlib only, mirroring
  `check_traceability.py`'s shape (dataclasses, report object with
  counts/ok/authority, argparse, best-effort `factory_log.emit_gate`).
- `tests/test_check_budget_tree.py` — 35 tests, written first (TDD).
- `docs/budget-trees.md` — concise doc: why percentiles don't sum, the
  construction, coverage/ASM/monotonicity rules, the two modes, authority
  boundary.

Core arithmetic (load-bearing, per the issue): a child set is consistent with
its parent iff `sum(child.alpha) <= parent.alpha` AND `sum(child.bound) +
headroom <= parent.bound` — a union bound, sound without assuming
independence. `arithmetic: "naive"` (sum-of-bounds only) is supported per
tree but is WARN-only and can never gate, demonstrated by the correlated-
tails counterexample from the issue: two children each p95=300ms against a
700ms parent naively "pass" (300+300=600<=700) while their tail-probability
budgets (alpha=0.05 each) sum to 0.10 against a 0.05 parent alpha — the union
bound catches what the naive sum structurally cannot see.

Every non-leaf node must declare a `residual` child (explicit unaccounted-
budget bucket) — missing residual is a structure finding. `asm_refs` entries
distinguish `covered` (sla-doc/live-probe) from `waived` (justified — a
documented waiver, not silently equal to covered); missing/invalid evidence
is a finding. Optional timeout chains check caller > callee monotonicity per
hop (WARN-only, always noting retries/hedging multiply worst-case occupancy).

Two modes: `static` (default, `--gate` fails only on structure/arithmetic
findings) and `--measured <file>` (k6 summary JSON or flat `{metric: {p95:
...}}` export; three-way per-binding status `held`/`unbound` (bound
breached)/`no_observations` (zero observations — a finding, never a pass);
evidence-only, permanently — never exits non-zero even with `--gate`). Every
report (text/JSON) carries an `authority` line stating exactly what was
proven, per the issue's authority-boundary requirement.

Ships report-only per `docs/gate-rollout.md` — not wired into `/architect` or
`/close-epic` as a blocker in this PR.

Fortunate alignment: `BUD`/`ASM` were independently reserved as system-layer
stable-ID kinds in `scripts/chief_wiggum/trace_ids.py` (#166, merged to main
after this branch was cut) with the identical `KIND-slug-NNN` grammar this
schema already uses — no changes needed, this PR rebases cleanly on top.

## Test plan

- [x] `python3 -m pytest tests/test_check_budget_tree.py -q` — 35 passed
- [x] `python3 -m pytest tests/ -q` — full suite, 825 passed, 4 skipped (pre-existing, unrelated)
- [x] `python3 -m ruff check scripts tests` — all checks passed
- [x] `python3 -m py_compile scripts/check_budget_tree.py`
- [x] `python3 scripts/check_portability.py` — harness-neutral
- [x] Manual end-to-end smoke test: authored a voice-agent pilot tree, ran static
      mode (clean, `--gate` exit 0), then measured mode against a synthetic k6-style
      export exercising all three statuses (`held`, `unbound` on a breached LLM TTFT
      bound, `no_observations` on a zero-count TTS metric) — confirmed `--gate` has
      no effect on measured mode (always exit 0).

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF