### PR TITLE
feat(traceability): suspect propagation + JUSTIFIED waivers (#169)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -392,7 +392,9 @@ python3 "$CW_HOME/scripts/check_unresolved.py" "$CW_TMP" --format text
 # the contract/invariant graph (see docs/traceability.md). Code/test coverage is
 # checked later by /close-epic; at architect time this validates the doc-level
 # graph. Assign stable BR-/CTR-/INV- IDs and `@cw-trace realizes` links so this
-# passes; it degrades gracefully when no IDs exist yet.
+# passes; it degrades gracefully when no IDs exist yet. (Suspect-link propagation
+# and `--write-links` are a /close-epic concern — no code/test links exist to
+# record yet at this stage.)
 python3 "$CW_HOME/scripts/check_traceability.py" "$CW_TMP" --gate soundness --format text
 
 # Single-writer soundness gate — validates that "single write path"/"single source

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -134,6 +134,18 @@ python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_R
 
 **Uncovered contracts** (no code `@cw-trace guards/ensures`) and **untested contracts** (no test `@cw-trace verifies`) are findings — the contract isn't proven implemented/tested. Dangling annotations (a tag referencing an ID that no longer exists) indicate a refactor left a stale link; fix the link or the ID. Degrades gracefully when the epic uses no annotations.
 
+**Suspect links (#169, report-only)**: the same run surfaces `suspect_links` — code/test links whose contract's definition hash has changed since that link was last validated ("code claims to guard CTR-X but CTR-X changed since that claim was validated"), distinct from a dangling/uncovered finding. This does not block the gate yet (see `docs/gate-rollout.md`) but re-review any suspect link before closing.
+
+**JUSTIFIED waivers**: a contract that's genuinely not going to be covered (e.g. manual QA only) may carry a committed waiver at `docs/epics/<slug>/justifications/*.json` (`reason`/`approver`/`expiry`/`ticket` — a justification without a ticket ref is invalid and does NOT satisfy coverage). Valid, non-expired waivers render as `justified_contracts` and satisfy the coverage gate honestly instead of a fabricated guard/verify annotation.
+
+Once the gate passes, (re)write the definition-hash sidecar so future runs can detect suspect links — never hand-maintain this file:
+
+```bash
+python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --write-links --format text
+```
+
+`--write-links` only updates `$TARGET_REPO/docs/quality/trace-links.json` when the coverage gate passes — a failing run leaves the sidecar untouched, so a broken state is never recorded as validated. Commit this file alongside the rest of `docs/quality/` in Step 2f.
+
 ### Step 2e: Single-writer coverage gate
 
 For every invariant that declares a **single write path** / **single source of truth** (carrying `controls_field` + `sanctioned_writers` metadata — see `docs/single-writer.md`), prove no second mutator exists. This catches the class of bug where a pre-existing control (e.g. a legacy admin `ChangePlan` dropdown) is a second writer of a field an epic's invariant said had one atomic write path — something traceability and the ratchet cannot see, because they check contract↔code↔test *links* and the pass-set, not *who writes a field*.
@@ -154,7 +166,7 @@ python3 "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO"
 python3 "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 10   # per-wave/ticket history for the retrospective
 ```
 
-A violation blocks the close: a regression means something merged that shouldn't have; a weakened/removed contract means the spec was edited outside the sanctioned path. If a contract revision was a *deliberate* decision made during the epic (confirm with the user — it should be visible in review threads, not discovered here), journal it explicitly so the baseline moves in the open, then re-check:
+A violation blocks the close: a regression means something merged that shouldn't have; a weakened/removed contract means the spec was edited outside the sanctioned path. `check`'s output also surfaces `suspect_links` (#169) — if `docs/quality/trace-links.json` exists, any link recorded against a contract whose definition hash just changed is printed explicitly, so a weakening is never silently absorbed into "the ratchet held"; this is report-only and does not change the exit code. If a contract revision was a *deliberate* decision made during the epic (confirm with the user — it should be visible in review threads, not discovered here), journal it explicitly so the baseline moves in the open, then re-check:
 
 ```bash
 python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-close \

--- a/docs/gate-rollout.md
+++ b/docs/gate-rollout.md
@@ -63,3 +63,4 @@ output), and only switch it to `--gate` once step 2 is satisfied.
 | SaaS NFR | `saas_gate.py --gate` | `--gate` | blocking (`/saas-gate`) |
 | **Minimal-CI** | `ci_scaffold.py` | `--gate` | **report-only** (#111); wired into `/close-epic` report-only; `--gate` mode held off until validated across shipped repos |
 | **AI-slop signals (code survival + duplication)** | `quality_slop_gate.py` | `--gate` | **report-only** (#113); `/close-epic`; promote after a dry-run shows the GitClear bands don't false-positive on shipped repos |
+| **Traceability: suspect-link propagation** | `check_traceability.py` (`suspect_links`) | none yet | **NEW — report-only** (#169); does not affect `coverage_ok`/the `--gate coverage` exit code; `ratchet.py check`/`regressed` surface the same sidecar cross-reference visibly. Promote once a dry-run across a real epic's link churn shows an acceptable false-positive rate (see docs/traceability.md) |

--- a/docs/ratchet.md
+++ b/docs/ratchet.md
@@ -148,6 +148,15 @@ deltas in the run output but only `--gate-quality` blocks) until it has been
 validated on a real, already-shipped repo. Promote it to `--gate-quality` in a
 follow-up that cites the dry-run.
 
+`check`/`regressed` also cross-reference `docs/quality/trace-links.json` (the
+suspect-link sidecar written by `check_traceability.py --write-links`, #169)
+against the CURRENT scorecard's `contract_hashes`: any link recorded against a
+hash that no longer matches is printed as a `suspect_links` finding — a
+definition-hash change with surviving suspect links is **visible, not
+silent**, even though (like complexity/churn) it is report-only and does not
+change `check`'s exit code. See [traceability.md](traceability.md) for the
+sidecar format and how a link becomes suspect.
+
 Like the other gates, it degrades gracefully: a target repo with no
 `docs/quality/ratchet.json` skips the ratchet (the workflows treat it as
 not-yet-adopted rather than failing). Adopt it with `init` + a baseline record.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -123,3 +123,105 @@ contents belong to the submodule's own repo and its own gates — this keeps the
 two scan modes agreeing on the file universe. A bad `--changed-since` ref or a
 non-git `--source` with `--changed-since` is a usage error (exit 2), reported
 concisely on stderr.
+
+## Suspect-link propagation (#169)
+
+A trace link only proves what it claimed at the moment it was last checked. If
+`CTR-order-001`'s wording changes and no one re-reviews the `@cw-trace guards
+CTR-order-001` annotation that cites it, the link still *looks* healthy —
+uncovered/untested/dangling all miss this, because the annotation still
+resolves to a real, defined ID. This is the doorstop pattern's fix: every link
+also records the **definition hash** of the ID it was verified against
+(the same stable-ID block hash `ratchet.py` uses to detect weakened contracts —
+`chief_wiggum.hashing.hash_epic_definitions`, shared, not duplicated).
+
+The hash-per-link record lives in a generated sidecar,
+`docs/quality/trace-links.json` (in the target repo, alongside the ratchet's
+own state) — never hand-maintained:
+
+```bash
+# Write/refresh the sidecar from the CURRENT scan (only actually writes if the
+# requested --gate passes; a failing gate leaves the file untouched):
+python3 "$CW_HOME/scripts/check_traceability.py" docs/epics/<slug> --source . \
+    --gate coverage --write-links --format text
+
+# Override the sidecar location (default: <--source or cwd>/docs/quality/trace-links.json):
+python3 "$CW_HOME/scripts/check_traceability.py" docs/epics/<slug> --links path/to/trace-links.json
+```
+
+On every run, if a sidecar exists at the resolved location, each recorded link
+is compared against the ID's CURRENT definition hash. A mismatch is **SUSPECT**
+— reported in `suspect_links`/`suspect_contracts`, distinct from both dangling
+(the ID doesn't exist at all) and uncovered/untested (no link exists): here a
+link exists, its claim about the contract is just stale. Rewording the
+contract flips its links to SUSPECT; re-running `--write-links` against the
+reworded contract clears them (the reviewer re-validated the claim).
+
+Suspect propagation is **report-only initially** (see
+[gate-rollout.md](gate-rollout.md)): it does not change `soundness_ok`/
+`coverage_ok`, and `--gate coverage` does not yet hard-fail on it. `ratchet.py
+check`/`regressed` also cross-reference the same sidecar against the CURRENT
+scorecard's contract hashes and print suspect links explicitly — a
+definition-hash change is never silently absorbed into "the ratchet held".
+
+**Known limitation**: the sidecar comparison is scoped to the single epic
+directory `check_traceability.py` is invoked against — a link whose target ID
+is declared in a *different* epic is invisible to that run (it will simply
+have no `current_hash` to compare and is skipped, not falsely flagged).
+Multi-epic sidecar aggregation is a follow-up, not yet needed for the
+single-epic-at-a-time workflow `/architect`/`/close-epic` already use.
+
+## JUSTIFIED waivers (#169)
+
+An uncovered/untested contract isn't always a bug — sometimes coverage is
+deliberately deferred (e.g. manual QA only for this release) and pretending
+otherwise with a fake `@cw-trace guards`/`verifies` annotation would be a lie.
+The LOBSTER pattern's fix: a first-class waiver record, distinct from both
+"OK" and "gap".
+
+Waivers live under `docs/epics/<slug>/justifications/*.json`, one file per
+waiver, diffable and committed like any other epic artifact:
+
+```json
+{
+  "id": "CTR-order-002",
+  "reason": "manual QA only for this release; automated coverage tracked separately",
+  "approver": "jane@example.com",
+  "expiry": "2026-12-31",
+  "ticket": "#170"
+}
+```
+
+All five fields are required. **A justification without a `ticket` ref is
+invalid** — per the ticket-every-deferral doctrine, a waiver is not a way to
+skip opening a tracking ticket, and an invalid record does NOT satisfy
+coverage (it's reported under `invalid_justifications`, and the contract stays
+uncovered/untested). An **expired** justification (`expiry` has passed) also
+does not satisfy coverage — it's reported under `expired_justifications` so a
+stale waiver is visible, not a silent pass forever.
+
+A valid, non-expired justification for a currently uncovered/untested contract
+moves it out of `uncovered_contracts`/`untested_contracts` into
+`justified_contracts` — `coverage_ok` becomes true honestly, because the gap
+is now a documented, ticket-tracked decision instead of an unexplained miss. A
+justification for an already-covered contract, or for an ID that isn't even
+defined, has no effect (not reported as JUSTIFIED — there's nothing to waive).
+
+Note the `justifications/` subtree is excluded from ID/hash scanning (a
+waiver's own `"id"` field names the CTR/INV it waives, not a new declaration).
+
+## Coverage-requirement alternatives (#169)
+
+By default any `verifies` link — from a test, probe, policy, or telemetry
+artifact — satisfies a contract's test coverage. A contract may instead
+declare which kinds are acceptable, with OR semantics, via a JSON model entry:
+
+```json
+{"id": "CTR-order-005", "coverage_requires": ["unit-test", "integration-spec"]}
+```
+
+`CTR-order-005` is then untested unless a `verifies` annotation's `source_kind`
+matches ONE of the declared alternatives — a `telemetry`-only signal, for
+example, would no longer count if only `["unit-test", "integration-spec"]` are
+declared acceptable. Omitting `coverage_requires` for an ID preserves the
+original "any verifying kind counts" behavior.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -149,6 +149,19 @@ python3 "$CW_HOME/scripts/check_traceability.py" docs/epics/<slug> --source . \
 python3 "$CW_HOME/scripts/check_traceability.py" docs/epics/<slug> --links path/to/trace-links.json
 ```
 
+`--write-links` is always a **full** source scan: the sidecar is the global
+record of validated links, and rewriting it from a `--changed-since` partial
+scan would silently drop every validated link in unchanged files (they could
+then never go suspect). The two flags together are a usage error (exit 2).
+
+Sidecar link targets and definition-hash keys share the **canonical ID form**
+(uppercase kind, lowercase slug — `chief_wiggum.trace_ids.canonical_id`), so an
+epic doc declaring `CTR-BIL-001` and an annotation citing it in any casing
+join on `CTR-bil-001`. The same form keys the ratchet's `contract_hashes`;
+journals written before this canonicalization are read compatibly (keys are
+canonicalized on load — hash *values* cover block content only and are
+unaffected).
+
 On every run, if a sidecar exists at the resolved location, each recorded link
 is compared against the ID's CURRENT definition hash. A mismatch is **SUSPECT**
 — reported in `suspect_links`/`suspect_contracts`, distinct from both dangling
@@ -192,13 +205,16 @@ waiver, diffable and committed like any other epic artifact:
 }
 ```
 
-All five fields are required. **A justification without a `ticket` ref is
+All five fields are required. **A justification without a real `ticket` ref is
 invalid** — per the ticket-every-deferral doctrine, a waiver is not a way to
-skip opening a tracking ticket, and an invalid record does NOT satisfy
-coverage (it's reported under `invalid_justifications`, and the contract stays
-uncovered/untested). An **expired** justification (`expiry` has passed) also
-does not satisfy coverage — it's reported under `expired_justifications` so a
-stale waiver is visible, not a silent pass forever.
+skip opening a tracking ticket. The ref must match one of the accepted forms:
+`#123`, `owner/repo#123`, an `http(s)` issue URL, or a JIRA-style `KEY-123` —
+placeholders (`"none"`, `"N/A"`, whitespace) are rejected, and an invalid
+record does NOT satisfy coverage (it's reported under
+`invalid_justifications`, and the contract stays uncovered/untested). An
+**expired** justification (`expiry` has passed) also does not satisfy coverage
+— it's reported under `expired_justifications` so a stale waiver is visible,
+not a silent pass forever.
 
 A valid, non-expired justification for a currently uncovered/untested contract
 moves it out of `uncovered_contracts`/`untested_contracts` into

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # agree on the file universe (the manifest never surfaces submodule blobs).
 from chief_wiggum.hashing import hash_epic_definitions, scanner_version  # noqa: E402
 from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
-from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE  # noqa: E402
+from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE, canonical_id  # noqa: E402
 
 # Suspect-link propagation (#169): a link is SUSPECT when the ID it was
 # verified against has a definition hash that no longer matches the hash
@@ -171,15 +171,10 @@ def kind_of(node_id: str) -> str:
     return node_id.split("-", 1)[0].upper()
 
 
-def canonical_id(node_id: str) -> str:
-    """Canonical form: uppercase kind prefix, lowercase remainder.
-
-    IDs are matched case-insensitively (CTR-order-001 == CTR-ORDER-001); this
-    keeps the familiar display shape while making links immune to case drift
-    between epic docs and code annotations.
-    """
-    kind, _, rest = node_id.partition("-")
-    return f"{kind.upper()}-{rest.lower()}"
+# canonical_id's home is chief_wiggum.trace_ids (shared with the hashing
+# module, so definition-hash keys and annotation targets join on the same
+# canonical form — PR #181 review); imported above, re-exported here for
+# existing callers.
 
 
 def parse_annotations(text: str) -> list[tuple[str, list[str]]]:
@@ -567,21 +562,23 @@ def write_links_sidecar(
     epic_dir: str | Path,
     source_root: str | Path | None,
     path: str | Path,
-    *,
-    changed_since: str | None = None,
 ) -> dict:
     """Write the ``docs/quality/trace-links.json`` sidecar (#169) from the
     CURRENT scan: every ``@cw-trace`` link's definition hash, at the moment
     this is called. Not hand-maintained — called by ``/architect``/
     ``/close-epic`` only once their respective gate has passed (see ``main``'s
     ``--write-links``), so a stale/failing state never gets recorded as
-    validated."""
+    validated.
+
+    Always a FULL source scan, by construction: the sidecar is the global
+    record of validated links, and rewriting it from a ``--changed-since``
+    partial scan would silently drop every validated link in unchanged files
+    (they'd then never be able to go suspect). ``main`` rejects the
+    ``--write-links --changed-since`` combination as a usage error (PR #181
+    review)."""
     annotations = scan_epic_annotations(epic_dir)
     if source_root:
-        only_files = None
-        if changed_since:
-            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
-        annotations += scan_source(source_root, only_files=only_files)
+        annotations += scan_source(source_root)
     current_hashes = hash_epic_definitions(Path(epic_dir))
     body = build_sidecar(annotations, current_hashes, scanner_version=_scanner_version())
     write_sidecar(path, body)
@@ -664,10 +661,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--write-links",
         action="store_true",
-        help="(Re)write the trace-links.json sidecar from this scan's current link/definition "
+        help="(Re)write the trace-links.json sidecar from a FULL scan's current link/definition "
         "hashes — but ONLY when the requested --gate passes (or no --gate was given). A failing "
         "gate leaves the sidecar untouched, so a stale/broken state is never recorded as "
-        "validated. Not hand-maintained; see docs/traceability.md.",
+        "validated. Incompatible with --changed-since (a partial scan would drop validated "
+        "links for unchanged files). Not hand-maintained; see docs/traceability.md.",
     )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
@@ -678,6 +676,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.epic_dir:
         print("Error: epic_dir is required unless --scanner-version is given", file=sys.stderr)
+        return 2
+
+    if args.write_links and args.changed_since:
+        print(
+            "Error: --write-links cannot be combined with --changed-since — the sidecar is the "
+            "global record of validated links and must be written from a FULL scan; a partial "
+            "scan would silently drop validated links for unchanged files",
+            file=sys.stderr,
+        )
         return 2
 
     try:
@@ -716,7 +723,7 @@ def main(argv: list[str] | None = None) -> int:
             or (args.gate == "coverage" and report.coverage_ok)
         )
         if gate_passed:
-            write_links_sidecar(args.epic_dir, args.source, links_path, changed_since=args.changed_since)
+            write_links_sidecar(args.epic_dir, args.source, links_path)
         else:
             print(
                 f"check_traceability: --write-links skipped — --gate {args.gate} did not pass "

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -37,6 +37,7 @@ import argparse
 import json
 import sys
 from dataclasses import asdict, dataclass, field
+from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -48,9 +49,26 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # the git-native manifest helper behind --changed-since (#160). walk_source_files
 # prunes submodules/nested git checkouts from the FULL scan so both scan modes
 # agree on the file universe (the manifest never surfaces submodule blobs).
-from chief_wiggum.hashing import scanner_version  # noqa: E402
+from chief_wiggum.hashing import hash_epic_definitions, scanner_version  # noqa: E402
 from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
 from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE  # noqa: E402
+
+# Suspect-link propagation (#169): a link is SUSPECT when the ID it was
+# verified against has a definition hash that no longer matches the hash
+# recorded in docs/quality/trace-links.json at the time the link last passed
+# a gate. JUSTIFIED waivers (docs/epics/<slug>/justifications/*.json) let an
+# uncovered/untested contract satisfy coverage with a committed, ticket-backed
+# reason instead of a false "guards"/"verifies" annotation. See
+# chief_wiggum.trace_links and docs/traceability.md.
+from chief_wiggum.trace_links import (  # noqa: E402
+    SIDECAR_RELPATH,
+    build_sidecar,
+    find_suspect_links,
+    is_justification_path,
+    load_justifications,
+    load_sidecar,
+    write_sidecar,
+)
 
 DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "templates" / "formal-models" / "tim-schema.json"
 
@@ -86,6 +104,20 @@ class TraceReport:
     untested_contracts: list[str] = field(default_factory=list)
     dangling: list[dict] = field(default_factory=list)
     invalid_links: list[dict] = field(default_factory=list)
+    # Suspect propagation (#169): links recorded in docs/quality/trace-links.json
+    # whose target's definition hash has since changed. Report-only — does NOT
+    # affect soundness_ok/coverage_ok (see docs/gate-rollout.md). Distinct from
+    # dangling (target gone) and uncovered/untested (no link at all): here a
+    # link DOES exist, its claim is just stale.
+    suspect_links: list[dict] = field(default_factory=list)
+    suspect_contracts: list[str] = field(default_factory=list)
+    # JUSTIFIED waivers (#169): an uncovered/untested contract with a valid,
+    # non-expired, ticket-backed justification record is moved out of
+    # uncovered_contracts/untested_contracts and reported here instead — a
+    # third status, neither a clean pass nor a silent gap.
+    justified_contracts: list[dict] = field(default_factory=list)
+    expired_justifications: list[dict] = field(default_factory=list)
+    invalid_justifications: list[dict] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
     @property
@@ -97,6 +129,10 @@ class TraceReport:
             "untested_contracts": len(self.untested_contracts),
             "dangling": len(self.dangling),
             "invalid_links": len(self.invalid_links),
+            "suspect_links": len(self.suspect_links),
+            "justified_contracts": len(self.justified_contracts),
+            "expired_justifications": len(self.expired_justifications),
+            "invalid_justifications": len(self.invalid_justifications),
         }
 
     @property
@@ -118,6 +154,11 @@ class TraceReport:
             "untested_contracts": self.untested_contracts,
             "dangling": self.dangling,
             "invalid_links": self.invalid_links,
+            "suspect_links": self.suspect_links,
+            "suspect_contracts": self.suspect_contracts,
+            "justified_contracts": self.justified_contracts,
+            "expired_justifications": self.expired_justifications,
+            "invalid_justifications": self.invalid_justifications,
             "warnings": self.warnings,
         }
 
@@ -153,13 +194,20 @@ def parse_annotations(text: str) -> list[tuple[str, list[str]]]:
 
 
 def extract_defined_ids(epic_dir: str | Path) -> dict[str, str]:
-    """Collect IDs *declared* in the epic's prose + model artifacts."""
+    """Collect IDs *declared* in the epic's prose + model artifacts.
+
+    The ``justifications/`` subtree (waiver records, #169) is excluded: a
+    waiver's own ``"id"`` field names the CTR/INV it waives and must never be
+    misread as a new stable-ID declaration.
+    """
     root = Path(epic_dir)
     defined: dict[str, str] = {}
     if not root.exists():
         return defined
     for path in sorted(root.rglob("*")):
         if path.suffix not in (".md", ".json") or not path.is_file():
+            continue
+        if is_justification_path(root, path):
             continue
         try:
             text = path.read_text()
@@ -169,6 +217,44 @@ def extract_defined_ids(epic_dir: str | Path) -> dict[str, str]:
             node_id = canonical_id(m.group(1))
             defined[node_id] = kind_of(node_id)
     return defined
+
+
+def _collect_coverage_requirements(node, out: dict[str, list[str]]) -> None:
+    if isinstance(node, dict):
+        cid = node.get("id")
+        reqs = node.get("coverage_requires")
+        if isinstance(cid, str) and ID_RE.fullmatch(cid) and isinstance(reqs, list) and reqs:
+            out[canonical_id(cid)] = [str(r) for r in reqs]
+        for v in node.values():
+            _collect_coverage_requirements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _collect_coverage_requirements(v, out)
+
+
+def extract_coverage_requirements(epic_dir: str | Path) -> dict[str, list[str]]:
+    """Per-contract coverage-requirement alternatives (LOBSTER pattern, #169).
+
+    A JSON model entry may declare ``"coverage_requires": ["unit-test", "probe"]``
+    alongside its ``"id"``: the contract is tested only by a ``verifies``
+    annotation whose ``source_kind`` is ONE of the listed alternatives (an "A
+    OR B" requirement), instead of the default "any verifying kind counts".
+    Absent for a given ID, behavior is unchanged. Degrades gracefully on a
+    missing epic dir or unparsable JSON (skipped, not raised).
+    """
+    root = Path(epic_dir)
+    out: dict[str, list[str]] = {}
+    if not root.exists():
+        return out
+    for path in sorted(root.rglob("*.json")):
+        if is_justification_path(root, path):
+            continue
+        try:
+            doc = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        _collect_coverage_requirements(doc, out)
+    return out
 
 
 def emit_epic_annotations(rel: str, text: str) -> list[Annotation]:
@@ -216,6 +302,8 @@ def scan_epic_annotations(epic_dir: str | Path) -> list[Annotation]:
         return annotations
     for path in sorted(root.rglob("*")):
         if path.suffix not in (".md", ".json") or not path.is_file():
+            continue
+        if is_justification_path(root, path):
             continue
         try:
             text = path.read_text()
@@ -321,13 +409,21 @@ def build_report(
     defined: dict[str, str],
     annotations: list[Annotation],
     schema: dict,
+    *,
+    coverage_requirements: dict[str, list[str]] | None = None,
 ) -> TraceReport:
+    """Build the trace report. ``coverage_requirements`` (#169, optional) maps a
+    contract ID to a list of ``source_kind`` alternatives (e.g.
+    ``["test", "probe"]``) — when present, a contract is tested only by a
+    ``verifies`` link whose kind is one of those alternatives ("A OR B");
+    absent, any verifying kind counts (unchanged prior behavior)."""
     report = TraceReport(defined=dict(defined))
     link_types = schema.get("link_types", {})
+    coverage_requirements = coverage_requirements or {}
 
     realized: set[str] = set()      # BR ids with an incoming realizes
     guarded: set[str] = set()       # CTR/INV with guards/ensures (code)
-    verified: set[str] = set()      # CTR/INV with verifies (test)
+    verified_kinds: dict[str, set[str]] = {}  # CTR/INV -> set of verifying source_kinds
 
     for ann in annotations:
         # Dangling: references an ID that isn't defined.
@@ -361,14 +457,21 @@ def build_report(
         elif ann.verb in ("guards", "ensures"):
             guarded.add(ann.target)
         elif ann.verb == "verifies":
-            verified.add(ann.target)
+            verified_kinds.setdefault(ann.target, set()).add(ann.source_kind)
 
     contracts = [i for i, k in defined.items() if k in ("CTR", "INV")]
     business_rules = [i for i, k in defined.items() if k == "BR"]
 
+    def _tested(cid: str) -> bool:
+        kinds = verified_kinds.get(cid, set())
+        required = coverage_requirements.get(cid)
+        if required:
+            return bool(kinds & set(required))
+        return bool(kinds)
+
     report.orphan_business_rules = sorted(b for b in business_rules if b not in realized)
     report.uncovered_contracts = sorted(c for c in contracts if c not in guarded)
-    report.untested_contracts = sorted(c for c in contracts if c not in verified)
+    report.untested_contracts = sorted(c for c in contracts if not _tested(c))
 
     if not annotations:
         report.warnings.append("no @cw-trace annotations found; reporting coverage as absent")
@@ -377,15 +480,67 @@ def build_report(
     return report
 
 
+def apply_justifications(
+    report: TraceReport,
+    justifications: dict,
+    invalid: list[dict],
+    *,
+    today: date | None = None,
+) -> None:
+    """Apply JUSTIFIED waivers (#169) to an already-built ``report``, in place.
+
+    A valid (ticket-backed, non-expired) justification for a currently
+    uncovered/untested contract moves it OUT of those lists and into
+    ``justified_contracts`` — satisfying coverage without a fake guard/verify
+    annotation. An expired justification is reported but does NOT satisfy
+    coverage. A justification referencing an ID that isn't even defined, or
+    that had no gap to waive in the first place, is not silently accepted.
+    """
+    today = today or date.today()
+    report.invalid_justifications = list(invalid)
+    justified: list[dict] = []
+    expired: list[dict] = []
+    for cid in sorted(justifications):
+        j = justifications[cid]
+        if cid not in report.defined:
+            report.invalid_justifications.append(
+                {"source": j.source, "reason": f"references undefined id {cid}"}
+            )
+            continue
+        if j.is_expired(today):
+            expired.append(j.to_dict())
+            continue
+        moved = False
+        if cid in report.uncovered_contracts:
+            report.uncovered_contracts.remove(cid)
+            moved = True
+        if cid in report.untested_contracts:
+            report.untested_contracts.remove(cid)
+            moved = True
+        if moved:
+            justified.append(j.to_dict())
+    report.justified_contracts = justified
+    report.expired_justifications = expired
+
+
 def check(
     epic_dir: str | Path,
     source_root: str | Path | None = None,
     *,
     schema: dict | None = None,
     changed_since: str | None = None,
+    links_path: str | Path | None = None,
+    today: date | None = None,
 ) -> TraceReport:
+    """Build the trace report. ``links_path`` (#169, optional), when given, is
+    the ``docs/quality/trace-links.json`` sidecar to compare current contract
+    definition hashes against for suspect-link detection — omitted, no sidecar
+    is read and ``suspect_links`` stays empty (nothing to compare against yet,
+    e.g. the very first validation). ``today`` (optional) overrides the clock
+    used for justification-expiry checks; defaults to the real today."""
     schema = schema or load_schema()
     defined = extract_defined_ids(epic_dir)
+    coverage_requirements = extract_coverage_requirements(epic_dir)
     # Contract->BR realizes links live in the epic docs; code/test links in source.
     annotations = scan_epic_annotations(epic_dir)
     if source_root:
@@ -395,7 +550,42 @@ def check(
             # gate, which must see the whole repo to be authoritative.
             only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
         annotations += scan_source(source_root, only_files=only_files)
-    return build_report(defined, annotations, schema)
+    report = build_report(defined, annotations, schema, coverage_requirements=coverage_requirements)
+
+    if links_path is not None:
+        current_hashes = hash_epic_definitions(Path(epic_dir))
+        sidecar = load_sidecar(links_path)
+        report.suspect_links = find_suspect_links(sidecar, current_hashes)
+        report.suspect_contracts = sorted({link["target"] for link in report.suspect_links})
+
+    justifications, invalid_justifications = load_justifications(epic_dir)
+    apply_justifications(report, justifications, invalid_justifications, today=today)
+    return report
+
+
+def write_links_sidecar(
+    epic_dir: str | Path,
+    source_root: str | Path | None,
+    path: str | Path,
+    *,
+    changed_since: str | None = None,
+) -> dict:
+    """Write the ``docs/quality/trace-links.json`` sidecar (#169) from the
+    CURRENT scan: every ``@cw-trace`` link's definition hash, at the moment
+    this is called. Not hand-maintained — called by ``/architect``/
+    ``/close-epic`` only once their respective gate has passed (see ``main``'s
+    ``--write-links``), so a stale/failing state never gets recorded as
+    validated."""
+    annotations = scan_epic_annotations(epic_dir)
+    if source_root:
+        only_files = None
+        if changed_since:
+            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
+        annotations += scan_source(source_root, only_files=only_files)
+    current_hashes = hash_epic_definitions(Path(epic_dir))
+    body = build_sidecar(annotations, current_hashes, scanner_version=_scanner_version())
+    write_sidecar(path, body)
+    return body
 
 
 def render_markdown(report: TraceReport) -> str:
@@ -415,6 +605,29 @@ def render_markdown(report: TraceReport) -> str:
     if report.invalid_links:
         lines += ["", "## Invalid links", ""]
         lines += [f"- {d['file']}:{d['line']} {d['reason']}" for d in report.invalid_links]
+    if report.suspect_links:
+        lines += ["", "## Suspect links (definition changed since verified)", ""]
+        lines += [
+            f"- {d['file']}:{d['line']} {d['verb']} {d['target']} "
+            f"(definition hash changed since this link was validated)"
+            for d in report.suspect_links
+        ]
+    if report.justified_contracts:
+        lines += ["", "## Justified (waived, ticket-tracked)", ""]
+        lines += [
+            f"- {j['id']} — {j['reason']} (ticket {j['ticket']}, approver {j['approver']}, "
+            f"expires {j['expiry']})"
+            for j in report.justified_contracts
+        ]
+    if report.expired_justifications:
+        lines += ["", "## Expired justifications (no longer satisfy coverage)", ""]
+        lines += [
+            f"- {j['id']} — expired {j['expiry']} (ticket {j['ticket']})"
+            for j in report.expired_justifications
+        ]
+    if report.invalid_justifications:
+        lines += ["", "## Invalid justifications", ""]
+        lines += [f"- {d['source']}: {d['reason']}" for d in report.invalid_justifications]
     if report.warnings:
         lines += ["", "## Warnings", ""] + [f"- {w}" for w in report.warnings]
     return "\n".join(lines) + "\n"
@@ -442,6 +655,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Print the hash-derived scanner version (source hash of this module + its "
         "chief_wiggum deps) and exit",
     )
+    parser.add_argument(
+        "--links",
+        metavar="PATH",
+        help="Path to the trace-links.json sidecar (#169) used for suspect-link detection. "
+        f"Defaults to <--source or cwd>/{SIDECAR_RELPATH}.",
+    )
+    parser.add_argument(
+        "--write-links",
+        action="store_true",
+        help="(Re)write the trace-links.json sidecar from this scan's current link/definition "
+        "hashes — but ONLY when the requested --gate passes (or no --gate was given). A failing "
+        "gate leaves the sidecar untouched, so a stale/broken state is never recorded as "
+        "validated. Not hand-maintained; see docs/traceability.md.",
+    )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
 
@@ -464,8 +691,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: epic dir not found: {args.epic_dir}", file=sys.stderr)
         return 2
 
+    links_path = Path(args.links) if args.links else Path(args.source or ".") / SIDECAR_RELPATH
+
     try:
-        report = check(args.epic_dir, args.source, schema=schema, changed_since=args.changed_since)
+        report = check(
+            args.epic_dir, args.source, schema=schema, changed_since=args.changed_since,
+            links_path=links_path,
+        )
     except ManifestError as exc:
         # Bad --changed-since ref, non-git --source, missing HEAD, no git binary:
         # a usage error, reported concisely — never a traceback.
@@ -476,6 +708,21 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report.to_dict(), indent=2))
     else:
         print(render_markdown(report))
+
+    if args.write_links:
+        gate_passed = (
+            args.gate is None
+            or (args.gate == "soundness" and report.soundness_ok)
+            or (args.gate == "coverage" and report.coverage_ok)
+        )
+        if gate_passed:
+            write_links_sidecar(args.epic_dir, args.source, links_path, changed_since=args.changed_since)
+        else:
+            print(
+                f"check_traceability: --write-links skipped — --gate {args.gate} did not pass "
+                "(sidecar left untouched)",
+                file=sys.stderr,
+            )
 
     try:  # factory telemetry; no-op unless enabled, never breaks the gate
         import os

--- a/scripts/chief_wiggum/hashing.py
+++ b/scripts/chief_wiggum/hashing.py
@@ -8,12 +8,24 @@ own source plus its ``chief_wiggum`` dependencies, so a forgotten manual bump
 (the previous failure mode — a hand-edited constant nobody remembers to touch)
 is structurally impossible. Any edit to the scanner or a dependency changes the
 version automatically.
+
+``hash_epic_definitions`` (#169) is the per-ID **contract-block hashing**
+``ratchet.py`` uses to detect weakened/removed contracts, relocated here so
+``check_traceability.py`` can reuse the exact same hashes for its suspect-link
+propagation (a link is SUSPECT when the ID it was verified against has a
+definition hash that no longer matches what was recorded at verification
+time) — one hashing implementation, not a parallel copy that could drift.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
+
+from chief_wiggum.trace_ids import ID_RE
+from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE
+from chief_wiggum.trace_links import is_justification_path
 
 
 def stable_hash(*parts: str) -> str:
@@ -34,3 +46,68 @@ def scanner_version(*module_paths: str | Path) -> str:
     scanner OR a dependency) changes it."""
     texts = [Path(p).read_text() for p in module_paths]
     return stable_hash(*texts)
+
+
+def hash_markdown_defs(text: str) -> dict[str, list[str]]:
+    """Map each stable ID declared in markdown ``text`` to the hash of its block.
+
+    A block runs from the declaring line to the next line that declares another
+    ID (or EOF), whitespace-normalized — so reformatting doesn't read as
+    weakening, but any wording change to the REQUIRES/ENSURES does.
+    """
+    lines = text.splitlines()
+    decls: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        m = DEFINE_RE.search(line)
+        if m:
+            decls.append((i, m.group(1)))
+    out: dict[str, list[str]] = {}
+    for idx, (start, cid) in enumerate(decls):
+        end = decls[idx + 1][0] if idx + 1 < len(decls) else len(lines)
+        block = "\n".join(ln.rstrip() for ln in lines[start:end]).strip()
+        out.setdefault(cid, []).append(stable_hash(block))
+    return out
+
+
+def walk_json_ids(node, out: dict[str, list[str]]) -> None:
+    """Recursively hash every JSON object carrying a stable-ID ``id`` field."""
+    if isinstance(node, dict):
+        cid = node.get("id")
+        if isinstance(cid, str) and ID_RE.fullmatch(cid):
+            out.setdefault(cid, []).append(
+                stable_hash(json.dumps(node, sort_keys=True))
+            )
+        for v in node.values():
+            walk_json_ids(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            walk_json_ids(v, out)
+
+
+def hash_epic_definitions(root: str | Path) -> dict[str, str]:
+    """Map stable ID -> definition hash across every ``.md``/``.json`` file under
+    ``root`` (an epic docs root, or a single epic directory).
+
+    An ID declared in several places hashes as the sorted combination, so the
+    result is deterministic and any one declaration changing is visible. A
+    missing ``root`` degrades gracefully to an empty map. The ``justifications/``
+    subtree (waiver records, #169) is excluded — a waiver's own ``"id"`` field
+    names the CTR/INV it waives and must never be misread as a NEW declaration.
+    """
+    root = Path(root)
+    collected: dict[str, list[str]] = {}
+    if root.is_dir():
+        for f in sorted(root.rglob("*.md")):
+            if is_justification_path(root, f):
+                continue
+            for cid, hashes in hash_markdown_defs(f.read_text(errors="replace")).items():
+                collected.setdefault(cid, []).extend(hashes)
+        for f in sorted(root.rglob("*.json")):
+            if is_justification_path(root, f):
+                continue
+            try:
+                doc = json.loads(f.read_text(errors="replace"))
+            except json.JSONDecodeError:
+                continue
+            walk_json_ids(doc, collected)
+    return {cid: stable_hash(*sorted(hs)) for cid, hs in collected.items()}

--- a/scripts/chief_wiggum/hashing.py
+++ b/scripts/chief_wiggum/hashing.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 from pathlib import Path
 
-from chief_wiggum.trace_ids import ID_RE
+from chief_wiggum.trace_ids import ID_RE, canonical_id
 from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE
 from chief_wiggum.trace_links import is_justification_path
 
@@ -54,6 +54,13 @@ def hash_markdown_defs(text: str) -> dict[str, list[str]]:
     A block runs from the declaring line to the next line that declares another
     ID (or EOF), whitespace-normalized — so reformatting doesn't read as
     weakening, but any wording change to the REQUIRES/ENSURES does.
+
+    Keys are in **canonical form** (``canonical_id``: uppercase kind, lowercase
+    slug) so they join cleanly against the traceability scanner's canonicalized
+    annotation targets — a raw-cased key (e.g. ``CTR-BIL-001``) on one side of
+    that join silently records no sidecar link and can never go suspect
+    (PR #181 review). The hash VALUES are unaffected: they cover the block
+    text, not the key.
     """
     lines = text.splitlines()
     decls: list[tuple[int, str]] = []
@@ -65,16 +72,19 @@ def hash_markdown_defs(text: str) -> dict[str, list[str]]:
     for idx, (start, cid) in enumerate(decls):
         end = decls[idx + 1][0] if idx + 1 < len(decls) else len(lines)
         block = "\n".join(ln.rstrip() for ln in lines[start:end]).strip()
-        out.setdefault(cid, []).append(stable_hash(block))
+        out.setdefault(canonical_id(cid), []).append(stable_hash(block))
     return out
 
 
 def walk_json_ids(node, out: dict[str, list[str]]) -> None:
-    """Recursively hash every JSON object carrying a stable-ID ``id`` field."""
+    """Recursively hash every JSON object carrying a stable-ID ``id`` field.
+
+    Keys are canonicalized (see ``hash_markdown_defs``); hash values cover the
+    node's JSON content and are unaffected."""
     if isinstance(node, dict):
         cid = node.get("id")
         if isinstance(cid, str) and ID_RE.fullmatch(cid):
-            out.setdefault(cid, []).append(
+            out.setdefault(canonical_id(cid), []).append(
                 stable_hash(json.dumps(node, sort_keys=True))
             )
         for v in node.values():

--- a/scripts/chief_wiggum/trace_ids.py
+++ b/scripts/chief_wiggum/trace_ids.py
@@ -54,3 +54,19 @@ TRACE_RE = re.compile(
     rf"(?P<ids>(?:{ID_BODY}(?![A-Za-z0-9-])[\s,]*)+)",
     re.IGNORECASE,
 )
+
+
+def canonical_id(node_id: str) -> str:
+    """Canonical form: uppercase kind prefix, lowercase remainder.
+
+    IDs are matched case-insensitively (CTR-order-001 == CTR-ORDER-001); this
+    keeps the familiar display shape while making links immune to case drift
+    between epic docs and code annotations. EVERY consumer that keys a map by
+    a stable ID (the traceability scanner's annotations, the definition-hash
+    maps in ``chief_wiggum.hashing``, the ratchet's contract-hash
+    comparisons) must key by THIS form — a raw-cased key on one side of a
+    join silently drops the match (PR #181 review: an uppercase-slug ID like
+    ``CTR-BIL-001`` recorded no sidecar link and could never go suspect).
+    """
+    kind, _, rest = node_id.partition("-")
+    return f"{kind.upper()}-{rest.lower()}"

--- a/scripts/chief_wiggum/trace_links.py
+++ b/scripts/chief_wiggum/trace_links.py
@@ -30,9 +30,12 @@ single-repo trace graph (``check_traceability.py`` / ``docs/traceability.md``):
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict, dataclass
 from datetime import date
 from pathlib import Path
+
+from chief_wiggum.trace_ids import canonical_id
 
 # Sidecar location, relative to the target repo root (alongside the ratchet's
 # own docs/quality/ state — see docs/ratchet.md).
@@ -135,6 +138,29 @@ def find_suspect_links(sidecar: dict, current_hashes: dict) -> list[dict]:
 
 _REQUIRED_JUSTIFICATION_FIELDS = ("id", "reason", "approver", "expiry", "ticket")
 
+# A ticket ref must actually POINT at a ticket (PR #181 review: truthiness-only
+# validation let placeholders like "  ", "none", "N/A" satisfy the
+# ticket-every-deferral requirement). Accepted forms:
+#   #123                    same-repo issue/PR number
+#   owner/repo#123          cross-repo GitHub-style ref
+#   http(s)://.../...       issue URL
+#   PROJ-123                JIRA-style key
+_TICKET_REF_RE = re.compile(
+    r"^(?:"
+    r"#\d+"
+    r"|[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*#\d+"
+    r"|https?://\S+"
+    r"|[A-Z][A-Z0-9]+-\d+"
+    r")$"
+)
+
+_TICKET_FORMS = "#123, owner/repo#123, an http(s) issue URL, or a JIRA-style KEY-123"
+
+
+def valid_ticket_ref(ticket: str) -> bool:
+    """True if ``ticket`` (stripped) matches one of the accepted ref forms."""
+    return bool(_TICKET_REF_RE.match(ticket.strip()))
+
 
 @dataclass
 class Justification:
@@ -160,8 +186,11 @@ def load_justifications(epic_dir: str | Path) -> tuple[dict[str, Justification],
 
     Missing directory degrades gracefully (no waivers declared). A malformed
     record (not an object, missing a required field, or — per the
-    ticket-every-deferral doctrine — missing its ``ticket`` ref) is reported as
-    invalid, never silently treated as a valid waiver.
+    ticket-every-deferral doctrine — missing OR placeholder ``ticket`` ref:
+    a ref must match one of the accepted forms, so ``"none"``/``"N/A"``/
+    whitespace never satisfy it) is reported as invalid, never silently
+    treated as a valid waiver. Waiver IDs are canonicalized so they join
+    against the report's canonical defined/uncovered/untested sets.
     """
     root = Path(epic_dir) / "justifications"
     justifications: dict[str, Justification] = {}
@@ -184,13 +213,20 @@ def load_justifications(epic_dir: str | Path) -> tuple[dict[str, Justification],
                 "reason": f"missing field(s): {', '.join(missing)}",
             })
             continue
-        jid = str(data["id"])
+        ticket = str(data["ticket"]).strip()
+        if not valid_ticket_ref(ticket):
+            invalid.append({
+                "source": str(path),
+                "reason": f"invalid ticket ref {str(data['ticket'])!r} — expected {_TICKET_FORMS}",
+            })
+            continue
+        jid = canonical_id(str(data["id"]))
         justifications[jid] = Justification(
             id=jid,
             reason=str(data["reason"]),
             approver=str(data["approver"]),
             expiry=str(data["expiry"]),
-            ticket=str(data["ticket"]),
+            ticket=ticket,
             source=str(path),
         )
     return justifications, invalid

--- a/scripts/chief_wiggum/trace_links.py
+++ b/scripts/chief_wiggum/trace_links.py
@@ -1,0 +1,196 @@
+"""Suspect-link propagation sidecar + JUSTIFIED waiver records (#169).
+
+Two cheap, high-value steals from safety-engineering tooling into the existing
+single-repo trace graph (``check_traceability.py`` / ``docs/traceability.md``):
+
+1. **Suspect propagation** (doorstop pattern). Every ``@cw-trace`` link records
+   the definition hash of the ID it was verified against, captured at the time
+   the link last passed review/gates — the exact contract-block hash
+   ``ratchet.py`` already computes to detect weakening
+   (``chief_wiggum.hashing.hash_epic_definitions``). Link-hash records live in
+   a generated sidecar, ``docs/quality/trace-links.json``, written by
+   ``check_traceability.py`` when its gate passes (never hand-maintained).
+   When a contract/invariant definition changes, every link recorded against
+   the OLD hash is SUSPECT: "code claims to guard CTR-X but CTR-X changed
+   since that claim was validated" — reported distinctly from dangling (the
+   target still exists, it just changed) or uncovered (a link DOES exist, it's
+   just stale). Suspect is report-only initially (see docs/gate-rollout.md).
+
+2. **JUSTIFIED waivers** (LOBSTER pattern). An uncovered/untested contract may
+   carry a committed justification record — ``reason``, ``approver``,
+   ``expiry``, and a required ``ticket`` ref (ticket-every-deferral: a
+   justification without one is invalid, not silently accepted) — rendering
+   as JUSTIFIED (distinct from both OK and a gap) and satisfying coverage
+   without lying about it. Records live under
+   ``docs/epics/<slug>/justifications/*.json``, one file per waiver, diffable.
+   Mirrors ``check_infra_writer.py``'s ``Exemption`` / ``check_budget_tree.py``'s
+   ``evidence: justified`` — same idiom, applied to the trace graph.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import date
+from pathlib import Path
+
+# Sidecar location, relative to the target repo root (alongside the ratchet's
+# own docs/quality/ state — see docs/ratchet.md).
+SIDECAR_RELPATH = "docs/quality/trace-links.json"
+
+# Justification records live under this subdirectory of an epic dir. It MUST
+# be excluded from every epic-doc ID/hash scanner (extract_defined_ids,
+# hash_epic_definitions, extract_coverage_requirements, scan_epic_annotations):
+# a waiver record's own "id" field (the CTR/INV it waives) would otherwise be
+# misread as a NEW stable-ID *declaration*, phantom-defining IDs that were
+# never actually declared in the epic's contracts/invariants.
+JUSTIFICATIONS_DIRNAME = "justifications"
+
+
+def is_justification_path(root: str | Path, path: str | Path) -> bool:
+    """True if ``path`` (under epic dir ``root``) lives inside the
+    justifications/ subtree and must be excluded from epic-doc ID scanning."""
+    try:
+        rel_parts = Path(path).resolve().relative_to(Path(root).resolve()).parts
+    except ValueError:
+        rel_parts = Path(path).parts
+    return JUSTIFICATIONS_DIRNAME in rel_parts
+
+
+# ---- link-hash sidecar ---------------------------------------------------------
+
+
+def _link_sort_key(link: dict) -> tuple:
+    return (link.get("file", ""), link.get("line", 0), link.get("verb", ""), link.get("target", ""))
+
+
+def build_sidecar(annotations, definition_hashes: dict, *, scanner_version: str | None = None) -> dict:
+    """Build the trace-links.json sidecar body from the CURRENT scan.
+
+    One record per annotation whose target has a known definition hash — an
+    annotation targeting an undefined ID (dangling) has no hash to record and
+    is excluded; it stays dangling's problem, not suspect's. Deterministically
+    ordered so the sidecar diffs cleanly when committed.
+    """
+    links = []
+    for ann in annotations:
+        h = definition_hashes.get(ann.target)
+        if h is None:
+            continue
+        links.append({
+            "verb": ann.verb,
+            "target": ann.target,
+            "file": ann.file,
+            "line": ann.line,
+            "source_kind": ann.source_kind,
+            "definition_hash": h,
+        })
+    links.sort(key=_link_sort_key)
+    return {"scanner_version": scanner_version, "links": links}
+
+
+def load_sidecar(path: str | Path) -> dict:
+    """Load a previously-written sidecar. Missing/malformed degrades to empty —
+    the first validation run simply has nothing to compare against yet."""
+    p = Path(path)
+    if not p.is_file():
+        return {"links": []}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"links": []}
+    if not isinstance(data, dict) or not isinstance(data.get("links"), list):
+        return {"links": []}
+    return data
+
+
+def write_sidecar(path: str | Path, body: dict) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+
+
+def find_suspect_links(sidecar: dict, current_hashes: dict) -> list[dict]:
+    """Links recorded in ``sidecar`` whose target's CURRENT definition hash no
+    longer matches the hash recorded when the link was last validated.
+
+    A target that has disappeared entirely (no longer defined at all) is NOT
+    suspect here — that's dangling's job. Suspect means "the definition
+    changed", not "the definition is gone".
+    """
+    out = []
+    for rec in sidecar.get("links", []):
+        target = rec.get("target")
+        recorded_hash = rec.get("definition_hash")
+        current_hash = current_hashes.get(target)
+        if current_hash is None:
+            continue
+        if current_hash != recorded_hash:
+            out.append({**rec, "current_hash": current_hash})
+    return sorted(out, key=_link_sort_key)
+
+
+# ---- JUSTIFIED waivers ----------------------------------------------------------
+
+
+_REQUIRED_JUSTIFICATION_FIELDS = ("id", "reason", "approver", "expiry", "ticket")
+
+
+@dataclass
+class Justification:
+    id: str
+    reason: str
+    approver: str
+    expiry: str  # ISO date (YYYY-MM-DD)
+    ticket: str  # required — a justification without a ticket ref is invalid
+    source: str  # file path, for reporting
+
+    def is_expired(self, today: date) -> bool:
+        try:
+            return date.fromisoformat(self.expiry) < today
+        except ValueError:
+            return True  # unparseable expiry treated as expired, not a silent pass
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def load_justifications(epic_dir: str | Path) -> tuple[dict[str, Justification], list[dict]]:
+    """Load committed waiver records from ``<epic_dir>/justifications/*.json``.
+
+    Missing directory degrades gracefully (no waivers declared). A malformed
+    record (not an object, missing a required field, or — per the
+    ticket-every-deferral doctrine — missing its ``ticket`` ref) is reported as
+    invalid, never silently treated as a valid waiver.
+    """
+    root = Path(epic_dir) / "justifications"
+    justifications: dict[str, Justification] = {}
+    invalid: list[dict] = []
+    if not root.is_dir():
+        return justifications, invalid
+    for path in sorted(root.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            invalid.append({"source": str(path), "reason": f"cannot parse justification: {exc}"})
+            continue
+        if not isinstance(data, dict):
+            invalid.append({"source": str(path), "reason": "justification must be a JSON object"})
+            continue
+        missing = [k for k in _REQUIRED_JUSTIFICATION_FIELDS if not data.get(k)]
+        if missing:
+            invalid.append({
+                "source": str(path),
+                "reason": f"missing field(s): {', '.join(missing)}",
+            })
+            continue
+        jid = str(data["id"])
+        justifications[jid] = Justification(
+            id=jid,
+            reason=str(data["reason"]),
+            approver=str(data["approver"]),
+            expiry=str(data["expiry"]),
+            ticket=str(data["ticket"]),
+            source=str(path),
+        )
+    return justifications, invalid

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -85,7 +85,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from chief_wiggum.hashing import hash_epic_definitions, stable_hash  # noqa: E402,F401
 from chief_wiggum.hashing import hash_markdown_defs as _hash_markdown_defs  # noqa: E402,F401
 from chief_wiggum.hashing import walk_json_ids as _walk_json_ids  # noqa: E402,F401
-from chief_wiggum.trace_ids import ID_RE  # noqa: E402,F401
+from chief_wiggum.trace_ids import ID_RE, canonical_id  # noqa: E402,F401
 from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE  # noqa: E402,F401
 from chief_wiggum.trace_links import SIDECAR_RELPATH, find_suspect_links, load_sidecar  # noqa: E402
 
@@ -432,7 +432,14 @@ def load_journal(cfg: Config) -> list[dict]:
 def derive_highwater(records: list[dict]) -> dict:
     """High-water = union of every case passing in a MERGED record, plus the
     definition hash each contract had when it first entered. Amendments and
-    retirements are deliberate, journaled human acts that move the baseline."""
+    retirements are deliberate, journaled human acts that move the baseline.
+
+    Contract-hash keys are canonicalized on read: journals written before
+    ``hash_epic_definitions`` keyed by canonical form (PR #181 review) may
+    carry raw-cased IDs (``CTR-BIL-001``), and without canonicalization here
+    every such contract would falsely read as *removed* against a new
+    canonical scorecard. The hash VALUES cover block content only, so they
+    compare identically across the change."""
     pass_set: set[str] = set()
     contract_hashes: dict[str, str] = {}
     for rec in records:
@@ -440,11 +447,11 @@ def derive_highwater(records: list[dict]) -> dict:
             sc = rec.get("scorecard", {}) or {}
             pass_set.update(sc.get("pass_set", []) or [])
             for cid, h in (sc.get("contract_hashes", {}) or {}).items():
-                contract_hashes.setdefault(cid, h)
+                contract_hashes.setdefault(canonical_id(cid), h)
         for cid, h in (rec.get("amended", {}) or {}).items():
-            contract_hashes[cid] = h
+            contract_hashes[canonical_id(cid)] = h
         for cid in rec.get("retired", []) or []:
-            contract_hashes.pop(cid, None)
+            contract_hashes.pop(canonical_id(cid), None)
     return {
         "pass_set": sorted(pass_set),
         "contract_hashes": contract_hashes,
@@ -454,7 +461,10 @@ def derive_highwater(records: list[dict]) -> dict:
 
 def violations(scorecard: dict, highwater: dict) -> dict:
     cur_pass = set(scorecard.get("pass_set", []))
-    cur_defs = scorecard.get("contract_hashes", {})
+    # Canonicalize both sides of the join (see derive_highwater) so a scorecard
+    # written by an older version cannot make canonical high-water keys look
+    # removed, and vice versa.
+    cur_defs = {canonical_id(c): h for c, h in (scorecard.get("contract_hashes", {}) or {}).items()}
     missing = sorted(set(highwater["pass_set"]) - cur_pass)
     weakened, removed = [], []
     for cid, h in sorted(highwater["contract_hashes"].items()):
@@ -648,6 +658,7 @@ def cmd_record(args) -> int:
         status = "held"
     amended = {}
     for cid in args.amend or []:
+        cid = canonical_id(cid)  # match hash_epic_definitions' canonical keys
         if cid not in sc.get("contract_hashes", {}):
             raise RatchetError(f"--amend {cid}: not defined in the current epic docs")
         amended[cid] = sc["contract_hashes"][cid]
@@ -659,7 +670,7 @@ def cmd_record(args) -> int:
         "merged": bool(args.merged),
         "scorecard": sc,
         "amended": amended,
-        "retired": sorted(args.retire or []),
+        "retired": sorted(canonical_id(c) for c in (args.retire or [])),
         "ratchet_status": status,
         "notes": args.notes,
     }

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -73,14 +73,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # Same stable-ID grammar as check_traceability.py and the TIM schema — shared
 # via chief_wiggum.trace_ids so a kind added in one place cannot be silently
 # dropped by another (#166; uppercase-id vacuity was the same class of bug,
-# chief-wiggum#86). Ratchet's DEFINE_RE is the markdown-only form: JSON "id"
-# nodes are hashed structurally by _walk_json_ids.
-# stable_hash's home is chief_wiggum.hashing (#160) — check_single_writer.py and
-# check_traceability.py import the same function for their --scanner-version,
-# so there is exactly one implementation, not a copy per module.
-from chief_wiggum.hashing import stable_hash  # noqa: E402,F401
-from chief_wiggum.trace_ids import ID_RE  # noqa: E402
-from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE
+# chief-wiggum#86). Re-exported here (identity, not a copy) so
+# tests/test_trace_ids.py can keep cross-checking that ratchet, check_traceability,
+# and the TIM schema all agree on the same regex objects.
+# stable_hash/hash_epic_definitions's home is chief_wiggum.hashing (#160, #169) —
+# check_single_writer.py and check_traceability.py import the same functions
+# for --scanner-version and per-link suspect-propagation hashing, so there is
+# exactly one contract-block hashing implementation, not a copy per module.
+# _hash_markdown_defs/_walk_json_ids are kept as thin aliases to that shared
+# home for callers/tests that reach into ratchet's (formerly private) internals.
+from chief_wiggum.hashing import hash_epic_definitions, stable_hash  # noqa: E402,F401
+from chief_wiggum.hashing import hash_markdown_defs as _hash_markdown_defs  # noqa: E402,F401
+from chief_wiggum.hashing import walk_json_ids as _walk_json_ids  # noqa: E402,F401
+from chief_wiggum.trace_ids import ID_RE  # noqa: E402,F401
+from chief_wiggum.trace_ids import MD_DEFINE_RE as DEFINE_RE  # noqa: E402,F401
+from chief_wiggum.trace_links import SIDECAR_RELPATH, find_suspect_links, load_sidecar  # noqa: E402
 
 CONFIG_NAME = "ratchet.json"
 JOURNAL_NAME = "ratchet-journal.jsonl"
@@ -191,58 +198,14 @@ def load_config(repo: Path) -> Config:
 # ---- contract definition hashes (weakening detection) --------------------------
 
 
-def _hash_markdown_defs(text: str) -> dict[str, list[str]]:
-    """Map each stable ID declared in the markdown to the hash of its block.
-
-    A block runs from the declaring line to the next line that declares another
-    ID (or EOF), whitespace-normalized — so reformatting doesn't read as
-    weakening, but any wording change to the REQUIRES/ENSURES does.
-    """
-    lines = text.splitlines()
-    decls: list[tuple[int, str]] = []
-    for i, line in enumerate(lines):
-        m = DEFINE_RE.search(line)
-        if m:
-            decls.append((i, m.group(1)))
-    out: dict[str, list[str]] = {}
-    for idx, (start, cid) in enumerate(decls):
-        end = decls[idx + 1][0] if idx + 1 < len(decls) else len(lines)
-        block = "\n".join(ln.rstrip() for ln in lines[start:end]).strip()
-        out.setdefault(cid, []).append(stable_hash(block))
-    return out
-
-
-def _walk_json_ids(node, out: dict[str, list[str]]) -> None:
-    if isinstance(node, dict):
-        cid = node.get("id")
-        if isinstance(cid, str) and ID_RE.fullmatch(cid):
-            out.setdefault(cid, []).append(
-                stable_hash(json.dumps(node, sort_keys=True))
-            )
-        for v in node.values():
-            _walk_json_ids(v, out)
-    elif isinstance(node, list):
-        for v in node:
-            _walk_json_ids(v, out)
-
-
 def load_contract_hashes(cfg: Config) -> dict[str, str]:
-    """Map stable ID -> definition hash across all epic docs (md + model JSON)."""
-    root = cfg.repo / cfg.epic_docs
-    collected: dict[str, list[str]] = {}
-    if root.is_dir():
-        for f in sorted(root.rglob("*.md")):
-            for cid, hashes in _hash_markdown_defs(f.read_text(errors="replace")).items():
-                collected.setdefault(cid, []).extend(hashes)
-        for f in sorted(root.rglob("*.json")):
-            try:
-                doc = json.loads(f.read_text(errors="replace"))
-            except json.JSONDecodeError:
-                continue
-            _walk_json_ids(doc, collected)
-    # An ID declared in several places hashes as the sorted combination, so the
-    # result is deterministic and any one declaration changing is visible.
-    return {cid: stable_hash(*sorted(hs)) for cid, hs in collected.items()}
+    """Map stable ID -> definition hash across all epic docs (md + model JSON).
+
+    Delegates to ``chief_wiggum.hashing.hash_epic_definitions`` (#169) — the
+    single implementation of contract-block hashing, also reused by
+    ``check_traceability.py`` for per-link suspect propagation.
+    """
+    return hash_epic_definitions(cfg.repo / cfg.epic_docs)
 
 
 # ---- suite parsers (pluggable, per target repo) --------------------------------
@@ -594,6 +557,22 @@ def cmd_score(args) -> int:
     return 0
 
 
+def suspect_links_for(cfg: Config, sc: dict) -> list[dict]:
+    """Suspect links (#169) visible from THIS scorecard's contract hashes.
+
+    Cross-references the ``docs/quality/trace-links.json`` sidecar (written by
+    ``check_traceability.py --write-links`` once its gate passes) against the
+    CURRENT scorecard's ``contract_hashes``: a link recorded against a hash
+    that no longer matches means the contract it claims to guard/verify
+    changed since that claim was last validated. A definition-hash change with
+    surviving suspect links must be VISIBLE here, not silently absorbed into
+    "the ratchet held" — report-only (see docs/gate-rollout.md); it does not
+    change ``check``'s exit code.
+    """
+    sidecar = load_sidecar(cfg.repo / SIDECAR_RELPATH)
+    return find_suspect_links(sidecar, sc.get("contract_hashes", {}) or {})
+
+
 def cmd_check(args) -> int:
     cfg = load_config(repo_root(args.repo))
     hw = derive_highwater(load_journal(cfg))
@@ -606,17 +585,26 @@ def cmd_check(args) -> int:
     qregs = quality_regressions(
         sc.get("quality", {}) or {}, hw.get("quality", {}) or {}, cfg.quality_tolerance
     )
+    susp = suspect_links_for(cfg, sc)
     hard = {k: v[k] for k in ("missing_tests", "weakened_contracts", "removed_contracts")}
     if args.format == "json":
-        print(json.dumps({**hard, "quality_regressions": qregs}, indent=2))
-    elif qregs:
-        tag = "VIOLATED (gated)" if args.gate_quality else "report-only"
-        sys.stderr.write(f"ratchet: complexity/churn regressions [{tag}]:\n")
-        for r in qregs:
+        print(json.dumps({**hard, "quality_regressions": qregs, "suspect_links": susp}, indent=2))
+    else:
+        if qregs:
+            tag = "VIOLATED (gated)" if args.gate_quality else "report-only"
+            sys.stderr.write(f"ratchet: complexity/churn regressions [{tag}]:\n")
+            for r in qregs:
+                sys.stderr.write(
+                    f"  {r['metric']}: {r['current']} > limit {r['limit']} "
+                    f"(best {r['best']}, +{r['delta']})\n"
+                )
+        if susp:
             sys.stderr.write(
-                f"  {r['metric']}: {r['current']} > limit {r['limit']} "
-                f"(best {r['best']}, +{r['delta']})\n"
+                f"ratchet: {len(susp)} suspect link(s) [report-only] — a definition changed "
+                "since the link was last validated (see docs/traceability.md):\n"
             )
+            for s in susp:
+                sys.stderr.write(f"  {s['file']}:{s['line']} {s['verb']} {s['target']}\n")
     if any(hard.values()):
         if args.format != "json":
             sys.stderr.write(
@@ -641,6 +629,7 @@ def cmd_regressed(args) -> int:
     out["quality_regressions"] = quality_regressions(
         sc.get("quality", {}) or {}, hw.get("quality", {}) or {}, cfg.quality_tolerance
     )
+    out["suspect_links"] = suspect_links_for(cfg, sc)
     print(json.dumps(out, indent=2))
     return 0
 

--- a/tests/fixtures/traceability_golden/expected.json.txt
+++ b/tests/fixtures/traceability_golden/expected.json.txt
@@ -11,7 +11,11 @@
     "uncovered_contracts": 1,
     "untested_contracts": 2,
     "dangling": 1,
-    "invalid_links": 1
+    "invalid_links": 1,
+    "suspect_links": 0,
+    "justified_contracts": 0,
+    "expired_justifications": 0,
+    "invalid_justifications": 0
   },
   "soundness_ok": false,
   "coverage_ok": false,
@@ -44,5 +48,10 @@
       "reason": "verifies cannot originate from code"
     }
   ],
+  "suspect_links": [],
+  "suspect_contracts": [],
+  "justified_contracts": [],
+  "expired_justifications": [],
+  "invalid_justifications": [],
   "warnings": []
 }

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -464,6 +464,48 @@ def test_cli_default_links_path_is_under_source_docs_quality(tmp_path):
     assert (src / SIDECAR_RELPATH).is_file()
 
 
+def test_uppercase_slug_id_records_a_link_and_goes_suspect(tmp_path):
+    """Regression (PR #181 review): definition-hash keys and annotation targets
+    must join on the SAME canonical form — an uppercase-slug ID like CTR-BIL-001
+    previously recorded no sidecar link and could never go suspect."""
+    epic = tmp_path / "epic"
+    epic.mkdir()
+    (epic / "contracts.md").write_text(
+        "### CTR-BIL-001 — customer uniqueness\nREQUIRES: one customer per provider\n"
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "billing.py").write_text("# @cw-trace guards CTR-BIL-001\n")
+    links_path = tmp_path / "trace-links.json"
+
+    body = ct.write_links_sidecar(epic, src, links_path)
+    assert len(body["links"]) == 1  # the uppercase-slug link IS recorded
+    assert body["links"][0]["target"] == "CTR-bil-001"
+
+    (epic / "contracts.md").write_text(
+        "### CTR-BIL-001 — customer uniqueness\nREQUIRES: True\n"  # reworded
+    )
+    r = ct.check(epic, src, links_path=links_path)
+    assert r.suspect_contracts == ["CTR-bil-001"]
+
+
+def test_cli_write_links_with_changed_since_is_usage_error(tmp_path, capsys):
+    """--write-links must always be a FULL scan (PR #181 review): rewriting the
+    global sidecar from a --changed-since partial scan would silently drop
+    validated links for unchanged files (false-negative suspects later)."""
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    links_path = tmp_path / "trace-links.json"
+    rc = ct.main([
+        str(epic), "--source", str(src), "--write-links", "--changed-since", "main",
+        "--links", str(links_path),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--write-links" in err and "--changed-since" in err and "FULL scan" in err
+    assert not links_path.exists()  # nothing was written
+
+
 # --- JUSTIFIED waivers (#169) -------------------------------------------------
 
 
@@ -530,6 +572,32 @@ def test_justification_for_undefined_id_is_reported_invalid(tmp_path):
     r = ct.check(epic)
     assert r.justified_contracts == []
     assert any("undefined" in d["reason"] for d in r.invalid_justifications)
+
+
+def test_justification_with_uppercase_slug_id_joins_canonical_contract(tmp_path):
+    """A waiver written with the epic doc's raw casing (CTR-ORDER-002) must join
+    the canonical uncovered/untested sets — same canonicalization rule as
+    annotations and definition hashes (PR #181 review)."""
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic, id="CTR-ORDER-002")
+    r = ct.check(epic)
+    assert r.coverage_ok
+    assert r.justified_contracts[0]["id"] == "CTR-order-002"
+    assert r.invalid_justifications == []
+
+
+def test_justification_with_placeholder_ticket_ref_is_invalid(tmp_path):
+    """Regression (PR #181 review): truthiness-only validation let placeholders
+    like '  ', 'none', 'N/A' satisfy the ticket requirement."""
+    for placeholder in ("  ", "none", "N/A", "TBD"):
+        epic = _epic_with_uncovered_ctr(tmp_path)
+        _write_justification(epic, ticket=placeholder)
+        r = ct.check(epic)
+        assert "CTR-order-002" in r.uncovered_contracts, placeholder
+        assert not r.coverage_ok, placeholder
+        assert r.justified_contracts == [], placeholder
+        assert len(r.invalid_justifications) == 1, placeholder
+        assert "ticket" in r.invalid_justifications[0]["reason"], placeholder
 
 
 def test_justification_for_already_covered_contract_has_no_effect(tmp_path):

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 
 import check_traceability as ct
+from chief_wiggum.hashing import hash_epic_definitions
+from chief_wiggum.trace_links import SIDECAR_RELPATH, build_sidecar, load_sidecar, write_sidecar
 
 SCHEMA = ct.load_schema()
 
@@ -349,3 +352,278 @@ def test_full_scan_skips_nested_git_checkout(tmp_path):
     (sub / "b.py").write_text("# @cw-trace guards CTR-b-001\n")
     anns = ct.scan_source(tmp_path)
     assert {a.target for a in anns} == {"CTR-a-001"}
+
+
+# --- suspect-link propagation (#169) -----------------------------------------
+
+
+def _epic_with_ctr(tmp_path, reworded=False):
+    epic = tmp_path / "epic"
+    epic.mkdir(exist_ok=True)
+    condition = "True" if reworded else "start_date <= end_date"
+    (epic / "contracts.md").write_text(
+        f"### CTR-order-001 — valid date range\nREQUIRES: {condition}\n"
+    )
+    return epic
+
+
+def _src_guarding_ctr(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    (src / "order.py").write_text("# @cw-trace guards CTR-order-001\n")
+    (src / "test_order.py").write_text("# @cw-trace verifies CTR-order-001\n")
+    return src
+
+
+def test_reword_flips_recorded_links_to_suspect_then_revalidation_clears(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    links_path = tmp_path / "docs" / "quality" / "trace-links.json"
+
+    # Initial validation: no prior sidecar -> nothing suspect yet; write it.
+    r0 = ct.check(epic, src, links_path=links_path)
+    assert r0.suspect_links == []
+    ct.write_links_sidecar(epic, src, links_path)
+    assert links_path.is_file()
+
+    # Reword the contract -> its definition hash changes.
+    _epic_with_ctr(tmp_path, reworded=True)
+
+    r1 = ct.check(epic, src, links_path=links_path)
+    assert len(r1.suspect_links) == 2  # the guards link AND the verifies link
+    assert r1.suspect_contracts == ["CTR-order-001"]
+    assert {d["verb"] for d in r1.suspect_links} == {"guards", "verifies"}
+
+    # Re-validation: refresh the sidecar against the reworded contract -> clears.
+    ct.write_links_sidecar(epic, src, links_path)
+    r2 = ct.check(epic, src, links_path=links_path)
+    assert r2.suspect_links == []
+    assert r2.suspect_contracts == []
+
+
+def test_suspect_links_do_not_affect_soundness_or_coverage_ok(tmp_path):
+    """Suspect is report-only initially (docs/gate-rollout.md doctrine)."""
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    links_path = tmp_path / "docs" / "quality" / "trace-links.json"
+    ct.write_links_sidecar(epic, src, links_path)
+    _epic_with_ctr(tmp_path, reworded=True)
+    r = ct.check(epic, src, links_path=links_path)
+    assert r.suspect_links  # something IS suspect
+    assert r.soundness_ok and r.coverage_ok  # but the existing gates are unaffected
+
+
+def test_no_sidecar_means_nothing_is_suspect(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    r = ct.check(epic, src, links_path=tmp_path / "nope" / "trace-links.json")
+    assert r.suspect_links == []
+
+
+def test_write_links_sidecar_records_current_definition_hashes(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    links_path = tmp_path / "trace-links.json"
+    body = ct.write_links_sidecar(epic, src, links_path)
+    hashes = hash_epic_definitions(epic)
+    assert all(link["definition_hash"] == hashes["CTR-order-001"] for link in body["links"])
+    reloaded = load_sidecar(links_path)
+    assert reloaded == body
+
+
+def test_cli_write_links_writes_sidecar_only_when_gate_passes(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    links_path = tmp_path / "docs" / "quality" / "trace-links.json"
+
+    # coverage gate passes (guarded + verified) -> sidecar is written.
+    rc = ct.main([
+        str(epic), "--source", str(src), "--gate", "coverage",
+        "--links", str(links_path), "--write-links", "--format", "json",
+    ])
+    assert rc == 0
+    assert links_path.is_file()
+
+    # Now break coverage (delete the verifying test) -> gate fails -> sidecar
+    # must NOT be overwritten with the new (uncovered) state.
+    before = links_path.read_text()
+    (src / "test_order.py").unlink()
+    rc2 = ct.main([
+        str(epic), "--source", str(src), "--gate", "coverage",
+        "--links", str(links_path), "--write-links", "--format", "json",
+    ])
+    assert rc2 == 1
+    assert links_path.read_text() == before
+
+
+def test_cli_default_links_path_is_under_source_docs_quality(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    rc = ct.main([str(epic), "--source", str(src), "--write-links", "--format", "json"])
+    assert rc == 0
+    assert (src / SIDECAR_RELPATH).is_file()
+
+
+# --- JUSTIFIED waivers (#169) -------------------------------------------------
+
+
+def _epic_with_uncovered_ctr(tmp_path):
+    epic = tmp_path / "epic"
+    epic.mkdir(exist_ok=True)
+    (epic / "contracts.md").write_text("### CTR-order-002 — idempotent creation\nNo code yet.\n")
+    return epic
+
+
+def _write_justification(epic, **overrides):
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": "CTR-order-002",
+        "reason": "manual QA only for this release",
+        "approver": "jane@example.com",
+        "expiry": "2099-01-01",
+        "ticket": "#170",
+    }
+    data.update(overrides)
+    (jdir / "ctr-order-002.json").write_text(json.dumps(data))
+
+
+def test_valid_justification_satisfies_coverage_and_renders_distinctly(tmp_path):
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic)
+    r = ct.check(epic)
+    assert r.uncovered_contracts == [] and r.untested_contracts == []
+    assert r.coverage_ok
+    assert len(r.justified_contracts) == 1
+    assert r.justified_contracts[0]["id"] == "CTR-order-002"
+    assert r.justified_contracts[0]["ticket"] == "#170"
+    assert r.expired_justifications == []
+    assert r.invalid_justifications == []
+
+
+def test_expired_justification_does_not_satisfy_coverage(tmp_path):
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic, expiry="2000-01-01")
+    r = ct.check(epic, today=date(2026, 1, 1))
+    assert "CTR-order-002" in r.uncovered_contracts
+    assert "CTR-order-002" in r.untested_contracts
+    assert not r.coverage_ok
+    assert r.justified_contracts == []
+    assert len(r.expired_justifications) == 1
+    assert r.expired_justifications[0]["id"] == "CTR-order-002"
+
+
+def test_justification_without_ticket_ref_is_invalid_and_does_not_satisfy_coverage(tmp_path):
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic, ticket="")
+    r = ct.check(epic)
+    assert "CTR-order-002" in r.uncovered_contracts
+    assert not r.coverage_ok
+    assert r.justified_contracts == []
+    assert len(r.invalid_justifications) == 1
+    assert "ticket" in r.invalid_justifications[0]["reason"]
+
+
+def test_justification_for_undefined_id_is_reported_invalid(tmp_path):
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic, id="CTR-ghost-999")
+    r = ct.check(epic)
+    assert r.justified_contracts == []
+    assert any("undefined" in d["reason"] for d in r.invalid_justifications)
+
+
+def test_justification_for_already_covered_contract_has_no_effect(tmp_path):
+    epic = _epic_with_ctr(tmp_path)
+    src = _src_guarding_ctr(tmp_path)
+    _write_justification(epic, id="CTR-order-001")
+    r = ct.check(epic, src)
+    assert r.uncovered_contracts == [] and r.untested_contracts == []
+    assert r.justified_contracts == []  # nothing to waive; not reported as JUSTIFIED
+
+
+def test_justified_renders_in_markdown_and_json(tmp_path, capsys):
+    epic = _epic_with_uncovered_ctr(tmp_path)
+    _write_justification(epic)
+    rc_text = ct.main([str(epic)])
+    assert rc_text == 0
+    text_out = capsys.readouterr().out
+    assert "Justified" in text_out
+    assert "#170" in text_out
+
+    rc_json = ct.main([str(epic), "--format", "json"])
+    assert rc_json == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["justified_contracts"][0]["id"] == "CTR-order-002"
+    assert data["coverage_ok"] is True
+
+
+# --- coverage-requirement alternatives (#169) --------------------------------
+
+
+def test_coverage_requires_alternatives_satisfied_by_any_declared_kind(tmp_path):
+    epic = tmp_path / "epic"
+    models = epic / "models"
+    models.mkdir(parents=True)
+    (epic / "contracts.md").write_text("### CTR-order-005 — refund idempotency\nx\n")
+    (models / "contracts.json").write_text(json.dumps({
+        "id": "CTR-order-005",
+        "coverage_requires": ["test", "probe"],
+    }))
+    src = tmp_path / "src"
+    src.mkdir()
+    # Only a telemetry verifies exists -- NOT in the declared alternatives.
+    (src / "slo.yaml").write_text("# @cw-trace verifies CTR-order-005\n")
+    r = ct.check(epic, src)
+    assert "CTR-order-005" in r.untested_contracts
+
+    # A probe verifies IS in the declared alternatives -> satisfied.
+    (src / "k6" / "latency.js").parent.mkdir(exist_ok=True)
+    (src / "k6" / "latency.js").write_text("// @cw-trace verifies CTR-order-005\n")
+    r2 = ct.check(epic, src)
+    assert "CTR-order-005" not in r2.untested_contracts
+
+
+def test_coverage_requires_absent_falls_back_to_any_verifies_kind(tmp_path):
+    """No coverage_requires declared -> unchanged behavior: ANY verifying kind
+    (test/probe/policy/telemetry) satisfies coverage."""
+    epic = tmp_path / "epic"
+    epic.mkdir()
+    (epic / "contracts.md").write_text("### CTR-order-006 — x\ny\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "slo.yaml").write_text("# @cw-trace verifies CTR-order-006\n")
+    r = ct.check(epic, src)
+    assert "CTR-order-006" not in r.untested_contracts
+
+
+def test_extract_coverage_requirements_from_json_model(tmp_path):
+    epic = tmp_path / "epic"
+    epic.mkdir()
+    (epic / "contracts.json").write_text(json.dumps({
+        "contracts": [{"id": "CTR-x-001", "coverage_requires": ["unit-test", "integration-spec"]}]
+    }))
+    reqs = ct.extract_coverage_requirements(epic)
+    assert reqs == {"CTR-x-001": ["unit-test", "integration-spec"]}
+
+
+# --- sidecar/report plumbing --------------------------------------------------
+
+
+def test_build_sidecar_and_load_sidecar_are_reexported_and_compatible(tmp_path):
+    """check_traceability composes chief_wiggum.trace_links directly — no
+    parallel re-implementation of the sidecar format."""
+    path = tmp_path / SIDECAR_RELPATH
+    body = build_sidecar([], {})
+    write_sidecar(path, body)
+    assert load_sidecar(path) == {"scanner_version": None, "links": []}
+
+
+def test_report_to_dict_includes_new_fields_and_is_json_serializable():
+    r = _report({"CTR-x-001": "CTR"}, [])
+    d = r.to_dict()
+    for key in (
+        "suspect_links", "suspect_contracts", "justified_contracts",
+        "expired_justifications", "invalid_justifications",
+    ):
+        assert key in d
+    json.loads(json.dumps(d))

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -359,6 +359,88 @@ def test_skipped_quality_snapshot_never_regresses(tmp_path):
     assert hw2 == {"ccn_mean": 3.0, "pct_ccn_gt10": 4.0, "relative_churn": 0.2}
 
 
+# ---- suspect-link visibility (#169) ----------------------------------------
+
+
+def _write_sidecar(cfg, links):
+    from chief_wiggum.trace_links import write_sidecar
+    write_sidecar(cfg.repo / ratchet.SIDECAR_RELPATH, {"links": links})
+
+
+def test_suspect_links_for_flags_a_changed_contract_hash(tmp_path):
+    cfg = make_repo(tmp_path)
+    hashes = ratchet.load_contract_hashes(cfg)
+    _write_sidecar(cfg, [{
+        "verb": "guards", "target": "CTR-order-001", "file": "order.go", "line": 10,
+        "source_kind": "code", "definition_hash": "stale-hash",
+    }])
+    sc = scorecard_from(cfg, set())
+    assert hashes["CTR-order-001"] != "stale-hash"
+    susp = ratchet.suspect_links_for(cfg, sc)
+    assert len(susp) == 1
+    assert susp[0]["target"] == "CTR-order-001"
+
+
+def test_suspect_links_for_is_empty_when_hash_matches(tmp_path):
+    cfg = make_repo(tmp_path)
+    hashes = ratchet.load_contract_hashes(cfg)
+    _write_sidecar(cfg, [{
+        "verb": "guards", "target": "CTR-order-001", "file": "order.go", "line": 10,
+        "source_kind": "code", "definition_hash": hashes["CTR-order-001"],
+    }])
+    sc = scorecard_from(cfg, set())
+    assert ratchet.suspect_links_for(cfg, sc) == []
+
+
+def test_suspect_links_for_is_empty_when_no_sidecar_written(tmp_path):
+    cfg = make_repo(tmp_path)
+    sc = scorecard_from(cfg, set())
+    assert ratchet.suspect_links_for(cfg, sc) == []
+
+
+def test_cmd_check_surfaces_suspect_links_visibly_but_does_not_block(tmp_path, capsys):
+    """AC3 (#169): a definition-hash change with surviving suspect links must be
+    VISIBLE in `check`'s output, never silently absorbed into 'the ratchet held'
+    — but suspect propagation ships report-only, so it must not change the exit
+    code (docs/gate-rollout.md)."""
+    cfg = make_repo(tmp_path)
+    hashes = ratchet.load_contract_hashes(cfg)
+    _write_sidecar(cfg, [{
+        "verb": "guards", "target": "CTR-order-001", "file": "order.go", "line": 10,
+        "source_kind": "code", "definition_hash": "stale-hash",
+    }])
+    sc = scorecard_from(cfg, set())
+    append_record(cfg, sc, merged=True)
+    _write_scorecard(cfg, sc)
+    assert hashes["CTR-order-001"] != "stale-hash"
+
+    args = argparse.Namespace(repo=str(tmp_path), format="text", gate_quality=False)
+    assert ratchet.cmd_check(args) == 0  # visible, but does not block
+    err = capsys.readouterr().err
+    assert "suspect link" in err
+    assert "CTR-order-001" in err
+
+    args_json = argparse.Namespace(repo=str(tmp_path), format="json", gate_quality=False)
+    ratchet.cmd_check(args_json)
+    data = json.loads(capsys.readouterr().out)
+    assert data["suspect_links"][0]["target"] == "CTR-order-001"
+
+
+def test_cmd_regressed_includes_suspect_links(tmp_path, capsys):
+    cfg = make_repo(tmp_path)
+    _write_sidecar(cfg, [{
+        "verb": "guards", "target": "CTR-order-001", "file": "order.go", "line": 10,
+        "source_kind": "code", "definition_hash": "stale-hash",
+    }])
+    sc = scorecard_from(cfg, set())
+    append_record(cfg, sc, merged=True)
+    _write_scorecard(cfg, sc)
+    args = argparse.Namespace(repo=str(tmp_path))
+    ratchet.cmd_regressed(args)
+    data = json.loads(capsys.readouterr().out)
+    assert data["suspect_links"][0]["target"] == "CTR-order-001"
+
+
 @pytest.mark.skipif(shutil.which("lizard") is None,
                     reason="lizard required for the end-to-end quality snapshot")
 def test_score_quality_end_to_end_on_a_real_repo(tmp_path):

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -40,7 +40,9 @@ def make_repo(tmp_path, contracts_md=None, suites=None):
 
 def test_uppercase_stable_ids_are_hashed(tmp_path):
     """Regression (chief-wiggum#86 class): uppercase INV-/CTR- ids must be detected
-    for weakening-hashing, not silently skipped by a lowercase-only grammar."""
+    for weakening-hashing, not silently skipped by a lowercase-only grammar.
+    Keys are CANONICAL (uppercase kind, lowercase slug — PR #181 review) so they
+    join against the traceability scanner's canonicalized annotation targets."""
     cfg = make_repo(
         tmp_path,
         contracts_md=(
@@ -51,8 +53,31 @@ def test_uppercase_stable_ids_are_hashed(tmp_path):
         ),
     )
     hashes = ratchet.load_contract_hashes(cfg)
-    assert "CTR-BIL-001" in hashes
-    assert "INV-FOWR-004" in hashes
+    assert "CTR-bil-001" in hashes
+    assert "INV-fowr-004" in hashes
+    # raw-cased keys must NOT appear — one canonical key per declared ID
+    assert "CTR-BIL-001" not in hashes and "INV-FOWR-004" not in hashes
+
+
+def test_highwater_from_precanonicalization_journal_is_not_falsely_removed(tmp_path):
+    """Back-compat (PR #181 review): journals written before hash keys were
+    canonicalized carry raw-cased IDs (CTR-BIL-001). derive_highwater/violations
+    must canonicalize both sides of the join, or every such contract would
+    falsely read as *removed* against a new canonical scorecard and block."""
+    cfg = make_repo(
+        tmp_path,
+        contracts_md="### CTR-BIL-001 — customer uniqueness\nREQUIRES: one customer per provider\n",
+    )
+    current = scorecard_from(cfg, set())  # canonical keys: CTR-bil-001
+    # Old-style journal record: same hash VALUE (it covers block content only),
+    # raw-cased KEY — exactly what a pre-#181 scorecard recorded.
+    old_sc = dict(current)
+    old_sc["contract_hashes"] = {"CTR-BIL-001": current["contract_hashes"]["CTR-bil-001"]}
+    append_record(cfg, old_sc, merged=True)
+    hw = ratchet.derive_highwater(ratchet.load_journal(cfg))
+    assert set(hw["contract_hashes"]) == {"CTR-bil-001"}
+    v = ratchet.violations(current, hw)
+    assert v["removed_contracts"] == [] and v["weakened_contracts"] == []
 
 
 def scorecard_from(cfg, pass_set):

--- a/tests/test_trace_links.py
+++ b/tests/test_trace_links.py
@@ -1,0 +1,199 @@
+"""Tests for chief_wiggum.trace_links (#169): suspect-link propagation sidecar
++ JUSTIFIED waiver records.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from chief_wiggum import trace_links as tl  # noqa: E402
+
+
+class _Ann:
+    """Minimal stand-in for check_traceability.Annotation (duck-typed: the
+    sidecar builder only reads these four attributes)."""
+
+    def __init__(self, verb, target, file, line, source_kind):
+        self.verb = verb
+        self.target = target
+        self.file = file
+        self.line = line
+        self.source_kind = source_kind
+
+
+# --- sidecar build/load/write -------------------------------------------------
+
+
+def test_build_sidecar_records_one_entry_per_known_target():
+    anns = [
+        _Ann("guards", "CTR-order-001", "order.py", 3, "code"),
+        _Ann("verifies", "CTR-order-001", "test_order.py", 1, "test"),
+        _Ann("guards", "CTR-ghost-999", "order.py", 9, "code"),  # unknown -> excluded
+    ]
+    hashes = {"CTR-order-001": "abc123"}
+    body = tl.build_sidecar(anns, hashes)
+    assert len(body["links"]) == 2
+    assert all(link["definition_hash"] == "abc123" for link in body["links"])
+    assert {link["target"] for link in body["links"]} == {"CTR-order-001"}
+
+
+def test_build_sidecar_output_is_deterministically_ordered():
+    anns = [
+        _Ann("guards", "CTR-b-001", "b.py", 1, "code"),
+        _Ann("guards", "CTR-a-001", "a.py", 1, "code"),
+    ]
+    hashes = {"CTR-a-001": "h1", "CTR-b-001": "h2"}
+    body = tl.build_sidecar(anns, hashes)
+    assert [link["file"] for link in body["links"]] == ["a.py", "b.py"]
+
+
+def test_write_and_load_sidecar_round_trips(tmp_path):
+    path = tmp_path / "docs" / "quality" / "trace-links.json"
+    body = tl.build_sidecar(
+        [_Ann("guards", "CTR-order-001", "order.py", 3, "code")],
+        {"CTR-order-001": "abc123"},
+    )
+    tl.write_sidecar(path, body)
+    loaded = tl.load_sidecar(path)
+    assert loaded["links"] == body["links"]
+
+
+def test_load_sidecar_missing_file_degrades_to_empty():
+    assert tl.load_sidecar("/nonexistent/trace-links.json") == {"links": []}
+
+
+def test_load_sidecar_malformed_json_degrades_to_empty(tmp_path):
+    path = tmp_path / "trace-links.json"
+    path.write_text("{not json")
+    assert tl.load_sidecar(path) == {"links": []}
+
+
+# --- suspect-link detection ----------------------------------------------------
+
+
+def test_find_suspect_links_flags_changed_definition_hash():
+    sidecar = {
+        "links": [
+            {"verb": "guards", "target": "CTR-order-001", "file": "order.py",
+             "line": 3, "source_kind": "code", "definition_hash": "old-hash"},
+        ]
+    }
+    suspect = tl.find_suspect_links(sidecar, {"CTR-order-001": "new-hash"})
+    assert len(suspect) == 1
+    assert suspect[0]["target"] == "CTR-order-001"
+    assert suspect[0]["current_hash"] == "new-hash"
+
+
+def test_find_suspect_links_clears_when_hash_matches():
+    sidecar = {
+        "links": [
+            {"verb": "guards", "target": "CTR-order-001", "file": "order.py",
+             "line": 3, "source_kind": "code", "definition_hash": "same-hash"},
+        ]
+    }
+    assert tl.find_suspect_links(sidecar, {"CTR-order-001": "same-hash"}) == []
+
+
+def test_find_suspect_links_ignores_targets_no_longer_defined():
+    """A target that vanished entirely is dangling's problem, not suspect's —
+    suspect means 'changed', not 'gone'."""
+    sidecar = {
+        "links": [
+            {"verb": "guards", "target": "CTR-gone-001", "file": "order.py",
+             "line": 3, "source_kind": "code", "definition_hash": "old-hash"},
+        ]
+    }
+    assert tl.find_suspect_links(sidecar, {}) == []
+
+
+def test_find_suspect_links_empty_sidecar_is_empty():
+    assert tl.find_suspect_links({"links": []}, {"CTR-order-001": "h"}) == []
+
+
+# --- JUSTIFIED waivers ----------------------------------------------------------
+
+
+def test_load_justifications_reads_valid_records(tmp_path):
+    epic = tmp_path / "order-lifecycle"
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True)
+    (jdir / "ctr-order-002.json").write_text(json.dumps({
+        "id": "CTR-order-002",
+        "reason": "manual QA only, automated coverage tracked separately",
+        "approver": "jane@example.com",
+        "expiry": "2099-01-01",
+        "ticket": "#170",
+    }))
+    justifications, invalid = tl.load_justifications(epic)
+    assert invalid == []
+    assert "CTR-order-002" in justifications
+    j = justifications["CTR-order-002"]
+    assert j.reason.startswith("manual QA")
+    assert j.ticket == "#170"
+
+
+def test_load_justifications_missing_dir_degrades_gracefully(tmp_path):
+    justifications, invalid = tl.load_justifications(tmp_path / "no-such-epic")
+    assert justifications == {}
+    assert invalid == []
+
+
+def test_load_justifications_without_ticket_ref_is_invalid(tmp_path):
+    """A justification without a ticket ref is invalid — ticket-every-deferral."""
+    epic = tmp_path / "epic"
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True)
+    (jdir / "bad.json").write_text(json.dumps({
+        "id": "CTR-order-002",
+        "reason": "no ticket",
+        "approver": "jane@example.com",
+        "expiry": "2099-01-01",
+    }))
+    justifications, invalid = tl.load_justifications(epic)
+    assert justifications == {}
+    assert len(invalid) == 1
+    assert "ticket" in invalid[0]["reason"]
+
+
+def test_load_justifications_malformed_json_is_invalid(tmp_path):
+    epic = tmp_path / "epic"
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True)
+    (jdir / "bad.json").write_text("{not json")
+    justifications, invalid = tl.load_justifications(epic)
+    assert justifications == {}
+    assert len(invalid) == 1
+    assert "cannot parse" in invalid[0]["reason"]
+
+
+def test_load_justifications_non_object_is_invalid(tmp_path):
+    epic = tmp_path / "epic"
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True)
+    (jdir / "bad.json").write_text(json.dumps(["not", "an", "object"]))
+    justifications, invalid = tl.load_justifications(epic)
+    assert justifications == {}
+    assert len(invalid) == 1
+
+
+def test_justification_expiry_check():
+    j = tl.Justification(
+        id="CTR-x-001", reason="r", approver="a", expiry="2020-01-01",
+        ticket="#1", source="f.json",
+    )
+    assert j.is_expired(date(2026, 1, 1)) is True
+    assert j.is_expired(date(2019, 1, 1)) is False
+
+
+def test_justification_unparseable_expiry_treated_as_expired():
+    j = tl.Justification(
+        id="CTR-x-001", reason="r", approver="a", expiry="not-a-date",
+        ticket="#1", source="f.json",
+    )
+    assert j.is_expired(date(2026, 1, 1)) is True

--- a/tests/test_trace_links.py
+++ b/tests/test_trace_links.py
@@ -197,3 +197,53 @@ def test_justification_unparseable_expiry_treated_as_expired():
         ticket="#1", source="f.json",
     )
     assert j.is_expired(date(2026, 1, 1)) is True
+
+
+# --- ticket-ref validation (PR #181 review) ----------------------------------
+
+
+def test_valid_ticket_ref_accepts_real_forms():
+    for ref in (
+        "#170",
+        "plwp/chief-wiggum#12",
+        "https://github.com/plwp/chief-wiggum/issues/170",
+        "http://tracker.example.com/t/99",
+        "PROJ-123",
+        "  #170  ",  # surrounding whitespace is stripped
+    ):
+        assert tl.valid_ticket_ref(ref), ref
+
+
+def test_valid_ticket_ref_rejects_placeholders():
+    for ref in ("", "  ", "none", "N/A", "TBD", "yes", "ticket", "#", "PROJ-", "170"):
+        assert not tl.valid_ticket_ref(ref), ref
+
+
+def test_load_justifications_placeholder_ticket_is_invalid(tmp_path):
+    """Regression: truthiness-only validation let '  '/'none'/'N/A' pass."""
+    for i, placeholder in enumerate(("  ", "none", "N/A")):
+        epic = tmp_path / f"epic-{i}"
+        jdir = epic / "justifications"
+        jdir.mkdir(parents=True)
+        (jdir / "w.json").write_text(json.dumps({
+            "id": "CTR-x-001", "reason": "r", "approver": "a",
+            "expiry": "2099-01-01", "ticket": placeholder,
+        }))
+        justifications, invalid = tl.load_justifications(epic)
+        assert justifications == {}, placeholder
+        assert len(invalid) == 1, placeholder
+        assert "ticket" in invalid[0]["reason"], placeholder
+
+
+def test_load_justifications_canonicalizes_waiver_id(tmp_path):
+    epic = tmp_path / "epic"
+    jdir = epic / "justifications"
+    jdir.mkdir(parents=True)
+    (jdir / "w.json").write_text(json.dumps({
+        "id": "CTR-BIL-001", "reason": "r", "approver": "a",
+        "expiry": "2099-01-01", "ticket": "#1",
+    }))
+    justifications, invalid = tl.load_justifications(epic)
+    assert invalid == []
+    assert set(justifications) == {"CTR-bil-001"}
+    assert justifications["CTR-bil-001"].id == "CTR-bil-001"


### PR DESCRIPTION
## Summary

Closes #169. Two cheap, high-value steals from safety-engineering tooling folded into the existing single-repo trace graph (no federation layer):

- **Suspect propagation (doorstop pattern)**: every `@cw-trace` link's definition hash is recorded in a generated sidecar, `docs/quality/trace-links.json` (in the target repo), written by `check_traceability.py --write-links` only once its requested `--gate` passes — never hand-maintained. A link whose target contract's definition hash has since changed is reported as **SUSPECT**, distinct from dangling (target gone)/uncovered/untested (no link at all). Rewording a contract flips its recorded links to SUSPECT; re-running `--write-links` against the reworded contract clears them. `ratchet.py check`/`regressed` cross-reference the same sidecar against the current scorecard's `contract_hashes`, so a definition-hash change with surviving suspect links is **visible, not silent** in ratchet output. Report-only initially (per `docs/gate-rollout.md`) — does not affect `soundness_ok`/`coverage_ok`/exit codes yet.
- **JUSTIFIED waivers (LOBSTER pattern)**: `docs/epics/<slug>/justifications/*.json` records (`reason`/`approver`/`expiry`/`ticket`) let an uncovered/untested contract satisfy coverage honestly instead of a fabricated guard/verify annotation. A justification **without a ticket ref is invalid** (ticket-every-deferral doctrine) and does not satisfy coverage; an **expired** one likewise does not, and is reported separately (`expired_justifications`). Valid, non-expired waivers move the contract into `justified_contracts` and `coverage_ok` becomes true honestly.
- **Coverage-requirement alternatives**: a contract may declare `"coverage_requires": ["unit-test", "probe"]` (OR semantics) on its JSON model entry instead of the default "any verifying kind counts".

Definition hashing is relocated from `ratchet.py` into `chief_wiggum.hashing.hash_epic_definitions` so `check_traceability.py` reuses the *exact same* contract-block hashing `ratchet.py` already computes for weakening detection — one implementation, not a parallel copy. `ratchet.py`'s public/private surface (`ID_RE`, `DEFINE_RE`, `_hash_markdown_defs`, `_walk_json_ids`, `load_contract_hashes`) is preserved via thin re-exports so existing cross-check tests (`test_trace_ids.py`) needed no behavioral changes.

A new shared module, `scripts/chief_wiggum/trace_links.py`, holds the sidecar build/load/write, suspect-link comparison, and `Justification` dataclass (mirroring `check_infra_writer.py`'s `Exemption` / `check_budget_tree.py`'s `evidence: justified` idiom). Both `check_traceability.py` and `ratchet.py` import from it.

`.claude/commands/close-epic.md` (Step 2d/2f) is wired to call `--write-links` after the coverage gate passes and documents the new report-only findings; `.claude/commands/architect.md` gets a one-line note that suspect propagation is a `/close-epic`-time concern (no code/test links exist yet at architect time). `docs/traceability.md`, `docs/ratchet.md`, and `docs/gate-rollout.md`'s gate ledger are updated accordingly.

## Test plan

- [x] New `tests/test_trace_links.py` — sidecar build/load/write round-trip, suspect-link detection (changed hash / matching hash / target gone / empty sidecar), `Justification` loading (valid / missing dir / missing ticket ref / malformed JSON / non-object / expiry check / unparseable expiry).
- [x] Extended `tests/test_check_traceability.py` — reword-a-contract-flips-to-SUSPECT-then-clears end-to-end (issue's first acceptance criterion), suspect links don't affect `soundness_ok`/`coverage_ok`, `--write-links` CLI only writes on a passing gate (and leaves the sidecar untouched on a failing one), default sidecar path resolution, JUSTIFIED rendering in markdown/JSON + satisfying coverage (issue's second AC), expired/invalid-ticket/undefined-id/already-covered justification edge cases, coverage-requirement alternatives (with and without a declared requirement).
- [x] Extended `tests/test_ratchet.py` — `suspect_links_for` detects a stale sidecar hash, is empty when hashes match or no sidecar exists, and `cmd_check`/`cmd_regressed` surface suspect links visibly without changing the exit code (issue's third acceptance criterion).
- [x] Updated the traceability golden fixture (`tests/fixtures/traceability_golden/expected.json.txt`) — additive-only new fields (`suspect_links`, `suspect_contracts`, `justified_contracts`, `expired_justifications`, `invalid_justifications` + their counts), verified byte-identical otherwise.
- [x] Full `pytest`: 1168 passed, 4 skipped (pre-existing `lizard`/optional-tool skips).
- [x] `ruff check` on all touched/new files: clean. (Repo-wide `ruff check .` has 30 pre-existing errors in `docs/formal-methods/examples/generated/*` unrelated to this change — confirmed identical count on `origin/main` before this branch's changes.)

## Deviations from the issue

- Suspect propagation and JUSTIFIED do **not** change `--gate coverage`'s pass/fail semantics in this PR — both ship strictly report-only (new fields on the report, not new blocking behavior), consistent with `docs/gate-rollout.md`'s "prove precision before blocking" doctrine. The issue's design notes ("`/close-epic` coverage gate treats suspect links as uncovered after validation") describe the eventual promotion target; wiring that as an actual hard-fail is left for a follow-up once there's a dry-run on a real epic's link churn to validate the false-positive rate against, per the gate-rollout checklist.
- `docs/quality/trace-links.json` is scoped per `check_traceability.py` invocation (i.e., per epic directory), not aggregated across all epics the way `ratchet.py`'s repo-wide `contract_hashes` is. A link whose target is declared in a different epic is simply skipped (no false SUSPECT), documented as a known limitation in `docs/traceability.md`. This matches how `check_traceability.py` already operates one epic at a time everywhere else in the codebase.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF