### PR TITLE
feat(system): @cw-emits + instrumentation-coverage meta-gate (#170)

### DIFF
--- a/docs/budget-trees.md
+++ b/docs/budget-trees.md
@@ -136,3 +136,81 @@ Exit codes: `0` ok/report-only, `1` `--gate` violation (static mode only), `2`
 usage error. Ships **report-only** per the gate-rollout doctrine
 (`docs/gate-rollout.md`) — not yet wired as a blocker into `/architect` or
 `/close-epic`.
+
+## Instrumentation coverage: telemetry bindings must be provable (#170)
+
+A budget tree bound to a `telemetry_ref` nobody emits (or a future trace-
+conformance check over an empty history) reports **zero violations** — not
+because the system is healthy, but because it never looked at anything. That
+is a vacuous pass, and it is the completeness-lens failure mode this section
+closes.
+
+**`@cw-emits <binding-name>`** marks the code site that emits a declared
+telemetry span/event/metric — same regex tier and grammar family as
+`@cw-writes` (`docs/single-writer.md`), both defined in
+`scripts/chief_wiggum/annotations.py`:
+
+```python
+# @cw-emits endpointing_latency_ms
+def on_endpoint_detected(ts):
+    span.set_attribute("endpointing_latency_ms", ts - start)
+```
+
+A tag may list more than one binding name (space- or comma-separated) when a
+single site fires several bindings.
+
+**`scripts/check_instrumentation.py`** reads every `telemetry_ref` out of one
+or more `system-contracts.json` budget docs (the walk is schema-agnostic — it
+looks for the field name, not a `BUD-` node specifically, so a future `SLO-`
+or trace-conformance doc that reuses `telemetry_ref` is covered without a
+checker update) and verifies **statically** that an `@cw-emits` site exists
+somewhere in `--source` for each one. A binding with no site is reported
+**missing**:
+
+```bash
+python3 scripts/check_instrumentation.py docs/system/system-contracts.json --source .
+python3 scripts/check_instrumentation.py docs/system/system-contracts.json --source . --gate  # hard-fail on missing
+```
+
+Report-only by default; `--gate` exits 1 on any missing binding. Without
+`--source`, the checker parses bindings but cannot claim anything is
+missing — it degrades gracefully (a warning, not a false-positive finding),
+mirroring `check_single_writer.py`.
+
+**What this proves, and what it doesn't.** Static presence of an `@cw-emits`
+site proves the binding is wired to *some* code path — it does NOT prove that
+line executes, executes on the path the budget assumes, or is ever actually
+observed at runtime. That's what measured mode above (an observed-at-least-
+once check against a real export) is for. The two are complementary: this
+checker answers "does an emitter exist"; measured mode answers "did it fire".
+Deleting the `@cw-emits` line while the runtime code is untouched flips the
+binding straight to missing — the "instrumentation deleted" seed class the
+issue calls out, exercised in
+`tests/test_check_instrumentation.py::test_deleting_emits_site_flips_binding_to_missing`.
+
+### Sharper measured-mode statuses: `--emits-report`
+
+Measured mode's `no_observations` conflates two different situations: a real
+emitter that simply didn't fire during this run (a measurement window), and a
+binding with no emitter anywhere in the codebase (a structural gap that no
+amount of waiting will fix). Passing `check_instrumentation.py`'s JSON report
+back into `check_budget_tree.py --measured` distinguishes them:
+
+```bash
+python3 scripts/check_instrumentation.py docs/system/system-contracts.json --source . --format json \
+    > /tmp/emits-report.json
+python3 scripts/check_budget_tree.py docs/system/system-contracts.json \
+    --measured k6-summary.json --emits-report /tmp/emits-report.json
+```
+
+With `--emits-report`, a `no_observations` binding with **no** `@cw-emits`
+site anywhere in source (per the instrumentation report's `emitted_bindings`)
+is reclassified to a new status, **`not_emitted`**. `unbound` (no
+`telemetry_ref` declared at all — a stronger, different gap) and
+`held`/`breached` (an actual observation exists) are never touched.
+
+This integration is **minimal and optional**: `--emits-report` is a single
+flag, and omitting it leaves `unbound`/`no_observations`/`held`/`breached`
+exactly as they were before #170 — the default behavior is unchanged.
+Measured mode remains evidence-only, permanently: none of this ever makes
+`--gate` exit non-zero.

--- a/docs/budget-trees.md
+++ b/docs/budget-trees.md
@@ -156,8 +156,13 @@ def on_endpoint_detected(ts):
     span.set_attribute("endpointing_latency_ms", ts - start)
 ```
 
-A tag may list more than one binding name (space- or comma-separated) when a
-single site fires several bindings.
+A tag may list more than one binding name when a single site fires several
+bindings — multiple names must be **comma-separated**
+(`@cw-emits asr_latency, endpointing_latency_ms`). A space-separated list is
+deliberately not a multi-binding: the first token is the binding and any
+prose after it is ignored (`# @cw-emits asr_latency records ASR latency`
+emits exactly one binding), so a trailing comment can never mint phantom
+bindings that accidentally satisfy the missing-binding check.
 
 **`scripts/check_instrumentation.py`** reads every `telemetry_ref` out of one
 or more `system-contracts.json` budget docs (the walk is schema-agnostic — it

--- a/scripts/check_budget_tree.py
+++ b/scripts/check_budget_tree.py
@@ -520,9 +520,22 @@ def _check_chains(chains: list[dict], report: BudgetTreeReport) -> None:
 def load_emits_report(path: str | Path) -> set[str]:
     """Load a ``check_instrumentation.py`` JSON report and return its
     ``emitted_bindings`` set (#170) — every binding name with at least one
-    ``@cw-emits`` site found, repo-wide."""
+    ``@cw-emits`` site found, repo-wide.
+
+    The shape is VALIDATED, not assumed: ``emitted_bindings`` must exist and be
+    a list of strings, else ``ValueError``. Accepting a wrong/old JSON file
+    here would silently treat every binding as unemitted and reclassify every
+    quiet metric to ``not_emitted`` — a wrong claim, worse than no refinement
+    (Codex review of PR #180).
+    """
     raw = json.loads(Path(path).read_text())
-    return set(raw.get("emitted_bindings") or [])
+    emitted = raw.get("emitted_bindings") if isinstance(raw, dict) else None
+    if not isinstance(emitted, list) or not all(isinstance(x, str) for x in emitted):
+        raise ValueError(
+            "not a check_instrumentation report: 'emitted_bindings' must be present "
+            "and a list of strings"
+        )
+    return set(emitted)
 
 
 def check_measured(
@@ -679,7 +692,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.emits_report:
             try:
                 emitted = load_emits_report(args.emits_report)
-            except (OSError, json.JSONDecodeError) as exc:
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
                 print(f"Error: cannot load emits report: {exc}", file=sys.stderr)
                 return 2
         report = check_measured(doc, measured_data, source=args.measured, schema=schema, emitted=emitted)

--- a/scripts/check_budget_tree.py
+++ b/scripts/check_budget_tree.py
@@ -77,6 +77,14 @@ invalid evidence is a finding.
   regardless of ``--gate`` (environment variance means a measured latency claim
   should never hard-block CI — see docs/gate-rollout.md).
 
+  **Optional refinement (#170):** pass ``--emits-report <check_instrumentation
+  JSON>`` to distinguish, within ``no_observations``, a binding with a real
+  ``@cw-emits`` site that simply wasn't triggered this run from one with NO
+  emitter anywhere in source — the latter is reclassified to a new status,
+  ``not_emitted`` (a structural gap, not a measurement window). Omitting the
+  flag leaves ``unbound``/``no_observations``/``held``/``breached`` exactly as
+  they were — this integration is additive and optional, never required.
+
 Every report (text and JSON) carries an ``authority`` line stating exactly what
 was proven:
 
@@ -156,7 +164,10 @@ class MeasuredResult:
     telemetry_ref: str | None
     bound: float | None
     observed: float | None
-    status: str  # "held" | "breached" | "no_observations" | "unbound"
+    status: str  # "held" | "breached" | "no_observations" | "not_emitted" | "unbound"
+    # None unless an --emits-report was supplied (#170): then True/False records
+    # whether ANY @cw-emits site was found for this telemetry_ref, repo-wide.
+    emitter_bound: bool | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -183,6 +194,7 @@ class BudgetTreeReport:
             "measured_held": sum(1 for m in self.measured if m.status == "held"),
             "measured_breached": sum(1 for m in self.measured if m.status == "breached"),
             "measured_no_observations": sum(1 for m in self.measured if m.status == "no_observations"),
+            "measured_not_emitted": sum(1 for m in self.measured if m.status == "not_emitted"),
             "measured_unbound": sum(1 for m in self.measured if m.status == "unbound"),
         }
 
@@ -505,17 +517,40 @@ def _check_chains(chains: list[dict], report: BudgetTreeReport) -> None:
 # --- measured mode --------------------------------------------------------------
 
 
-def check_measured(doc: dict, measured: dict[str, dict], source: str, schema: dict | None = None) -> BudgetTreeReport:
+def load_emits_report(path: str | Path) -> set[str]:
+    """Load a ``check_instrumentation.py`` JSON report and return its
+    ``emitted_bindings`` set (#170) — every binding name with at least one
+    ``@cw-emits`` site found, repo-wide."""
+    raw = json.loads(Path(path).read_text())
+    return set(raw.get("emitted_bindings") or [])
+
+
+def check_measured(
+    doc: dict,
+    measured: dict[str, dict],
+    source: str,
+    schema: dict | None = None,
+    emitted: set[str] | None = None,
+) -> BudgetTreeReport:
+    """``emitted``, if given, is the ``emitted_bindings`` set from a
+    ``check_instrumentation.py`` report (#170) — optional and additive. When
+    omitted, statuses are computed exactly as before this integration existed.
+    """
     report = BudgetTreeReport(mode="measured", source=source)
     report.findings.extend(validate_doc(doc, schema if schema is not None else load_schema()))
     for idx, tree in enumerate(doc.get("trees") or []):
         root = tree.get("root") or {}
         report.trees.append(root.get("id", f"tree[{idx}]"))
-        _measure_node(root, measured, report)
+        _measure_node(root, measured, report, emitted)
     return report
 
 
-def _measure_node(node: dict, measured: dict[str, dict], report: BudgetTreeReport) -> None:
+def _measure_node(
+    node: dict,
+    measured: dict[str, dict],
+    report: BudgetTreeReport,
+    emitted: set[str] | None = None,
+) -> None:
     node_id = node.get("id", "<node>")
     telemetry_ref = node.get("telemetry_ref")
     bound = node.get("bound")
@@ -536,12 +571,25 @@ def _measure_node(node: dict, measured: dict[str, dict], report: BudgetTreeRepor
     else:
         status = "held"
 
-    report.measured.append(MeasuredResult(node_id, telemetry_ref, bound, observed, status))
+    # Optional refinement (#170): when an emits-report was supplied, a
+    # no_observations binding with NO @cw-emits site anywhere in source is
+    # reclassified as not_emitted — a structural gap (nothing ever emits it),
+    # not a quiet measurement window (a real emitter that just didn't fire
+    # this run). unbound/held/breached are untouched: unbound already means
+    # "no binding at all" (stronger than not_emitted), and held/breached have
+    # actual observations regardless of what the static scan found.
+    emitter_bound: bool | None = None
+    if emitted is not None and telemetry_ref:
+        emitter_bound = telemetry_ref in emitted
+        if status == "no_observations" and not emitter_bound:
+            status = "not_emitted"
+
+    report.measured.append(MeasuredResult(node_id, telemetry_ref, bound, observed, status, emitter_bound))
 
     for child in node.get("children") or []:
-        _measure_node(child, measured, report)
+        _measure_node(child, measured, report, emitted)
     if node.get("residual"):
-        _measure_node(node["residual"], measured, report)
+        _measure_node(node["residual"], measured, report, emitted)
 
 
 # --- rendering ------------------------------------------------------------------
@@ -572,8 +620,10 @@ def render_text(report: BudgetTreeReport) -> str:
             lines += ["", "## Measured bindings"]
             for m in report.measured:
                 obs = m.observed if m.observed is not None else "—"
+                emit_note = "" if m.emitter_bound is None else f" (emitter {'found' if m.emitter_bound else 'MISSING'})"
                 lines.append(
-                    f"- {m.id} ref={m.telemetry_ref or '(none)'} bound={m.bound} observed={obs} -> {m.status}"
+                    f"- {m.id} ref={m.telemetry_ref or '(none)'} bound={m.bound} observed={obs} "
+                    f"-> {m.status}{emit_note}"
                 )
 
     return "\n".join(lines) + "\n"
@@ -592,6 +642,12 @@ def main(argv: list[str] | None = None) -> int:
         "--measured",
         help="k6 summary JSON or flat {metric: {p95: ...}} export; switches to measured mode "
         "(evidence-only, never gates)",
+    )
+    parser.add_argument(
+        "--emits-report",
+        help="Optional check_instrumentation.py JSON report (#170); when given with --measured, "
+        "refines no_observations to not_emitted for bindings with no @cw-emits site anywhere "
+        "in source. Omit for today's three-way status unchanged.",
     )
     parser.add_argument(
         "--gate",
@@ -619,7 +675,14 @@ def main(argv: list[str] | None = None) -> int:
         except (OSError, json.JSONDecodeError) as exc:
             print(f"Error: cannot load measured data: {exc}", file=sys.stderr)
             return 2
-        report = check_measured(doc, measured_data, source=args.measured, schema=schema)
+        emitted = None
+        if args.emits_report:
+            try:
+                emitted = load_emits_report(args.emits_report)
+            except (OSError, json.JSONDecodeError) as exc:
+                print(f"Error: cannot load emits report: {exc}", file=sys.stderr)
+                return 2
+        report = check_measured(doc, measured_data, source=args.measured, schema=schema, emitted=emitted)
     else:
         report = check_static(doc, schema=schema)
 

--- a/scripts/check_instrumentation.py
+++ b/scripts/check_instrumentation.py
@@ -20,7 +20,11 @@ the source tree marking the code site that emits it. A binding with no
 Annotation grammar (``chief_wiggum.annotations.EMITS_TAG_RE`` — same regex
 tier and grammar family as ``@cw-writes``, see ``docs/single-writer.md``):
 
-    @cw-emits <binding-name> [<binding-name> ...]
+    @cw-emits <binding-name>[, <binding-name> ...]
+
+Multiple bindings on one tag must be COMMA-separated; after the first
+binding, space-separated tokens are treated as prose and ignored (so a
+trailing comment cannot mint phantom bindings).
 
 Place it in a comment at the code site that emits the span/event/metric:
 
@@ -352,9 +356,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
 
+    # A corrupt/unreadable budget doc must be a USAGE ERROR (exit 2), never a
+    # silent degrade to "nothing to check" — that would let a broken contract
+    # file disable the gate while appearing green (Codex review of PR #180).
     for bf in args.budget_files:
-        if not Path(bf).exists():
+        path = Path(bf)
+        if not path.exists():
             print(f"Error: budget file not found: {bf}", file=sys.stderr)
+            return 2
+        try:
+            json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Error: cannot load budget file {bf}: {exc}", file=sys.stderr)
             return 2
 
     report = check(args.budget_files, args.source, exclude=args.exclude)

--- a/scripts/check_instrumentation.py
+++ b/scripts/check_instrumentation.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Instrumentation-coverage checker (#170): telemetry bindings must be provable.
+
+Completeness-lens top finding on the system layer: a budget tree (or, once
+they ship, an SLO/trace-conformance contract) can bind ``telemetry_ref`` to a
+span/metric name that NOTHING in the codebase ever emits. Every gate built on
+top of that binding — ``check_budget_tree.py --measured``, future trace
+conformance — then reports "zero violations" not because the system is
+healthy, but because it never looked at anything. A budget bound to a metric
+nobody emits, or a conformance check over an empty history, PASSES VACUOUSLY.
+
+This checker closes that gap **statically**: for every telemetry binding
+referenced in a ``system-contracts.json`` budget doc (or any future doc that
+reuses the ``telemetry_ref`` field — this walk is schema-agnostic, so BUD-/
+SLO-/trace-conformance nodes are all covered without a checker update), it
+verifies that an ``@cw-emits <binding-name>`` annotation exists somewhere in
+the source tree marking the code site that emits it. A binding with no
+``@cw-emits`` site is reported as **missing**.
+
+Annotation grammar (``chief_wiggum.annotations.EMITS_TAG_RE`` — same regex
+tier and grammar family as ``@cw-writes``, see ``docs/single-writer.md``):
+
+    @cw-emits <binding-name> [<binding-name> ...]
+
+Place it in a comment at the code site that emits the span/event/metric:
+
+    # @cw-emits endpointing_latency_ms
+    def on_endpoint_detected(ts):
+        span.set_attribute("endpointing_latency_ms", ts - start)
+
+**What this does NOT prove.** Static presence of an ``@cw-emits`` site proves
+the binding is *wired to code*, not that the line executes, not that it
+executes on the path the budget doc assumes, and not that the metric is ever
+actually emitted at runtime — that's what ``check_budget_tree.py --measured``
+(an observed-at-least-once check against a real export) is for. This checker
+and that one are complementary, not redundant: this is "does an emitter
+exist"; that is "did it fire". Deleting the ``@cw-emits`` line while the
+runtime code path is untouched is exactly the regression this checker is
+built to catch (the "instrumentation deleted" seed class from the issue) —
+see the fixture in ``tests/test_check_instrumentation.py``.
+
+**Optional, minimal integration with check_budget_tree.py.** This checker's
+JSON report exposes ``emitted_bindings`` (every binding name with at least one
+``@cw-emits`` site, repo-wide). Pass that report to
+``check_budget_tree.py --measured ... --emits-report <this-report.json>`` and
+measured mode's ``no_observations`` status is refined to ``not_emitted``
+when NO code site emits the binding at all (a structural gap, not just a
+quiet measurement window) — see docs/budget-trees.md. The flag is optional;
+omitting it leaves measured mode's three-way status exactly as it was.
+
+Report-only per doctrine (``docs/gate-rollout.md``): prints findings and
+exits 0 by default; ``--gate`` exits 1 on any missing binding. Mirrors
+``check_budget_tree.py``'s and ``check_single_writer.py``'s shape (dataclasses,
+report object with counts/ok, argparse, best-effort factory_log emit).
+Stdlib only.
+
+Exit codes: 0 = ok/report-only, 1 = ``--gate`` violation, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum.annotations import EMITS_TAG_RE, split_binding_names  # noqa: E402
+
+AUTHORITY = (
+    "static mode proves an @cw-emits site exists in source for each telemetry "
+    "binding declared in the given budget doc(s); it does NOT prove the site "
+    "executes, or that the metric is ever observed at runtime — see "
+    "check_budget_tree.py --measured for observed-at-least-once evidence"
+)
+
+SOURCE_EXTS = {".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".java", ".rb", ".rs"}
+SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv", "vendor", "dist", "build"}
+
+
+def _excluded(rel: str, patterns: list[str]) -> bool:
+    """Same convention as ``check_single_writer._excluded``: a bare token matches
+    that directory and everything under it; a glob matches via fnmatch."""
+    for g in patterns:
+        g = g.rstrip("/")
+        if not g:
+            continue
+        if rel == g or rel.startswith(g + "/"):
+            return True
+        if fnmatch.fnmatch(rel, g) or fnmatch.fnmatch(rel, g + "/*"):
+            return True
+    return False
+
+
+# --- report data model -------------------------------------------------------
+
+
+@dataclass
+class Binding:
+    """A telemetry binding declared by ``telemetry_ref`` on one or more nodes."""
+
+    name: str
+    nodes: list[str]
+    source: str  # budget doc file it was declared in
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class EmitSite:
+    """A source-code site carrying an ``@cw-emits <name>`` annotation."""
+
+    name: str
+    file: str
+    line: int
+    text: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Finding:
+    category: str  # "missing"
+    id: str  # binding name
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class InstrumentationReport:
+    bindings: list[Binding] = field(default_factory=list)
+    emit_sites: list[EmitSite] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict:
+        return {
+            "bindings": len(self.bindings),
+            "emit_sites": len(self.emit_sites),
+            "findings": len(self.findings),
+        }
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+    @property
+    def authority(self) -> str:
+        return AUTHORITY
+
+    @property
+    def emitted_bindings(self) -> list[str]:
+        """Every binding name with at least one ``@cw-emits`` site, repo-wide —
+        the artifact ``check_budget_tree.py --emits-report`` consumes."""
+        return sorted({s.name for s in self.emit_sites})
+
+    def to_dict(self) -> dict:
+        return {
+            "authority": self.authority,
+            "counts": self.counts,
+            "ok": self.ok,
+            "bindings": [b.to_dict() for b in self.bindings],
+            "emit_sites": [e.to_dict() for e in self.emit_sites],
+            "emitted_bindings": self.emitted_bindings,
+            "findings": [f.to_dict() for f in self.findings],
+            "warnings": self.warnings,
+        }
+
+
+# --- collecting declared bindings --------------------------------------------
+
+
+def collect_bindings(doc: dict, source: str) -> list[Binding]:
+    """Recursively walk a budget-tree (or any ``telemetry_ref``-bearing) doc,
+    collecting every ``telemetry_ref`` along with the id(s) of the node(s) that
+    declare it. Schema-agnostic on purpose: this walks ANY dict/list shape
+    looking for a ``telemetry_ref`` string field, so it covers ``BUD-`` budget
+    trees today and ``SLO-``/trace-conformance docs the moment they reuse the
+    same field name, with no checker update required.
+    """
+    found: dict[str, list[str]] = {}
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            ref = node.get("telemetry_ref")
+            if isinstance(ref, str) and ref:
+                found.setdefault(ref, []).append(str(node.get("id", "<node>")))
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(doc)
+    return [Binding(name=name, nodes=ids, source=source) for name, ids in sorted(found.items())]
+
+
+def collect_bindings_from_files(paths: list[Path]) -> tuple[list[Binding], list[str]]:
+    """Load and merge bindings from one or more budget-doc JSON files. A
+    binding name declared in more than one file/node accumulates all
+    declaring node ids rather than being reported twice."""
+    merged: dict[str, Binding] = {}
+    warnings: list[str] = []
+    for path in paths:
+        try:
+            doc = json.loads(Path(path).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            warnings.append(f"cannot load {path}: {exc}")
+            continue
+        for b in collect_bindings(doc, str(path)):
+            if b.name in merged:
+                merged[b.name].nodes.extend(n for n in b.nodes if n not in merged[b.name].nodes)
+            else:
+                merged[b.name] = b
+    return [merged[name] for name in sorted(merged)], warnings
+
+
+# --- scanning the repo for @cw-emits sites -----------------------------------
+
+
+def scan_emit_sites(source_root: str | Path, exclude: list[str] | None = None) -> list[EmitSite]:
+    """Find every ``@cw-emits`` annotation across the source tree."""
+    root = Path(source_root)
+    exclude = exclude or []
+    sites: list[EmitSite] = []
+    if not root.exists():
+        return sites
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in SOURCE_EXTS:
+            continue
+        if any(part in SKIP_PARTS for part in path.parts):
+            continue
+        rel = str(path.relative_to(root))
+        if _excluded(rel, exclude):
+            continue
+        try:
+            lines = path.read_text().splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            for m in EMITS_TAG_RE.finditer(line):
+                for name in split_binding_names(m.group("names")):
+                    sites.append(EmitSite(name=name, file=rel, line=i + 1, text=line.strip()[:200]))
+    return sites
+
+
+# --- top-level check ----------------------------------------------------------
+
+
+def check(
+    budget_files: list[str | Path],
+    source_root: str | Path | None = None,
+    exclude: list[str] | None = None,
+) -> InstrumentationReport:
+    report = InstrumentationReport()
+    bindings, warnings = collect_bindings_from_files([Path(p) for p in budget_files])
+    report.bindings = bindings
+    report.warnings.extend(warnings)
+
+    if not bindings:
+        report.warnings.append(
+            "no telemetry bindings found (no telemetry_ref field in the given budget doc(s)); "
+            "nothing to check"
+        )
+        return report
+
+    if not source_root:
+        # Mirrors check_single_writer.py: without a repo scan we cannot claim a
+        # binding is "missing" — we simply haven't looked. Degrade gracefully
+        # (report bindings parsed, no findings) rather than false-positive.
+        report.warnings.append("no --source given; parsed telemetry bindings only (no repo scan)")
+        return report
+
+    sites = scan_emit_sites(source_root, exclude=exclude)
+    report.emit_sites = sites
+    emitted_names = {s.name for s in sites}
+
+    for b in bindings:
+        if b.name not in emitted_names:
+            report.findings.append(
+                Finding(
+                    "missing",
+                    b.name,
+                    f"{b.name}: declared as telemetry_ref on {', '.join(b.nodes)} but no "
+                    f"@cw-emits site found in {source_root}",
+                )
+            )
+
+    return report
+
+
+# --- rendering ----------------------------------------------------------------
+
+
+def render_text(report: InstrumentationReport) -> str:
+    c = report.counts
+    lines = [
+        "# Instrumentation Coverage Report",
+        "",
+        f"Authority: {report.authority}",
+        "",
+        f"Bindings declared: {c['bindings']}  |  @cw-emits sites found: {c['emit_sites']}  |  "
+        f"Missing: {c['findings']}",
+        f"Status: {'OK' if report.ok else 'FINDINGS'}",
+    ]
+    if report.findings:
+        lines += ["", "## Missing bindings (gateable under --gate)", ""]
+        lines += [f"- {f.message}" for f in report.findings]
+    if report.bindings and not report.findings:
+        lines += ["", "## Bound telemetry bindings", ""]
+        for b in report.bindings:
+            lines.append(f"- {b.name} (declared on {', '.join(b.nodes)})")
+    if report.warnings:
+        lines += ["", "## Warnings", ""] + [f"- {w}" for w in report.warnings]
+    return "\n".join(lines) + "\n"
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Instrumentation-coverage checker: telemetry bindings must be provable (#170)"
+    )
+    parser.add_argument(
+        "budget_files",
+        nargs="+",
+        help="One or more system-contracts.json budget-tree documents to read telemetry_ref bindings from",
+    )
+    parser.add_argument("--source", help="Repo root to scan for @cw-emits sites")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="Repo-relative path/dir/glob to skip; repeatable",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit 1 on any missing binding (no @cw-emits site found)",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    for bf in args.budget_files:
+        if not Path(bf).exists():
+            print(f"Error: budget file not found: {bf}", file=sys.stderr)
+            return 2
+
+    report = check(args.budget_files, args.source, exclude=args.exclude)
+
+    print(json.dumps(report.to_dict(), indent=2) if args.format == "json" else render_text(report))
+
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+
+        emit_gate("check_instrumentation", "fail" if not report.ok else "pass", caught=len(report.findings))
+    except Exception:
+        pass
+
+    if args.gate and not report.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -83,16 +83,16 @@ import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The @cw-writes tag grammar is shared (#170: a third @cw-* tag, @cw-emits,
+# joins it) — see chief_wiggum/annotations.py. Re-exported under these names
+# for backward compatibility with any existing `check_single_writer.WRITES_TAG_RE`
+# references.
+from chief_wiggum.annotations import ATTR_RE, WRITES_TAG_RE  # noqa: E402, F401
+
 # Same INV- shape as check_traceability.py (case-insensitive slug segment).
 INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])", re.IGNORECASE)
-
-# Prose metadata tag, mirroring the @cw-trace LOBSTER-style namespaced tag.
-# `@cw-writes <INV-ID> controls_field=a,b sanctioned_writers=x,y`  (order-free).
-WRITES_TAG_RE = re.compile(
-    r"@cw-writes\s+(?P<id>INV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3})(?P<attrs>(?:\s+\w+=[^\s]+)+)",
-    re.IGNORECASE,
-)
-ATTR_RE = re.compile(r"(\w+)=([^\s]+)")
 
 # Prose invariant declaration (bold label), same as check_traceability's DEFINE_RE
 # but scoped to INV- and capturing the description for reporting.

--- a/scripts/chief_wiggum/annotations.py
+++ b/scripts/chief_wiggum/annotations.py
@@ -38,17 +38,30 @@ ATTR_RE = re.compile(r"(\w+)=([^\s]+)")
 # `@cw-emits <binding-name>` where binding-name is an OTel span/event name or
 # a k6/metrics-exporter metric name — e.g. `endpointing_latency_ms`,
 # `llm.ttft`, `tts/ttfb`. Not a stable ID (no KIND-slug-NNN shape), so it does
-# not reuse chief_wiggum.trace_ids.ID_BODY. Multiple names may be listed on one
-# tag (space- or comma-separated), mirroring @cw-trace's multi-id capture, for
-# a single emit site that fires more than one binding (e.g. a span that also
-# bumps a counter).
+# not reuse chief_wiggum.trace_ids.ID_BODY.
+#
+# Multiple names on one tag (a single emit site that fires more than one
+# binding, e.g. a span that also bumps a counter) must be COMMA-separated:
+#
+#     # @cw-emits asr_latency, endpointing_latency_ms
+#
+# A bare space-separated token list is deliberately NOT accepted: the first
+# token is the binding, and any space-separated prose after it is ignored
+# ("# @cw-emits asr_latency records ASR latency" emits exactly one binding).
+# Otherwise trailing prose words would become phantom bindings that could
+# accidentally satisfy check_instrumentation's missing-binding check.
 _BINDING_TOKEN = r"[A-Za-z0-9_][A-Za-z0-9_./:-]*"
 EMITS_TAG_RE = re.compile(
-    rf"@cw-emits\s+(?P<names>{_BINDING_TOKEN}(?:[\s,]+{_BINDING_TOKEN})*)",
+    rf"@cw-emits\s+(?P<names>{_BINDING_TOKEN}(?:\s*,\s*{_BINDING_TOKEN})*)",
     re.IGNORECASE,
 )
 
 
 def split_binding_names(raw: str) -> list[str]:
-    """Split an ``EMITS_TAG_RE`` ``names`` capture into individual binding names."""
-    return [n for n in re.split(r"[\s,]+", raw.strip()) if n]
+    """Split an ``EMITS_TAG_RE`` ``names`` capture into individual binding names.
+
+    Commas are the ONLY multi-binding separator (see grammar note above);
+    whitespace around each comma is tolerated. A space-separated list is one
+    binding plus ignored prose — the regex never captures it as multiple names.
+    """
+    return [n for n in (part.strip() for part in raw.split(",")) if n]

--- a/scripts/chief_wiggum/annotations.py
+++ b/scripts/chief_wiggum/annotations.py
@@ -1,0 +1,54 @@
+"""Shared home for the ``@cw-<verb> <payload>`` code-annotation tag family.
+
+Distinct from ``chief_wiggum.trace_ids`` (the ``@cw-trace <verb> <ID>``
+grammar for STABLE IDS — ``BR-``/``CTR-``/``INV-``/etc). The tags in this
+module mark a **code site** with a **free-form binding name**, not a stable
+ID:
+
+- ``@cw-writes <INV-ID> controls_field=... sanctioned_writers=...`` (#93,
+  ``scripts/check_single_writer.py``) — marks an invariant's metadata, parsed
+  out of prose ``invariants.md``.
+- ``@cw-emits <binding-name>`` (#170, ``scripts/check_instrumentation.py``) —
+  marks the code site that emits a declared telemetry span/event/metric.
+
+Both are namespaced ``@cw-*`` tags read comment-agnostically (the regex
+matches wherever the text appears; callers are expected to place it inside a
+language comment, but nothing here parses comment syntax). Collecting the
+family's regexes in one module means a THIRD tag never has to duplicate the
+attribute-parsing helper, and a future audit of "every ``@cw-*`` tag this
+repo recognizes" has exactly one place to look.
+"""
+
+from __future__ import annotations
+
+import re
+
+# --- @cw-writes (#93) --------------------------------------------------------
+#
+# `@cw-writes <INV-ID> controls_field=a,b sanctioned_writers=x,y [sink=db]`
+# (order-free key=value attrs). See docs/single-writer.md.
+WRITES_TAG_RE = re.compile(
+    r"@cw-writes\s+(?P<id>INV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3})(?P<attrs>(?:\s+\w+=[^\s]+)+)",
+    re.IGNORECASE,
+)
+ATTR_RE = re.compile(r"(\w+)=([^\s]+)")
+
+# --- @cw-emits (#170) ---------------------------------------------------------
+#
+# `@cw-emits <binding-name>` where binding-name is an OTel span/event name or
+# a k6/metrics-exporter metric name — e.g. `endpointing_latency_ms`,
+# `llm.ttft`, `tts/ttfb`. Not a stable ID (no KIND-slug-NNN shape), so it does
+# not reuse chief_wiggum.trace_ids.ID_BODY. Multiple names may be listed on one
+# tag (space- or comma-separated), mirroring @cw-trace's multi-id capture, for
+# a single emit site that fires more than one binding (e.g. a span that also
+# bumps a counter).
+_BINDING_TOKEN = r"[A-Za-z0-9_][A-Za-z0-9_./:-]*"
+EMITS_TAG_RE = re.compile(
+    rf"@cw-emits\s+(?P<names>{_BINDING_TOKEN}(?:[\s,]+{_BINDING_TOKEN})*)",
+    re.IGNORECASE,
+)
+
+
+def split_binding_names(raw: str) -> list[str]:
+    """Split an ``EMITS_TAG_RE`` ``names`` capture into individual binding names."""
+    return [n for n in re.split(r"[\s,]+", raw.strip()) if n]

--- a/tests/test_check_budget_tree.py
+++ b/tests/test_check_budget_tree.py
@@ -746,10 +746,45 @@ def test_load_emits_report_reads_emitted_bindings(tmp_path):
     assert cbt.load_emits_report(p) == {"asr_latency", "llm_ttft"}
 
 
-def test_load_emits_report_missing_key_is_empty_set(tmp_path):
+def test_load_emits_report_empty_list_is_valid(tmp_path):
+    p = tmp_path / "emits.json"
+    p.write_text(json.dumps({"emitted_bindings": [], "ok": True}))
+    assert cbt.load_emits_report(p) == set()
+
+
+def test_load_emits_report_rejects_missing_key(tmp_path):
+    # Codex review of PR #180: a wrong/old JSON (e.g. a k6 summary passed by
+    # mistake) must NOT be read as "empty emitted set" — that would reclassify
+    # every quiet binding as not_emitted, a wrong claim.
     p = tmp_path / "emits.json"
     p.write_text(json.dumps({"ok": True}))
-    assert cbt.load_emits_report(p) == set()
+    try:
+        cbt.load_emits_report(p)
+        raise AssertionError("expected ValueError for missing emitted_bindings")
+    except ValueError as exc:
+        assert "emitted_bindings" in str(exc)
+
+
+def test_load_emits_report_rejects_non_list_and_non_string_items(tmp_path):
+    p = tmp_path / "emits.json"
+    p.write_text(json.dumps({"emitted_bindings": "asr_latency"}))  # string, not list
+    try:
+        cbt.load_emits_report(p)
+        raise AssertionError("expected ValueError for non-list emitted_bindings")
+    except ValueError:
+        pass
+    p.write_text(json.dumps({"emitted_bindings": ["asr_latency", 42]}))  # non-string item
+    try:
+        cbt.load_emits_report(p)
+        raise AssertionError("expected ValueError for non-string binding")
+    except ValueError:
+        pass
+    p.write_text(json.dumps(["asr_latency"]))  # not even a dict
+    try:
+        cbt.load_emits_report(p)
+        raise AssertionError("expected ValueError for non-dict report")
+    except ValueError:
+        pass
 
 
 # --- load_measured: k6 summary + flat export shapes ---------------------------
@@ -911,6 +946,18 @@ def test_cli_measured_with_emits_report_flag(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "not_emitted" in out
     assert "emitter MISSING" in out
+
+
+def test_cli_measured_with_invalid_emits_report_is_usage_error(tmp_path, capsys):
+    # A wrong-shaped emits report (missing emitted_bindings) must exit 2, not
+    # silently reclassify every quiet binding as not_emitted.
+    doc = {"trees": [{"root": _leaf("BUD-cli-011", 300, telemetry_ref="asr_latency")}]}
+    budget_path = _write(tmp_path, "budget.json", doc)
+    measured_path = _write(tmp_path, "measured.json", {})
+    bad_emits = _write(tmp_path, "emits.json", {"metrics": {"asr_latency": {"p95": 1}}})  # a k6 file, not a report
+    rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--emits-report", str(bad_emits)])
+    assert rc == 2
+    assert "cannot load emits report" in capsys.readouterr().err
 
 
 def test_cli_measured_without_emits_report_flag_is_unchanged(tmp_path, capsys):

--- a/tests/test_check_budget_tree.py
+++ b/tests/test_check_budget_tree.py
@@ -664,6 +664,94 @@ def test_measured_recurses_into_children_and_residual():
     assert ids["BUD-meas-008"] == "unbound"  # residual has no telemetry_ref
 
 
+# --- measured mode: --emits-report integration (#170) --------------------------
+#
+# Optional, additive refinement: when an `emitted` set (the `emitted_bindings`
+# from a check_instrumentation.py report) is supplied, a no_observations
+# binding with NO @cw-emits site anywhere in source is reclassified to
+# not_emitted. Omitting `emitted` (None, the default) must leave every status
+# exactly as it was before this integration existed.
+
+
+def test_no_emits_report_leaves_status_unchanged():
+    doc = {"trees": [{"root": _leaf("BUD-emit-001", 300, telemetry_ref="asr_latency")}]}
+    report = cbt.check_measured(doc, {}, source="k6-summary.json")  # emitted defaults to None
+    assert report.measured[0].status == "no_observations"
+    assert report.measured[0].emitter_bound is None
+
+
+def test_no_observations_becomes_not_emitted_when_no_emitter_found():
+    doc = {"trees": [{"root": _leaf("BUD-emit-002", 300, telemetry_ref="asr_latency")}]}
+    report = cbt.check_measured(doc, {}, source="k6-summary.json", emitted=set())
+    assert report.measured[0].status == "not_emitted"
+    assert report.measured[0].emitter_bound is False
+
+
+def test_no_observations_stays_no_observations_when_emitter_exists():
+    # A real @cw-emits site exists for this binding — the metric just wasn't
+    # observed THIS run (a measurement window, not a structural gap).
+    doc = {"trees": [{"root": _leaf("BUD-emit-003", 300, telemetry_ref="asr_latency")}]}
+    report = cbt.check_measured(doc, {}, source="k6-summary.json", emitted={"asr_latency"})
+    assert report.measured[0].status == "no_observations"
+    assert report.measured[0].emitter_bound is True
+
+
+def test_unbound_is_not_reclassified_by_emits_report():
+    # unbound (no telemetry_ref declared at all) is a stronger/different gap
+    # than not_emitted (bound but nothing emits it) — emits-report must never
+    # turn an unbound node into not_emitted.
+    doc = {"trees": [{"root": _leaf("BUD-emit-004", 300)}]}  # no telemetry_ref
+    report = cbt.check_measured(doc, {}, source="k6-summary.json", emitted=set())
+    assert report.measured[0].status == "unbound"
+    assert report.measured[0].emitter_bound is None
+
+
+def test_held_and_breached_are_not_reclassified_by_emits_report():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-emit-005",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [_leaf("BUD-emit-006", 300, telemetry_ref="m_held")],
+                    "residual": _leaf("BUD-emit-007", 100, telemetry_ref="m_breached"),
+                }
+            }
+        ]
+    }
+    measured = {
+        "m_held": {"p95": 250, "count": 100},
+        "m_breached": {"p95": 999, "count": 100},
+    }
+    # Neither binding has an emitter in this (deliberately empty) emitted set —
+    # but both have real observations, so status must stay held/breached.
+    report = cbt.check_measured(doc, measured, source="k6-summary.json", emitted=set())
+    statuses = {m.id: m.status for m in report.measured}
+    assert statuses["BUD-emit-006"] == "held"
+    assert statuses["BUD-emit-007"] == "breached"
+
+
+def test_measured_not_emitted_count():
+    doc = {"trees": [{"root": _leaf("BUD-emit-008", 300, telemetry_ref="ghost_metric")}]}
+    report = cbt.check_measured(doc, {}, source="k6-summary.json", emitted=set())
+    assert report.counts["measured_not_emitted"] == 1
+    assert report.ok  # still evidence-only, never gates
+
+
+def test_load_emits_report_reads_emitted_bindings(tmp_path):
+    p = tmp_path / "emits.json"
+    p.write_text(json.dumps({"emitted_bindings": ["asr_latency", "llm_ttft"], "ok": True}))
+    assert cbt.load_emits_report(p) == {"asr_latency", "llm_ttft"}
+
+
+def test_load_emits_report_missing_key_is_empty_set(tmp_path):
+    p = tmp_path / "emits.json"
+    p.write_text(json.dumps({"ok": True}))
+    assert cbt.load_emits_report(p) == set()
+
+
 # --- load_measured: k6 summary + flat export shapes ---------------------------
 
 
@@ -811,6 +899,29 @@ def test_cli_measured_with_schema_findings_still_exits_zero_even_with_gate(tmp_p
     measured_path = _write(tmp_path, "measured.json", {"m1": {"p95": 50, "count": 5}})
     rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--gate"])
     assert rc == 0
+
+
+def test_cli_measured_with_emits_report_flag(tmp_path, capsys):
+    doc = {"trees": [{"root": _leaf("BUD-cli-009", 300, telemetry_ref="ghost_metric")}]}
+    budget_path = _write(tmp_path, "budget.json", doc)
+    measured_path = _write(tmp_path, "measured.json", {})
+    emits_path = _write(tmp_path, "emits.json", {"emitted_bindings": []})
+    rc = cbt.main([str(budget_path), "--measured", str(measured_path), "--emits-report", str(emits_path)])
+    assert rc == 0  # measured mode never gates
+    out = capsys.readouterr().out
+    assert "not_emitted" in out
+    assert "emitter MISSING" in out
+
+
+def test_cli_measured_without_emits_report_flag_is_unchanged(tmp_path, capsys):
+    doc = {"trees": [{"root": _leaf("BUD-cli-010", 300, telemetry_ref="asr_latency")}]}
+    budget_path = _write(tmp_path, "budget.json", doc)
+    measured_path = _write(tmp_path, "measured.json", {})
+    rc = cbt.main([str(budget_path), "--measured", str(measured_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no_observations" in out
+    assert "not_emitted" not in out
 
 
 def test_cli_json_format_includes_authority_and_counts(tmp_path, capsys):

--- a/tests/test_check_instrumentation.py
+++ b/tests/test_check_instrumentation.py
@@ -1,0 +1,337 @@
+"""Tests for the instrumentation-coverage checker (#170)."""
+
+from __future__ import annotations
+
+import json
+
+import check_instrumentation as ci
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, (dict, list)):
+        p.write_text(json.dumps(content))
+    else:
+        p.write_text(content)
+    return p
+
+
+# --- @cw-emits regex (chief_wiggum.annotations) ------------------------------
+
+
+def test_emits_tag_matches_single_binding():
+    from chief_wiggum.annotations import EMITS_TAG_RE, split_binding_names
+
+    m = EMITS_TAG_RE.search("# @cw-emits endpointing_latency_ms")
+    assert m
+    assert split_binding_names(m.group("names")) == ["endpointing_latency_ms"]
+
+
+def test_emits_tag_matches_dotted_and_slashed_names():
+    from chief_wiggum.annotations import EMITS_TAG_RE
+
+    assert EMITS_TAG_RE.search("// @cw-emits llm.ttft")
+    assert EMITS_TAG_RE.search("// @cw-emits tts/ttfb")
+    assert EMITS_TAG_RE.search("# @cw-emits transport-rtt-ms")
+
+
+def test_emits_tag_supports_multiple_names():
+    from chief_wiggum.annotations import EMITS_TAG_RE, split_binding_names
+
+    m = EMITS_TAG_RE.search("# @cw-emits asr_latency, endpointing_latency_ms")
+    assert split_binding_names(m.group("names")) == ["asr_latency", "endpointing_latency_ms"]
+
+
+def test_writes_and_emits_regex_do_not_cross_match():
+    from chief_wiggum.annotations import EMITS_TAG_RE, WRITES_TAG_RE
+
+    assert not EMITS_TAG_RE.search("<!-- @cw-writes INV-x-001 controls_field=a sanctioned_writers=b -->")
+    assert not WRITES_TAG_RE.search("# @cw-emits asr_latency")
+
+
+# --- collect_bindings: schema-agnostic telemetry_ref walk --------------------
+
+
+def test_collect_bindings_from_budget_tree():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-voice-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 800,
+                    "children": [
+                        {
+                            "id": "BUD-voice-002",
+                            "kind": "latency",
+                            "unit": "ms",
+                            "bound": 300,
+                            "telemetry_ref": "asr_latency",
+                        }
+                    ],
+                    "residual": {
+                        "id": "BUD-voice-003",
+                        "kind": "latency",
+                        "unit": "ms",
+                        "bound": 100,
+                    },
+                }
+            }
+        ]
+    }
+    bindings = ci.collect_bindings(doc, "system-contracts.json")
+    assert len(bindings) == 1
+    assert bindings[0].name == "asr_latency"
+    assert bindings[0].nodes == ["BUD-voice-002"]
+
+
+def test_collect_bindings_is_schema_agnostic_future_slo_section():
+    # No BUD- schema involved at all — proves the walk isn't budget-tree-specific,
+    # so a future SLO-/trace-conformance doc that reuses telemetry_ref is covered
+    # without a checker update.
+    doc = {"slos": [{"id": "SLO-voice-001", "telemetry_ref": "p95_latency"}]}
+    bindings = ci.collect_bindings(doc, "slo.json")
+    assert bindings[0].name == "p95_latency"
+    assert bindings[0].nodes == ["SLO-voice-001"]
+
+
+def test_collect_bindings_within_one_doc_merges_same_name_nodes():
+    doc = {
+        "trees": [
+            {
+                "root": {
+                    "id": "BUD-a-001",
+                    "kind": "latency",
+                    "unit": "ms",
+                    "bound": 1,
+                    "children": [_bud_node("BUD-a-002", "shared")],
+                    "residual": _bud_node("BUD-a-003", "shared"),
+                }
+            }
+        ]
+    }
+    bindings = ci.collect_bindings(doc, "a.json")
+    assert len(bindings) == 1
+    assert set(bindings[0].nodes) == {"BUD-a-002", "BUD-a-003"}
+
+
+def test_collect_bindings_from_files_merges_across_files(tmp_path):
+    p1 = _write(tmp_path, "a.json", {"trees": [{"root": _bud_node("BUD-a-001", "shared")}]})
+    p2 = _write(tmp_path, "b.json", {"trees": [{"root": _bud_node("BUD-b-001", "shared")}]})
+    bindings, warnings = ci.collect_bindings_from_files([p1, p2])
+    assert warnings == []
+    assert len(bindings) == 1
+    assert set(bindings[0].nodes) == {"BUD-a-001", "BUD-b-001"}
+
+
+def test_collect_bindings_from_files_warns_on_bad_json(tmp_path):
+    p = _write(tmp_path, "bad.json", "{not json")
+    bindings, warnings = ci.collect_bindings_from_files([p])
+    assert bindings == []
+    assert warnings and "bad.json" in warnings[0]
+
+
+def _bud_node(id_, telemetry_ref):
+    return {"id": id_, "kind": "latency", "unit": "ms", "bound": 100, "telemetry_ref": telemetry_ref}
+
+
+# --- scan_emit_sites: Go/Py/TS fixtures --------------------------------------
+
+
+def test_scan_finds_emit_site_in_python_comment(tmp_path):
+    _write(
+        tmp_path,
+        "app/pipeline.py",
+        "# @cw-emits endpointing_latency_ms\ndef on_endpoint(ts):\n    pass\n",
+    )
+    sites = ci.scan_emit_sites(tmp_path)
+    assert len(sites) == 1
+    assert sites[0].name == "endpointing_latency_ms"
+    assert sites[0].file == "app/pipeline.py"
+    assert sites[0].line == 1
+
+
+def test_scan_finds_emit_site_in_go_comment(tmp_path):
+    _write(
+        tmp_path,
+        "internal/voice/transport.go",
+        "// @cw-emits transport_rtt_ms\nfunc RecordRTT(d time.Duration) {}\n",
+    )
+    sites = ci.scan_emit_sites(tmp_path)
+    assert len(sites) == 1
+    assert sites[0].name == "transport_rtt_ms"
+
+
+def test_scan_finds_emit_site_in_ts_comment(tmp_path):
+    _write(
+        tmp_path,
+        "ui/src/tts.ts",
+        "// @cw-emits tts_ttfb_ms\nexport function onTtsFirstByte() {}\n",
+    )
+    sites = ci.scan_emit_sites(tmp_path)
+    assert len(sites) == 1
+    assert sites[0].name == "tts_ttfb_ms"
+
+
+def test_scan_ignores_non_source_extensions(tmp_path):
+    _write(tmp_path, "notes.txt", "@cw-emits should_not_count\n")
+    sites = ci.scan_emit_sites(tmp_path)
+    assert sites == []
+
+
+def test_scan_respects_exclude_globs(tmp_path):
+    _write(tmp_path, "vendor_extra/gen.py", "# @cw-emits excluded_metric\n")
+    _write(tmp_path, "app/real.py", "# @cw-emits real_metric\n")
+    sites = ci.scan_emit_sites(tmp_path, exclude=["vendor_extra"])
+    names = {s.name for s in sites}
+    assert names == {"real_metric"}
+
+
+def test_scan_missing_source_root_returns_empty(tmp_path):
+    assert ci.scan_emit_sites(tmp_path / "does-not-exist") == []
+
+
+# --- check(): missing bindings, gate semantics -------------------------------
+
+
+def test_check_reports_missing_binding_when_no_emit_site(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-x-001", "ghost_metric")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("def handler():\n    pass\n")  # no @cw-emits at all
+    report = ci.check([budget], src)
+    assert not report.ok
+    assert len(report.findings) == 1
+    assert report.findings[0].id == "ghost_metric"
+    assert "ghost_metric" in report.findings[0].message
+
+
+def test_check_passes_when_emit_site_exists(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-x-002", "asr_latency")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("# @cw-emits asr_latency\ndef handler():\n    pass\n")
+    report = ci.check([budget], src)
+    assert report.ok
+    assert report.findings == []
+    assert report.emitted_bindings == ["asr_latency"]
+
+
+def test_check_no_bindings_at_all_is_a_warning_not_a_finding(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node_no_ref("BUD-x-003")}]})
+    src = tmp_path / "repo"
+    src.mkdir()
+    report = ci.check([budget], src)
+    assert report.ok
+    assert report.bindings == []
+    assert any("nothing to check" in w for w in report.warnings)
+
+
+def _bud_node_no_ref(id_):
+    return {"id": id_, "kind": "latency", "unit": "ms", "bound": 100}
+
+
+def test_check_without_source_degrades_gracefully_no_findings(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-x-004", "asr_latency")}]})
+    report = ci.check([budget], None)
+    assert report.ok  # no repo scan happened -> can't claim "missing"
+    assert report.findings == []
+    assert any("no --source given" in w for w in report.warnings)
+
+
+def test_check_missing_budget_file_is_a_warning(tmp_path):
+    report = ci.check([tmp_path / "does-not-exist.json"], tmp_path)
+    assert report.bindings == []
+    assert any("does-not-exist.json" in w for w in report.warnings)
+
+
+# --- the core fixture: deleting an @cw-emits site flips the binding to missing
+
+
+def test_deleting_emits_site_flips_binding_to_missing(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-x-005", "endpointing_ms")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    handler = src / "app" / "handler.py"
+    handler.write_text("# @cw-emits endpointing_ms\ndef on_endpoint():\n    pass\n")
+
+    report_before = ci.check([budget], src)
+    assert report_before.ok
+
+    # Simulate the "instrumentation deleted" seed class: remove the @cw-emits
+    # line while the runtime code is untouched.
+    handler.write_text("def on_endpoint():\n    pass\n")
+
+    report_after = ci.check([budget], src)
+    assert not report_after.ok
+    assert report_after.findings[0].id == "endpointing_ms"
+
+
+# --- gate semantics -----------------------------------------------------------
+
+
+def test_cli_default_is_report_only_even_with_missing_binding(tmp_path, capsys):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-cli-001", "ghost")}]})
+    src = tmp_path / "repo"
+    src.mkdir()
+    rc = ci.main([str(budget), "--source", str(src)])
+    assert rc == 0
+    assert "FINDINGS" in capsys.readouterr().out
+
+
+def test_cli_gate_fails_on_missing_binding(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-cli-002", "ghost")}]})
+    src = tmp_path / "repo"
+    src.mkdir()
+    rc = ci.main([str(budget), "--source", str(src), "--gate"])
+    assert rc == 1
+
+
+def test_cli_gate_passes_when_bound(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-cli-003", "asr_latency")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("# @cw-emits asr_latency\n")
+    rc = ci.main([str(budget), "--source", str(src), "--gate"])
+    assert rc == 0
+
+
+def test_cli_missing_budget_file_is_usage_error(tmp_path, capsys):
+    rc = ci.main([str(tmp_path / "nope.json")])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_json_format_includes_authority_and_counts(tmp_path, capsys):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-cli-004", "asr_latency")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("# @cw-emits asr_latency\n")
+    rc = ci.main([str(budget), "--source", str(src), "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert "authority" in data
+    assert data["counts"]["bindings"] == 1
+    assert data["emitted_bindings"] == ["asr_latency"]
+
+
+# --- report shape -------------------------------------------------------------
+
+
+def test_report_json_serializable(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-json-001", "m1")}]})
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("# @cw-emits m1\n")
+    report = ci.check([budget], src)
+    json.dumps(report.to_dict())  # must not raise
+
+
+def test_render_text_includes_authority_line(tmp_path):
+    budget = _write(tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-txt-001", "m1")}]})
+    report = ci.check([budget], tmp_path / "repo")
+    text = ci.render_text(report)
+    assert "Authority:" in text
+    assert report.authority in text

--- a/tests/test_check_instrumentation.py
+++ b/tests/test_check_instrumentation.py
@@ -36,11 +36,41 @@ def test_emits_tag_matches_dotted_and_slashed_names():
     assert EMITS_TAG_RE.search("# @cw-emits transport-rtt-ms")
 
 
-def test_emits_tag_supports_multiple_names():
+def test_emits_tag_supports_multiple_names_comma_separated():
     from chief_wiggum.annotations import EMITS_TAG_RE, split_binding_names
 
     m = EMITS_TAG_RE.search("# @cw-emits asr_latency, endpointing_latency_ms")
     assert split_binding_names(m.group("names")) == ["asr_latency", "endpointing_latency_ms"]
+    # whitespace around the comma is tolerated
+    m = EMITS_TAG_RE.search("# @cw-emits asr_latency ,endpointing_latency_ms")
+    assert split_binding_names(m.group("names")) == ["asr_latency", "endpointing_latency_ms"]
+
+
+def test_emits_tag_ignores_trailing_prose():
+    # Codex review of PR #180: a space-separated token list is NOT a multi-
+    # binding — the first token is the binding, prose after it is ignored.
+    # Otherwise "records", "ASR", and "latency" would become phantom bindings
+    # that could accidentally satisfy a missing-binding check.
+    from chief_wiggum.annotations import EMITS_TAG_RE, split_binding_names
+
+    m = EMITS_TAG_RE.search("# @cw-emits asr_latency records ASR latency")
+    assert m
+    assert split_binding_names(m.group("names")) == ["asr_latency"]
+
+
+def test_prose_word_cannot_satisfy_a_missing_binding(tmp_path):
+    # End-to-end: the budget doc binds "records"; a comment whose PROSE contains
+    # the word "records" after an @cw-emits tag must NOT count as an emitter.
+    budget = _write(
+        tmp_path, "system-contracts.json", {"trees": [{"root": _bud_node("BUD-prose-001", "records")}]}
+    )
+    src = tmp_path / "repo"
+    (src / "app").mkdir(parents=True)
+    (src / "app" / "handler.py").write_text("# @cw-emits asr_latency records ASR latency\n")
+    report = ci.check([budget], src)
+    assert not report.ok
+    assert report.findings[0].id == "records"
+    assert report.emitted_bindings == ["asr_latency"]
 
 
 def test_writes_and_emits_regex_do_not_cross_match():
@@ -302,6 +332,30 @@ def test_cli_missing_budget_file_is_usage_error(tmp_path, capsys):
     rc = ci.main([str(tmp_path / "nope.json")])
     assert rc == 2
     assert "not found" in capsys.readouterr().err
+
+
+def test_cli_malformed_budget_json_is_usage_error(tmp_path, capsys):
+    # Codex review of PR #180: a corrupt contract file must NOT silently
+    # degrade to "nothing to check" (exit 0) — that disables the gate while
+    # appearing green. Unreadable/malformed budget docs are a usage error.
+    bad = _write(tmp_path, "system-contracts.json", "{not json")
+    rc = ci.main([str(bad), "--source", str(tmp_path)])
+    assert rc == 2
+    assert "cannot load budget file" in capsys.readouterr().err
+
+
+def test_cli_malformed_budget_json_is_usage_error_even_with_gate(tmp_path, capsys):
+    bad = _write(tmp_path, "system-contracts.json", "{not json")
+    rc = ci.main([str(bad), "--source", str(tmp_path), "--gate"])
+    assert rc == 2
+    assert "cannot load budget file" in capsys.readouterr().err
+
+
+def test_cli_one_malformed_file_among_many_is_usage_error(tmp_path):
+    good = _write(tmp_path, "good.json", {"trees": [{"root": _bud_node("BUD-mix-001", "m1")}]})
+    bad = _write(tmp_path, "bad.json", "{not json")
+    rc = ci.main([str(good), str(bad), "--source", str(tmp_path)])
+    assert rc == 2
 
 
 def test_cli_json_format_includes_authority_and_counts(tmp_path, capsys):


### PR DESCRIPTION
## Summary

Telemetry bindings must be provable or system-layer measured-mode gates pass
vacuously (completeness-lens finding from #170): a budget tree bound to a
span/metric nobody emits reports zero violations because it never observed
anything.

- **`@cw-emits <binding-name>`** — a code-site annotation marking where a
  declared telemetry span/event/metric is emitted. Same regex tier/grammar
  family as `@cw-writes`; both now live in `scripts/chief_wiggum/annotations.py`
  (`WRITES_TAG_RE`/`ATTR_RE` moved there from `check_single_writer.py`, which
  re-exports them for backward compatibility; new `EMITS_TAG_RE` +
  `split_binding_names`).
- **`scripts/check_instrumentation.py`** — for every `telemetry_ref` in one or
  more `system-contracts.json` budget docs, verifies **statically** that an
  `@cw-emits` site exists in `--source`. The `telemetry_ref` walk is
  schema-agnostic (looks for the field name, not a `BUD-` node specifically),
  so a future `SLO-`/trace-conformance doc is covered without a checker
  update. Report-only by default; `--gate` hard-fails on any missing binding.
  Degrades gracefully without `--source` (warns, doesn't false-positive),
  mirroring `check_single_writer.py`.
- **`check_budget_tree.py --measured` integration** — new optional
  `--emits-report <check_instrumentation JSON>` flag. When given, a
  `no_observations` binding with **no** `@cw-emits` site anywhere in source
  (per the instrumentation report's `emitted_bindings`) is reclassified to a
  new status, **`not_emitted`** — distinguishing "nothing could ever emit
  this" (structural gap) from "a real emitter just didn't fire this run"
  (measurement window). `unbound`/`held`/`breached` are untouched. Omitting
  the flag leaves all four statuses exactly as before — minimal, additive,
  optional.
- Docs: new section in `docs/budget-trees.md` covering `@cw-emits`,
  `check_instrumentation.py`, and the `--emits-report` integration.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 995 passed, 4 skipped (pre-existing,
      unrelated skips)
- [x] `python3 -m ruff check scripts tests` — clean
- [x] New fixtures cover `@cw-emits` in Go/Python/TS comments, a missing
      binding, `--gate` semantics, and the "instrumentation deleted" seed
      class (`test_deleting_emits_site_flips_binding_to_missing`)
- [x] Manual smoke test of the full pipeline (`check_instrumentation.py` →
      `--emits-report` → `check_budget_tree.py --measured`) against a
      hand-built voice-agent-style budget doc, confirming `not_emitted` only
      appears for the genuinely-unemitted binding

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF