### PR TITLE
refactor(gates): emission/claim split, hash-derived scanner versions, --changed-since (#160)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -328,6 +328,14 @@ Run the integration check **on the staging branch, before promoting to main**:
    python3 "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO"
    ```
    A violation is a hard blocker exactly like a test failure: fix it on the staging branch (or drop the offending ticket's merge from the wave) before promoting. Never resolve a violation by editing the contract or the journal.
+6. **Single-writer / traceability quick check** (report-only, wave-scoped) — if the epic has `docs/epics/<slug>/`, scope both checkers to what THIS wave changed with `--changed-since "$DEFAULT_BRANCH"` (see `docs/single-writer.md`, `docs/traceability.md`):
+   ```bash
+   python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" \
+     --changed-since "$DEFAULT_BRANCH" --format text
+   python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" \
+     --changed-since "$DEFAULT_BRANCH" --format text
+   ```
+   Report-only: this is a fast wave-scoped signal, not the authoritative gate — `--changed-since` cannot see a stale writer/annotation outside this wave's diff. `/close-epic`'s coverage gate always scans the whole repo and is what actually blocks the epic. Surface findings for the fixer; don't hard-block the wave on them here.
 
 If the integration check fails:
 - **Test failure caused by merge**: Fix it on the staging branch. Launch an implementation worker (contract: `docs/worker-contracts.md#implementation-worker`) to diagnose and fix.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -371,6 +371,14 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    python3 "$CW_HOME/scripts/ratchet.py" check --repo "$(git rev-parse --show-toplevel)"
    ```
    A violation is a hard blocker, same as a failing test: a `missing_tests` entry means a previously-passing case regressed; `weakened_contracts`/`removed_contracts` means the branch edited a contract definition to make the implementation pass. Fix the code — never the contract. If a contract genuinely needs revising, that is a human decision: surface it to the user and journal it with `record --amend`/`--retire`, don't edit around the gate. Skip this item only when the repo has no ratchet config (not yet adopted).
+4c. **Single-writer / traceability quick check** (report-only, ticket-scoped) — if `$EPIC_DIR` exists, run both checkers scoped to just this ticket's changed files with `--changed-since "$DEFAULT_BRANCH"` (see `docs/single-writer.md`, `docs/traceability.md`). This is a fast early signal, NOT the authoritative gate — `--changed-since` scans only what this branch touched, so it cannot see a stale writer/annotation elsewhere in the repo. `/close-epic`'s coverage gate always scans the whole repo and is what actually blocks the epic:
+   ```bash
+   python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
+     --changed-since "$DEFAULT_BRANCH" --format text
+   python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
+     --changed-since "$DEFAULT_BRANCH" --format text
+   ```
+   Surface any findings to the fixer as early feedback (a new unsanctioned writer, a missing `@cw-trace guards`/`verifies` on the code this ticket just wrote); don't hard-block on them here. Skip this item if the ticket has no epic context.
 5. **Start services** and verify they work:
    - If `docker-compose.yml` exists: `docker compose up -d` and wait for healthy
    - If Docker isn't running, start it (`open -a Docker` on macOS, `sudo systemctl start docker` on Linux) and wait

--- a/docs/single-writer.md
+++ b/docs/single-writer.md
@@ -119,7 +119,17 @@ absence of a violation.
 — the version IS the content hash, so there's no hand-bumped constant to forget
 to update when the detection logic changes.
 
-Exit codes: `0` ok, `1` gate violation, `2` usage error.
+**Submodules / nested git checkouts are excluded from BOTH scan modes.** A
+directory under `--source` that contains a `.git` entry (a submodule's gitlink
+file, or a vendored/nested repo) is pruned from the full-tree walk, and the
+manifest behind `--changed-since` never surfaces a submodule's files either
+(git records a submodule as a single gitlink entry, not blobs). Submodule
+contents belong to the submodule's own repo and its own gates — this keeps the
+two scan modes agreeing on the file universe instead of one seeing files the
+other can't.
+
+Exit codes: `0` ok, `1` gate violation, `2` usage error (including a bad
+`--changed-since` ref or a non-git `--source` with `--changed-since`).
 
 ### Emission/claim seam (internal)
 

--- a/docs/single-writer.md
+++ b/docs/single-writer.md
@@ -88,6 +88,12 @@ python3 scripts/check_single_writer.py docs/epics/<slug> --source . --gate cover
 
 # report only (no gate), JSON or text
 python3 scripts/check_single_writer.py docs/epics/<slug> --source . --format json
+
+# ticket-scoped speed-up (/implement, /implement-wave): scan only what changed
+python3 scripts/check_single_writer.py docs/epics/<slug> --source . --changed-since main
+
+# hash-derived version (source of the scanner + its chief_wiggum deps)
+python3 scripts/check_single_writer.py --scanner-version
 ```
 
 Gates (mirroring `check_traceability.py`):
@@ -98,7 +104,34 @@ Gates (mirroring `check_traceability.py`):
 - `--gate coverage` — hard-fails on any **unsanctioned writer** (and on malformed
   metadata).
 
+`--changed-since <ref>` scopes the `--source` scan to files that differ from
+`<ref>` (committed diff + dirty tracked + untracked, via
+`chief_wiggum.manifest`) instead of walking the whole tree — a fast per-ticket
+signal for `/implement`/`/implement-wave` (report-only there; see those
+skills). **Whole-repo scanning remains the default, and `/close-epic --gate
+coverage` NEVER passes `--changed-since`** — the coverage gate must see every
+writer in the repo to be authoritative; a scoped scan can only ever report a
+false "no writer found"/"uncovered" for code outside its window, never prove
+absence of a violation.
+
+`--scanner-version` prints a hash of the scanner's own source plus its
+`chief_wiggum` dependencies (`chief_wiggum/manifest.py`, `chief_wiggum/hashing.py`)
+— the version IS the content hash, so there's no hand-bumped constant to forget
+to update when the detection logic changes.
+
 Exit codes: `0` ok, `1` gate violation, `2` usage error.
+
+### Emission/claim seam (internal)
+
+`scan_writers` is implemented as two pure phases (#160): `emit_write_sites(path,
+text) -> list[WriteSite]` finds every FIELD-AGNOSTIC candidate write site in one
+file's content — an assignment/struct-literal/quoted-literal/SQL-SET token, its
+line, and its enclosing symbol — with no knowledge of any invariant.
+`match_writers(sites, invariant) -> list[Writer]` is the query-time join: does
+any site's token belong to THIS invariant's controlled field, honoring
+`persistence_only`? This is the seam a future content-addressed cache would key
+off (`chief_wiggum.manifest.build_manifest`) — a file's emitted sites are valid
+cache entries as long as its content hash is unchanged.
 
 ## Worked example (the incident)
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -69,6 +69,12 @@ verifying test), **dangling annotations** (reference to an undefined ID), and
 python3 scripts/check_traceability.py docs/epics/<slug> --source . --format json
 python3 scripts/check_traceability.py docs/epics/<slug> --source . --gate soundness  # /architect
 python3 scripts/check_traceability.py docs/epics/<slug> --source . --gate coverage   # /close-epic
+
+# ticket-scoped speed-up (/implement, /implement-wave): scan only what changed
+python3 scripts/check_traceability.py docs/epics/<slug> --source . --changed-since main
+
+# hash-derived version (source of the scanner + its chief_wiggum deps)
+python3 scripts/check_traceability.py --scanner-version
 ```
 
 It is a **separate pass**, not compile-time enforcement, and degrades gracefully:
@@ -76,3 +82,34 @@ an epic with no annotations reports absence rather than failing. It proves a
 trace *link exists* — not that a guard is semantically correct (that is the
 Design-by-Contract verification frontier, out of scope; LSP symbol resolution
 is the cheaper next step). Mirrors `check_unresolved.py`.
+
+## Emission/claim seam, `--changed-since`, `--scanner-version` (#160)
+
+Per-file **emission** is a pair of pure functions of file content, with no
+knowledge of the defined-ID set: `emit_epic_annotations(rel, text)` (epic docs
+— attributes a `realizes`/`derive` annotation to the nearest stable ID declared
+above it) and `emit_source_annotations(rel, text, suffix)` (source/test/
+verification files — classifies by `source_kind`). `scan_epic_annotations` /
+`scan_source` walk the tree and call these per file; the orphan/uncovered/
+untested/dangling/invalid-link **verdicts** are computed once, at report time,
+in `build_report` — a join against the full defined-ID set. This is the same
+shape as `check_single_writer.py`'s `emit_write_sites`/`match_writers` split,
+and the basis for a future content-addressed cache
+(`chief_wiggum.manifest.build_manifest`): a file's emitted annotations are a
+valid cache entry as long as its content hash is unchanged.
+
+`--changed-since <ref>` scopes the `--source` scan (`scan_source`) to files
+that differ from `<ref>` (committed diff + dirty tracked + untracked, via
+`chief_wiggum.manifest`) instead of walking the whole tree. It does NOT scope
+the epic-doc scan — the epic's own docs are always read in full. This is a fast
+per-ticket signal for `/implement`/`/implement-wave` (report-only there).
+**Whole-repo scanning remains the default, and `/close-epic --gate coverage`
+NEVER passes `--changed-since`**: a scoped scan can only under-report coverage
+(annotations outside its window are invisible to it), never prove a contract IS
+covered — using it for the authoritative gate would produce false "uncovered"/
+"untested" findings for code the scan never looked at.
+
+`--scanner-version` prints a hash of the scanner's own source plus its
+`chief_wiggum` dependencies (`trace_ids.py`, `manifest.py`, `hashing.py`) — the
+version IS the content hash, so there's no hand-bumped constant to forget to
+update when the annotation grammar or ID kinds change.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -113,3 +113,13 @@ covered — using it for the authoritative gate would produce false "uncovered"/
 `chief_wiggum` dependencies (`trace_ids.py`, `manifest.py`, `hashing.py`) — the
 version IS the content hash, so there's no hand-bumped constant to forget to
 update when the annotation grammar or ID kinds change.
+
+**Submodules / nested git checkouts are excluded from BOTH scan modes.** A
+directory under `--source` that contains a `.git` entry (a submodule's gitlink
+file, or a vendored/nested repo) is pruned from the full-tree walk, and the
+manifest behind `--changed-since` never surfaces a submodule's files either
+(git records a submodule as a single gitlink entry, not blobs). Submodule
+contents belong to the submodule's own repo and its own gates — this keeps the
+two scan modes agreeing on the file universe. A bad `--changed-since` ref or a
+non-git `--source` with `--changed-since` is a usage error (exit 2), reported
+concisely on stderr.

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -70,6 +70,14 @@ Gates (mirrors ``check_traceability.py``):
     --gate soundness  -> /architect: fail on malformed metadata; surface writers.
     --gate coverage   -> /close-epic: hard-fail on any unsanctioned writer.
 
+Internally, scanning is split into per-file EMISSION (``emit_write_sites``: every
+field-agnostic candidate write site) and query-time CLAIM (``match_writers``: is
+this site's token one of THIS invariant's controlled fields?) — see
+``docs/single-writer.md``. ``--changed-since <ref>`` scopes ``--source`` to files
+changed since ``ref`` (never used by /close-epic's coverage gate, which must see
+the whole repo). ``--scanner-version`` prints a hash of this module's source plus
+its ``chief_wiggum`` deps.
+
 Exit codes: 0 = ok, 1 = gate violation, 2 = usage error.
 """
 
@@ -80,6 +88,7 @@ import fnmatch
 import json
 import re
 import sys
+from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -90,6 +99,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # for backward compatibility with any existing `check_single_writer.WRITES_TAG_RE`
 # references.
 from chief_wiggum.annotations import ATTR_RE, WRITES_TAG_RE  # noqa: E402, F401
+
+# Shared with check_traceability.py: the hash-derived --scanner-version and the
+# git-native manifest helper behind --changed-since (#160).
+from chief_wiggum.hashing import scanner_version  # noqa: E402
+from chief_wiggum.manifest import changed_paths  # noqa: E402
 
 # Same INV- shape as check_traceability.py (case-insensitive slug segment).
 INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])", re.IGNORECASE)
@@ -357,36 +371,30 @@ def collect_invariants(epic_dir: str | Path) -> tuple[list[SingleWriterInvariant
 # --- scanning the repo for writers ------------------------------------------
 
 
-def _writer_patterns(token: str) -> list[re.Pattern]:
-    """Build write-detection regexes for a controlled field's leaf ``token``.
+# Generic (field-agnostic) write-site detectors. Each captures a candidate
+# identifier token; whether that token belongs to any particular invariant's
+# controlled field is a QUERY-TIME decision (match_writers), not baked into the
+# regex. Kind indices (0-3) mirror the four write shapes documented in the
+# module docstring and drive `persistence_only` filtering in match_writers.
+KIND_ASSIGN, KIND_STRUCT, KIND_QUOTED, KIND_SQL = range(4)
 
-    ``token`` is already lowercased+de-underscored (e.g. ``stripeplan``). We match
-    the identifier case-insensitively and tolerant of a single underscore between
-    word chars, so ``StripePlan``, ``stripe_plan``, and ``StripePlan`` all hit.
-    """
-    # Rebuild a flexible identifier: optional underscores between characters.
-    ident = re.escape(token)
-    # Also accept the snake form: insert optional underscores is overkill; instead
-    # match either the compacted token or the original snake token. We pass both in.
-    pats: list[re.Pattern] = []
-    # 1. Assignment: `something.Plan =` / `.stripe_plan =` (not ==, not :=... actually
-    #    := is a Go declaration+assignment which IS a write, so allow it).
-    pats.append(re.compile(rf"\.{ident}\s*:?=[^=]", re.IGNORECASE))
-    # 2. Struct-literal / map set: `Plan: value` or `"plan": value` or `Key: "plan"`.
-    #    `:(?!=)` so Go's short-var-decl `plan := expr` is NOT read as a field set
-    #    (the token would be the local var name, and `:` the `:` of `:=`).
-    pats.append(re.compile(rf"""(^|[\s,{{(])['"]?{ident}['"]?\s*:(?!=)\s*""", re.IGNORECASE))
-    # 3. bson/Mongo update key referencing the field literally in a set expression.
-    pats.append(re.compile(rf"""['"]{ident}['"]""", re.IGNORECASE))
-    # 4. SQL UPDATE ... SET plan =
-    pats.append(re.compile(rf"\bSET\b[^;]*\b{ident}\s*=", re.IGNORECASE))
-    return pats
-
+# 0. Assignment: `something.Plan =` / `.stripe_plan =` (not ==; `:=` — Go's
+#    declare+assign — IS a write, so it's allowed).
+ASSIGN_RE = re.compile(r"\.(\w+)\s*:?=[^=]")
+# 1. Struct-literal / map set: `Plan: value` or `"plan": value` or `Key: "plan"`.
+#    `:(?!=)` so Go's short-var-decl `plan := expr` is NOT read as a field set
+#    (the captured token would be the local var name, and `:` the `:` of `:=`).
+STRUCT_RE = re.compile(r"""(^|[\s,{(])['"]?(\w+)['"]?\s*:(?!=)\s*""")
+# 2. bson/Mongo update key referenced literally in a set expression.
+QUOTED_RE = re.compile(r"""['"](\w+)['"]""")
+# 3. SQL UPDATE ... SET <field> = ...  (multiple fields may be set on one line).
+SQL_SET_KEYWORD_RE = re.compile(r"\bSET\b", re.IGNORECASE)
+SQL_FIELD_RE = re.compile(r"\b(\w+)\s*=")
 
 # A bson $set / Mongo update / SQL UPDATE context marker — a bare `"plan":` in a
 # non-mutating context (e.g. a JSON response DTO field) shouldn't count. We only
-# treat pattern #3 (quoted-literal) as a write when the surrounding lines look
-# like a mutation. Assignment (#1) and struct-literal (#2) are writes on their own.
+# treat KIND_QUOTED (quoted-literal) as a write when the surrounding lines look
+# like a mutation. KIND_ASSIGN and KIND_STRUCT are writes on their own.
 MUTATION_CONTEXT_RE = re.compile(
     r"\$set|UpdateOne|UpdateMany|UpdateByID|FindOneAndUpdate|bson\.[ME]|SET\b|UPDATE\b",
     re.IGNORECASE,
@@ -470,84 +478,167 @@ def _distinct_field_forms(inv: SingleWriterInvariant) -> list[tuple[str, str]]:
     return forms
 
 
+@dataclass
+class WriteSite:
+    """A FIELD-AGNOSTIC candidate write site: emission time knows nothing about
+    any invariant's controlled field — just "this line assigns/sets/matches an
+    identifier token, in this file, in this enclosing symbol". Whether ``token``
+    belongs to a controlled field is a query-time decision (``match_writers``).
+    """
+
+    file: str
+    line: int  # 1-indexed
+    text: str  # raw (comment-un-stripped) line, stripped + truncated for display
+    symbol: str | None
+    is_test: bool
+    kind: int  # KIND_ASSIGN | KIND_STRUCT | KIND_QUOTED | KIND_SQL
+    token: str  # the identifier exactly as it appears in source (case preserved)
+
+
+def emit_write_sites(path: str, text: str) -> list[WriteSite]:
+    """Emission: every candidate write site in a single file's ``text``, with NO
+    knowledge of any specific invariant or controlled field (see module + class
+    docstrings). ``path`` is a repo-relative label used only for ``.suffix``
+    (comment-marker lookup) and the ``file`` attribute — the file is never
+    re-read from disk, so this is safe to call on manifest-sourced content.
+    """
+    suffix = Path(path).suffix
+    raw_lines = text.splitlines()
+    code_lines = [_strip_line_comment(rl, suffix) for rl in raw_lines]
+    is_test = _is_test_path(path)
+    sites: list[WriteSite] = []
+    for i, line in enumerate(code_lines):
+        candidates: list[tuple[int, str]] = []  # (kind, token)
+        for m in ASSIGN_RE.finditer(line):
+            candidates.append((KIND_ASSIGN, m.group(1)))
+        for m in STRUCT_RE.finditer(line):
+            candidates.append((KIND_STRUCT, m.group(2)))
+        for m in QUOTED_RE.finditer(line):
+            # A bare quoted literal only counts as a write in a mutation context
+            # (this line or either of the two lines above) and NOT when the same
+            # line carries a query operator (a filter clause, not a $set value).
+            # Both checks are invariant-independent, so resolved once here.
+            if not (
+                MUTATION_CONTEXT_RE.search(line)
+                or (i > 0 and MUTATION_CONTEXT_RE.search(code_lines[i - 1]))
+                or (i > 1 and MUTATION_CONTEXT_RE.search(code_lines[i - 2]))
+            ):
+                continue
+            if FILTER_OPERATOR_RE.search(line):
+                continue
+            candidates.append((KIND_QUOTED, m.group(1)))
+        for set_m in SQL_SET_KEYWORD_RE.finditer(line):
+            tail = line[set_m.end():]
+            semi = tail.find(";")
+            if semi != -1:
+                tail = tail[:semi]
+            for fm in SQL_FIELD_RE.finditer(tail):
+                candidates.append((KIND_SQL, fm.group(1)))
+        if not candidates:
+            continue
+        symbol = _enclosing_symbol(code_lines, i)
+        snippet = raw_lines[i].strip()[:200]
+        for kind, token in candidates:
+            sites.append(WriteSite(
+                file=path, line=i + 1, text=snippet, symbol=symbol,
+                is_test=is_test, kind=kind, token=token,
+            ))
+    return sites
+
+
+def match_writers(sites: list[WriteSite], invariant: SingleWriterInvariant) -> list[Writer]:
+    """Claim: query-time filter of field-agnostic ``sites`` against a single
+    invariant's controlled fields + sanctioned writers. Mirrors the original
+    interleaved scan exactly — including "one write record per (line,
+    invariant), first controlled-field-form wins" — but now as a pure function
+    of pre-emitted sites, with no filesystem access.
+    """
+    by_line: dict[tuple[str, int], list[WriteSite]] = defaultdict(list)
+    for s in sites:
+        by_line[(s.file, s.line)].append(s)
+
+    writers: list[Writer] = []
+    for (file, line), line_sites in by_line.items():
+        for fpath, tok in _distinct_field_forms(invariant):
+            matched: WriteSite | None = None
+            for s in line_sites:
+                # persistence_only (`sink=db`): only DB sinks count — the bare
+                # quoted-literal-in-mutation-context and SQL UPDATE kinds. Skip
+                # in-memory assignment and struct/map literals — those don't
+                # write the row.
+                if invariant.persistence_only and s.kind in (KIND_ASSIGN, KIND_STRUCT):
+                    continue
+                if s.token.lower() != tok:
+                    continue
+                matched = s
+                break  # which kind hit doesn't affect the output; take the first
+            if matched is None:
+                continue
+            sanctioned = matched.is_test or _is_sanctioned(invariant, file, matched.symbol)
+            writers.append(Writer(
+                invariant_id=invariant.id,
+                field=fpath,
+                file=file,
+                line=line,
+                text=matched.text,
+                symbol=matched.symbol,
+                sanctioned=sanctioned,
+                is_test=matched.is_test,
+            ))
+            break  # one write record per (line, invariant)
+    return writers
+
+
 def scan_writers(
     source_root: str | Path,
     invariants: list[SingleWriterInvariant],
     exclude: list[str] | None = None,
+    only_files: set[str] | None = None,
 ) -> list[Writer]:
-    """Find every writer of every controlled field across the repo."""
+    """Find every writer of every controlled field across the repo: emit
+    field-agnostic write sites per file, then claim them against each
+    invariant. ``only_files`` (repo-relative paths), when given, restricts the
+    walk to that set instead of the whole tree — used by ``--changed-since``.
+    """
     root = Path(source_root)
     exclude = exclude or []
     writers: list[Writer] = []
     if not root.exists() or not invariants:
         return writers
 
-    # Precompute per-invariant field patterns.
-    inv_patterns: list[tuple[SingleWriterInvariant, list[tuple[str, str, list[re.Pattern]]]]] = []
-    for inv in invariants:
-        field_pats: list[tuple[str, str, list[re.Pattern]]] = []
-        for fpath, tok in _distinct_field_forms(inv):
-            field_pats.append((fpath, tok, _writer_patterns(tok)))
-        inv_patterns.append((inv, field_pats))
+    if only_files is not None:
+        candidates = sorted(only_files)
+    else:
+        candidates = sorted(
+            str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()
+        )
 
-    for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.suffix not in SOURCE_EXTS:
+    for rel in candidates:
+        if Path(rel).suffix not in SOURCE_EXTS:
             continue
-        if any(part in SKIP_PARTS for part in path.parts):
+        if any(part in SKIP_PARTS for part in Path(rel).parts):
             continue
-        rel = str(path.relative_to(root))
         if _excluded(rel, exclude):
             continue
+        path = root / rel
         try:
-            raw_lines = path.read_text().splitlines()
+            text = path.read_text()
         except OSError:
             continue
-        # Match on comment-stripped lines so a field mentioned in a comment is not read
-        # as a write; keep raw_lines only for the human-readable `text` of a finding.
-        code_lines = [_strip_line_comment(rl, path.suffix) for rl in raw_lines]
-        is_test = _is_test_path(rel)
-        for i, line in enumerate(code_lines):
-            for inv, field_pats in inv_patterns:
-                for fpath, _tok, pats in field_pats:
-                    hit = False
-                    for pi, pat in enumerate(pats):
-                        # persistence_only (`sink=db`): only DB sinks count — the bare
-                        # quoted-literal-in-mutation-context (#3, index 2) and SQL
-                        # UPDATE (#4, index 3). Skip in-memory assignment (#1) and
-                        # struct/map literals (#2) — those don't write the row.
-                        if inv.persistence_only and pi in (0, 1):
-                            continue
-                        if not pat.search(line):
-                            continue
-                        # Pattern #3 (bare quoted literal, index 2) only counts as a
-                        # write inside a mutation context; otherwise skip (DTO field).
-                        if pi == 2 and not (
-                            MUTATION_CONTEXT_RE.search(line)
-                            or (i > 0 and MUTATION_CONTEXT_RE.search(code_lines[i - 1]))
-                            or (i > 1 and MUTATION_CONTEXT_RE.search(code_lines[i - 2]))
-                        ):
-                            continue
-                        # ...but a query-operator on the line makes it a filter clause,
-                        # not a write (which document to match, not what to set). Skip.
-                        if pi == 2 and FILTER_OPERATOR_RE.search(line):
-                            continue
-                        hit = True
-                        break
-                    if not hit:
-                        continue
-                    symbol = _enclosing_symbol(code_lines, i)
-                    sanctioned = is_test or _is_sanctioned(inv, rel, symbol)
-                    writers.append(Writer(
-                        invariant_id=inv.id,
-                        field=fpath,
-                        file=rel,
-                        line=i + 1,
-                        text=raw_lines[i].strip()[:200],
-                        symbol=symbol,
-                        sanctioned=sanctioned,
-                        is_test=is_test,
-                    ))
-                    break  # one write record per (line, invariant)
+        sites = emit_write_sites(rel, text)
+        if not sites:
+            continue
+        # Claim per invariant, then merge preserving the ORIGINAL ordering: line
+        # ascending first, invariant list-order second (the original scan looped
+        # "for line: for invariant", not "for invariant: for line" — a file with
+        # hits for multiple invariants at interleaved lines must come out in line
+        # order, not grouped by invariant).
+        tagged: list[tuple[int, Writer]] = []
+        for idx, inv in enumerate(invariants):
+            for w in match_writers(sites, inv):
+                tagged.append((idx, w))
+        tagged.sort(key=lambda t: (t[1].line, t[0]))
+        writers.extend(w for _, w in tagged)
     return writers
 
 
@@ -571,6 +662,30 @@ def _is_sanctioned(inv: SingleWriterInvariant, rel: str, symbol: str | None) -> 
     return False
 
 
+# --- manifest-scoped scanning (--changed-since) -----------------------------
+
+
+def _file_predicate(rel: str) -> bool:
+    """The scanner's EXACT file-selection rule (extension allow-list + skipped
+    directories) — the same predicate `scan_writers` applies during its own
+    walk, reused to build a manifest whose keys are exactly the files that walk
+    would visit (see ``chief_wiggum.manifest``)."""
+    p = Path(rel)
+    if p.suffix not in SOURCE_EXTS:
+        return False
+    if any(part in SKIP_PARTS for part in p.parts):
+        return False
+    return True
+
+
+def _scanner_version() -> str:
+    """Hash-derived ``--scanner-version``: the source of this module plus its
+    ``chief_wiggum`` dependencies. No hand-bumped constant to forget."""
+    here = Path(__file__).resolve()
+    cw_dir = here.parent / "chief_wiggum"
+    return scanner_version(here, cw_dir / "manifest.py", cw_dir / "hashing.py")
+
+
 # --- top-level check --------------------------------------------------------
 
 
@@ -578,6 +693,7 @@ def check(
     epic_dir: str | Path,
     source_root: str | Path | None = None,
     exclude: list[str] | None = None,
+    changed_since: str | None = None,
 ) -> SingleWriterReport:
     report = SingleWriterReport()
     invariants, malformed = collect_invariants(epic_dir)
@@ -607,18 +723,26 @@ def check(
                 scan_exclude.append(rel_str)
         except ValueError:
             pass  # epic_dir is outside source_root (e.g. CW_TMP at architect time)
-        writers = scan_writers(source_root, invariants, exclude=scan_exclude)
+        only_files = None
+        if changed_since:
+            # Ticket-scoped speed-up ONLY — never used by /close-epic's coverage
+            # gate, which must see the whole repo to be authoritative.
+            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
+        writers = scan_writers(source_root, invariants, exclude=scan_exclude, only_files=only_files)
         report.writers = [w.to_dict() for w in writers]
         report.violations = [w.to_dict() for w in writers if not w.sanctioned]
         # Surface any invariant whose controlled field has NO writer at all — the
         # sanctioned path may be missing/misnamed (a soft warning, not a violation).
-        written_ids = {w.invariant_id for w in writers}
-        for inv in invariants:
-            if inv.id not in written_ids:
-                report.warnings.append(
-                    f"{inv.id}: no writer found for {inv.controls_field} — "
-                    f"sanctioned writer(s) {inv.sanctioned_writers} may be missing or misnamed"
-                )
+        # Skipped under --changed-since: a ticket-scoped scan is EXPECTED to miss
+        # unrelated invariants' writers, so this warning would just be noise.
+        if not changed_since:
+            written_ids = {w.invariant_id for w in writers}
+            for inv in invariants:
+                if inv.id not in written_ids:
+                    report.warnings.append(
+                        f"{inv.id}: no writer found for {inv.controls_field} — "
+                        f"sanctioned writer(s) {inv.sanctioned_writers} may be missing or misnamed"
+                    )
     else:
         report.warnings.append("no --source given; parsed invariant metadata only (no repo scan)")
 
@@ -666,7 +790,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Single-writer / mutator-inventory checker for single-write-path invariants"
     )
-    parser.add_argument("epic_dir", help="docs/epics/<slug> directory (or CW_TMP at architect time)")
+    parser.add_argument(
+        "epic_dir", nargs="?", default=None,
+        help="docs/epics/<slug> directory (or CW_TMP at architect time); not required with --scanner-version",
+    )
     parser.add_argument("--source", help="Repo root to scan for writers of controlled fields")
     parser.add_argument(
         "--exclude",
@@ -681,14 +808,35 @@ def main(argv: list[str] | None = None) -> int:
         help="Fail (exit 1) on this gate's findings (soundness=malformed metadata; "
         "coverage=unsanctioned writers)",
     )
+    parser.add_argument(
+        "--changed-since",
+        metavar="REF",
+        help="Scope the --source scan to files changed since REF (via git diff + the "
+        "content-addressed manifest) instead of the whole tree. Ticket-scoped speed-up "
+        "ONLY — /close-epic's coverage gate NEVER uses this; whole-repo remains the default.",
+    )
+    parser.add_argument(
+        "--scanner-version",
+        action="store_true",
+        help="Print the hash-derived scanner version (source hash of this module + its "
+        "chief_wiggum deps) and exit",
+    )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
+
+    if args.scanner_version:
+        print(_scanner_version())
+        return 0
+
+    if not args.epic_dir:
+        print("Error: epic_dir is required unless --scanner-version is given", file=sys.stderr)
+        return 2
 
     if not Path(args.epic_dir).exists():
         print(f"Error: epic dir not found: {args.epic_dir}", file=sys.stderr)
         return 2
 
-    report = check(args.epic_dir, args.source, exclude=args.exclude)
+    report = check(args.epic_dir, args.source, exclude=args.exclude, changed_since=args.changed_since)
 
     if args.format == "json":
         print(json.dumps(report.to_dict(), indent=2))

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -691,10 +691,13 @@ def _file_predicate(rel: str) -> bool:
 
 def _scanner_version() -> str:
     """Hash-derived ``--scanner-version``: the source of this module plus its
-    ``chief_wiggum`` dependencies. No hand-bumped constant to forget."""
+    ``chief_wiggum`` dependencies (annotations.py carries the @cw-writes
+    grammar — #170 moved it there). No hand-bumped constant to forget."""
     here = Path(__file__).resolve()
     cw_dir = here.parent / "chief_wiggum"
-    return scanner_version(here, cw_dir / "manifest.py", cw_dir / "hashing.py")
+    return scanner_version(
+        here, cw_dir / "annotations.py", cw_dir / "manifest.py", cw_dir / "hashing.py"
+    )
 
 
 # --- top-level check --------------------------------------------------------

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -101,9 +101,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from chief_wiggum.annotations import ATTR_RE, WRITES_TAG_RE  # noqa: E402, F401
 
 # Shared with check_traceability.py: the hash-derived --scanner-version and the
-# git-native manifest helper behind --changed-since (#160).
+# git-native manifest helper behind --changed-since (#160). walk_source_files
+# prunes submodules/nested git checkouts from the FULL scan so both scan modes
+# agree on the file universe (the manifest never surfaces submodule blobs).
 from chief_wiggum.hashing import scanner_version  # noqa: E402
-from chief_wiggum.manifest import changed_paths  # noqa: E402
+from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
 
 # Same INV- shape as check_traceability.py (case-insensitive slug segment).
 INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])", re.IGNORECASE)
@@ -378,18 +380,27 @@ def collect_invariants(epic_dir: str | Path) -> tuple[list[SingleWriterInvariant
 # module docstring and drive `persistence_only` filtering in match_writers.
 KIND_ASSIGN, KIND_STRUCT, KIND_QUOTED, KIND_SQL = range(4)
 
+# The token classes are wider than `\w+` on purpose: the pre-split scanner
+# built its regexes from `re.escape(leaf_token)`, so a controlled field whose
+# leaf contains a hyphen (e.g. a Mongo key `plan-tier`) DID match. Emission
+# must cover at least that same token surface or a full scan could silently
+# miss an unsanctioned writer of such a field; over-wide captures are harmless
+# (a token that matches no invariant's field is dropped at claim time).
 # 0. Assignment: `something.Plan =` / `.stripe_plan =` (not ==; `:=` — Go's
 #    declare+assign — IS a write, so it's allowed).
-ASSIGN_RE = re.compile(r"\.(\w+)\s*:?=[^=]")
+ASSIGN_RE = re.compile(r"\.([\w-]+)\s*:?=[^=]")
 # 1. Struct-literal / map set: `Plan: value` or `"plan": value` or `Key: "plan"`.
 #    `:(?!=)` so Go's short-var-decl `plan := expr` is NOT read as a field set
 #    (the captured token would be the local var name, and `:` the `:` of `:=`).
-STRUCT_RE = re.compile(r"""(^|[\s,{(])['"]?(\w+)['"]?\s*:(?!=)\s*""")
-# 2. bson/Mongo update key referenced literally in a set expression.
-QUOTED_RE = re.compile(r"""['"](\w+)['"]""")
+STRUCT_RE = re.compile(r"""(^|[\s,{(])['"]?([\w.-]+)['"]?\s*:(?!=)\s*""")
+# 2. bson/Mongo update key referenced literally in a set expression. `.` is in
+#    the class so a dotted key (`"provider.plan"`) is captured whole — leaf
+#    tokens never contain dots, so it can't claim-match a leaf field, exactly
+#    like the old quote-delimited exact-token match behaved.
+QUOTED_RE = re.compile(r"""['"]([\w.-]+)['"]""")
 # 3. SQL UPDATE ... SET <field> = ...  (multiple fields may be set on one line).
 SQL_SET_KEYWORD_RE = re.compile(r"\bSET\b", re.IGNORECASE)
-SQL_FIELD_RE = re.compile(r"\b(\w+)\s*=")
+SQL_FIELD_RE = re.compile(r"\b([\w-]+)\s*=")
 
 # A bson $set / Mongo update / SQL UPDATE context marker — a bare `"plan":` in a
 # non-mutating context (e.g. a JSON response DTO field) shouldn't count. We only
@@ -609,9 +620,9 @@ def scan_writers(
     if only_files is not None:
         candidates = sorted(only_files)
     else:
-        candidates = sorted(
-            str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()
-        )
+        # walk_source_files prunes submodules/nested git checkouts, keeping the
+        # full scan's file universe identical to the manifest's (--changed-since).
+        candidates = walk_source_files(root)
 
     for rel in candidates:
         if Path(rel).suffix not in SOURCE_EXTS:
@@ -836,7 +847,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: epic dir not found: {args.epic_dir}", file=sys.stderr)
         return 2
 
-    report = check(args.epic_dir, args.source, exclude=args.exclude, changed_since=args.changed_since)
+    try:
+        report = check(args.epic_dir, args.source, exclude=args.exclude, changed_since=args.changed_since)
+    except ManifestError as exc:
+        # Bad --changed-since ref, non-git --source, missing HEAD, no git binary:
+        # a usage error, reported concisely — never a traceback.
+        print(f"Error: --changed-since manifest failed: {exc}", file=sys.stderr)
+        return 2
 
     if args.format == "json":
         print(json.dumps(report.to_dict(), indent=2))

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -45,9 +45,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # a kind added in one place but not the others is silently dropped, so all
 # three build from chief_wiggum.trace_ids (cross-checked in tests).
 # Shared with check_single_writer.py: the hash-derived --scanner-version and
-# the git-native manifest helper behind --changed-since (#160).
+# the git-native manifest helper behind --changed-since (#160). walk_source_files
+# prunes submodules/nested git checkouts from the FULL scan so both scan modes
+# agree on the file universe (the manifest never surfaces submodule blobs).
 from chief_wiggum.hashing import scanner_version  # noqa: E402
-from chief_wiggum.manifest import changed_paths  # noqa: E402
+from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
 from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE  # noqa: E402
 
 DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "templates" / "formal-models" / "tim-schema.json"
@@ -292,7 +294,9 @@ def scan_source(source_root: str | Path, only_files: set[str] | None = None) -> 
     if only_files is not None:
         candidates = sorted(only_files)
     else:
-        candidates = sorted(str(p.relative_to(root)) for p in root.rglob("*") if p.is_file())
+        # walk_source_files prunes submodules/nested git checkouts, keeping the
+        # full scan's file universe identical to the manifest's (--changed-since).
+        candidates = walk_source_files(root)
     for rel in candidates:
         if not _file_predicate(rel):
             continue
@@ -460,7 +464,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: epic dir not found: {args.epic_dir}", file=sys.stderr)
         return 2
 
-    report = check(args.epic_dir, args.source, schema=schema, changed_since=args.changed_since)
+    try:
+        report = check(args.epic_dir, args.source, schema=schema, changed_since=args.changed_since)
+    except ManifestError as exc:
+        # Bad --changed-since ref, non-git --source, missing HEAD, no git binary:
+        # a usage error, reported concisely — never a traceback.
+        print(f"Error: --changed-since manifest failed: {exc}", file=sys.stderr)
+        return 2
 
     if args.format == "json":
         print(json.dumps(report.to_dict(), indent=2))

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -21,6 +21,14 @@ gracefully: a repo/epic with no annotations reports absence rather than crashing
 Mirrors ``check_unresolved.py``. Gates:
     --gate soundness  -> fail on orphan BRs + dangling refs + invalid links (/architect)
     --gate coverage   -> fail on uncovered + untested contracts (/close-epic)
+
+Internally, scanning is split into per-file EMISSION (``emit_epic_annotations``,
+``emit_source_annotations``: every ``@cw-trace`` annotation in one file) and
+report-time joins against the defined-ID set (``build_report``) — see
+``docs/traceability.md``. ``--changed-since <ref>`` scopes the ``--source`` scan
+to files changed since ``ref`` (never used by /close-epic's coverage gate, which
+must see the whole repo). ``--scanner-version`` prints a hash of this module's
+source plus its ``chief_wiggum`` deps.
 """
 
 from __future__ import annotations
@@ -36,6 +44,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # The ID grammar and verb set are shared with ratchet.py and the TIM schema —
 # a kind added in one place but not the others is silently dropped, so all
 # three build from chief_wiggum.trace_ids (cross-checked in tests).
+# Shared with check_single_writer.py: the hash-derived --scanner-version and
+# the git-native manifest helper behind --changed-since (#160).
+from chief_wiggum.hashing import scanner_version  # noqa: E402
+from chief_wiggum.manifest import changed_paths  # noqa: E402
 from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE  # noqa: E402
 
 DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "templates" / "formal-models" / "tim-schema.json"
@@ -157,8 +169,40 @@ def extract_defined_ids(epic_dir: str | Path) -> dict[str, str]:
     return defined
 
 
+def emit_epic_annotations(rel: str, text: str) -> list[Annotation]:
+    """Per-file EMISSION: every ``@cw-trace`` annotation declared in one epic doc's
+    ``text``, attributed to the nearest stable ID declared above it. Pure function
+    of file content — no knowledge of the full defined-ID set (that join is
+    query-time, in ``build_report``).
+
+    A realizes/derive annotation is attributed to the nearest stable ID
+    *declared above it* in the same file, so it is tied to a real source.
+    Any kind that can be a link SOURCE qualifies (BUD-/EDG-/... declare
+    derive links the same way CTR-/INV- declare realizes — #166). BR is
+    only ever a link target, so a BR declaration RESETS attribution: an
+    annotation under a BR heading must not inherit an earlier contract
+    (that would let a stray realizes clear the BR's own orphan status).
+    """
+    annotations: list[Annotation] = []
+    nearest_contract: str | None = None
+    for i, line in enumerate(text.splitlines(), start=1):
+        for dm in DEFINE_RE.finditer(line):
+            if kind_of(dm.group(1)) == "BR":
+                nearest_contract = None
+            else:
+                nearest_contract = canonical_id(dm.group(1))
+        for verb, ids in parse_annotations(line):
+            src_kind = kind_of(nearest_contract) if nearest_contract else "CTR"
+            for target in ids:
+                annotations.append(
+                    Annotation(verb, target, rel, i, src_kind, source_id=nearest_contract)
+                )
+    return annotations
+
+
 def scan_epic_annotations(epic_dir: str | Path) -> list[Annotation]:
-    """Scan the epic docs for ``@cw-trace realizes`` (and other) annotations.
+    """Walk the epic docs, emitting ``@cw-trace realizes`` (and other)
+    annotations per file via ``emit_epic_annotations``.
 
     Annotations authored in the contract/invariant docs originate from a contract
     (source kind ``CTR``) — this is how a contract declares which business
@@ -172,30 +216,11 @@ def scan_epic_annotations(epic_dir: str | Path) -> list[Annotation]:
         if path.suffix not in (".md", ".json") or not path.is_file():
             continue
         try:
-            lines = path.read_text().splitlines()
+            text = path.read_text()
         except OSError:
             continue
         rel = str(path.relative_to(root))
-        # A realizes/derive annotation is attributed to the nearest stable ID
-        # *declared above it* in the same file, so it is tied to a real source.
-        # Any kind that can be a link SOURCE qualifies (BUD-/EDG-/... declare
-        # derive links the same way CTR-/INV- declare realizes — #166). BR is
-        # only ever a link target, so a BR declaration RESETS attribution: an
-        # annotation under a BR heading must not inherit an earlier contract
-        # (that would let a stray realizes clear the BR's own orphan status).
-        nearest_contract: str | None = None
-        for i, line in enumerate(lines, start=1):
-            for dm in DEFINE_RE.finditer(line):
-                if kind_of(dm.group(1)) == "BR":
-                    nearest_contract = None
-                else:
-                    nearest_contract = canonical_id(dm.group(1))
-            for verb, ids in parse_annotations(line):
-                src_kind = kind_of(nearest_contract) if nearest_contract else "CTR"
-                for target in ids:
-                    annotations.append(
-                        Annotation(verb, target, rel, i, src_kind, source_id=nearest_contract)
-                    )
+        annotations.extend(emit_epic_annotations(rel, text))
     return annotations
 
 
@@ -225,28 +250,67 @@ def classify_source_kind(rel: str, suffix: str) -> str:
     return "test" if is_test else "code"
 
 
-def scan_source(source_root: str | Path) -> list[Annotation]:
-    """Scan source/test/verification files for ``@cw-trace`` annotations."""
+SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv"}
+
+
+def _file_predicate(rel: str) -> bool:
+    """The scanner's EXACT file-selection rule (extension allow-list + skipped
+    directories) — the same predicate ``scan_source`` applies during its own
+    walk, reused to build a manifest whose keys are exactly the files that walk
+    would visit (see ``chief_wiggum.manifest``)."""
+    p = Path(rel)
+    if p.suffix not in SOURCE_EXTS:
+        return False
+    if any(part in SKIP_PARTS for part in p.parts):
+        return False
+    return True
+
+
+def emit_source_annotations(rel: str, text: str, suffix: str) -> list[Annotation]:
+    """Per-file EMISSION: every ``@cw-trace`` annotation in one source/test/
+    verification file's ``text``, classified by this file's source kind. Pure
+    function of file content — no knowledge of the defined-ID set (that join
+    happens in ``build_report``, at query/report time)."""
+    source_kind = classify_source_kind(rel, suffix)
+    annotations: list[Annotation] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for verb, ids in parse_annotations(line):
+            for target in ids:
+                annotations.append(Annotation(verb, target, rel, i, source_kind))
+    return annotations
+
+
+def scan_source(source_root: str | Path, only_files: set[str] | None = None) -> list[Annotation]:
+    """Walk source/test/verification files, emitting ``@cw-trace`` annotations
+    per file via ``emit_source_annotations``. ``only_files`` (repo-relative
+    paths), when given, restricts the walk to that set instead of the whole
+    tree — used by ``--changed-since``."""
     root = Path(source_root)
     annotations: list[Annotation] = []
     if not root.exists():
         return annotations
-    for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.suffix not in SOURCE_EXTS:
+    if only_files is not None:
+        candidates = sorted(only_files)
+    else:
+        candidates = sorted(str(p.relative_to(root)) for p in root.rglob("*") if p.is_file())
+    for rel in candidates:
+        if not _file_predicate(rel):
             continue
-        if any(part in {".git", "node_modules", "__pycache__", ".venv"} for part in path.parts):
-            continue
+        path = root / rel
         try:
-            lines = path.read_text().splitlines()
+            text = path.read_text()
         except OSError:
             continue
-        rel = str(path.relative_to(root))
-        source_kind = classify_source_kind(rel, path.suffix)
-        for i, line in enumerate(lines, start=1):
-            for verb, ids in parse_annotations(line):
-                for target in ids:
-                    annotations.append(Annotation(verb, target, rel, i, source_kind))
+        annotations.extend(emit_source_annotations(rel, text, path.suffix))
     return annotations
+
+
+def _scanner_version() -> str:
+    """Hash-derived ``--scanner-version``: the source of this module plus its
+    ``chief_wiggum`` dependencies. No hand-bumped constant to forget."""
+    here = Path(__file__).resolve()
+    cw_dir = here.parent / "chief_wiggum"
+    return scanner_version(here, cw_dir / "trace_ids.py", cw_dir / "manifest.py", cw_dir / "hashing.py")
 
 
 def build_report(
@@ -314,13 +378,19 @@ def check(
     source_root: str | Path | None = None,
     *,
     schema: dict | None = None,
+    changed_since: str | None = None,
 ) -> TraceReport:
     schema = schema or load_schema()
     defined = extract_defined_ids(epic_dir)
     # Contract->BR realizes links live in the epic docs; code/test links in source.
     annotations = scan_epic_annotations(epic_dir)
     if source_root:
-        annotations += scan_source(source_root)
+        only_files = None
+        if changed_since:
+            # Ticket-scoped speed-up ONLY — never used by /close-epic's coverage
+            # gate, which must see the whole repo to be authoritative.
+            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
+        annotations += scan_source(source_root, only_files=only_files)
     return build_report(defined, annotations, schema)
 
 
@@ -348,12 +418,36 @@ def render_markdown(report: TraceReport) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Traceability graph checker (TIM/DbC)")
-    parser.add_argument("epic_dir", help="docs/epics/<slug> directory with contract/invariant IDs")
+    parser.add_argument(
+        "epic_dir", nargs="?", default=None,
+        help="docs/epics/<slug> directory with contract/invariant IDs; not required with --scanner-version",
+    )
     parser.add_argument("--source", help="Repo root to scan for @cw-trace annotations")
     parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
     parser.add_argument("--gate", choices=["soundness", "coverage"], help="Fail (exit 1) on this gate's findings")
+    parser.add_argument(
+        "--changed-since",
+        metavar="REF",
+        help="Scope the --source scan to files changed since REF (via git diff + the "
+        "content-addressed manifest) instead of the whole tree. Ticket-scoped speed-up "
+        "ONLY — /close-epic's coverage gate NEVER uses this; whole-repo remains the default.",
+    )
+    parser.add_argument(
+        "--scanner-version",
+        action="store_true",
+        help="Print the hash-derived scanner version (source hash of this module + its "
+        "chief_wiggum deps) and exit",
+    )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
+
+    if args.scanner_version:
+        print(_scanner_version())
+        return 0
+
+    if not args.epic_dir:
+        print("Error: epic_dir is required unless --scanner-version is given", file=sys.stderr)
+        return 2
 
     try:
         schema = load_schema(Path(args.schema))
@@ -366,7 +460,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: epic dir not found: {args.epic_dir}", file=sys.stderr)
         return 2
 
-    report = check(args.epic_dir, args.source, schema=schema)
+    report = check(args.epic_dir, args.source, schema=schema, changed_since=args.changed_since)
 
     if args.format == "json":
         print(json.dumps(report.to_dict(), indent=2))

--- a/scripts/chief_wiggum/hashing.py
+++ b/scripts/chief_wiggum/hashing.py
@@ -1,0 +1,36 @@
+"""Shared stable-hash helpers (#160).
+
+``stable_hash`` originated in ``ratchet.py`` (contract-definition hashing) and is
+now the single home for it, imported back into ``ratchet.py`` so there is one
+implementation, not a copy. ``scanner_version`` builds on it for a
+hash-derived scanner version: the version of a gate script IS the hash of its
+own source plus its ``chief_wiggum`` dependencies, so a forgotten manual bump
+(the previous failure mode — a hand-edited constant nobody remembers to touch)
+is structurally impossible. Any edit to the scanner or a dependency changes the
+version automatically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def stable_hash(*parts: str) -> str:
+    """Deterministic hash of one or more string parts (order-sensitive, NUL-joined)."""
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def scanner_version(*module_paths: str | Path) -> str:
+    """Hash-derived version for a scanner: ``stable_hash`` over the raw source text
+    of ``module_paths`` (the scanner module itself plus its ``chief_wiggum`` deps),
+    in the order given. Order matters — callers pass a fixed, deterministic list
+    (their own file first, then each imported dependency module) so the same
+    inputs always produce the same version, and any source change (in the
+    scanner OR a dependency) changes it."""
+    texts = [Path(p).read_text() for p in module_paths]
+    return stable_hash(*texts)

--- a/scripts/chief_wiggum/manifest.py
+++ b/scripts/chief_wiggum/manifest.py
@@ -33,6 +33,7 @@ set of files that scanner would otherwise walk, no more and no less.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -40,15 +41,52 @@ from pathlib import Path
 Predicate = Callable[[str], bool]
 
 
+class ManifestError(RuntimeError):
+    """A git invocation underlying the manifest failed — bad ref, ``repo_root``
+    is not a git repository, unborn/missing HEAD, or git itself is absent.
+    Callers (the checker CLIs) turn this into a concise usage error (exit 2)
+    instead of a traceback."""
+
+
 def _run_git(args: list[str], cwd: Path) -> str:
-    result = subprocess.run(
-        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+        )
+    except FileNotFoundError as exc:
+        raise ManifestError("git executable not found") from exc
+    except subprocess.CalledProcessError as exc:
+        detail_lines = (exc.stderr or "").strip().splitlines()
+        detail = detail_lines[0] if detail_lines else f"exit status {exc.returncode}"
+        raise ManifestError(f"git {args[0]} failed in {cwd}: {detail}") from exc
     return result.stdout
 
 
+def walk_source_files(root: str | Path) -> list[str]:
+    """Sorted repo-relative paths of every file under ``root``, pruning nested
+    git checkouts: any directory below the root that contains a ``.git`` entry
+    (a submodule's gitlink file, or a vendored/nested repo's ``.git`` dir) is
+    skipped entirely. The scanners use this for their FULL-tree walk so it stays
+    consistent with the manifest/``--changed-since`` view, which is built from
+    the parent repo's git index and therefore never surfaces a submodule's
+    files — a submodule is a single non-blob gitlink entry there, not blobs
+    (see ``_ls_tree``/``build_manifest``). Submodule contents belong to the
+    submodule's own repo and its own gates; they are excluded from BOTH scan
+    modes rather than visible to one and invisible to the other."""
+    root_path = Path(root)
+    out: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root_path):
+        dpath = Path(dirpath)
+        dirnames[:] = [d for d in dirnames if not (dpath / d / ".git").exists()]
+        for name in filenames:
+            out.append(str((dpath / name).relative_to(root_path)))
+    return sorted(out)
+
+
 def _ls_tree(repo_root: Path, ref: str) -> dict[str, str]:
-    """path -> blob sha for every tracked blob at ``ref``."""
+    """path -> blob sha for every tracked blob at ``ref``. Non-blob entries —
+    notably submodule gitlinks (``commit`` objects) — are skipped: a submodule
+    is not part of this repo's scannable content."""
     out = _run_git(["ls-tree", "-r", "-z", ref], repo_root)
     manifest: dict[str, str] = {}
     for entry in out.split("\0"):
@@ -105,8 +143,13 @@ def build_manifest(repo_root: str | Path, predicate: Predicate | None = None) ->
     for path in present:
         full = root / path
         if not full.is_file():
-            # Raced out from under us (deleted/replaced by a dir) between the
-            # git status read and the hash-object call — drop rather than stale.
+            # Not a regular file: a submodule whose pointer changed shows up in
+            # `git diff` as its gitlink PATH (a directory on disk), and a file
+            # can be raced out from under us (deleted/replaced by a dir) between
+            # the git status read and the hash-object call. Drop rather than
+            # surface a stale or non-blob entry — submodule contents are
+            # excluded from the manifest just as `_ls_tree` skips their
+            # gitlinks, matching `walk_source_files`' full-scan pruning.
             manifest.pop(path, None)
             continue
         manifest[path] = _hash_object(root, full)

--- a/scripts/chief_wiggum/manifest.py
+++ b/scripts/chief_wiggum/manifest.py
@@ -1,0 +1,131 @@
+"""Content-addressed file manifest helper (#160).
+
+A **manifest** is ``{repo-relative path: content hash}`` for the set of files a
+scanner would walk. It is the future cache-validity key (a scanner's findings
+for a file are valid as long as the file's hash in the manifest hasn't
+changed) and, right now, the basis for ``--changed-since <ref>`` scoping on
+``check_single_writer.py`` / ``check_traceability.py``: diff the manifest at a
+ref against the current manifest and only the paths whose hash differs need
+re-scanning.
+
+``build_manifest`` is deliberately git-native rather than re-implementing
+"what changed" from scratch:
+
+    manifest = (git ls-tree -r HEAD)  ∪  (git hash-object over dirty tracked
+                                           + untracked non-ignored files)
+               minus deletions
+
+- ``git ls-tree -r HEAD`` gives the committed blob hash for every tracked path
+  — free, no file I/O.
+- Dirty tracked files (staged or unstaged changes vs HEAD) and untracked,
+  non-ignored files are re-hashed from the working tree with
+  ``git hash-object`` — the same hashing git itself would use if the file were
+  added, so manifest hashes are comparable across "committed" and "dirty"
+  paths without a scheme change.
+- A path deleted in the working tree (vs HEAD) is dropped, never surfaced with
+  a stale hash.
+
+The result is filtered through a caller-supplied ``predicate(path) -> bool` —
+each scanner has its own file-selection rule (extension allow-list, skipped
+directories, ``--exclude`` globs), and the manifest must reflect exactly the
+set of files that scanner would otherwise walk, no more and no less.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+Predicate = Callable[[str], bool]
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def _ls_tree(repo_root: Path, ref: str) -> dict[str, str]:
+    """path -> blob sha for every tracked blob at ``ref``."""
+    out = _run_git(["ls-tree", "-r", "-z", ref], repo_root)
+    manifest: dict[str, str] = {}
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        meta, _, path = entry.partition("\t")
+        parts = meta.split()
+        if len(parts) != 3:
+            continue
+        _mode, obj_type, sha = parts
+        if obj_type != "blob":
+            continue
+        manifest[path] = sha
+    return manifest
+
+
+def _dirty_and_untracked(repo_root: Path) -> tuple[set[str], set[str]]:
+    """(present, deleted): tracked paths that differ from HEAD (working tree +
+    index) plus untracked non-ignored paths, split by whether the path still
+    exists on disk. Rename detection is disabled (``--no-renames``) so a rename
+    surfaces as a plain delete + add pair — simpler and unambiguous for a
+    content-addressed manifest (the new path's content is hashed either way)."""
+    present: set[str] = set()
+    deleted: set[str] = set()
+    diff_out = _run_git(["diff", "--no-renames", "--name-status", "-z", "HEAD"], repo_root)
+    tokens = [t for t in diff_out.split("\0") if t]
+    i = 0
+    while i < len(tokens):
+        status, path = tokens[i], tokens[i + 1]
+        i += 2
+        if status.startswith("D"):
+            deleted.add(path)
+        else:
+            present.add(path)
+    untracked_out = _run_git(["ls-files", "--others", "--exclude-standard", "-z"], repo_root)
+    present.update(p for p in untracked_out.split("\0") if p)
+    return present, deleted
+
+
+def _hash_object(repo_root: Path, path: Path) -> str:
+    return _run_git(["hash-object", str(path)], repo_root).strip()
+
+
+def build_manifest(repo_root: str | Path, predicate: Predicate | None = None) -> dict[str, str]:
+    """``{path: content_hash}`` for the current working tree: ``git ls-tree -r
+    HEAD`` unioned with re-hashed dirty tracked + untracked non-ignored files,
+    minus deletions, filtered through ``predicate`` (default: everything)."""
+    root = Path(repo_root)
+    pred = predicate or (lambda _p: True)
+    manifest = _ls_tree(root, "HEAD")
+    present, deleted = _dirty_and_untracked(root)
+    for path in deleted:
+        manifest.pop(path, None)
+    for path in present:
+        full = root / path
+        if not full.is_file():
+            # Raced out from under us (deleted/replaced by a dir) between the
+            # git status read and the hash-object call — drop rather than stale.
+            manifest.pop(path, None)
+            continue
+        manifest[path] = _hash_object(root, full)
+    return {p: h for p, h in manifest.items() if pred(p)}
+
+
+def tree_manifest(repo_root: str | Path, ref: str, predicate: Predicate | None = None) -> dict[str, str]:
+    """Pure ``git ls-tree`` manifest at ``ref`` — no working-tree overlay. The
+    baseline ``--changed-since <ref>`` diffs the current ``build_manifest()``
+    against."""
+    pred = predicate or (lambda _p: True)
+    manifest = _ls_tree(Path(repo_root), ref)
+    return {p: h for p, h in manifest.items() if pred(p)}
+
+
+def changed_paths(repo_root: str | Path, ref: str, predicate: Predicate | None = None) -> set[str]:
+    """Paths whose content differs between ``ref`` and the current working tree
+    (dirty + untracked included), restricted to ``predicate``. This is what
+    ``--changed-since <ref>`` scans instead of the whole repo."""
+    current = build_manifest(repo_root, predicate)
+    baseline = tree_manifest(repo_root, ref, predicate)
+    return {p for p in set(current) | set(baseline) if current.get(p) != baseline.get(p)}

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -60,7 +60,6 @@ Exit codes: 0 = ok, 1 = gate violation, 2 = usage/config error,
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
 import subprocess
@@ -76,6 +75,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # dropped by another (#166; uppercase-id vacuity was the same class of bug,
 # chief-wiggum#86). Ratchet's DEFINE_RE is the markdown-only form: JSON "id"
 # nodes are hashed structurally by _walk_json_ids.
+# stable_hash's home is chief_wiggum.hashing (#160) — check_single_writer.py and
+# check_traceability.py import the same function for their --scanner-version,
+# so there is exactly one implementation, not a copy per module.
+from chief_wiggum.hashing import stable_hash  # noqa: E402,F401
 from chief_wiggum.trace_ids import ID_RE  # noqa: E402
 from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE
 
@@ -116,14 +119,6 @@ class RatchetError(Exception):
 
 class TamperError(Exception):
     """Journal hash chain broken. Maps to exit 4 — fail closed."""
-
-
-def stable_hash(*parts: str) -> str:
-    h = hashlib.sha256()
-    for p in parts:
-        h.update(p.encode("utf-8"))
-        h.update(b"\x00")
-    return h.hexdigest()
 
 
 # ---- config ------------------------------------------------------------------

--- a/tests/fixtures/single_writer_golden/epic/invariants.md
+++ b/tests/fixtures/single_writer_golden/epic/invariants.md
@@ -1,0 +1,7 @@
+# Invariants
+
+**INV-bil-001**: single atomic Stripe→plan write / single write path
+<!-- @cw-writes INV-bil-001 controls_field=provider.plan,provider.stripe_plan sanctioned_writers=ReconcileStripe,internal/billing/reconcile.go sink=db -->
+
+**INV-leg-002**: single write path for the legacy quota override
+<!-- @cw-writes INV-leg-002 controls_field=provider.quota_minutes sanctioned_writers=internal/legacy/store.go sink=db -->

--- a/tests/fixtures/single_writer_golden/epic/invariants.md
+++ b/tests/fixtures/single_writer_golden/epic/invariants.md
@@ -5,3 +5,6 @@
 
 **INV-leg-002**: single write path for the legacy quota override
 <!-- @cw-writes INV-leg-002 controls_field=provider.quota_minutes sanctioned_writers=internal/legacy/store.go sink=db -->
+
+**INV-tier-004**: single write path for the hyphenated Mongo key plan-tier
+<!-- @cw-writes INV-tier-004 controls_field=provider.plan-tier sanctioned_writers=SetPlanTier sink=db -->

--- a/tests/fixtures/single_writer_golden/epic/models/state-machines.json
+++ b/tests/fixtures/single_writer_golden/epic/models/state-machines.json
@@ -1,0 +1,15 @@
+{
+  "invariants": [
+    {
+      "id": "INV-seat-003",
+      "description": "single write path for the owner counter",
+      "controls_field": ["provider.active_owner_count"],
+      "sanctioned_writers": ["RemoveStaff", "internal/db/owner_count.go"]
+    },
+    {
+      "id": "INV-seat-004",
+      "description": "plain invariant, no single-write-path metadata",
+      "category": "consistency"
+    }
+  ]
+}

--- a/tests/fixtures/single_writer_golden/expected.coverage_gate.txt
+++ b/tests/fixtures/single_writer_golden/expected.coverage_gate.txt
@@ -1,0 +1,14 @@
+# Single-Writer Audit
+
+Single-write-path invariants: 3
+Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
+
+- Soundness (metadata well-formed): OK
+- Coverage (no unsanctioned writer): FINDINGS
+
+## Unsanctioned writers (single-write-path violations)
+
+- INV-bil-001 field `provider.plan` written at internal/admin/handlers.go:6 in ChangePlan()
+    c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan": newPlan}})
+
+exit=1

--- a/tests/fixtures/single_writer_golden/expected.coverage_gate.txt
+++ b/tests/fixtures/single_writer_golden/expected.coverage_gate.txt
@@ -1,7 +1,7 @@
 # Single-Writer Audit
 
-Single-write-path invariants: 3
-Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
+Single-write-path invariants: 4
+Writers found: 7  |  Violations: 2  |  Malformed metadata: 0
 
 - Soundness (metadata well-formed): OK
 - Coverage (no unsanctioned writer): FINDINGS
@@ -10,5 +10,7 @@ Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
 
 - INV-bil-001 field `provider.plan` written at internal/admin/handlers.go:6 in ChangePlan()
     c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan": newPlan}})
+- INV-tier-004 field `provider.plan-tier` written at internal/tier/store.go:13 in LegacyTier()
+    c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan-tier": v}})
 
 exit=1

--- a/tests/fixtures/single_writer_golden/expected.json.txt
+++ b/tests/fixtures/single_writer_golden/expected.json.txt
@@ -1,0 +1,117 @@
+{
+  "counts": {
+    "invariants": 3,
+    "writers": 5,
+    "violations": 1,
+    "malformed": 0
+  },
+  "soundness_ok": true,
+  "coverage_ok": false,
+  "invariants": [
+    {
+      "id": "INV-bil-001",
+      "description": "single atomic Stripe\u2192plan write / single write path",
+      "controls_field": [
+        "provider.plan",
+        "provider.stripe_plan"
+      ],
+      "sanctioned_writers": [
+        "ReconcileStripe",
+        "internal/billing/reconcile.go"
+      ],
+      "source": "invariants.md:4",
+      "persistence_only": true
+    },
+    {
+      "id": "INV-leg-002",
+      "description": "single write path for the legacy quota override",
+      "controls_field": [
+        "provider.quota_minutes"
+      ],
+      "sanctioned_writers": [
+        "internal/legacy/store.go"
+      ],
+      "source": "invariants.md:7",
+      "persistence_only": true
+    },
+    {
+      "id": "INV-seat-003",
+      "description": "single write path for the owner counter",
+      "controls_field": [
+        "provider.active_owner_count"
+      ],
+      "sanctioned_writers": [
+        "RemoveStaff",
+        "internal/db/owner_count.go"
+      ],
+      "source": "models/state-machines.json",
+      "persistence_only": false
+    }
+  ],
+  "writers": [
+    {
+      "invariant_id": "INV-bil-001",
+      "field": "provider.plan",
+      "file": "internal/admin/handlers.go",
+      "line": 6,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan\": newPlan}})",
+      "symbol": "ChangePlan",
+      "sanctioned": false,
+      "is_test": false
+    },
+    {
+      "invariant_id": "INV-seat-003",
+      "field": "provider.active_owner_count",
+      "file": "internal/admin/handlers.go",
+      "line": 12,
+      "text": "p.ActiveOwnerCount = p.ActiveOwnerCount - 1",
+      "symbol": "RemoveStaff",
+      "sanctioned": true,
+      "is_test": false
+    },
+    {
+      "invariant_id": "INV-bil-001",
+      "field": "provider.stripe_plan",
+      "file": "internal/billing/reconcile.go",
+      "line": 5,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"stripe_plan\": plan}})",
+      "symbol": "ReconcileStripe",
+      "sanctioned": true,
+      "is_test": false
+    },
+    {
+      "invariant_id": "INV-bil-001",
+      "field": "provider.stripe_plan",
+      "file": "internal/billing/reconcile_test.go",
+      "line": 10,
+      "text": "fake.UpdateOne(ctx, bson.M{\"_id\": \"1\"}, bson.M{\"$set\": bson.M{\"stripe_plan\": \"pro\"}})",
+      "symbol": "TestReconcileSetsPlan",
+      "sanctioned": true,
+      "is_test": true
+    },
+    {
+      "invariant_id": "INV-leg-002",
+      "field": "provider.quota_minutes",
+      "file": "internal/legacy/store.go",
+      "line": 6,
+      "text": "_, err := db.Exec(\"UPDATE providers SET quota_minutes = $1 WHERE id = $2\", minutes, id)",
+      "symbol": "UpdateQuotaOverride",
+      "sanctioned": true,
+      "is_test": false
+    }
+  ],
+  "violations": [
+    {
+      "invariant_id": "INV-bil-001",
+      "field": "provider.plan",
+      "file": "internal/admin/handlers.go",
+      "line": 6,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan\": newPlan}})",
+      "symbol": "ChangePlan",
+      "sanctioned": false,
+      "is_test": false
+    }
+  ],
+  "malformed": [],
+  "warnings": []
+}

--- a/tests/fixtures/single_writer_golden/expected.json.txt
+++ b/tests/fixtures/single_writer_golden/expected.json.txt
@@ -1,8 +1,8 @@
 {
   "counts": {
-    "invariants": 3,
-    "writers": 5,
-    "violations": 1,
+    "invariants": 4,
+    "writers": 7,
+    "violations": 2,
     "malformed": 0
   },
   "soundness_ok": true,
@@ -32,6 +32,18 @@
         "internal/legacy/store.go"
       ],
       "source": "invariants.md:7",
+      "persistence_only": true
+    },
+    {
+      "id": "INV-tier-004",
+      "description": "single write path for the hyphenated Mongo key plan-tier",
+      "controls_field": [
+        "provider.plan-tier"
+      ],
+      "sanctioned_writers": [
+        "SetPlanTier"
+      ],
+      "source": "invariants.md:10",
       "persistence_only": true
     },
     {
@@ -98,6 +110,26 @@
       "symbol": "UpdateQuotaOverride",
       "sanctioned": true,
       "is_test": false
+    },
+    {
+      "invariant_id": "INV-tier-004",
+      "field": "provider.plan-tier",
+      "file": "internal/tier/store.go",
+      "line": 6,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan-tier\": v}})",
+      "symbol": "SetPlanTier",
+      "sanctioned": true,
+      "is_test": false
+    },
+    {
+      "invariant_id": "INV-tier-004",
+      "field": "provider.plan-tier",
+      "file": "internal/tier/store.go",
+      "line": 13,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan-tier\": v}})",
+      "symbol": "LegacyTier",
+      "sanctioned": false,
+      "is_test": false
     }
   ],
   "violations": [
@@ -108,6 +140,16 @@
       "line": 6,
       "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan\": newPlan}})",
       "symbol": "ChangePlan",
+      "sanctioned": false,
+      "is_test": false
+    },
+    {
+      "invariant_id": "INV-tier-004",
+      "field": "provider.plan-tier",
+      "file": "internal/tier/store.go",
+      "line": 13,
+      "text": "c.UpdateOne(ctx, bson.M{\"_id\": id}, bson.M{\"$set\": bson.M{\"plan-tier\": v}})",
+      "symbol": "LegacyTier",
       "sanctioned": false,
       "is_test": false
     }

--- a/tests/fixtures/single_writer_golden/expected.text.txt
+++ b/tests/fixtures/single_writer_golden/expected.text.txt
@@ -1,0 +1,13 @@
+# Single-Writer Audit
+
+Single-write-path invariants: 3
+Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
+
+- Soundness (metadata well-formed): OK
+- Coverage (no unsanctioned writer): FINDINGS
+
+## Unsanctioned writers (single-write-path violations)
+
+- INV-bil-001 field `provider.plan` written at internal/admin/handlers.go:6 in ChangePlan()
+    c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan": newPlan}})
+

--- a/tests/fixtures/single_writer_golden/expected.text.txt
+++ b/tests/fixtures/single_writer_golden/expected.text.txt
@@ -1,7 +1,7 @@
 # Single-Writer Audit
 
-Single-write-path invariants: 3
-Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
+Single-write-path invariants: 4
+Writers found: 7  |  Violations: 2  |  Malformed metadata: 0
 
 - Soundness (metadata well-formed): OK
 - Coverage (no unsanctioned writer): FINDINGS
@@ -10,4 +10,6 @@ Writers found: 5  |  Violations: 1  |  Malformed metadata: 0
 
 - INV-bil-001 field `provider.plan` written at internal/admin/handlers.go:6 in ChangePlan()
     c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan": newPlan}})
+- INV-tier-004 field `provider.plan-tier` written at internal/tier/store.go:13 in LegacyTier()
+    c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan-tier": v}})
 

--- a/tests/fixtures/single_writer_golden/src/internal/admin/handlers.go
+++ b/tests/fixtures/single_writer_golden/src/internal/admin/handlers.go
@@ -1,0 +1,13 @@
+package admin
+
+// ChangePlan is a LEGACY admin control — a SECOND writer of provider.stripe_plan,
+// which INV-bil-001 declares must have a single sanctioned writer.
+func ChangePlan(c *mongo.Collection, id ID, newPlan string) {
+	c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan": newPlan}})
+}
+
+// RemoveStaff is the sanctioned writer of provider.active_owner_count
+// (INV-seat-003, an in-memory field — no sink=db, so any assignment counts).
+func RemoveStaff(p *Provider) {
+	p.ActiveOwnerCount = p.ActiveOwnerCount - 1
+}

--- a/tests/fixtures/single_writer_golden/src/internal/billing/reconcile.go
+++ b/tests/fixtures/single_writer_golden/src/internal/billing/reconcile.go
@@ -1,0 +1,15 @@
+package billing
+
+// ReconcileStripe is the sanctioned single writer of provider.stripe_plan.
+func ReconcileStripe(c *mongo.Collection, id ID, plan string) {
+	c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"stripe_plan": plan}})
+}
+
+// EffectiveLimits builds an in-memory struct — not a persistence write, and
+// Plan here is a different (unrelated) in-memory field, exercising the
+// sink=db filter that only counts DB sinks for INV-bil-001.
+func EffectiveLimits(p *Provider) Limits {
+	out := Limits{}
+	out.Plan = "computed"
+	return out
+}

--- a/tests/fixtures/single_writer_golden/src/internal/billing/reconcile_test.go
+++ b/tests/fixtures/single_writer_golden/src/internal/billing/reconcile_test.go
@@ -1,0 +1,11 @@
+package billing
+
+import "testing"
+
+// A test fixture writing stripe_plan directly (via the same $set shape as
+// production) — must be surfaced as a writer but never a violation (test
+// files are fixtures, not production write paths).
+func TestReconcileSetsPlan(t *testing.T) {
+	fake := &fakeCollection{}
+	fake.UpdateOne(ctx, bson.M{"_id": "1"}, bson.M{"$set": bson.M{"stripe_plan": "pro"}})
+}

--- a/tests/fixtures/single_writer_golden/src/internal/legacy/store.go
+++ b/tests/fixtures/single_writer_golden/src/internal/legacy/store.go
@@ -1,0 +1,8 @@
+package legacy
+
+// UpdateQuotaOverride is the sanctioned (by file path) single writer of
+// provider.quota_minutes (INV-leg-002, sink=db — SQL UPDATE ... SET).
+func UpdateQuotaOverride(db *sql.DB, id string, minutes int) error {
+	_, err := db.Exec("UPDATE providers SET quota_minutes = $1 WHERE id = $2", minutes, id)
+	return err
+}

--- a/tests/fixtures/single_writer_golden/src/internal/tier/store.go
+++ b/tests/fixtures/single_writer_golden/src/internal/tier/store.go
@@ -1,0 +1,14 @@
+package tier
+
+// SetPlanTier is the sanctioned single writer of the hyphenated Mongo key
+// provider.plan-tier (INV-tier-004, sink=db).
+func SetPlanTier(c *mongo.Collection, id ID, v string) {
+	c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan-tier": v}})
+}
+
+// LegacyTier is an UNSANCTIONED second writer of the same hyphenated key —
+// the emission layer must capture non-\w quoted field names or this real
+// violation would be invisible to a full scan.
+func LegacyTier(c *mongo.Collection, id ID, v string) {
+	c.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"plan-tier": v}})
+}

--- a/tests/fixtures/single_writer_golden/src/ui/types.ts
+++ b/tests/fixtures/single_writer_golden/src/ui/types.ts
@@ -1,0 +1,6 @@
+// A DTO interface mentioning "plan" as a field name — must NOT be flagged as
+// a writer (no assignment, no mutation context, just a type declaration).
+export interface ProviderDTO {
+  plan: string;
+  stripe_plan: string;
+}

--- a/tests/fixtures/traceability_golden/epic/contracts.md
+++ b/tests/fixtures/traceability_golden/epic/contracts.md
@@ -1,0 +1,9 @@
+### CTR-order-001 — valid date range
+<!-- @cw-trace realizes BR-order-001 -->
+
+REQUIRES: start_date <= end_date
+ENSURES: order.total > 0
+
+### CTR-order-002 — idempotent creation
+
+No tests written yet for this one — should surface as untested (and uncovered).

--- a/tests/fixtures/traceability_golden/epic/invariants.md
+++ b/tests/fixtures/traceability_golden/epic/invariants.md
@@ -1,0 +1,2 @@
+- **BR-order-001**: orders must have a positive total
+- **INV-order-003**: order status never regresses

--- a/tests/fixtures/traceability_golden/expected.json.txt
+++ b/tests/fixtures/traceability_golden/expected.json.txt
@@ -1,0 +1,48 @@
+{
+  "defined": {
+    "CTR-order-001": "CTR",
+    "CTR-order-002": "CTR",
+    "BR-order-001": "BR",
+    "INV-order-003": "INV"
+  },
+  "counts": {
+    "defined": 4,
+    "orphan_business_rules": 0,
+    "uncovered_contracts": 1,
+    "untested_contracts": 2,
+    "dangling": 1,
+    "invalid_links": 1
+  },
+  "soundness_ok": false,
+  "coverage_ok": false,
+  "orphan_business_rules": [],
+  "uncovered_contracts": [
+    "CTR-order-002"
+  ],
+  "untested_contracts": [
+    "CTR-order-002",
+    "INV-order-003"
+  ],
+  "dangling": [
+    {
+      "verb": "guards",
+      "target": "CTR-ghost-999",
+      "file": "order.py",
+      "line": 6,
+      "source_kind": "code",
+      "source_id": null
+    }
+  ],
+  "invalid_links": [
+    {
+      "verb": "verifies",
+      "target": "CTR-order-002",
+      "file": "bad_verify.py",
+      "line": 3,
+      "source_kind": "code",
+      "source_id": null,
+      "reason": "verifies cannot originate from code"
+    }
+  ],
+  "warnings": []
+}

--- a/tests/fixtures/traceability_golden/expected.text.txt
+++ b/tests/fixtures/traceability_golden/expected.text.txt
@@ -1,0 +1,24 @@
+# Traceability Audit
+
+Defined IDs: 4
+
+- Soundness (orphans/dangling/invalid): FINDINGS
+- Coverage (uncovered/untested): FINDINGS
+
+## Uncovered contracts (no code guard)
+
+- CTR-order-002
+
+## Untested contracts (no test)
+
+- CTR-order-002
+- INV-order-003
+
+## Dangling annotations
+
+- order.py:6 guards CTR-ghost-999 (undefined)
+
+## Invalid links
+
+- bad_verify.py:3 verifies cannot originate from code
+

--- a/tests/fixtures/traceability_golden/src/bad_verify.py
+++ b/tests/fixtures/traceability_golden/src/bad_verify.py
@@ -1,0 +1,5 @@
+# A 'verifies' from a non-test file is an invalid link (verifies must come from
+# test/probe/policy/telemetry, not plain code) — CTR-order-002 stays untested.
+# @cw-trace verifies CTR-order-002
+def not_a_test():
+    ...

--- a/tests/fixtures/traceability_golden/src/order.py
+++ b/tests/fixtures/traceability_golden/src/order.py
@@ -1,0 +1,8 @@
+# @cw-trace guards CTR-order-001 INV-order-003
+def create_order(req):
+    ...
+
+
+# @cw-trace guards CTR-ghost-999
+def dangling_guard():
+    ...

--- a/tests/fixtures/traceability_golden/src/test_order.py
+++ b/tests/fixtures/traceability_golden/src/test_order.py
@@ -1,0 +1,3 @@
+# @cw-trace verifies CTR-order-001
+def test_create_order():
+    ...

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -596,6 +596,69 @@ def test_scan_writers_preserves_line_major_ordering_across_invariants(tmp_path):
     ]
 
 
+def test_emission_captures_hyphenated_quoted_key(tmp_path):
+    """Regression (#179 review): the pre-split scanner built regexes from the
+    escaped field token, so a hyphenated Mongo key (`"plan-tier"`) matched. The
+    field-agnostic emission must cover the same token surface — a `\\w+`-only
+    capture would silently MISS this unsanctioned writer on a full scan.
+    (Old-vs-new agreement on this case is also pinned by the golden fixture's
+    INV-tier-004, whose expected outputs were generated with the pre-split
+    scanner.)"""
+    inv = sw.SingleWriterInvariant(
+        id="INV-tier-001", description="", controls_field=["provider.plan-tier"],
+        sanctioned_writers=["SetPlanTier"], source="s", persistence_only=True,
+    )
+    (tmp_path / "legacy.go").write_text(
+        "func LegacyTier(c *mongo.Collection, v string) {\n"
+        "\tc.UpdateOne(ctx, f, bson.M{\"$set\": bson.M{\"plan-tier\": v}})\n}\n"
+    )
+    writers = sw.scan_writers(tmp_path, [inv])
+    assert len(writers) == 1
+    assert writers[0].symbol == "LegacyTier" and writers[0].sanctioned is False
+    # And the raw emission carries the full hyphenated token, not a fragment.
+    sites = sw.emit_write_sites("legacy.go", (tmp_path / "legacy.go").read_text())
+    assert any(s.token == "plan-tier" and s.kind == sw.KIND_QUOTED for s in sites)
+
+
+def test_emission_captures_hyphenated_sql_field(tmp_path):
+    inv = sw.SingleWriterInvariant(
+        id="INV-tier-001", description="", controls_field=["provider.plan-tier"],
+        sanctioned_writers=["Nobody"], source="s", persistence_only=True,
+    )
+    (tmp_path / "store.go").write_text(
+        "func UpdateTier(db *sql.DB) {\n"
+        "\tdb.Exec(`UPDATE providers SET \"plan-tier\" = $1 WHERE id = $2`, v, id)\n}\n"
+    )
+    writers = sw.scan_writers(tmp_path, [inv])
+    assert writers and writers[0].sanctioned is False
+
+
+def test_dotted_quoted_key_does_not_claim_leaf_field():
+    """`"provider.plan"` is captured as ONE token (`provider.plan`) — it must
+    not claim-match the leaf `plan`, mirroring the old quote-delimited
+    exact-token behavior."""
+    sites = sw.emit_write_sites(
+        "repo.go",
+        "func f(c *mongo.Collection) {\n"
+        "\tc.UpdateOne(ctx, f, bson.M{\"$set\": bson.M{\"provider.plan\": v}})\n}\n",
+    )
+    assert any(s.token == "provider.plan" for s in sites)
+    assert not any(s.token == "plan" and s.kind == sw.KIND_QUOTED for s in sites)
+
+
+def test_full_scan_skips_nested_git_checkout(tmp_path):
+    """Submodules / vendored repos (a dir containing a .git entry) are excluded
+    from the FULL scan, matching --changed-since (whose manifest never surfaces
+    a submodule's files — a submodule is a single gitlink entry there)."""
+    (tmp_path / "admin.go").write_text("func Bad(p *Provider) {\n\tp.Plan = x\n}\n")
+    sub = tmp_path / "vendor-app"
+    sub.mkdir()
+    (sub / ".git").write_text("gitdir: ../.git/modules/vendor-app\n")  # gitlink file
+    (sub / "other.go").write_text("func AlsoBad(p *Provider) {\n\tp.Plan = y\n}\n")
+    writers = sw.scan_writers(tmp_path, [_inv()])
+    assert {w.file for w in writers} == {"admin.go"}
+
+
 # --- --scanner-version / --changed-since (#160) ------------------------------
 
 
@@ -664,3 +727,34 @@ def test_changed_since_whole_repo_default_is_unaffected(tmp_path, capsys):
     )
     rc = sw.main([str(epic), "--source", str(src), "--gate", "coverage"])
     assert rc == 0
+
+
+def test_changed_since_non_git_source_is_usage_error(tmp_path, capsys):
+    """--changed-since against a non-git --source must exit 2 with a concise
+    message, never a traceback (#179 review)."""
+    epic = _write_billing_epic(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    rc = sw.main([str(epic), "--source", str(src), "--changed-since", "main"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Error" in err and "Traceback" not in err
+
+
+def test_changed_since_bad_ref_is_usage_error(tmp_path, capsys):
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.go").write_text("func A() {}\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    epic = _write_billing_epic(tmp_path)
+    rc = sw.main([str(epic), "--source", str(tmp_path), "--changed-since", "no-such-ref"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Error" in err and "Traceback" not in err

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -511,3 +511,156 @@ def test_sink_db_skips_query_filter_clause(tmp_path):
         "\tc.UpdateMany(ctx, bson.M{\"plan\": bson.M{\"$exists\": false}}, upd)\n}\n"
     )
     assert sw.scan_writers(tmp_path, [_inv_persist()]) == []
+
+
+# --- emission/claim split (#160) --------------------------------------------
+
+
+def test_emit_write_sites_is_field_agnostic():
+    """emit_write_sites needs no invariant at all — it just finds candidate
+    write-shaped tokens."""
+    sites = sw.emit_write_sites(
+        "admin.go", "func ChangePlan(p *Provider, v string) {\n\tp.StripePlan = v\n}\n"
+    )
+    assert any(s.token == "StripePlan" and s.kind == sw.KIND_ASSIGN for s in sites)
+    assert all(s.file == "admin.go" for s in sites)
+    assert any(s.symbol == "ChangePlan" for s in sites)
+
+
+def test_emit_write_sites_struct_literal_kind():
+    sites = sw.emit_write_sites("seed.go", "func mk() Provider {\n\treturn Provider{Plan: \"pro\"}\n}\n")
+    assert any(s.token == "Plan" and s.kind == sw.KIND_STRUCT for s in sites)
+
+
+def test_emit_write_sites_sql_kind():
+    sites = sw.emit_write_sites(
+        "store.go",
+        "func UpdateQuota(db *sql.DB) {\n\tdb.Exec(\"UPDATE t SET plan = $1, quota = $2\", a, b)\n}\n",
+    )
+    tokens = {s.token for s in sites if s.kind == sw.KIND_SQL}
+    assert tokens == {"plan", "quota"}
+
+
+def test_emit_write_sites_no_candidates_on_dead_line():
+    assert sw.emit_write_sites("f.go", "func f() {\n\tx := 1\n\t_ = x\n}\n") == []
+
+
+def test_match_writers_filters_by_field_token_and_sink():
+    sites = sw.emit_write_sites(
+        "billing.go",
+        "func ReconcileStripe(c *mongo.Collection) {\n"
+        "\tc.UpdateOne(ctx, f, bson.M{\"$set\": bson.M{\"stripe_plan\": v}})\n}\n",
+    )
+    inv = _inv_persist()  # controls provider.plan + provider.quota_minutes, sink=db
+    other_inv = sw.SingleWriterInvariant(
+        id="INV-unrelated-001", description="", controls_field=["x.unrelated"],
+        sanctioned_writers=["Foo"], source="s",
+    )
+    assert sw.match_writers(sites, other_inv) == []  # token doesn't match this invariant
+
+    bil_inv = _inv()  # controls provider.plan, provider.stripe_plan; no sink
+    matched = sw.match_writers(sites, bil_inv)
+    assert len(matched) == 1
+    assert matched[0].field == "provider.stripe_plan"
+    assert matched[0].sanctioned is True
+
+
+def test_match_writers_same_sites_different_invariants_yield_independent_results():
+    """The same emitted sites can be claimed by multiple invariants — emission
+    ran once, matching is a pure per-invariant query over it."""
+    sites = sw.emit_write_sites(
+        "admin.go", "func ChangePlan(p *Provider) {\n\tp.Plan = \"x\"\n}\n"
+    )
+    inv_a = sw.SingleWriterInvariant("INV-a-001", "", ["p.plan"], ["ChangePlan"], "s")
+    inv_b = sw.SingleWriterInvariant("INV-b-001", "", ["p.plan"], ["SomeoneElse"], "s")
+    assert sw.match_writers(sites, inv_a)[0].sanctioned is True
+    assert sw.match_writers(sites, inv_b)[0].sanctioned is False
+
+
+def test_scan_writers_preserves_line_major_ordering_across_invariants(tmp_path):
+    """Regression guard for the refactor: when two invariants both hit in the
+    same file at interleaved lines, the overall order must stay line-ascending
+    (not grouped by invariant) — matching the original interleaved scan."""
+    inv_a = sw.SingleWriterInvariant("INV-a-001", "", ["p.alpha"], ["Foo"], "s")
+    inv_b = sw.SingleWriterInvariant("INV-b-001", "", ["p.beta"], ["Foo"], "s")
+    (tmp_path / "f.go").write_text(
+        "func f(p *P) {\n"
+        "\tp.Alpha = 1\n"      # line 2: INV-a-001
+        "\tp.Beta = 2\n"       # line 3: INV-b-001
+        "\tp.Alpha = 3\n"      # line 4: INV-a-001 again
+        "}\n"
+    )
+    writers = sw.scan_writers(tmp_path, [inv_a, inv_b])
+    assert [(w.invariant_id, w.line) for w in writers] == [
+        ("INV-a-001", 2), ("INV-b-001", 3), ("INV-a-001", 4),
+    ]
+
+
+# --- --scanner-version / --changed-since (#160) ------------------------------
+
+
+def test_scanner_version_is_deterministic_and_stable_across_calls():
+    rc1 = sw.main(["--scanner-version"])
+    assert rc1 == 0
+
+
+def test_cli_scanner_version_prints_hex_digest(capsys):
+    rc = sw.main(["--scanner-version"])
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert len(out) == 64  # sha256 hex digest
+    int(out, 16)  # valid hex
+
+
+def test_cli_requires_epic_dir_unless_scanner_version(capsys):
+    rc = sw.main([])
+    assert rc == 2
+    assert "epic_dir is required" in capsys.readouterr().err
+
+
+def test_changed_since_scopes_scan_to_changed_files(tmp_path, capsys):
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.go").write_text("func A(p *Provider) {\n\tp.Unrelated = \"x\"\n}\n")
+    (tmp_path / "b.go").write_text("func B() {}\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    epic = _write_billing_epic(tmp_path)
+    # New unsanctioned writer, added AFTER base, unrelated file to a.go.
+    (tmp_path / "b.go").write_text("func ChangePlan(p *Provider) {\n\tp.StripePlan = \"y\"\n}\n")
+
+    rc_full = sw.main([str(epic), "--source", str(tmp_path), "--gate", "coverage", "--format", "json"])
+    full = json.loads(capsys.readouterr().out)
+    rc_scoped = sw.main([
+        str(epic), "--source", str(tmp_path), "--changed-since", base,
+        "--gate", "coverage", "--format", "json",
+    ])
+    scoped = json.loads(capsys.readouterr().out)
+
+    assert rc_full == 1 and rc_scoped == 1
+    assert full["counts"]["violations"] == 1
+    assert scoped["counts"]["violations"] == 1
+    assert scoped["violations"][0]["file"] == "b.go"
+
+
+def test_changed_since_whole_repo_default_is_unaffected(tmp_path, capsys):
+    """No --changed-since given -> unchanged whole-repo behavior (regression
+    guard: the new parameter must be fully opt-in)."""
+    epic = _write_billing_epic(tmp_path)
+    src = tmp_path / "src"
+    (src / "internal" / "billing").mkdir(parents=True)
+    (src / "internal" / "billing" / "reconcile.go").write_text(
+        "func ReconcileStripe(p *Provider, v string) {\n\tp.StripePlan = v\n}\n"
+    )
+    rc = sw.main([str(epic), "--source", str(src), "--gate", "coverage"])
+    assert rc == 0

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -305,3 +305,47 @@ def test_changed_since_whole_repo_default_is_unaffected(tmp_path, capsys):
     epic = _write_epic(tmp_path)
     rc = ct.main([str(epic), "--gate", "coverage"])
     assert rc == 1
+
+
+def test_changed_since_non_git_source_is_usage_error(tmp_path, capsys):
+    """--changed-since against a non-git --source must exit 2 with a concise
+    message, never a traceback (#179 review)."""
+    epic = _write_epic(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    rc = ct.main([str(epic), "--source", str(src), "--changed-since", "main"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Error" in err and "Traceback" not in err
+
+
+def test_changed_since_bad_ref_is_usage_error(tmp_path, capsys):
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.py").write_text("pass\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    epic = _write_epic(tmp_path)
+    rc = ct.main([str(epic), "--source", str(tmp_path), "--changed-since", "no-such-ref"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Error" in err and "Traceback" not in err
+
+
+def test_full_scan_skips_nested_git_checkout(tmp_path):
+    """Submodules / vendored repos (a dir containing a .git entry) are excluded
+    from the FULL scan, matching --changed-since (whose manifest never surfaces
+    a submodule's files — a submodule is a single gitlink entry there)."""
+    (tmp_path / "a.py").write_text("# @cw-trace guards CTR-a-001\n")
+    sub = tmp_path / "vendor-app"
+    sub.mkdir()
+    (sub / ".git").write_text("gitdir: ../.git/modules/vendor-app\n")
+    (sub / "b.py").write_text("# @cw-trace guards CTR-b-001\n")
+    anns = ct.scan_source(tmp_path)
+    assert {a.target for a in anns} == {"CTR-a-001"}

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -209,3 +209,99 @@ def test_cli_text_output(tmp_path, capsys):
     rc = ct.main([str(epic)])
     assert rc == 0
     assert "# Traceability Audit" in capsys.readouterr().out
+
+
+# --- emission/claim seam (#160) ----------------------------------------------
+
+
+def test_emit_source_annotations_is_pure_function_of_text():
+    anns = ct.emit_source_annotations("order.py", "# @cw-trace guards CTR-order-001\n", ".py")
+    assert len(anns) == 1
+    a = anns[0]
+    assert a.verb == "guards" and a.target == "CTR-order-001"
+    assert a.file == "order.py" and a.line == 1 and a.source_kind == "code"
+
+
+def test_emit_source_annotations_classifies_test_kind():
+    anns = ct.emit_source_annotations("test_order.py", "# @cw-trace verifies CTR-order-001\n", ".py")
+    assert anns[0].source_kind == "test"
+
+
+def test_emit_epic_annotations_attributes_to_nearest_contract():
+    text = "### CTR-x-001 — valid range\n<!-- @cw-trace realizes BR-x-001 -->\n"
+    anns = ct.emit_epic_annotations("contracts.md", text)
+    assert anns[0].verb == "realizes" and anns[0].source_id == "CTR-x-001"
+
+
+def test_scan_source_uses_emit_source_annotations_per_file(tmp_path):
+    (tmp_path / "a.py").write_text("# @cw-trace guards CTR-a-001\n")
+    (tmp_path / "test_a.py").write_text("# @cw-trace verifies CTR-a-001\n")
+    anns = ct.scan_source(tmp_path)
+    assert {(a.file, a.source_kind) for a in anns} == {("a.py", "code"), ("test_a.py", "test")}
+
+
+def test_scan_source_only_files_restricts_the_walk(tmp_path):
+    (tmp_path / "a.py").write_text("# @cw-trace guards CTR-a-001\n")
+    (tmp_path / "b.py").write_text("# @cw-trace guards CTR-b-001\n")
+    anns = ct.scan_source(tmp_path, only_files={"a.py"})
+    assert {a.target for a in anns} == {"CTR-a-001"}
+
+
+# --- --scanner-version / --changed-since (#160) ------------------------------
+
+
+def test_cli_scanner_version_prints_hex_digest(capsys):
+    rc = ct.main(["--scanner-version"])
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert len(out) == 64
+    int(out, 16)
+
+
+def test_cli_requires_epic_dir_unless_scanner_version(capsys):
+    rc = ct.main([])
+    assert rc == 2
+    assert "epic_dir is required" in capsys.readouterr().err
+
+
+def test_changed_since_scopes_source_scan(tmp_path, capsys):
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.py").write_text("# @cw-trace guards CTR-x-001\n")
+    (tmp_path / "b.py").write_text("pass\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    epic = tmp_path / "epic"
+    epic.mkdir()
+    (epic / "contracts.md").write_text("### CTR-x-001 — x\n### CTR-y-001 — y\n")
+    # A guard for CTR-y-001 lands in b.go AFTER base (dirty, uncommitted).
+    (tmp_path / "b.py").write_text("# @cw-trace guards CTR-y-001\n")
+
+    rc_full = ct.main([str(epic), "--source", str(tmp_path), "--format", "json"])
+    full = json.loads(capsys.readouterr().out)
+    rc_scoped = ct.main([str(epic), "--source", str(tmp_path), "--changed-since", base, "--format", "json"])
+    scoped = json.loads(capsys.readouterr().out)
+
+    assert rc_full == 0
+    assert full["uncovered_contracts"] == []
+    # Scoped scan only sees b.py (the changed file) — a.py's guard of CTR-x-001
+    # is invisible to it, so CTR-x-001 looks uncovered. This is exactly why
+    # --changed-since must never back /close-epic's authoritative coverage gate.
+    assert rc_scoped == 0  # no --gate passed; report-only
+    assert scoped["uncovered_contracts"] == ["CTR-x-001"]
+
+
+def test_changed_since_whole_repo_default_is_unaffected(tmp_path, capsys):
+    epic = _write_epic(tmp_path)
+    rc = ct.main([str(epic), "--gate", "coverage"])
+    assert rc == 1

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,203 @@
+"""Tests for the content-addressed manifest helper (#160), against a real temp
+git repo (init, commit, dirty a file, add untracked) — not mocked git plumbing."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from chief_wiggum import manifest as m
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+
+def _commit(repo: Path, message: str = "commit") -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+def test_build_manifest_includes_committed_files(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    (repo / "b.py").write_text("x = 1\n")
+    _commit(repo)
+
+    result = m.build_manifest(repo)
+    assert set(result) == {"a.go", "b.py"}
+    assert all(len(h) == 40 for h in result.values())  # git blob sha1
+
+
+def test_build_manifest_reflects_dirty_tracked_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+    before = m.build_manifest(repo)["a.go"]
+
+    (repo / "a.go").write_text("package a\n\nfunc f() {}\n")  # dirty, uncommitted
+    after = m.build_manifest(repo)["a.go"]
+
+    assert before != after
+
+
+def test_build_manifest_includes_untracked_non_ignored_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+
+    (repo / "new_untracked.go").write_text("package a\n\nfunc g() {}\n")
+    result = m.build_manifest(repo)
+    assert "new_untracked.go" in result
+
+
+def test_build_manifest_excludes_gitignored_untracked_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / ".gitignore").write_text("ignored.go\n")
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+
+    (repo / "ignored.go").write_text("package a\n// should never be scanned\n")
+    result = m.build_manifest(repo)
+    assert "ignored.go" not in result
+
+
+def test_build_manifest_excludes_deleted_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    (repo / "b.go").write_text("package a\n")
+    _commit(repo)
+
+    (repo / "b.go").unlink()  # deleted, uncommitted
+    result = m.build_manifest(repo)
+    assert "b.go" not in result
+    assert "a.go" in result
+
+
+def test_build_manifest_applies_predicate(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    (repo / "readme.md").write_text("# hi\n")
+    _commit(repo)
+
+    result = m.build_manifest(repo, predicate=lambda p: p.endswith(".go"))
+    assert set(result) == {"a.go"}
+
+
+def test_build_manifest_matches_git_hash_object(tmp_path):
+    """Manifest hashes are exactly what ``git hash-object`` would produce — so a
+    future content-addressed cache can key directly off them."""
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+
+    expected = subprocess.run(
+        ["git", "hash-object", "a.go"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert m.build_manifest(repo)["a.go"] == expected
+
+
+# --- tree_manifest / changed_paths ------------------------------------------
+
+
+def test_tree_manifest_is_pure_committed_state_no_working_tree_overlay(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo, "first")
+    first_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    (repo / "a.go").write_text("package a\n\nfunc f() {}\n")  # dirty after the ref
+
+    baseline = m.tree_manifest(repo, first_sha)
+    assert baseline["a.go"] == subprocess.run(
+        ["git", "rev-parse", "HEAD:a.go"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def test_changed_paths_detects_dirty_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    (repo / "b.go").write_text("package a\n")
+    _commit(repo, "first")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    (repo / "a.go").write_text("package a\n\nfunc f() {}\n")  # dirty
+    changed = m.changed_paths(repo, base_sha)
+    assert changed == {"a.go"}
+
+
+def test_changed_paths_detects_new_commit_since_ref(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo, "first")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    (repo / "b.go").write_text("package b\n")
+    _commit(repo, "second")
+
+    changed = m.changed_paths(repo, base_sha)
+    assert changed == {"b.go"}
+
+
+def test_changed_paths_detects_untracked_file(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo, "first")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    (repo / "c.go").write_text("package c\n")  # untracked
+    changed = m.changed_paths(repo, base_sha)
+    assert changed == {"c.go"}
+
+
+def test_changed_paths_empty_when_nothing_changed(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo, "first")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    assert m.changed_paths(repo, base_sha) == set()
+
+
+def test_changed_paths_applies_predicate(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo, "first")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    (repo / "a.go").write_text("package a\n\nfunc f() {}\n")
+    (repo / "notes.md").write_text("dirty markdown\n")
+    changed = m.changed_paths(repo, base_sha, predicate=lambda p: p.endswith(".go"))
+    assert changed == {"a.go"}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
 from chief_wiggum import manifest as m
 
 
@@ -201,3 +202,99 @@ def test_changed_paths_applies_predicate(tmp_path):
     (repo / "notes.md").write_text("dirty markdown\n")
     changed = m.changed_paths(repo, base_sha, predicate=lambda p: p.endswith(".go"))
     assert changed == {"a.go"}
+
+
+# --- error handling (#179 review) --------------------------------------------
+
+
+def test_build_manifest_non_git_dir_raises_manifest_error(tmp_path):
+    with pytest.raises(m.ManifestError):
+        m.build_manifest(tmp_path)
+
+
+def test_changed_paths_bad_ref_raises_manifest_error(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+    with pytest.raises(m.ManifestError):
+        m.changed_paths(repo, "no-such-ref")
+
+
+def test_build_manifest_unborn_head_raises_manifest_error(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)  # no commit -> HEAD is unborn
+    with pytest.raises(m.ManifestError):
+        m.build_manifest(repo)
+
+
+def test_manifest_error_message_is_concise(tmp_path):
+    repo = tmp_path / "r"
+    _init_repo(repo)
+    (repo / "a.go").write_text("package a\n")
+    _commit(repo)
+    with pytest.raises(m.ManifestError) as exc_info:
+        m.tree_manifest(repo, "no-such-ref")
+    msg = str(exc_info.value)
+    assert "git" in msg and "\n" not in msg  # one-line, no dumped traceback
+
+
+# --- submodules / nested checkouts (#179 review) ------------------------------
+
+
+def _add_submodule_like(parent: Path, name: str) -> Path:
+    """Create a nested git repo at parent/name and gitlink it into the parent's
+    index (same 160000 entry a real submodule creates)."""
+    sub = parent / name
+    _init_repo(sub)
+    (sub / "inner.go").write_text("package inner\n")
+    _commit(sub, "inner init")
+    # `git add <dir-with-.git>` records a gitlink (embedded repo warning is fine).
+    _git(parent, "add", name)
+    _git(parent, "commit", "-q", "-m", "add gitlink")
+    return sub
+
+
+def test_build_manifest_excludes_submodule_gitlink(tmp_path):
+    parent = tmp_path / "p"
+    _init_repo(parent)
+    (parent / "a.go").write_text("package a\n")
+    _commit(parent)
+    _add_submodule_like(parent, "sub")
+
+    result = m.build_manifest(parent)
+    assert "sub" not in result  # the gitlink itself
+    assert not any(p.startswith("sub/") for p in result)  # nor its contents
+    assert "a.go" in result
+
+
+def test_changed_paths_ignores_submodule_pointer_change(tmp_path):
+    parent = tmp_path / "p"
+    _init_repo(parent)
+    (parent / "a.go").write_text("package a\n")
+    _commit(parent)
+    sub = _add_submodule_like(parent, "sub")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=parent, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    # Advance the submodule: parent's `git diff` now shows `sub` as modified
+    # (a gitlink pointer change) — changed_paths must not surface it or crash.
+    (sub / "inner.go").write_text("package inner\n\nfunc g() {}\n")
+    _commit(sub, "inner change")
+
+    assert m.changed_paths(parent, base_sha) == set()
+
+
+def test_walk_source_files_prunes_nested_git_checkouts(tmp_path):
+    (tmp_path / "a.go").write_text("package a\n")
+    nested = tmp_path / "vendor-repo"
+    nested.mkdir()
+    (nested / ".git").mkdir()  # nested checkout (.git dir form)
+    (nested / "b.go").write_text("package b\n")
+    linked = tmp_path / "sub"
+    linked.mkdir()
+    (linked / ".git").write_text("gitdir: ../.git/modules/sub\n")  # gitlink file form
+    (linked / "c.go").write_text("package c\n")
+
+    assert m.walk_source_files(tmp_path) == ["a.go"]

--- a/tests/test_single_writer_golden.py
+++ b/tests/test_single_writer_golden.py
@@ -1,0 +1,49 @@
+"""Golden-parity test for check_single_writer.py (#160).
+
+The emission/claim split is a REFACTOR: `scan_writers`'s output for the fixture
+below was captured to `tests/fixtures/single_writer_golden/expected.*.txt`
+BEFORE the split (see PR #160), by running the CLI directly against the
+fixture. This test re-runs the CLI against the same fixture and asserts
+byte-identical output — any drift in the internal emission/claim boundary
+must never change what a user sees.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURE = Path(__file__).parent / "fixtures" / "single_writer_golden"
+SCRIPT = Path(__file__).parent.parent / "scripts" / "check_single_writer.py"
+
+
+def _run(*extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(FIXTURE / "epic"), "--source", str(FIXTURE / "src"), *extra_args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_golden_text_output_byte_identical():
+    result = _run("--format", "text")
+    expected = (FIXTURE / "expected.text.txt").read_text()
+    assert result.stdout == expected
+    assert result.returncode == 0
+
+
+def test_golden_json_output_byte_identical():
+    result = _run("--format", "json")
+    expected = (FIXTURE / "expected.json.txt").read_text()
+    assert result.stdout == expected
+    assert result.returncode == 0
+
+
+def test_golden_coverage_gate_byte_identical_and_still_fails():
+    result = _run("--gate", "coverage", "--format", "text")
+    expected_lines = (FIXTURE / "expected.coverage_gate.txt").read_text().splitlines()
+    expected_stdout = "\n".join(expected_lines[:-1]) + "\n"
+    expected_exit = int(expected_lines[-1].split("=")[1])
+    assert result.stdout == expected_stdout
+    assert result.returncode == expected_exit

--- a/tests/test_traceability_golden.py
+++ b/tests/test_traceability_golden.py
@@ -1,0 +1,37 @@
+"""Golden-parity test for check_traceability.py (#160).
+
+Same discipline as `test_single_writer_golden.py`: the emission/claim seam is
+formalized as a refactor, not a behavior change. Output for this fixture was
+captured to `tests/fixtures/traceability_golden/expected.*.txt` BEFORE the
+refactor (see PR #160); this test re-runs the CLI and asserts byte-identical
+output.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURE = Path(__file__).parent / "fixtures" / "traceability_golden"
+SCRIPT = Path(__file__).parent.parent / "scripts" / "check_traceability.py"
+
+
+def _run(*extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(FIXTURE / "epic"), "--source", str(FIXTURE / "src"), *extra_args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_golden_text_output_byte_identical():
+    result = _run("--format", "text")
+    expected = (FIXTURE / "expected.text.txt").read_text()
+    assert result.stdout == expected
+
+
+def test_golden_json_output_byte_identical():
+    result = _run("--format", "json")
+    expected = (FIXTURE / "expected.json.txt").read_text()
+    assert result.stdout == expected


### PR DESCRIPTION
## Summary

Implements #160 (depends on / builds atop #166's `chief_wiggum.trace_ids`, already on `main`). This is a refactor: **no gate behavior changes**, only internal structure + two new opt-in flags.

1. **`check_single_writer.py`: emission/claim split.** `scan_writers` used to interleave detection with per-field matching. Now:
   - `emit_write_sites(path, text) -> list[WriteSite]` — per-file, FIELD-AGNOSTIC: every candidate write site (assignment / struct-literal / bson `$set`-context quoted-literal / SQL `SET`), tagged with its leaf token, enclosing symbol, and line. No knowledge of any invariant.
   - `match_writers(sites, invariant) -> list[Writer]` — query-time filter: does a site's token belong to this invariant's `controls_field`, honoring `persistence_only` (`sink=db`)?
   - `scan_writers` is now the thin orchestrator: emit once per file, then claim per invariant, re-merging results to preserve the **original line-major, invariant-minor ordering** (a subtlety verified by a dedicated regression test, since a naive per-invariant loop would reorder output when multiple invariants hit interleaved lines in the same file).

2. **`check_traceability.py`: same seam, formalized.** This checker's claim/report join (`build_report`) was already separate; this PR extracts the missing per-file emission boundary: `emit_epic_annotations(rel, text)` and `emit_source_annotations(rel, text, suffix)`, called by `scan_epic_annotations`/`scan_source` per file. Pure extraction — no logic change.

3. **`--scanner-version` on both CLIs** — prints `stable_hash(source of the module + its chief_wiggum deps)`. `stable_hash` moved from `ratchet.py` to a new shared home, `scripts/chief_wiggum/hashing.py` (ratchet.py now re-imports it — one implementation, not a copy; `tests/test_ratchet.py` confirms `ratchet.stable_hash` still works). A forgotten manual version bump is now structurally impossible: the version *is* the hash.

4. **`scripts/chief_wiggum/manifest.py`** — `build_manifest(repo_root, predicate)`: `git ls-tree -r HEAD` ∪ `git hash-object` over dirty-tracked + untracked non-ignored files, minus deletions, filtered through the caller's predicate. Plus `tree_manifest(repo_root, ref, predicate)` (pure historical-ref manifest) and `changed_paths(repo_root, ref, predicate)` (diff of the two — what `--changed-since` scans). This is the future content-addressed-cache key; right now it powers (5).

5. **`--changed-since <ref>` on both CLIs** — scopes the `--source` scan to files changed since `ref` (via the manifest helper + `git diff --name-only ref...HEAD` + dirty/untracked). Whole-repo remains the default. **`/close-epic.md` is untouched** — its coverage gate always scans the whole repo and must stay authoritative; a scoped scan can only under-report (never prove absence of a violation), which a test (`test_changed_since_scopes_source_scan`) demonstrates concretely. Wired a new **report-only**, ticket/wave-scoped invocation of both checkers into `.claude/commands/implement.md` (Step 8, item 4c) and `.claude/commands/implement-wave.md` (wave integration check, item 6) — early signal for the fixer, not a new hard blocker (neither checker was previously invoked at all in these two skills; per `docs/gate-rollout.md`, a new gate usage ships report-only first).

## Golden-parity evidence

- `tests/test_single_writer_golden.py` / `tests/test_traceability_golden.py` run the CLIs against representative fixtures (`tests/fixtures/{single_writer,traceability}_golden/`) and assert output == a copy captured from the **pre-refactor** code (text, json, and — for single-writer — the coverage-gate exit code). Both pass post-refactor.
- Additionally verified against a real shipped repo (`dogeared-coach`, 7 epics, single-writer invariants + 219 files carrying `@cw-trace` annotations): ran the pre-refactor scripts (checked out from `origin/main`) and the post-refactor scripts against every epic, `--format text` and `--format json`, single-writer and traceability — **zero diffs, zero stderr**, across epics with non-trivial findings (e.g. `epic-team-seats`: 6 writers; `epic-billing`: 15 defined IDs, 2 uncovered/untested; `epic-admin-panel`: 34 defined IDs, 1 uncovered).

## Test plan

- [x] `python3 -m pytest tests/ -q` — 830 passed, 4 skipped (pre-existing optional-dep skips)
- [x] `python3 -m ruff check scripts tests` — clean
- [x] New: `tests/test_manifest.py` (13 tests) against a **real temp git repo** — init/commit, dirty a tracked file, add an untracked file, gitignore exclusion, deletion exclusion, predicate filtering, `tree_manifest` vs `build_manifest`, `changed_paths` (dirty / new commit / untracked / predicate / no-op)
- [x] New: unit tests for `emit_write_sites`/`match_writers` (field-agnostic emission, sink filtering, cross-invariant independence, line-major ordering regression guard) and `emit_epic_annotations`/`emit_source_annotations`
- [x] New: `--scanner-version` (deterministic hex digest) and `--changed-since` (scoped-vs-full-scan divergence, whole-repo-default-unaffected regression guard) tests for both CLIs
- [x] Golden-parity tests (fixture, described above) + manual real-repo verification (described above)

## Deviations from the issue

- `stable_hash`'s new home is `scripts/chief_wiggum/hashing.py` (not left in `ratchet.py`) — cleaner than either duplicating it or having `check_single_writer.py`/`check_traceability.py` import from `ratchet.py` (which pulls in unrelated journal/scorecard machinery). `ratchet.py` re-exports it so nothing else needs updating.
- `--scanner-version` and `--changed-since` required making `epic_dir` an optional positional (`nargs="?"`) on both CLIs so `--scanner-version` can run standalone; existing invocations (which always pass `epic_dir`) are unaffected.
- The usage-error path for a missing `epic_dir` now prints to stderr and returns 2 (matching the existing "epic dir not found" convention) rather than using `argparse`'s `parser.error` (which calls `sys.exit` directly) — kept both CLIs' `main()` consistently return-based rather than exit-based, so tests can assert on the return code.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF