### PR TITLE
feat(system): DST-readiness scanner + architect stamps (#167)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -48,13 +48,13 @@ cat "$TARGET_REPO/docs/domain-context.md" 2>/dev/null
 ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 ```
 
-**New-product check.** DST (deterministic-simulation testing, FoundationDB/TigerBeetle/Antithesis-style) is only cheap if determinism is designed in from day one — retrofitting it into a codebase with wall-clock reads and unseeded randomness scattered through business logic is brutal. This is the one window where it's free, so detect whether this is the epic that first architects the product:
+**New-product check.** DST (deterministic-simulation testing, FoundationDB/TigerBeetle/Antithesis-style) is only cheap if determinism is designed in from day one — retrofitting it into a codebase with wall-clock reads and unseeded randomness scattered through business logic is brutal. This is the one window where it's free, so detect whether this is the epic that first architects the product. The default heuristic: no prior CW epic artifacts AND no existing CW quality state:
 
 ```bash
-IS_NEW_PRODUCT=$([ -d "$TARGET_REPO/docs/epics" ] && echo false || echo true)
+IS_NEW_PRODUCT=$([ ! -d "$TARGET_REPO/docs/epics" ] && [ ! -f "$TARGET_REPO/docs/quality/ratchet.json" ] && echo true || echo false)
 ```
 
-If `IS_NEW_PRODUCT` is `true`, Step 4e stamps DST-readiness invariants and Step 4f's ADR notes the clock/random/IO seam scaffolding (see below). Skip both for a repo that already has epics — retrofitting the invariant onto existing tickets is a separate, deliberate decision, not something to silently stamp in.
+This is a **default the operator can override**, not a proof — a repo can have real history without either marker (e.g. imported code CW never touched), or be effectively greenfield despite a stray artifact. If the signal looks wrong for this repo, say so at the Step 6 checkpoint and let the user decide. If `IS_NEW_PRODUCT` is `true`, Step 4b's structured model gains DST-readiness invariants (rendered into `invariants.md` via Step 4e) and Step 4f's ADR notes the clock/random/IO seam scaffolding (see below). Skip both for an established repo — retrofitting the invariants onto existing code is a separate, deliberate decision, not something to silently stamp in.
 
 `docs/domain-context.md` (written by `/seed` Step 2.5) is the **ground truth for data contracts**: canonical metric definitions, real schema names, source caveats, and mined use cases — each with citations. If the epic touches an existing data source and this file doesn't exist, run the `/seed` Step 2.5 ingestion now (semantic layer, schema introspection, transformation-repo history) before writing any data contract. Contracts authored from guessed table/column names are how query layers get built against names that don't exist.
 
@@ -242,29 +242,33 @@ Each invariant MUST have a unique ID (e.g., INV-001) that matches its ID in the 
 
 The connected requirements arrive as a set — adopt the **whole** cluster for a realized pattern, not a subset. Any `unresolved` parameter reported for that pattern must be resolved (or explicitly re-marked `TBD:`) before an invariant depends on it.
 
-**DST-readiness invariants (new products only — `IS_NEW_PRODUCT=true` from Step 1).** Stamp a small, fixed cluster of determinism-readiness invariants so the seams exist from ticket one instead of getting retrofitted later:
+**DST-readiness invariants (new products only — `IS_NEW_PRODUCT=true` from Step 1).** Stamp a small, fixed cluster of determinism-readiness invariants so the seams exist from ticket one instead of getting retrofitted later. **Structured model first**: these go into `state-machines.json`'s top-level `invariants` array as schema-valid invariant objects (Step 4b), and the prose in `invariants.md` is then consolidated from the models like every other invariant — never authored verbatim into the prose alone (JSON is the source of truth; prose is derived):
 
-```markdown
-### Determinism & Simulation Readiness
-- **INV-dst-001 — No wall-clock reads outside the clock seam**: production code reads
-  the current time only through a designated clock module/package (e.g. `internal/clock`),
-  never `time.Now()` / `datetime.now()` / `Date.now()` directly.
-- **INV-dst-002 — No unseeded randomness outside the random seam**: production code
-  draws randomness only through a designated, seedable source (e.g. `internal/rand`),
-  never the default `math/rand` package functions / Python `random` module / `Math.random()`
-  directly.
-- **INV-dst-003 — IO behind seam interfaces**: network/filesystem/DB calls are made only
-  from designated IO packages, behind an interface a test can substitute. (Checked by
-  code review, not `check_dst_readiness.py` — see below; grepping "any IO outside package
-  X" is too noisy for a v1 regex tier.)
+```json
+{
+  "id": "INV-dst-001",
+  "description": "No wall-clock reads outside the clock seam: production code reads the current time only through the designated clock module (e.g. internal/clock), never time.Now() / datetime.now() / Date.now() directly.",
+  "expression": "forall call in production_code: is_wall_clock_read(call) => module(call) == clock_seam",
+  "scope": "global",
+  "category": "operational_safety"
+},
+{
+  "id": "INV-dst-002",
+  "description": "No unseeded randomness outside the random seam: production code draws randomness only through a designated, seedable source (e.g. internal/rand), never default math/rand package functions / Python random module / Math.random() directly.",
+  "expression": "forall call in production_code: is_default_source_random(call) => module(call) == rand_seam",
+  "scope": "global",
+  "category": "operational_safety"
+},
+{
+  "id": "INV-dst-003",
+  "description": "IO behind seam interfaces: network/filesystem/DB calls are made only from designated IO packages, behind an interface a test can substitute. Checked by code review, not check_dst_readiness.py — grepping 'any IO outside package X' is too noisy for a v1 regex tier.",
+  "expression": "forall call in production_code: is_io(call) => package(call) in io_seam_packages",
+  "scope": "global",
+  "category": "operational_safety"
+}
 ```
 
-These are advisory, not blocking: `scripts/check_dst_readiness.py` mechanically checks
-INV-dst-001/002 (report-only by default, FOREVER — this is design-readiness signal, not
-enforcement) and is run in Step 5a. INV-dst-003 has no mechanical check yet; it's
-scaffolding for code review to hold workers to. Fold these into `invariants.md` verbatim
-with the IDs above so downstream `/implement` tickets and `check_dst_readiness.py`'s
-`**/clock*` / `**/rand*` / `**/telemetry/**` seam allowlist line up with real packages.
+After `render_models.py` regenerates the prose, verify the three IDs appear in `invariants.md` under their own subsection (e.g. "Determinism & Simulation Readiness"). These are advisory, not blocking: `scripts/check_dst_readiness.py` mechanically checks INV-dst-001/002 (report-only by default, FOREVER — this is design-readiness signal, not enforcement) and is run in Step 5a. INV-dst-003 has no mechanical check yet; it's scaffolding for code review to hold workers to. Keep the IDs stable so downstream `/implement` tickets and `check_dst_readiness.py`'s `**/clock*` / `**/rand*` / `**/telemetry/**` seam allowlist line up with real packages.
 
 #### 4f. ADR (`adr.md`)
 

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -48,6 +48,14 @@ cat "$TARGET_REPO/docs/domain-context.md" 2>/dev/null
 ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 ```
 
+**New-product check.** DST (deterministic-simulation testing, FoundationDB/TigerBeetle/Antithesis-style) is only cheap if determinism is designed in from day one — retrofitting it into a codebase with wall-clock reads and unseeded randomness scattered through business logic is brutal. This is the one window where it's free, so detect whether this is the epic that first architects the product:
+
+```bash
+IS_NEW_PRODUCT=$([ -d "$TARGET_REPO/docs/epics" ] && echo false || echo true)
+```
+
+If `IS_NEW_PRODUCT` is `true`, Step 4e stamps DST-readiness invariants and Step 4f's ADR notes the clock/random/IO seam scaffolding (see below). Skip both for a repo that already has epics — retrofitting the invariant onto existing tickets is a separate, deliberate decision, not something to silently stamp in.
+
 `docs/domain-context.md` (written by `/seed` Step 2.5) is the **ground truth for data contracts**: canonical metric definitions, real schema names, source caveats, and mined use cases — each with citations. If the epic touches an existing data source and this file doesn't exist, run the `/seed` Step 2.5 ingestion now (semantic layer, schema introspection, transformation-repo history) before writing any data contract. Contracts authored from guessed table/column names are how query layers get built against names that don't exist.
 
 **Adopted patterns.** If the product has adopted registry patterns (via `/apply-pattern`), load their invariant clusters now — they are **pre-derived contracts** this epic must not re-invent:
@@ -234,6 +242,30 @@ Each invariant MUST have a unique ID (e.g., INV-001) that matches its ID in the 
 
 The connected requirements arrive as a set — adopt the **whole** cluster for a realized pattern, not a subset. Any `unresolved` parameter reported for that pattern must be resolved (or explicitly re-marked `TBD:`) before an invariant depends on it.
 
+**DST-readiness invariants (new products only — `IS_NEW_PRODUCT=true` from Step 1).** Stamp a small, fixed cluster of determinism-readiness invariants so the seams exist from ticket one instead of getting retrofitted later:
+
+```markdown
+### Determinism & Simulation Readiness
+- **INV-dst-001 — No wall-clock reads outside the clock seam**: production code reads
+  the current time only through a designated clock module/package (e.g. `internal/clock`),
+  never `time.Now()` / `datetime.now()` / `Date.now()` directly.
+- **INV-dst-002 — No unseeded randomness outside the random seam**: production code
+  draws randomness only through a designated, seedable source (e.g. `internal/rand`),
+  never the default `math/rand` package functions / Python `random` module / `Math.random()`
+  directly.
+- **INV-dst-003 — IO behind seam interfaces**: network/filesystem/DB calls are made only
+  from designated IO packages, behind an interface a test can substitute. (Checked by
+  code review, not `check_dst_readiness.py` — see below; grepping "any IO outside package
+  X" is too noisy for a v1 regex tier.)
+```
+
+These are advisory, not blocking: `scripts/check_dst_readiness.py` mechanically checks
+INV-dst-001/002 (report-only by default, FOREVER — this is design-readiness signal, not
+enforcement) and is run in Step 5a. INV-dst-003 has no mechanical check yet; it's
+scaffolding for code review to hold workers to. Fold these into `invariants.md` verbatim
+with the IDs above so downstream `/implement` tickets and `check_dst_readiness.py`'s
+`**/clock*` / `**/rand*` / `**/telemetry/**` seam allowlist line up with real packages.
+
 #### 4f. ADR (`adr.md`)
 
 Architectural Decision Record capturing the key decisions for this epic:
@@ -262,6 +294,26 @@ Accepted
 - [Negative consequences / tech debt accepted]
 - [Follow-up work needed]
 ```
+
+**New products (`IS_NEW_PRODUCT=true`) add a decision entry for the DST seams**, naming the actual packages this codebase will use — not a hypothetical:
+
+```markdown
+### N. Determinism & simulation readiness (clock/random/IO seams)
+- **Decision**: All wall-clock reads go through `internal/clock` (a single `Now() time.Time`
+  seam); all randomness goes through `internal/rand` (seeded, injectable); network/DB/FS
+  calls are made behind interfaces owned by the designated IO packages listed here: [...].
+- **Alternatives considered**: Leaving `time.Now()`/`rand.Intn()` inline — rejected because
+  retrofitting determinism later means touching every call site instead of one seam.
+- **AI consensus**: [Where the three AIs agreed/diverged]
+- **Trade-offs**: One extra layer of indirection for time/randomness/IO from ticket one, in
+  exchange for this codebase staying simulation-testable (fast, reproducible, shrinkable bug
+  repros) instead of needing a painful determinism retrofit later.
+```
+
+This is the scaffolding note that makes INV-dst-001/002/003 (Step 4e) actionable — the
+invariant says "no wall-clock reads outside the clock seam"; this decision says which
+package IS the clock seam, so `/implement` workers build against it from ticket one instead
+of learning about it after the fact.
 
 #### 4g. Integration Test Specification (`integration-tests.md`)
 
@@ -347,6 +399,14 @@ python3 "$CW_HOME/scripts/check_single_writer.py" "$CW_TMP" --source "$TARGET_RE
 
 Any invariant that says "single write path" or "single source of truth" for a field/state MUST name its `controls_field` and `sanctioned_writers` — either as arrays on the structured `state-machines.json` invariant, or via a `<!-- @cw-writes INV-... controls_field=a.b sanctioned_writers=Sym,path.go -->` tag next to its `**INV-...**` label in `invariants.md`. Without this metadata the invariant is prose only and a second mutator (e.g. a legacy admin control) can silently violate it. Review the surfaced writer inventory: if the gate lists a writer outside the sanctioned set, that is a pre-existing violation to fix or explicitly sanction before the epic builds on the invariant.
 
+**DST-readiness baseline (new products only — `IS_NEW_PRODUCT=true`).** Run the scanner report-only against the target repo to document the current wall-clock/random-call baseline — this NEVER blocks (advisory forever, per the design decision behind it):
+
+```bash
+python3 "$CW_HOME/scripts/check_dst_readiness.py" "$TARGET_REPO" --format text
+```
+
+Note the finding counts in Step 6's summary (a fresh repo should have ~zero; a real baseline scan may surface some pre-existing calls worth folding into the seam allowlist or fixing before the first ticket lands). This never gates — `--gate` exists in the script for a repo that later opts in via its own ratchet config, but `/architect` never passes it.
+
 Check the graph analysis output for:
 - **Unreachable states**: States that can't be reached from the initial state — these are model bugs
 - **Dead states**: Non-terminal states with no outgoing transitions — entities get stuck here
@@ -407,6 +467,7 @@ python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name architect-rev
 - **Model health**: graph analysis — any unreachable states, dead states, missing paths
 - **Open unknowns**: every surviving `TBD:`/`UNRESOLVED:` marker, which tickets each one blocks, and the plan to resolve it (who/what/when)
 - **Test coverage preview**: number of test paths that will be mechanically generated (from the test view)
+- **DST readiness** (new products only): the INV-dst-001/002/003 invariants stamped, the clock/random/IO seam packages named in the ADR, and `check_dst_readiness.py`'s baseline finding counts
 - ADR: key decisions with trade-offs
 - Integration tests: what will be validated at epic close
 - Traceability: coverage gaps (any AC without a planned test)
@@ -503,6 +564,12 @@ Your implementation must satisfy the contracts and invariants. The /implement sk
 
 ### Coverage gaps
 - [Any AC without a planned test — these need attention during implementation]
+
+### DST readiness (new products only)
+- Invariants stamped: INV-dst-001 (clock seam), INV-dst-002 (random seam), INV-dst-003 (IO seam)
+- Seam packages named in the ADR: [e.g. `internal/clock`, `internal/rand`]
+- `check_dst_readiness.py` baseline: N findings (report-only — advisory forever, not a blocker)
+- [Omit this section for a repo that already has prior epics]
 
 ### Open unknowns (blockers)
 - [Each surviving TBD/UNRESOLVED marker: what it is, which tickets it blocks, how to resolve it]

--- a/scripts/check_dst_readiness.py
+++ b/scripts/check_dst_readiness.py
@@ -10,23 +10,56 @@ codebase". This checker is advisory: it stamps the opportunity into new products
 `/architect` (see the "DST readiness" step there) and reports violations here — it does
 not, by itself, block anything.
 
-Rules (regex tier, language-aware, mirrors ``check_single_writer.py``'s style of
-line-scanning with comment stripping):
+Rules (regex tier, language-aware line scanning over comment- and string-stripped
+source; see "What is stripped" below):
 
 - **wall-clock** — a direct wall-clock read outside a designated clock seam:
-  Go ``time.Now``; Python ``datetime.now``, ``datetime.utcnow``, ``time.time``;
-  TS/JS ``Date.now`` and no-arg ``new Date`` construction.
-- **unseeded-random** — an unseeded, default-source random call outside a designated
-  random seam: Go ``math/rand`` package-level calls (``rand.Intn(``, ``rand.Float64(``,
-  etc — deliberately not trying to detect "is there a seeded *rand.Rand nearby", that's
-  too clever for a regex tier); Python module-level ``random.<fn>(`` calls (excluding
-  ``random.seed(``, which is the seam pattern, not a violation of it); JS/TS
-  ``Math.random(``.
+  Go ``time.Now``; Python ``datetime.now`` / ``datetime.utcnow`` (both the
+  ``datetime.now(...)`` and ``datetime.datetime.now(...)`` spellings), ``time.time``,
+  plus per-file import-alias forms (``import datetime as dt`` → ``dt.now`` /
+  ``dt.datetime.now``; ``import time as tm`` → ``tm.time``; ``from time import time``
+  → a bare ``time(...)`` call, ``as`` aliases included); TS/JS ``Date.now`` and
+  no-arg ``new Date`` construction.
+- **unseeded-random** — an unseeded, DEFAULT-SOURCE random call outside a designated
+  random seam:
+  - Go: package-level calls on the ``math/rand`` (or ``math/rand/v2``) import —
+    resolved per file from the import declarations, so an aliased import
+    (``mrand "math/rand"``) is tracked, and a file that imports ``crypto/rand`` as
+    ``rand`` is NOT misflagged. Seeded/explicit-source construction
+    (``rand.New(rand.NewSource(...))``, ``rand.Seed(...)``) is not flagged — only
+    the default-source draw functions (``Intn``, ``Float64``, v2's ``N``/``IntN``,
+    etc). A file with no visible rand-related import falls back to matching the
+    conventional ``rand.`` package name (snippets/fixtures).
+  - Python: module-level ``random.<fn>(`` calls (canonical name, an
+    ``import random as X`` alias, or bare names from ``from random import randint,
+    choice``), excluding ``random.seed(`` (seeding explicitly is the seam pattern,
+    not a violation of it) and capitalized constructors (``random.Random(42)``,
+    ``random.SystemRandom()`` — constructing an explicit source is a deliberate
+    decision, and instance-method calls on the resulting variable are untrackable
+    at a regex tier anyway).
+  - JS/TS: ``Math.random(``.
 - **IO in non-designated modules is OUT OF SCOPE for v1.** Grepping for "any file
   read/network call/db call outside package X" is far noisier than the two rules above
   (imports, wrapper libraries, and legitimate framework glue all look like violations)
   and needs project-specific knowledge of which packages are the designated IO seam.
   Revisit once the clock/random tier has proven itself on real repos.
+
+**Precision over recall.** This gate is advisory; per the gate-rollout doctrine a noisy
+advisory is worse than none. Wherever a regex tier cannot decide (an aliased local
+variable holding a rand source, code inside a JS template-literal interpolation, a
+dynamically imported module), the scanner deliberately UNDER-reports rather than risk
+false positives. Known under-reporting: instance-method randomness (``rng.Intn(`` /
+``my_rng.random(``), calls inside JS/TS template-literal ``${...}`` interpolations
+(the whole literal is stripped), multi-line ``from random import (...)`` continuation
+lines, star/dot imports, and rare multi-line ``'``/``"`` string literals.
+
+What is stripped before matching (so prose can't be misread as live code):
+
+- line comments (``//``, ``#``), string-literal aware;
+- Go/TS/JS block comments (``/* ... */``), including multi-line;
+- Python triple-quoted strings/docstrings, including multi-line;
+- quoted string-literal CONTENTS on a line (``'...'``, ``"..."``, and backtick
+  raw/template literals in Go/JS — backtick literals are tracked across lines).
 
 Allowlist (a file is exempt from every rule, not scanned at all):
 
@@ -68,6 +101,8 @@ PY_EXTS = {".py"}
 JS_EXTS = {".ts", ".tsx", ".js", ".jsx"}
 ALL_EXTS = GO_EXTS | PY_EXTS | JS_EXTS
 
+# Matched against path components RELATIVE to the scanned root — a checkout that
+# happens to live under /tmp/build/ or /vendor/ must still be scanned in full.
 SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv", "vendor", "dist", "build"}
 
 DEFAULT_SEAMS = ["**/clock*", "**/rand*", "**/telemetry/**"]
@@ -75,78 +110,236 @@ DEFAULT_SEAMS = ["**/clock*", "**/rand*", "**/telemetry/**"]
 EXEMPT_MARKER = "cw:dst-exempt"
 TOP_MARKER_LINES = 20
 
-# Go's default (package-level, unseeded) math/rand surface. Deliberately not trying to
-# detect "is there a seeded *rand.Rand in scope" — that needs real type/data-flow
-# analysis, not a grep tier. If a repo seeds its own generator, it belongs behind a
-# `**/rand*` seam (or gets a `cw:dst-exempt` marker) so it doesn't show up here.
+WALL_CLOCK = "wall-clock"
+UNSEEDED_RANDOM = "unseeded-random"
+
+# Go's default (package-level, unseeded) math/rand draw surface, v1 and v2 names.
+# Deliberately excludes the seam-construction surface (`New`, `NewSource`, `Seed`,
+# `NewPCG`, `NewChaCha8`) — building a seeded/explicit source is the FIX, not a
+# violation — and instance methods on a *rand.Rand variable are untrackable at a
+# regex tier (documented under-reporting).
 _GO_RAND_FUNCS = (
     "Intn", "Int31n", "Int63n", "Int31", "Int63", "Int",
     "Float32", "Float64", "Perm", "Shuffle", "NormFloat64", "ExpFloat64",
+    # math/rand/v2 spellings
+    "N", "IntN", "Int32N", "Int64N", "Int32", "Int64",
+    "Uint", "UintN", "Uint32", "Uint32N", "Uint64", "Uint64N",
+)
+_GO_RAND_TAIL = r"\.(?:" + "|".join(_GO_RAND_FUNCS) + r")\s*\("
+
+# Python module-level random calls: lowercase names only, so capitalized constructors
+# (`random.Random(42)`, `random.SystemRandom()`) are never flagged, and `seed` is
+# excluded (seeding explicitly IS the seam pattern).
+_PY_RANDOM_TAIL = r"\.(?!seed\b)[a-z]\w*\s*\("
+
+# Static per-extension checks that need no import context.
+_STATIC_CHECKS: dict[str, list[tuple[str, re.Pattern]]] = {}
+for _ext in GO_EXTS:
+    _STATIC_CHECKS[_ext] = [
+        (WALL_CLOCK, re.compile(r"\btime\.Now\s*\(")),
+    ]
+for _ext in PY_EXTS:
+    _STATIC_CHECKS[_ext] = [
+        # `\bdatetime\.now(` also matches inside `datetime.datetime.now(` — one
+        # pattern covers both spellings (findings dedupe per rule+line).
+        (WALL_CLOCK, re.compile(r"\bdatetime\.(?:now|utcnow)\s*\(")),
+        (WALL_CLOCK, re.compile(r"\btime\.time\s*\(")),
+        (UNSEEDED_RANDOM, re.compile(r"\brandom" + _PY_RANDOM_TAIL)),
+    ]
+for _ext in JS_EXTS:
+    _STATIC_CHECKS[_ext] = [
+        (WALL_CLOCK, re.compile(r"\bDate\.now\s*\(")),
+        (WALL_CLOCK, re.compile(r"\bnew\s+Date\s*\(\s*\)")),
+        (UNSEEDED_RANDOM, re.compile(r"\bMath\.random\s*\(")),
+    ]
+
+
+# --- import-alias tracking (per file) ----------------------------------------
+
+# Go import of math/rand or crypto/rand, plain or aliased, single-line or inside an
+# import block. Matched against RAW lines: the sanitizer blanks string literals, and
+# an import path IS a string literal.
+_GO_IMPORT_RE = re.compile(
+    r'^\s*(?:import\s+)?(?:(?P<alias>[A-Za-z_.]\w*)\s+)?"(?P<path>math/rand(?:/v2)?|crypto/rand)"'
 )
 
-RULES: list[dict] = [
-    {
-        "id": "wall-clock",
-        "label": "wall-clock read",
-        "checks": [
-            (GO_EXTS, re.compile(r"\btime\.Now\s*\(")),
-            (PY_EXTS, re.compile(r"\bdatetime\.now\s*\(")),
-            (PY_EXTS, re.compile(r"\bdatetime\.utcnow\s*\(")),
-            (PY_EXTS, re.compile(r"\btime\.time\s*\(")),
-            (JS_EXTS, re.compile(r"\bDate\.now\s*\(")),
-            (JS_EXTS, re.compile(r"\bnew\s+Date\s*\(\s*\)")),
-        ],
-    },
-    {
-        "id": "unseeded-random",
-        "label": "unseeded randomness",
-        "checks": [
-            (GO_EXTS, re.compile(r"\brand\.(?:" + "|".join(_GO_RAND_FUNCS) + r")\s*\(")),
-            # Module-level `random.<fn>(` — excluding `random.seed(`, which IS the seam
-            # pattern (a repo that seeds explicitly is doing the right thing).
-            (PY_EXTS, re.compile(r"\brandom\.(?!seed\b)\w+\s*\(")),
-            (JS_EXTS, re.compile(r"\bMath\.random\s*\(")),
-        ],
-    },
-]
-
-# Line-comment markers per language, used to strip trailing comments before matching so
-# a call mentioned in a comment/docstring isn't misread as live code. Mirrors
-# check_single_writer.py's _strip_line_comment / _COMMENT_MARKERS.
-_COMMENT_MARKERS = {
-    ".go": ("//",), ".ts": ("//",), ".tsx": ("//",), ".js": ("//",), ".jsx": ("//",),
-    ".py": ("#",),
-}
+_PY_IMPORT_AS_RE = re.compile(r"^\s*import\s+(?P<mod>random|datetime|time)\s+as\s+(?P<alias>\w+)\s*$")
+_PY_FROM_IMPORT_RE = re.compile(r"^\s*from\s+(?P<mod>random|datetime|time)\s+import\s+(?P<names>.+)$")
 
 
-def _strip_line_comment(line: str, suffix: str) -> str:
-    """Drop a trailing line comment, respecting string/char literals so an in-string
-    marker (a URL's `//`, a `#` inside a Python string) is preserved. Per-line only —
-    a rare multi-line string literal isn't tracked, matching check_single_writer.py."""
-    markers = _COMMENT_MARKERS.get(suffix)
-    if not markers:
-        return line
-    quote: str | None = None
-    i, n = 0, len(line)
+def _py_from_names(names: str) -> list[tuple[str, str]]:
+    """Parse `a, b as c` (parens tolerated) into [(imported_name, local_name)].
+    Single-line form only — a multi-line parenthesized import's continuation lines
+    are documented under-reporting."""
+    out: list[tuple[str, str]] = []
+    for part in names.split(","):
+        part = part.strip().lstrip("(").rstrip(")").strip()
+        if not part or part == "*":
+            continue
+        m = re.match(r"^(\w+)(?:\s+as\s+(\w+))?$", part)
+        if m:
+            out.append((m.group(1), m.group(2) or m.group(1)))
+    return out
+
+
+def _dynamic_checks(
+    suffix: str, raw_lines: list[str], code_lines: list[str]
+) -> list[tuple[str, re.Pattern]]:
+    """Per-file checks derived from the file's own import declarations."""
+    checks: list[tuple[str, re.Pattern]] = []
+
+    if suffix in GO_EXTS:
+        math_aliases: list[str] = []
+        crypto_seen = False
+        for line in raw_lines:
+            m = _GO_IMPORT_RE.match(line)
+            if not m:
+                continue
+            alias = m.group("alias")
+            if m.group("path").startswith("math/rand"):
+                if alias in ("_", "."):
+                    continue  # blank/dot import: bare-name calls are untrackable
+                math_aliases.append(alias or "rand")
+            else:
+                crypto_seen = True
+        if math_aliases:
+            for a in dict.fromkeys(math_aliases):
+                checks.append((UNSEEDED_RANDOM, re.compile(r"\b" + re.escape(a) + _GO_RAND_TAIL)))
+        elif not crypto_seen:
+            # No visible rand-related import (snippet/fixture): fall back to the
+            # conventional package name. A file importing ONLY crypto/rand gets no
+            # rand check — its `rand.` is the crypto package, not math/rand.
+            checks.append((UNSEEDED_RANDOM, re.compile(r"\brand" + _GO_RAND_TAIL)))
+
+    elif suffix in PY_EXTS:
+        for line in code_lines:
+            m = _PY_IMPORT_AS_RE.match(line)
+            if m:
+                alias = re.escape(m.group("alias"))
+                mod = m.group("mod")
+                if mod == "random":
+                    checks.append((UNSEEDED_RANDOM, re.compile(r"\b" + alias + _PY_RANDOM_TAIL)))
+                elif mod == "datetime":
+                    checks.append((WALL_CLOCK, re.compile(
+                        r"\b" + alias + r"\.(?:datetime\.)?(?:now|utcnow)\s*\(")))
+                elif mod == "time":
+                    checks.append((WALL_CLOCK, re.compile(r"\b" + alias + r"\.time\s*\(")))
+                continue
+            m = _PY_FROM_IMPORT_RE.match(line)
+            if not m:
+                continue
+            mod = m.group("mod")
+            for name, local in _py_from_names(m.group("names")):
+                esc = re.escape(local)
+                if mod == "time" and name == "time":
+                    checks.append((WALL_CLOCK, re.compile(r"(?<![\w.])" + esc + r"\s*\(")))
+                elif mod == "datetime" and name == "datetime" and local != "datetime":
+                    # unaliased `from datetime import datetime` is covered statically
+                    checks.append((WALL_CLOCK, re.compile(r"\b" + esc + r"\.(?:now|utcnow)\s*\(")))
+                elif mod == "random" and name[:1].islower() and name != "seed":
+                    checks.append((UNSEEDED_RANDOM, re.compile(r"(?<![\w.])" + esc + r"\s*\(")))
+
+    return checks
+
+
+# --- comment/string stripping ------------------------------------------------
+
+
+def _skip_string(line: str, i: int) -> int:
+    """Index just past the string literal opening at ``line[i]`` (backslash-escape
+    aware). An unclosed literal blanks the rest of the line (documented: rare
+    multi-line ``'``/``"`` literals are not tracked across lines)."""
+    quote = line[i]
+    i += 1
+    n = len(line)
     while i < n:
         ch = line[i]
-        if quote is not None:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == quote:
-                quote = None
-            i += 1
+        if ch == "\\":
+            i += 2
             continue
-        if ch in ("'", '"', "`"):
-            quote = ch
-            i += 1
-            continue
-        for m in markers:
-            if line.startswith(m, i):
-                return line[:i]
+        if ch == quote:
+            return i + 1
         i += 1
-    return line
+    return n
+
+
+def sanitize_lines(raw_lines: list[str], suffix: str) -> list[str]:
+    """Strip comments and string-literal contents so prose can't match as live code.
+
+    Handles line comments, Go/TS/JS block comments and backtick literals (both
+    tracked across lines), Python triple-quoted strings/docstrings (tracked across
+    lines), and single/double-quoted literal contents on a line. Code inside a JS
+    template-literal interpolation is stripped with the literal — deliberate
+    under-reporting (see module docstring).
+    """
+    is_py = suffix in PY_EXTS
+    out: list[str] = []
+    mode = "code"  # code | block_comment | triple | backtick
+    triple_delim = ""
+    for line in raw_lines:
+        buf: list[str] = []
+        i, n = 0, len(line)
+        while i < n:
+            if mode == "block_comment":
+                j = line.find("*/", i)
+                if j == -1:
+                    i = n
+                else:
+                    i, mode = j + 2, "code"
+                continue
+            if mode == "triple":
+                j = line.find(triple_delim, i)
+                if j == -1:
+                    i = n
+                else:
+                    i, mode = j + 3, "code"
+                continue
+            if mode == "backtick":
+                j = line.find("`", i)
+                if j == -1:
+                    i = n
+                else:
+                    i, mode = j + 1, "code"
+                continue
+            ch = line[i]
+            if is_py:
+                if line.startswith('"""', i) or line.startswith("'''", i):
+                    triple_delim = line[i:i + 3]
+                    j = line.find(triple_delim, i + 3)
+                    if j == -1:
+                        mode, i = "triple", n
+                    else:
+                        i = j + 3
+                    continue
+                if ch == "#":
+                    break
+                if ch in ("'", '"'):
+                    i = _skip_string(line, i)
+                    continue
+            else:
+                if line.startswith("//", i):
+                    break
+                if line.startswith("/*", i):
+                    j = line.find("*/", i + 2)
+                    if j == -1:
+                        mode, i = "block_comment", n
+                    else:
+                        i = j + 2
+                    continue
+                if ch == "`":
+                    j = line.find("`", i + 1)
+                    if j == -1:
+                        mode, i = "backtick", n
+                    else:
+                        i = j + 1
+                    continue
+                if ch in ("'", '"'):
+                    i = _skip_string(line, i)
+                    continue
+            buf.append(ch)
+            i += 1
+        out.append("".join(buf))
+    return out
 
 
 def _is_test_path(rel: str) -> bool:
@@ -204,10 +397,7 @@ def _is_seam(posix_rel: str, seam_regexes: list[re.Pattern]) -> bool:
 
 
 def _has_exempt_marker(raw_lines: list[str]) -> bool:
-    for line in raw_lines[:TOP_MARKER_LINES]:
-        if EXEMPT_MARKER in line:
-            return True
-    return False
+    return any(EXEMPT_MARKER in line for line in raw_lines[:TOP_MARKER_LINES])
 
 
 @dataclass
@@ -233,8 +423,8 @@ class DSTReport:
 
     @property
     def counts(self) -> dict:
-        wall_clock = sum(1 for f in self.findings if f["rule"] == "wall-clock")
-        unseeded_random = sum(1 for f in self.findings if f["rule"] == "unseeded-random")
+        wall_clock = sum(1 for f in self.findings if f["rule"] == WALL_CLOCK)
+        unseeded_random = sum(1 for f in self.findings if f["rule"] == UNSEEDED_RANDOM)
         return {
             "total": len(self.findings),
             "wall_clock": wall_clock,
@@ -279,6 +469,34 @@ def _load_seams(config_path: str | Path | None, warnings: list[str]) -> list[str
     return seams
 
 
+def scan_file(suffix: str, raw_lines: list[str], rel: str) -> list[Finding]:
+    """Scan one file's lines: sanitize, resolve per-file import aliases, match rules.
+
+    At most one finding per (rule, line) — a line spelling several banned calls of
+    the same rule is one item to fix, not several findings.
+    """
+    code_lines = sanitize_lines(raw_lines, suffix)
+    checks = list(_STATIC_CHECKS.get(suffix, ())) + _dynamic_checks(suffix, raw_lines, code_lines)
+    findings: list[Finding] = []
+    seen: set[tuple[str, int]] = set()
+    for i, line in enumerate(code_lines):
+        for rule, pattern in checks:
+            if (rule, i) in seen:
+                continue
+            m = pattern.search(line)
+            if not m:
+                continue
+            seen.add((rule, i))
+            findings.append(Finding(
+                rule=rule,
+                file=rel,
+                line=i + 1,
+                text=raw_lines[i].strip()[:200],
+                match=m.group(0).strip(),
+            ))
+    return findings
+
+
 def check(source_root: str | Path, config_path: str | Path | None = None) -> DSTReport:
     root = Path(source_root)
     warnings: list[str] = []
@@ -296,9 +514,10 @@ def check(source_root: str | Path, config_path: str | Path | None = None) -> DST
     for path in sorted(root.rglob("*")):
         if not path.is_file() or path.suffix not in ALL_EXTS:
             continue
-        if any(part in SKIP_PARTS for part in path.parts):
+        rel_path = path.relative_to(root)
+        if any(part in SKIP_PARTS for part in rel_path.parts):
             continue
-        rel = str(path.relative_to(root))
+        rel = str(rel_path)
         posix_rel = rel.replace("\\", "/")
 
         if _is_test_path(rel):
@@ -316,20 +535,7 @@ def check(source_root: str | Path, config_path: str | Path | None = None) -> DST
             continue
 
         scanned += 1
-        code_lines = [_strip_line_comment(rl, path.suffix) for rl in raw_lines]
-        for i, line in enumerate(code_lines):
-            for rule in RULES:
-                for exts, pattern in rule["checks"]:
-                    if path.suffix not in exts:
-                        continue
-                    for m in pattern.finditer(line):
-                        findings.append(Finding(
-                            rule=rule["id"],
-                            file=rel,
-                            line=i + 1,
-                            text=raw_lines[i].strip()[:200],
-                            match=m.group(0).strip(),
-                        ))
+        findings += scan_file(path.suffix, raw_lines, rel)
 
     return DSTReport(
         findings=[f.to_dict() for f in findings],

--- a/scripts/check_dst_readiness.py
+++ b/scripts/check_dst_readiness.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""DST-readiness scanner (#167): flags nondeterminism-shaped calls before they calcify.
+
+Deterministic-simulation testing (FoundationDB/TigerBeetle/Antithesis-style) is only
+cheap if determinism is designed in from day one — a wall-clock read or an unseeded
+random call sprinkled through business logic makes a repo un-simulatable, and by the
+time anyone notices, it is everywhere. Chief Wiggum builds repos from scratch, so this
+is the one window where the fix is "put it behind a seam" instead of "rewrite half the
+codebase". This checker is advisory: it stamps the opportunity into new products via
+`/architect` (see the "DST readiness" step there) and reports violations here — it does
+not, by itself, block anything.
+
+Rules (regex tier, language-aware, mirrors ``check_single_writer.py``'s style of
+line-scanning with comment stripping):
+
+- **wall-clock** — a direct wall-clock read outside a designated clock seam:
+  Go ``time.Now``; Python ``datetime.now``, ``datetime.utcnow``, ``time.time``;
+  TS/JS ``Date.now`` and no-arg ``new Date`` construction.
+- **unseeded-random** — an unseeded, default-source random call outside a designated
+  random seam: Go ``math/rand`` package-level calls (``rand.Intn(``, ``rand.Float64(``,
+  etc — deliberately not trying to detect "is there a seeded *rand.Rand nearby", that's
+  too clever for a regex tier); Python module-level ``random.<fn>(`` calls (excluding
+  ``random.seed(``, which is the seam pattern, not a violation of it); JS/TS
+  ``Math.random(``.
+- **IO in non-designated modules is OUT OF SCOPE for v1.** Grepping for "any file
+  read/network call/db call outside package X" is far noisier than the two rules above
+  (imports, wrapper libraries, and legitimate framework glue all look like violations)
+  and needs project-specific knowledge of which packages are the designated IO seam.
+  Revisit once the clock/random tier has proven itself on real repos.
+
+Allowlist (a file is exempt from every rule, not scanned at all):
+
+- its path matches a **seam glob** — default ``**/clock*``, ``**/rand*``,
+  ``**/telemetry/**`` (a repo can add more via ``--config``'s ``seams`` list; additions
+  are unioned with, not a replacement for, the defaults);
+- it carries a ``# cw:dst-exempt`` / ``// cw:dst-exempt`` line comment in its first 20
+  lines;
+- it is a test file, by the same heuristic ``check_traceability.py`` uses ("test" or
+  "spec" in the path, or an ``e2e`` path segment).
+
+**Authority boundary**: this flags nondeterminism-shaped calls in scanned first-party
+code; it does not prove dependencies or unscanned files are deterministic.
+
+**Advisory FOREVER by default** (per #167's design decision: this is design-readiness
+signal, not enforcement — a repo opts into gating via its own ratchet config, not by
+this script defaulting to `--gate`). `--gate` exists for that opt-in case: exit 1 if
+any finding survives the allowlist.
+
+Exit codes: 0 = ok (or report-only with findings), 1 = `--gate` violation, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+AUTHORITY = (
+    "flags nondeterminism-shaped calls in scanned first-party code; does not prove "
+    "dependencies or unscanned files are deterministic"
+)
+
+GO_EXTS = {".go"}
+PY_EXTS = {".py"}
+JS_EXTS = {".ts", ".tsx", ".js", ".jsx"}
+ALL_EXTS = GO_EXTS | PY_EXTS | JS_EXTS
+
+SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv", "vendor", "dist", "build"}
+
+DEFAULT_SEAMS = ["**/clock*", "**/rand*", "**/telemetry/**"]
+
+EXEMPT_MARKER = "cw:dst-exempt"
+TOP_MARKER_LINES = 20
+
+# Go's default (package-level, unseeded) math/rand surface. Deliberately not trying to
+# detect "is there a seeded *rand.Rand in scope" — that needs real type/data-flow
+# analysis, not a grep tier. If a repo seeds its own generator, it belongs behind a
+# `**/rand*` seam (or gets a `cw:dst-exempt` marker) so it doesn't show up here.
+_GO_RAND_FUNCS = (
+    "Intn", "Int31n", "Int63n", "Int31", "Int63", "Int",
+    "Float32", "Float64", "Perm", "Shuffle", "NormFloat64", "ExpFloat64",
+)
+
+RULES: list[dict] = [
+    {
+        "id": "wall-clock",
+        "label": "wall-clock read",
+        "checks": [
+            (GO_EXTS, re.compile(r"\btime\.Now\s*\(")),
+            (PY_EXTS, re.compile(r"\bdatetime\.now\s*\(")),
+            (PY_EXTS, re.compile(r"\bdatetime\.utcnow\s*\(")),
+            (PY_EXTS, re.compile(r"\btime\.time\s*\(")),
+            (JS_EXTS, re.compile(r"\bDate\.now\s*\(")),
+            (JS_EXTS, re.compile(r"\bnew\s+Date\s*\(\s*\)")),
+        ],
+    },
+    {
+        "id": "unseeded-random",
+        "label": "unseeded randomness",
+        "checks": [
+            (GO_EXTS, re.compile(r"\brand\.(?:" + "|".join(_GO_RAND_FUNCS) + r")\s*\(")),
+            # Module-level `random.<fn>(` — excluding `random.seed(`, which IS the seam
+            # pattern (a repo that seeds explicitly is doing the right thing).
+            (PY_EXTS, re.compile(r"\brandom\.(?!seed\b)\w+\s*\(")),
+            (JS_EXTS, re.compile(r"\bMath\.random\s*\(")),
+        ],
+    },
+]
+
+# Line-comment markers per language, used to strip trailing comments before matching so
+# a call mentioned in a comment/docstring isn't misread as live code. Mirrors
+# check_single_writer.py's _strip_line_comment / _COMMENT_MARKERS.
+_COMMENT_MARKERS = {
+    ".go": ("//",), ".ts": ("//",), ".tsx": ("//",), ".js": ("//",), ".jsx": ("//",),
+    ".py": ("#",),
+}
+
+
+def _strip_line_comment(line: str, suffix: str) -> str:
+    """Drop a trailing line comment, respecting string/char literals so an in-string
+    marker (a URL's `//`, a `#` inside a Python string) is preserved. Per-line only —
+    a rare multi-line string literal isn't tracked, matching check_single_writer.py."""
+    markers = _COMMENT_MARKERS.get(suffix)
+    if not markers:
+        return line
+    quote: str | None = None
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"', "`"):
+            quote = ch
+            i += 1
+            continue
+        for m in markers:
+            if line.startswith(m, i):
+                return line[:i]
+        i += 1
+    return line
+
+
+def _is_test_path(rel: str) -> bool:
+    """Same heuristic as check_traceability.py: test infrastructure isn't a production
+    nondeterminism concern the way live business logic is."""
+    low = rel.lower()
+    return "test" in low or "spec" in low or any(p == "e2e" for p in Path(low).parts)
+
+
+def _glob_to_regex(glob: str) -> re.Pattern:
+    """Translate a small gitignore-ish glob to an anchored regex.
+
+    Supports ``**`` (any number of path segments, including none — so ``**/clock*``
+    matches both a root-level ``clock.go`` and ``internal/clock/clock.go``), ``*``
+    (anything within one path segment), and ``?`` (one char within a segment).
+    Good enough for the handful of small, human-authored seam globs this tool takes;
+    not a general-purpose glob library.
+    """
+    out: list[str] = []
+    i, n = 0, len(glob)
+    while i < n:
+        if glob[i:i + 3] == "**/":
+            out.append(r"(?:.*/)?")
+            i += 3
+        elif glob[i:i + 2] == "**":
+            out.append(r".*")
+            i += 2
+        elif glob[i] == "*":
+            out.append(r"[^/]*")
+            i += 1
+        elif glob[i] == "?":
+            out.append(r"[^/]")
+            i += 1
+        else:
+            out.append(re.escape(glob[i]))
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def _is_seam(posix_rel: str, seam_regexes: list[re.Pattern]) -> bool:
+    """True if ``posix_rel`` (or one of its ancestor directories) matches a seam glob.
+
+    Testing ancestor directories, not just the full file path, means a seam glob that
+    matches a *directory* name (e.g. ``**/clock*`` matching a ``internal/clock/``
+    package) exempts every file under it, not just files whose own name starts with
+    "clock".
+    """
+    segments = posix_rel.split("/")
+    candidates = ["/".join(segments[:k]) for k in range(1, len(segments) + 1)]
+    for regex in seam_regexes:
+        for cand in candidates:
+            if regex.match(cand):
+                return True
+    return False
+
+
+def _has_exempt_marker(raw_lines: list[str]) -> bool:
+    for line in raw_lines[:TOP_MARKER_LINES]:
+        if EXEMPT_MARKER in line:
+            return True
+    return False
+
+
+@dataclass
+class Finding:
+    rule: str
+    file: str
+    line: int
+    text: str
+    match: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class DSTReport:
+    findings: list[dict] = field(default_factory=list)
+    scanned_files: int = 0
+    exempted_files: list[dict] = field(default_factory=list)
+    seams: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    authority: str = AUTHORITY
+
+    @property
+    def counts(self) -> dict:
+        wall_clock = sum(1 for f in self.findings if f["rule"] == "wall-clock")
+        unseeded_random = sum(1 for f in self.findings if f["rule"] == "unseeded-random")
+        return {
+            "total": len(self.findings),
+            "wall_clock": wall_clock,
+            "unseeded_random": unseeded_random,
+            "files_scanned": self.scanned_files,
+            "files_exempted": len(self.exempted_files),
+        }
+
+    @property
+    def ok(self) -> bool:
+        """True if there are no findings — the single gate condition ``--gate`` checks."""
+        return not self.findings
+
+    def to_dict(self) -> dict:
+        return {
+            "counts": self.counts,
+            "ok": self.ok,
+            "authority": self.authority,
+            "seams": self.seams,
+            "findings": self.findings,
+            "exempted_files": self.exempted_files,
+            "warnings": self.warnings,
+        }
+
+
+def _load_seams(config_path: str | Path | None, warnings: list[str]) -> list[str]:
+    seams = list(DEFAULT_SEAMS)
+    if not config_path:
+        return seams
+    try:
+        cfg = json.loads(Path(config_path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        warnings.append(f"could not read --config {config_path}: {exc}")
+        return seams
+    extra = cfg.get("seams") if isinstance(cfg, dict) else None
+    if extra is None:
+        return seams
+    if not isinstance(extra, list):
+        warnings.append(f"--config {config_path}: 'seams' must be a list of glob strings; ignoring")
+        return seams
+    seams += [str(s) for s in extra if s]
+    return seams
+
+
+def check(source_root: str | Path, config_path: str | Path | None = None) -> DSTReport:
+    root = Path(source_root)
+    warnings: list[str] = []
+    seams = _load_seams(config_path, warnings)
+    seam_regexes = [_glob_to_regex(g) for g in seams]
+
+    findings: list[Finding] = []
+    exempted: list[dict] = []
+    scanned = 0
+
+    if not root.exists():
+        warnings.append(f"source root not found: {source_root}")
+        return DSTReport(seams=seams, warnings=warnings)
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in ALL_EXTS:
+            continue
+        if any(part in SKIP_PARTS for part in path.parts):
+            continue
+        rel = str(path.relative_to(root))
+        posix_rel = rel.replace("\\", "/")
+
+        if _is_test_path(rel):
+            exempted.append({"file": rel, "reason": "test-path"})
+            continue
+        if _is_seam(posix_rel, seam_regexes):
+            exempted.append({"file": rel, "reason": "seam-glob"})
+            continue
+        try:
+            raw_lines = path.read_text().splitlines()
+        except OSError:
+            continue
+        if _has_exempt_marker(raw_lines):
+            exempted.append({"file": rel, "reason": f"{EXEMPT_MARKER} marker"})
+            continue
+
+        scanned += 1
+        code_lines = [_strip_line_comment(rl, path.suffix) for rl in raw_lines]
+        for i, line in enumerate(code_lines):
+            for rule in RULES:
+                for exts, pattern in rule["checks"]:
+                    if path.suffix not in exts:
+                        continue
+                    for m in pattern.finditer(line):
+                        findings.append(Finding(
+                            rule=rule["id"],
+                            file=rel,
+                            line=i + 1,
+                            text=raw_lines[i].strip()[:200],
+                            match=m.group(0).strip(),
+                        ))
+
+    return DSTReport(
+        findings=[f.to_dict() for f in findings],
+        scanned_files=scanned,
+        exempted_files=exempted,
+        seams=seams,
+        warnings=warnings,
+    )
+
+
+def render_text(report: DSTReport) -> str:
+    c = report.counts
+    lines = [
+        "# DST-Readiness Scan",
+        "",
+        f"Files scanned: {c['files_scanned']}  |  Exempted: {c['files_exempted']}",
+        f"Findings: {c['total']}  (wall-clock: {c['wall_clock']}, unseeded-random: {c['unseeded_random']})",
+        "",
+        f"Authority: {report.authority}",
+        "",
+        f"Seams: {', '.join(report.seams)}",
+    ]
+    if report.findings:
+        lines += ["", "## Findings", ""]
+        for f in report.findings:
+            lines.append(f"- [{f['rule']}] {f['file']}:{f['line']} — `{f['match']}`")
+            lines.append(f"    {f['text']}")
+    else:
+        lines += ["", "No findings."]
+    if report.warnings:
+        lines += ["", "## Warnings", ""] + [f"- {w}" for w in report.warnings]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="DST-readiness scanner: flags wall-clock reads and unseeded "
+        "randomness outside designated seams (report-only by default)"
+    )
+    parser.add_argument("source_root", help="Repo root to scan")
+    parser.add_argument(
+        "--config",
+        help="JSON file with a 'seams' array of glob patterns, unioned with the "
+        "built-in defaults (**/clock*, **/rand*, **/telemetry/**)",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Fail (exit 1) if any finding survives the allowlist. This scanner is "
+        "advisory FOREVER by default — a repo opts into gating via its own ratchet "
+        "config, not by this flag being on by default anywhere in the pipeline.",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    if not Path(args.source_root).exists():
+        print(f"Error: source root not found: {args.source_root}", file=sys.stderr)
+        return 2
+
+    report = check(args.source_root, args.config)
+
+    if args.format == "json":
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(render_text(report))
+
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+        caught = len(report.findings)
+        emit_gate(
+            "check_dst_readiness",
+            "fail" if caught else "pass",
+            caught=caught,
+            repo=os.path.basename(os.path.abspath(args.source_root)),
+        )
+    except Exception:
+        pass
+
+    if args.gate and not report.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_dst_readiness.py
+++ b/tests/test_check_dst_readiness.py
@@ -1,0 +1,335 @@
+"""Tests for the DST-readiness scanner (#167)."""
+
+from __future__ import annotations
+
+import json
+
+import check_dst_readiness as dst
+
+
+def _rule_files(report, rule):
+    return sorted(f["file"] for f in report.findings if f["rule"] == rule)
+
+
+# --- wall-clock rule, per language -------------------------------------------
+
+
+def test_go_wall_clock_detected(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        "package svc\n\nfunc Now() time.Time {\n\treturn time.Now()\n}\n"
+    )
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.go"]
+    finding = report.findings[0]
+    assert finding["line"] == 4
+    assert "time.Now(" in finding["match"]
+
+
+def test_python_datetime_now_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import datetime\n\nx = datetime.now()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+
+
+def test_python_datetime_utcnow_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("x = datetime.utcnow()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+
+
+def test_python_time_time_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import time\nstart = time.time()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+
+
+def test_js_date_now_detected(tmp_path):
+    (tmp_path / "svc.js").write_text("const t = Date.now();\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.js"]
+
+
+def test_ts_new_date_no_args_detected(tmp_path):
+    (tmp_path / "svc.ts").write_text("const t = new Date();\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.ts"]
+
+
+def test_ts_new_date_with_arg_not_flagged(tmp_path):
+    # A reconstructed/parsed date is not a live wall-clock read.
+    (tmp_path / "svc.ts").write_text("const t = new Date(payload.timestamp);\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- unseeded-random rule, per language ---------------------------------------
+
+
+def test_go_rand_intn_detected(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        "package svc\n\nfunc Roll() int {\n\treturn rand.Intn(6)\n}\n"
+    )
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.go"]
+
+
+def test_go_rand_float64_detected(tmp_path):
+    (tmp_path / "svc.go").write_text("x := rand.Float64()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.go"]
+
+
+def test_python_random_module_call_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import random\nx = random.random()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.py"]
+
+
+def test_python_random_randint_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("x = random.randint(1, 6)\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.py"]
+
+
+def test_python_random_seed_not_flagged(tmp_path):
+    # Seeding explicitly IS the seam pattern, not a violation of it.
+    (tmp_path / "svc.py").write_text("random.seed(42)\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_js_math_random_detected(tmp_path):
+    (tmp_path / "svc.js").write_text("const x = Math.random();\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.js"]
+
+
+# --- comment stripping --------------------------------------------------------
+
+
+def test_call_in_comment_not_flagged(tmp_path):
+    (tmp_path / "svc.go").write_text("// example: time.Now() returns wall clock\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_call_in_python_comment_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text("# x = random.random()\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- allowlist: seam globs -----------------------------------------------------
+
+
+def test_default_clock_seam_file_exempt(tmp_path):
+    (tmp_path / "clock.go").write_text("func Now() time.Time { return time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+    assert any(e["file"] == "clock.go" and e["reason"] == "seam-glob" for e in report.exempted_files)
+
+
+def test_default_clock_seam_directory_exempt(tmp_path):
+    d = tmp_path / "internal" / "clock"
+    d.mkdir(parents=True)
+    (d / "impl.go").write_text("func Now() time.Time { return time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_default_rand_seam_exempt(tmp_path):
+    (tmp_path / "randsource.go").write_text("func Roll() int { return rand.Intn(6) }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_default_telemetry_seam_exempt(tmp_path):
+    d = tmp_path / "telemetry"
+    d.mkdir()
+    (d / "emit.go").write_text("func Emit() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_non_seam_file_still_flagged(tmp_path):
+    (tmp_path / "handler.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["handler.go"]
+
+
+def test_config_adds_extra_seam(tmp_path):
+    (tmp_path / "widgets.go").write_text("func H() { _ = time.Now() }\n")
+    config = tmp_path / "dst-config.json"
+    config.write_text(json.dumps({"seams": ["**/widgets*"]}))
+    report = dst.check(tmp_path, config)
+    assert report.findings == []
+    # Built-in defaults still apply alongside the config additions.
+    (tmp_path / "clock.go").write_text("func Now() time.Time { return time.Now() }\n")
+    report2 = dst.check(tmp_path, config)
+    assert report2.findings == []
+
+
+def test_config_bad_seams_type_warns_but_keeps_defaults(tmp_path):
+    (tmp_path / "clock.go").write_text("func Now() time.Time { return time.Now() }\n")
+    config = tmp_path / "dst-config.json"
+    config.write_text(json.dumps({"seams": "not-a-list"}))
+    report = dst.check(tmp_path, config)
+    assert report.findings == []  # default clock seam still exempts it
+    assert any("must be a list" in w for w in report.warnings)
+
+
+def test_missing_config_file_warns(tmp_path):
+    (tmp_path / "handler.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path, tmp_path / "does-not-exist.json")
+    assert any("could not read --config" in w for w in report.warnings)
+    # Scan still proceeds with default seams.
+    assert _rule_files(report, "wall-clock") == ["handler.go"]
+
+
+# --- allowlist: cw:dst-exempt marker -------------------------------------------
+
+
+def test_hash_marker_exempts_python_file(tmp_path):
+    (tmp_path / "legacy.py").write_text("# cw:dst-exempt\nx = datetime.now()\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+    assert any(e["file"] == "legacy.py" for e in report.exempted_files)
+
+
+def test_slash_marker_exempts_go_file(tmp_path):
+    (tmp_path / "legacy.go").write_text("// cw:dst-exempt\nfunc H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_marker_beyond_top_lines_does_not_exempt(tmp_path):
+    body = "\n".join(f"// line {i}" for i in range(25))
+    content = body + "\n// cw:dst-exempt\nfunc H() { _ = time.Now() }\n"
+    (tmp_path / "legacy.go").write_text(content)
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["legacy.go"]
+
+
+# --- allowlist: test paths ------------------------------------------------------
+
+
+def test_test_file_exempt_by_filename(tmp_path):
+    (tmp_path / "svc_test.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+    assert any(e["reason"] == "test-path" for e in report.exempted_files)
+
+
+def test_spec_file_exempt(tmp_path):
+    (tmp_path / "svc.spec.ts").write_text("const t = Date.now();\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_e2e_directory_exempt(tmp_path):
+    d = tmp_path / "e2e"
+    d.mkdir()
+    (d / "helpers.ts").write_text("const t = Date.now();\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- report shape / rendering --------------------------------------------------
+
+
+def test_ok_true_when_no_findings(tmp_path):
+    (tmp_path / "svc.go").write_text("package svc\n")
+    report = dst.check(tmp_path)
+    assert report.ok is True
+    assert report.counts["total"] == 0
+
+
+def test_ok_false_when_findings(tmp_path):
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert report.ok is False
+    assert report.counts["total"] == 1
+    assert report.counts["wall_clock"] == 1
+    assert report.counts["unseeded_random"] == 0
+
+
+def test_authority_string_present_in_dict_and_text():
+    report = dst.DSTReport()
+    d = report.to_dict()
+    assert "does not prove" in d["authority"]
+    text = dst.render_text(report)
+    assert "Authority:" in text
+    assert "does not prove" in text
+
+
+def test_render_text_lists_findings(tmp_path):
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    text = dst.render_text(report)
+    assert "svc.go:1" in text
+    assert "wall-clock" in text
+
+
+def test_missing_source_root_warns_and_returns_empty(tmp_path):
+    missing = tmp_path / "nope"
+    report = dst.check(missing)
+    assert report.findings == []
+    assert any("source root not found" in w for w in report.warnings)
+
+
+# --- CLI / gate exit codes ------------------------------------------------------
+
+
+def test_main_default_report_only_exit_zero_even_with_findings(tmp_path, capsys):
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    rc = dst.main([str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "svc.go" in out
+
+
+def test_main_gate_exit_one_on_findings(tmp_path, capsys):
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    rc = dst.main([str(tmp_path), "--gate"])
+    assert rc == 1
+
+
+def test_main_gate_exit_zero_when_clean(tmp_path):
+    (tmp_path / "svc.go").write_text("package svc\n")
+    rc = dst.main([str(tmp_path), "--gate"])
+    assert rc == 0
+
+
+def test_main_usage_error_on_missing_root(tmp_path, capsys):
+    rc = dst.main([str(tmp_path / "does-not-exist")])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+def test_main_json_format(tmp_path, capsys):
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    rc = dst.main([str(tmp_path), "--format", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["counts"]["total"] == 1
+    assert data["ok"] is False
+
+
+# --- glob translation internals -------------------------------------------------
+
+
+def test_glob_to_regex_matches_root_and_nested():
+    regex = dst._glob_to_regex("**/clock*")
+    assert regex.match("clock.go")
+    assert regex.match("internal/clock")
+    assert regex.match("internal/clock/impl.go") is None  # only the dir itself, not a
+    # non-clock-prefixed leaf inside it — but the directory-ancestor check in
+    # _is_seam is what actually exempts files under the dir (tested above).
+
+
+def test_glob_to_regex_star_does_not_cross_slash():
+    regex = dst._glob_to_regex("*.go")
+    assert regex.match("svc.go")
+    assert regex.match("pkg/svc.go") is None

--- a/tests/test_check_dst_readiness.py
+++ b/tests/test_check_dst_readiness.py
@@ -333,3 +333,240 @@ def test_glob_to_regex_star_does_not_cross_slash():
     regex = dst._glob_to_regex("*.go")
     assert regex.match("svc.go")
     assert regex.match("pkg/svc.go") is None
+
+
+# --- skip-dirs are relative to the scanned root (P1 regression) -----------------
+
+
+def test_checkout_under_skip_named_ancestor_is_scanned(tmp_path):
+    # A checkout living under .../build/... must still be scanned in full — only
+    # skip-dirs INSIDE the root count.
+    root = tmp_path / "build" / "checkout"
+    root.mkdir(parents=True)
+    (root / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(root)
+    assert _rule_files(report, "wall-clock") == ["svc.go"]
+
+
+def test_skip_dir_inside_root_still_skipped(tmp_path):
+    d = tmp_path / "vendor" / "lib"
+    d.mkdir(parents=True)
+    (d / "dep.go").write_text("func H() { _ = time.Now() }\n")
+    (tmp_path / "svc.go").write_text("func H() { _ = time.Now() }\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.go"]
+
+
+# --- Python idioms: qualified datetime, from-imports, aliases (P1 regression) ----
+
+
+def test_python_datetime_datetime_now_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import datetime\nx = datetime.datetime.now()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+    assert len(report.findings) == 1  # deduped: one finding per rule per line
+
+
+def test_python_datetime_datetime_utcnow_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import datetime\nx = datetime.datetime.utcnow()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+
+
+def test_python_import_datetime_as_alias_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import datetime as dt\na = dt.datetime.now()\nb = dt.now()\n")
+    report = dst.check(tmp_path)
+    assert [f["line"] for f in report.findings if f["rule"] == "wall-clock"] == [2, 3]
+
+
+def test_python_from_time_import_time_bare_call_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("from time import time\nstart = time()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+    assert report.findings[0]["line"] == 2
+
+
+def test_python_from_time_import_time_aliased_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("from time import time as wall\nstart = wall()\n")
+    report = dst.check(tmp_path)
+    assert report.findings and report.findings[0]["line"] == 2
+
+
+def test_python_bare_time_without_from_import_not_flagged(tmp_path):
+    # A bare time() call in a file that never does `from time import time` could be
+    # any local helper — not flagged (precision over recall).
+    (tmp_path / "svc.py").write_text("start = time()\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_import_time_as_alias_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import time as tm\nstart = tm.time()\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.py"]
+
+
+def test_python_import_random_as_alias_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("import random as rr\nx = rr.randint(1, 6)\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.py"]
+
+
+def test_python_from_random_import_bare_call_detected(tmp_path):
+    (tmp_path / "svc.py").write_text(
+        "from random import randint, choice\nx = randint(1, 6)\ny = choice([1, 2])\n"
+    )
+    report = dst.check(tmp_path)
+    lines = [f["line"] for f in report.findings if f["rule"] == "unseeded-random"]
+    assert lines == [2, 3]
+
+
+def test_python_from_random_import_aliased_detected(tmp_path):
+    (tmp_path / "svc.py").write_text("from random import choice as pick\nx = pick([1, 2])\n")
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.py"]
+
+
+def test_python_from_random_import_seed_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text("from random import seed\nseed(42)\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- Go import aliasing (P1 regression) -----------------------------------------
+
+
+def test_go_aliased_math_rand_import_detected(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        'package svc\n\nimport mrand "math/rand"\n\nfunc Roll() int {\n\treturn mrand.Intn(6)\n}\n'
+    )
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.go"]
+    assert report.findings[0]["line"] == 6
+
+
+def test_go_aliased_import_in_block_detected(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        'package svc\n\nimport (\n\t"fmt"\n\tmrand "math/rand/v2"\n)\n\n'
+        "func Roll() int {\n\treturn mrand.IntN(6)\n}\n"
+    )
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "unseeded-random") == ["svc.go"]
+
+
+def test_go_crypto_rand_not_misflagged(tmp_path):
+    # crypto/rand imports under the default name `rand` — its calls are NOT the
+    # unseeded math/rand default source.
+    (tmp_path / "svc.go").write_text(
+        'package svc\n\nimport "crypto/rand"\n\n'
+        "func Key() {\n\tn, _ := rand.Int(rand.Reader, max)\n\t_ = n\n}\n"
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_go_aliased_import_suppresses_default_rand_name(tmp_path):
+    # With math/rand imported under an alias, a symbol literally named `rand.` is
+    # something else entirely (a local var, another package) — not flagged.
+    (tmp_path / "svc.go").write_text(
+        'package svc\n\nimport mrand "math/rand"\n\nfunc Roll() int {\n\treturn rand.Intn(6)\n}\n'
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- seed-awareness: seeded constructors are NOT flagged (P2 regression) ---------
+
+
+def test_go_seeded_source_not_flagged(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        'package svc\n\nimport "math/rand"\n\nfunc New() *rand.Rand {\n'
+        "\treturn rand.New(rand.NewSource(42))\n}\n"
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_go_rand_seed_call_not_flagged(tmp_path):
+    (tmp_path / "svc.go").write_text('import "math/rand"\n\nfunc init() { rand.Seed(42) }\n')
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_random_random_constructor_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text("import random\nrng = random.Random(42)\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_system_random_constructor_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text("import random\nrng = random.SystemRandom()\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_aliased_random_constructor_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text("import random as rr\nrng = rr.Random(42)\nrr.seed(1)\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+# --- string literals / docstrings / block comments (P2 regression) ---------------
+
+
+def test_python_docstring_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text(
+        '"""Module doc.\n\nNever call datetime.now() or random.random() directly.\n"""\n\nx = 1\n'
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_string_literal_not_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text('msg = "do not use time.time() here"\n')
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_python_code_after_docstring_still_flagged(tmp_path):
+    (tmp_path / "svc.py").write_text(
+        '"""Doc mentioning datetime.now()."""\n\nimport datetime\nx = datetime.now()\n'
+    )
+    report = dst.check(tmp_path)
+    assert [f["line"] for f in report.findings] == [4]
+
+
+def test_go_block_comment_not_flagged(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        "package svc\n\n/*\nExample:\n\tt := time.Now()\n*/\n\nfunc H() {}\n"
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_go_raw_string_across_lines_not_flagged(tmp_path):
+    (tmp_path / "svc.go").write_text(
+        "package svc\n\nvar doc = `\nusage: never call time.Now() inline\n`\n"
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_ts_block_comment_not_flagged(tmp_path):
+    (tmp_path / "svc.ts").write_text(
+        "/**\n * Do not use Date.now() or Math.random() directly.\n */\nexport const x = 1;\n"
+    )
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_ts_string_literal_not_flagged(tmp_path):
+    (tmp_path / "svc.ts").write_text("const msg = 'avoid Date.now() calls';\n")
+    report = dst.check(tmp_path)
+    assert report.findings == []
+
+
+def test_code_on_same_line_as_string_still_flagged(tmp_path):
+    (tmp_path / "svc.ts").write_text('log("stamp", Date.now());\n')
+    report = dst.check(tmp_path)
+    assert _rule_files(report, "wall-clock") == ["svc.ts"]


### PR DESCRIPTION
## Summary

Closes #167. Stamps deterministic-simulation-testing (DST) readiness into new products while it's free, and adds the mechanical scanner behind it.

- **`scripts/check_dst_readiness.py`** — report-only-forever-by-default scanner (Go/Python/TS-JS aware, comment-stripping line scan, same style as `check_single_writer.py`):
  - **wall-clock**: Go `time.Now(`; Python `datetime.now(`/`datetime.utcnow(`/`time.time(`; TS/JS `Date.now(` and no-arg `new Date()`.
  - **unseeded-random**: Go `math/rand` default-source package-level calls (`rand.Intn(`, `rand.Float64(`, etc — deliberately not trying to detect a nearby seeded source, that's too clever for a regex tier); Python module-level `random.<fn>(` (excluding `random.seed(`, which is the seam pattern itself); JS/TS `Math.random(`.
  - **IO** is explicitly out of scope for v1 (documented in the module docstring as too noisy for a grep tier).
  - Allowlist: seam globs (default `**/clock*`, `**/rand*`, `**/telemetry/**`, extendable via `--config`'s `seams` list), a `# cw:dst-exempt` / `// cw:dst-exempt` marker in a file's first 20 lines, and test files (same heuristic as `check_traceability.py`).
  - `--gate` exists but is never passed by `/architect` — advisory forever per the issue's design decision; a repo opts in via its own ratchet config.
  - CLI: `check_dst_readiness.py <source_root> [--config path] [--gate] [--format text|json]`.
- **`.claude/commands/architect.md`** — Step 1 detects a new product (`docs/epics/` absent in the target repo); for new products, Step 4e stamps INV-dst-001/002/003 into `invariants.md`, Step 4f's ADR names the actual clock/random/IO seam packages, Step 5a runs the scanner report-only against the target repo to document a baseline, and Steps 6/9 surface the counts. Existing products (prior epics already present) are left untouched — retrofitting is a separate, deliberate decision.

## Validation

- `tests/test_check_dst_readiness.py` — 41 new tests: fixtures per language per rule, seam-glob exemption (file and directory forms, config-added seams, bad-config-type warning), `cw:dst-exempt` marker (both comment styles, and confirming it must be within the first 20 lines), test-path exemption, comment-stripping, report/JSON rendering, CLI `--gate` exit codes, and the internal glob→regex translator.
- Full suite: `python3 -m pytest tests/ -q` → **831 passed, 4 skipped** (pre-existing skips), 0 failures.
- Baseline run on chief-wiggum itself (a real, already-shipped repo, per the issue's acceptance criterion): `python3 scripts/check_dst_readiness.py . --format text` → **9 findings, all genuine wall-clock reads** (`datetime.now(`/`time.time(` in `apply_pattern.py`, `task_protocol.py`, `factory_log.py`, `transcribe_with_screenshots.py`, `verify_transitions.py`), **0 unseeded-random findings**, 0 false positives. (Caught and fixed one self-inflicted false positive along the way: the module's own docstring literally spelled out example call syntax like `` datetime.now( ``, which the Python-rule scan then flagged in its own file — reworded the docstring to drop the trailing parens.)

## Deviations from the issue text

- The issue's CLI sketch was `check_dst_readiness.py <source_root> [--config path] [--gate] [--format text|json]` with no epic-dir argument, unlike the epic-scoped `check_single_writer.py`/`check_traceability.py` — implemented as a repo-wide scanner with a single boolean `--gate` (not `soundness`/`coverage` gates), since there's no epic-level metadata to validate here, matching "advisory forever" framing.
- Config's `seams` list is documented and implemented as **additive** to the built-in defaults (union), not a replacement — not explicitly specified in the issue, but avoids a config accidentally un-exempting the standard clock/rand/telemetry seams.
- No new `docs/*.md` companion doc was added (unlike `docs/single-writer.md`/`docs/traceability.md`) — the issue's scope only asked for the checker, tests, and the `/architect` stamp; the scanner's docstring carries the full contract instead.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 831 passed, 4 skipped
- [x] `python3 -m pytest tests/test_check_dst_readiness.py -q` — 41 passed
- [x] Baseline scan on chief-wiggum itself documented above

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF