### PR TITLE
feat(languages): declared support matrix + per-language emitter seam (#162)

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -68,20 +68,29 @@ Read the current `$CW_HOME/models.md` and update it with the new information:
 
 For tiered models, record the base (≤200k-context) rate. Leave a row `null` + `verified: false` if a price genuinely can't be confirmed (don't fabricate). `python3 -c "import json;json.load(open('config/model_pricing.json'))"` must stay valid.
 
+### Step 3.6: Refresh the language support matrix doc (`docs/languages.md`)
+
+`docs/languages.md` is mechanically rendered from `config/languages.json` (#162) — never hand-edit it. If the matrix changed (a new language, tier promotion, dep_profile change), regenerate the doc so it can't drift from the artifact:
+
+```bash
+python3 "$CW_HOME/scripts/render_languages_doc.py"
+```
+
 ### Step 4: Review changes
 
-Show the user a diff of what changed in `models.md` and `config/model_pricing.json`:
+Show the user a diff of what changed in `models.md`, `config/model_pricing.json`, and (if regenerated) `docs/languages.md`:
 - Highlight new models
 - Highlight deprecated models
 - Highlight version bumps
 - Highlight price changes
+- Highlight any language-matrix changes
 - Ask if the changes look correct
 
 ### Step 5: Commit and push
 
 ```bash
 cd "$CW_HOME"
-git add models.md config/model_pricing.json
+git add models.md config/model_pricing.json docs/languages.md
 git commit -m "docs: update models, pricing, and library versions — $(date +%Y-%m-%d)"
 git push
 ```

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ fmt:
 
 lint:
 	python3 -m ruff check scripts tests
-	python3 -m py_compile scripts/*.py scripts/extractors/*.py scripts/chief_wiggum/*.py
+	python3 -m py_compile scripts/*.py scripts/extractors/*.py scripts/chief_wiggum/*.py scripts/emitters/*.py
 	python3 scripts/check_portability.py
 	python3 scripts/check_patterns.py
 	python3 scripts/check_cw_standards.py --gate

--- a/config/languages.json
+++ b/config/languages.json
@@ -1,0 +1,70 @@
+{
+  "version": 1,
+  "description": "Declared per-language support matrix (#162): which capabilities exist for a language and their maturity tier. Consumed by scripts/chief_wiggum/languages.py, which check_deps.py (dependency profiles) and scripts/emitters/ (the emitter fallback chain) both read. Rendered by scripts/render_languages_doc.py into docs/languages.md.",
+  "languages": {
+    "go": {
+      "tier": 1,
+      "status": "supported",
+      "extensions": [".go"],
+      "lsp": "gopls",
+      "emitters": ["writer", "trace"],
+      "test_parser": "go test -json / gotestsum JUnit XML (scripts/ratchet.py)",
+      "extractor": "go_mongo (scripts/extractors/go_mongo.py, stitch-audit)",
+      "func_regex": true,
+      "dep_profile": "go-lsp"
+    },
+    "python": {
+      "tier": 1,
+      "status": "supported",
+      "extensions": [".py"],
+      "lsp": "pyright",
+      "emitters": ["writer", "trace"],
+      "test_parser": "pytest --junitxml (JUnit XML, scripts/ratchet.py)",
+      "extractor": null,
+      "func_regex": true,
+      "dep_profile": "python-lsp"
+    },
+    "typescript": {
+      "tier": 1,
+      "status": "supported",
+      "extensions": [".ts", ".tsx", ".js", ".jsx"],
+      "lsp": null,
+      "emitters": ["writer", "trace"],
+      "test_parser": "jest/vitest JUnit reporter",
+      "extractor": "typescript (scripts/extractors/typescript.py, stitch-audit)",
+      "func_regex": true,
+      "dep_profile": null
+    },
+    "rust": {
+      "tier": "designed",
+      "status": "designed, unbuilt",
+      "extensions": [".rs"],
+      "lsp": "rust-analyzer",
+      "emitters": [],
+      "test_parser": "cargo nextest (JUnit XML) + Cargo.toml autodetect",
+      "extractor": null,
+      "func_regex": false,
+      "dep_profile": null,
+      "trigger": "first real Rust target repo",
+      "requires": [
+        "rust-analyzer entry in scripts/chief_wiggum/lsp.py SERVERS",
+        "cargo nextest JUnit XML output + Cargo.toml autodetect wired into scripts/ratchet.py's test-result parser",
+        "fn regex for enclosing-symbol resolution (scripts/chief_wiggum/write_emission.py _enclosing_symbol)",
+        "writer patterns for struct literals + sqlx macros (a Rust-specific write-site emitter under scripts/emitters/)"
+      ],
+      "note": "The .rs extension is already scanned today by the generic regex tier (see generic_tier below) — write-site/trace-annotation facts ARE emitted for Rust files, just without a dedicated func_regex for enclosing-symbol resolution. 'designed, unbuilt' means the TIER-1 emitter (rust-analyzer + cargo nextest + fn regex + sqlx-aware writer patterns) is not built, not that Rust is unscanned."
+    }
+  },
+  "generic_tier": {
+    "description": "Extensions with NO dedicated per-language emitter module, scanned by the generic (language-agnostic) regex tier — scripts/emitters/generic.py — which is exactly the pre-#162 SOURCE_EXTS behavior of check_single_writer.py / check_traceability.py.",
+    "extensions": [".java", ".rb", ".rs"]
+  },
+  "unsupported_extensions": {
+    "description": "Recognized programming-language extensions with NO emitter coverage at all (neither a tier-1 module nor the generic tier). A file with one of these extensions is NEVER silently skipped: check_single_writer.py / check_traceability.py surface an explicit coverage warning in both --gate and plain (query) output instead. This list is curated, not exhaustive — extend it as new unsupported languages show up in a target repo.",
+    "extensions": [
+      ".c", ".h", ".cpp", ".cc", ".hpp", ".cs", ".php", ".kt", ".kts",
+      ".swift", ".scala", ".m", ".mm", ".clj", ".cljs", ".ex", ".exs",
+      ".erl", ".hs", ".lua", ".dart", ".groovy", ".jl", ".pl", ".r"
+    ]
+  }
+}

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,41 @@
+# Language Support Matrix
+
+Generated from `config/languages.json` by `scripts/render_languages_doc.py` (#162) — do not hand-edit this file; edit the config and re-run the script (wired into `/update`).
+
+Consumed by `check_deps.py` (`--list-languages`, the `language-tier-1` dependency profile) and by `scripts/emitters/` (the per-language emitter fallback chain: language-specific emitter -> generic regex tier -> skip-with-warning). See `docs/single-writer.md` / `docs/traceability.md` for what the emitters feed.
+
+## Languages
+
+| Language | Tier | Status | Extensions | LSP | Emitters | Test parser | Extractor | func_regex |
+|---|---|---|---|---|---|---|---|---|
+| go | 1 | supported | `.go` | gopls | writer, trace | go test -json / gotestsum JUnit XML (scripts/ratchet.py) | go_mongo (scripts/extractors/go_mongo.py, stitch-audit) | yes |
+| python | 1 | supported | `.py` | pyright | writer, trace | pytest --junitxml (JUnit XML, scripts/ratchet.py) | — | yes |
+| typescript | 1 | supported | `.ts`, `.tsx`, `.js`, `.jsx` | — | writer, trace | jest/vitest JUnit reporter | typescript (scripts/extractors/typescript.py, stitch-audit) | yes |
+| rust | designed | designed, unbuilt | `.rs` | rust-analyzer | — | cargo nextest (JUnit XML) + Cargo.toml autodetect | — | no |
+
+## Generic regex tier
+
+Extensions with no dedicated per-language emitter module, scanned by the generic (language-agnostic) regex tier (`scripts/emitters/generic.py`) — the pre-#162 behavior of `check_single_writer.py` / `check_traceability.py`:
+
+`.java`, `.rb`, `.rs`
+
+## Recognized-but-unsupported extensions
+
+Encountering one of these during a full-repo scan is NEVER a silent skip — `check_single_writer.py` / `check_traceability.py` surface an explicit coverage warning (`unsupported_extension_counts`) in both `--gate` and plain (query) output:
+
+`.c`, `.cc`, `.clj`, `.cljs`, `.cpp`, `.cs`, `.dart`, `.erl`, `.ex`, `.exs`, `.groovy`, `.h`, `.hpp`, `.hs`, `.jl`, `.kt`, `.kts`, `.lua`, `.m`, `.mm`, `.php`, `.pl`, `.r`, `.scala`, `.swift`
+
+## Designed, unbuilt slots
+
+### Rust
+
+Trigger: first real Rust target repo
+
+Requires when triggered:
+
+- rust-analyzer entry in scripts/chief_wiggum/lsp.py SERVERS
+- cargo nextest JUnit XML output + Cargo.toml autodetect wired into scripts/ratchet.py's test-result parser
+- fn regex for enclosing-symbol resolution (scripts/chief_wiggum/write_emission.py _enclosing_symbol)
+- writer patterns for struct literals + sqlx macros (a Rust-specific write-site emitter under scripts/emitters/)
+
+The .rs extension is already scanned today by the generic regex tier (see generic_tier below) — write-site/trace-annotation facts ARE emitted for Rust files, just without a dedicated func_regex for enclosing-symbol resolution. 'designed, unbuilt' means the TIER-1 emitter (rust-analyzer + cargo nextest + fn regex + sqlx-aware writer patterns) is not built, not that Rust is unscanned.

--- a/docs/single-writer.md
+++ b/docs/single-writer.md
@@ -323,3 +323,25 @@ sandbox workspace) before wiring `--gate` into `/close-epic` for repos that
 declare infra invariants.
 
 Exit codes: `0` ok / report-only, `1` gate violation, `2` usage error.
+
+## Per-language emitter seam + coverage metadata (#162)
+
+`emit_write_sites` moved to `chief_wiggum.write_emission` (re-exported here
+unchanged) so it can sit BEHIND `scripts/emitters/` — a per-language
+`emit(path, content) -> [Fact]` interface with one module per Go/Python/
+TypeScript, delegating to the same emission function every language shares,
+plus a `generic` module for extensions with no dedicated language module
+(Java, Ruby, Rust today). The declared support matrix lives in
+`config/languages.json`, rendered to `docs/languages.md` by
+`scripts/render_languages_doc.py` — see that doc for Rust's designed-but-
+unbuilt tier-1 slot.
+
+`SOURCE_EXTS` is now derived from the matrix
+(`chief_wiggum.languages.all_known_extensions()`) — identical set to the
+pre-#162 hardcoded list. A file whose extension the matrix doesn't recognize
+at all (neither a tier-1 emitter nor the generic regex tier) is **never
+silently dropped**: a full `--source` scan counts every such file
+(`unsupported_extension_counts`) and surfaces one aggregated `warnings` entry
+in both `--gate` and plain (query) output — e.g. `"3 file(s) skipped: no
+emitter coverage for recognized-but-unsupported extension(s) .php (2), .cpp
+(1) — see config/languages.json"`.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -241,3 +241,23 @@ matches ONE of the declared alternatives — a `telemetry`-only signal, for
 example, would no longer count if only `["unit-test", "integration-spec"]` are
 declared acceptable. Omitting `coverage_requires` for an ID preserves the
 original "any verifying kind counts" behavior.
+
+## Per-language emitter seam + coverage metadata (#162)
+
+`emit_source_annotations` moved to `chief_wiggum.trace_emission` (re-exported
+here unchanged) so it can sit BEHIND `scripts/emitters/` — a per-language
+`emit(path, content) -> [Fact]` interface with one module per Go/Python/
+TypeScript, delegating to the same emission function every language shares.
+The declared support matrix (which language has which capability, and its
+maturity tier) lives in `config/languages.json`, rendered to
+`docs/languages.md` by `scripts/render_languages_doc.py`.
+
+`SOURCE_EXTS` is now derived from that matrix (`chief_wiggum.languages.
+all_known_extensions()`) plus this checker's own verification-artifact
+extensions (`.rego`/`.yaml`/`.yml`) — identical set to the pre-#162 hardcoded
+list. A file whose extension the matrix doesn't recognize at all (neither a
+tier-1 emitter nor the generic regex tier) is **never silently dropped**: a
+full `--source` scan counts every such file (`unsupported_extension_counts`)
+and surfaces one aggregated `warnings` entry, e.g. `"3 file(s) skipped: no
+emitter coverage for recognized-but-unsupported extension(s) .php (2), .cpp
+(1) — see config/languages.json"` — in both `--gate` and plain (query) output.

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+from chief_wiggum import languages as cw_languages
 from keychain import has_secret
 
 GREEN = "\033[0;32m"
@@ -116,6 +117,23 @@ WORKFLOW_REQUIREMENTS = {
         "pkgs": set(),
         "secrets": set(),
     },
+}
+
+# A profile per BUILT language tier (#162), derived from config/languages.json's
+# `dep_profile` field rather than hand-listed — a language added to the matrix
+# with a dep_profile is automatically covered here, no second place to update.
+# Only tier-1 (built) languages contribute; a designed-but-unbuilt slot (Rust)
+# has no toolchain to check yet.
+_LANGUAGE_TIER1_DEP_PROFILES = {
+    lang.dep_profile
+    for lang in cw_languages.languages().values()
+    if lang.built and lang.dep_profile
+}
+WORKFLOW_REQUIREMENTS["language-tier-1"] = {
+    "extends": _LANGUAGE_TIER1_DEP_PROFILES,
+    "cmds": set(),
+    "pkgs": set(),
+    "secrets": set(),
 }
 
 
@@ -300,11 +318,29 @@ def main():
         help="Provider role to recommend profiles for. Repeatable.",
     )
     parser.add_argument("--list-profiles", action="store_true", help="List all dependency profiles.")
+    parser.add_argument(
+        "--list-languages",
+        action="store_true",
+        help="Print the declared language support matrix (config/languages.json): "
+        "tier, status, and dependency profile per language.",
+    )
     args = parser.parse_args()
 
     if args.list_profiles:
         for profile in sorted(WORKFLOW_REQUIREMENTS):
             print(profile)
+        return
+
+    if args.list_languages:
+        print("=== Language Support Matrix (config/languages.json) ===\n")
+        for name, lang in cw_languages.languages().items():
+            print(f"{name:<12s} tier={lang.tier:<10s} status={lang.status}")
+            print(f"{'':<12s} extensions={', '.join(lang.extensions)}")
+            print(f"{'':<12s} dep_profile={lang.dep_profile or '(none)'}  lsp={lang.lsp or '(none)'}")
+            if not lang.built and lang.trigger:
+                print(f"{'':<12s} trigger={lang.trigger}")
+            print()
+        print("See docs/languages.md for the full rendered matrix.")
         return
 
     if args.recommend:

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -94,6 +94,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# The per-language emitter registry (#162): language-specific emitter -> generic
+# regex tier -> skip-with-warning. Used by scan_writers/unsupported_extension_counts
+# below to surface files with NO emitter coverage instead of dropping them silently.
+import emitters  # noqa: E402
+
+# The declared language support matrix (#162) — SOURCE_EXTS below is derived
+# from it (tier-1 + generic-tier extensions), and the emitter fallback chain
+# (scripts/emitters/) reports files with no coverage at all as an explicit
+# warning rather than a silent skip. See config/languages.json + docs/languages.md.
+from chief_wiggum import languages as cw_languages  # noqa: E402
+
 # The @cw-writes tag grammar is shared (#170: a third @cw-* tag, @cw-emits,
 # joins it) — see chief_wiggum/annotations.py. Re-exported under these names
 # for backward compatibility with any existing `check_single_writer.WRITES_TAG_RE`
@@ -107,6 +118,33 @@ from chief_wiggum.annotations import ATTR_RE, WRITES_TAG_RE  # noqa: E402, F401
 from chief_wiggum.hashing import scanner_version  # noqa: E402
 from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
 
+# The write-site emission family (regexes, WriteSite, emit_write_sites) moved to
+# chief_wiggum.write_emission (#162) so scripts/emitters/*.py can sit BEHIND the
+# same per-file emission logic this checker uses — re-exported here unchanged
+# so every existing `check_single_writer.X` reference keeps working (golden
+# parity; see tests/test_single_writer_golden.py).
+from chief_wiggum.write_emission import (  # noqa: E402, F401
+    ASSIGN_RE,
+    FILTER_OPERATOR_RE,
+    GO_FUNC_RE,
+    KIND_ASSIGN,
+    KIND_QUOTED,
+    KIND_SQL,
+    KIND_STRUCT,
+    MUTATION_CONTEXT_RE,
+    PY_FUNC_RE,
+    QUOTED_RE,
+    SQL_FIELD_RE,
+    SQL_SET_KEYWORD_RE,
+    STRUCT_RE,
+    TS_FUNC_RE,
+    WriteSite,
+    _enclosing_symbol,
+    _is_test_path,
+    _strip_line_comment,
+    emit_write_sites,
+)
+
 # Same INV- shape as check_traceability.py (case-insensitive slug segment).
 INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])", re.IGNORECASE)
 
@@ -114,15 +152,12 @@ INV_ID_RE = re.compile(r"\bINV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}(?![A-Za-z0-9-])
 # but scoped to INV- and capturing the description for reporting.
 INV_DEFINE_RE = re.compile(r"\*\*\s*(INV-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3})\s*\*\*\s*:?\s*(.*)")
 
-SOURCE_EXTS = {".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".java", ".rb", ".rs"}
+# The set of extensions this checker scans — every tier-1 (Go/Python/TypeScript)
+# and generic-tier (Java/Ruby/Rust today) extension declared in
+# config/languages.json. Backward-compatible: identical to the pre-#162
+# hardcoded set. See chief_wiggum.languages + docs/languages.md.
+SOURCE_EXTS = cw_languages.all_known_extensions()
 SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv", "vendor", "dist", "build"}
-
-# A file is test infrastructure (not a sanctioned/unsanctioned production writer)
-# — same heuristic as check_traceability.py. Test writes of a controlled field
-# are fixtures, not a competing production write path, so they don't violate.
-def _is_test_path(rel: str) -> bool:
-    low = rel.lower()
-    return "test" in low or "spec" in low or any(p == "e2e" for p in Path(low).parts)
 
 
 def canonical_id(node_id: str) -> str:
@@ -373,109 +408,6 @@ def collect_invariants(epic_dir: str | Path) -> tuple[list[SingleWriterInvariant
 # --- scanning the repo for writers ------------------------------------------
 
 
-# Generic (field-agnostic) write-site detectors. Each captures a candidate
-# identifier token; whether that token belongs to any particular invariant's
-# controlled field is a QUERY-TIME decision (match_writers), not baked into the
-# regex. Kind indices (0-3) mirror the four write shapes documented in the
-# module docstring and drive `persistence_only` filtering in match_writers.
-KIND_ASSIGN, KIND_STRUCT, KIND_QUOTED, KIND_SQL = range(4)
-
-# The token classes are wider than `\w+` on purpose: the pre-split scanner
-# built its regexes from `re.escape(leaf_token)`, so a controlled field whose
-# leaf contains a hyphen (e.g. a Mongo key `plan-tier`) DID match. Emission
-# must cover at least that same token surface or a full scan could silently
-# miss an unsanctioned writer of such a field; over-wide captures are harmless
-# (a token that matches no invariant's field is dropped at claim time).
-# 0. Assignment: `something.Plan =` / `.stripe_plan =` (not ==; `:=` — Go's
-#    declare+assign — IS a write, so it's allowed).
-ASSIGN_RE = re.compile(r"\.([\w-]+)\s*:?=[^=]")
-# 1. Struct-literal / map set: `Plan: value` or `"plan": value` or `Key: "plan"`.
-#    `:(?!=)` so Go's short-var-decl `plan := expr` is NOT read as a field set
-#    (the captured token would be the local var name, and `:` the `:` of `:=`).
-STRUCT_RE = re.compile(r"""(^|[\s,{(])['"]?([\w.-]+)['"]?\s*:(?!=)\s*""")
-# 2. bson/Mongo update key referenced literally in a set expression. `.` is in
-#    the class so a dotted key (`"provider.plan"`) is captured whole — leaf
-#    tokens never contain dots, so it can't claim-match a leaf field, exactly
-#    like the old quote-delimited exact-token match behaved.
-QUOTED_RE = re.compile(r"""['"]([\w.-]+)['"]""")
-# 3. SQL UPDATE ... SET <field> = ...  (multiple fields may be set on one line).
-SQL_SET_KEYWORD_RE = re.compile(r"\bSET\b", re.IGNORECASE)
-SQL_FIELD_RE = re.compile(r"\b([\w-]+)\s*=")
-
-# A bson $set / Mongo update / SQL UPDATE context marker — a bare `"plan":` in a
-# non-mutating context (e.g. a JSON response DTO field) shouldn't count. We only
-# treat KIND_QUOTED (quoted-literal) as a write when the surrounding lines look
-# like a mutation. KIND_ASSIGN and KIND_STRUCT are writes on their own.
-MUTATION_CONTEXT_RE = re.compile(
-    r"\$set|UpdateOne|UpdateMany|UpdateByID|FindOneAndUpdate|bson\.[ME]|SET\b|UPDATE\b",
-    re.IGNORECASE,
-)
-
-# A bson/Mongo QUERY operator on the same line means the `"field":` there is a FILTER
-# clause (which document to match), not a `$set` value (what to write). e.g.
-# `bson.M{"plan": bson.M{"$exists": false}}` selects rows, it doesn't write plan. Skip it.
-FILTER_OPERATOR_RE = re.compile(
-    r"\$(?:exists|in|nin|ne|eq|gt|gte|lt|lte|regex|or|and|not|nor|type|all|elemMatch|size)\b"
-)
-
-# Line-comment markers per language. Used to strip trailing comments before matching,
-# so a field name mentioned in a comment (e.g. `// Free plan: …`) is not read as a write.
-_COMMENT_MARKERS = {
-    ".go": ("//",), ".ts": ("//",), ".tsx": ("//",), ".js": ("//",), ".jsx": ("//",),
-    ".java": ("//",), ".rs": ("//",), ".py": ("#",), ".rb": ("#",),
-}
-
-
-def _strip_line_comment(line: str, suffix: str) -> str:
-    """Drop a trailing line comment, respecting string/char literals so an in-string
-    marker (a URL's `//`, a TS `#private`, a `#` inside a Python string) is preserved.
-    Multi-line strings aren't tracked (per-line scan) — acceptable: at worst a comment
-    marker inside a rare multi-line literal truncates a line we only search for writes."""
-    markers = _COMMENT_MARKERS.get(suffix)
-    if not markers:
-        return line
-    quote: str | None = None
-    i, n = 0, len(line)
-    while i < n:
-        ch = line[i]
-        if quote is not None:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == quote:
-                quote = None
-            i += 1
-            continue
-        if ch in ("'", '"', "`"):
-            quote = ch
-            i += 1
-            continue
-        for m in markers:
-            if line.startswith(m, i):
-                return line[:i]
-        i += 1
-    return line
-
-
-GO_FUNC_RE = re.compile(r"^\s*func\s+(?:\([^)]*\)\s*)?([A-Za-z_][A-Za-z0-9_]*)")
-PY_FUNC_RE = re.compile(r"^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)")
-TS_FUNC_RE = re.compile(r"(?:function\s+([A-Za-z_$][\w$]*)|([A-Za-z_$][\w$]*)\s*[:=]\s*(?:async\s*)?\()")
-
-
-def _enclosing_symbol(lines: list[str], idx: int) -> str | None:
-    """Nearest function/method name declared at or above line index ``idx``."""
-    for j in range(idx, -1, -1):
-        line = lines[j]
-        for pat in (GO_FUNC_RE, PY_FUNC_RE):
-            m = pat.match(line)
-            if m:
-                return m.group(1)
-        m = TS_FUNC_RE.search(line)
-        if m:
-            return m.group(1) or m.group(2)
-    return None
-
-
 def _distinct_field_forms(inv: SingleWriterInvariant) -> list[tuple[str, str]]:
     """(original controlled-field path, leaf-token) pairs, both snake and compact."""
     forms: list[tuple[str, str]] = []
@@ -487,74 +419,6 @@ def _distinct_field_forms(inv: SingleWriterInvariant) -> list[tuple[str, str]]:
                 seen.add(tok)
                 forms.append((fpath, tok))
     return forms
-
-
-@dataclass
-class WriteSite:
-    """A FIELD-AGNOSTIC candidate write site: emission time knows nothing about
-    any invariant's controlled field — just "this line assigns/sets/matches an
-    identifier token, in this file, in this enclosing symbol". Whether ``token``
-    belongs to a controlled field is a query-time decision (``match_writers``).
-    """
-
-    file: str
-    line: int  # 1-indexed
-    text: str  # raw (comment-un-stripped) line, stripped + truncated for display
-    symbol: str | None
-    is_test: bool
-    kind: int  # KIND_ASSIGN | KIND_STRUCT | KIND_QUOTED | KIND_SQL
-    token: str  # the identifier exactly as it appears in source (case preserved)
-
-
-def emit_write_sites(path: str, text: str) -> list[WriteSite]:
-    """Emission: every candidate write site in a single file's ``text``, with NO
-    knowledge of any specific invariant or controlled field (see module + class
-    docstrings). ``path`` is a repo-relative label used only for ``.suffix``
-    (comment-marker lookup) and the ``file`` attribute — the file is never
-    re-read from disk, so this is safe to call on manifest-sourced content.
-    """
-    suffix = Path(path).suffix
-    raw_lines = text.splitlines()
-    code_lines = [_strip_line_comment(rl, suffix) for rl in raw_lines]
-    is_test = _is_test_path(path)
-    sites: list[WriteSite] = []
-    for i, line in enumerate(code_lines):
-        candidates: list[tuple[int, str]] = []  # (kind, token)
-        for m in ASSIGN_RE.finditer(line):
-            candidates.append((KIND_ASSIGN, m.group(1)))
-        for m in STRUCT_RE.finditer(line):
-            candidates.append((KIND_STRUCT, m.group(2)))
-        for m in QUOTED_RE.finditer(line):
-            # A bare quoted literal only counts as a write in a mutation context
-            # (this line or either of the two lines above) and NOT when the same
-            # line carries a query operator (a filter clause, not a $set value).
-            # Both checks are invariant-independent, so resolved once here.
-            if not (
-                MUTATION_CONTEXT_RE.search(line)
-                or (i > 0 and MUTATION_CONTEXT_RE.search(code_lines[i - 1]))
-                or (i > 1 and MUTATION_CONTEXT_RE.search(code_lines[i - 2]))
-            ):
-                continue
-            if FILTER_OPERATOR_RE.search(line):
-                continue
-            candidates.append((KIND_QUOTED, m.group(1)))
-        for set_m in SQL_SET_KEYWORD_RE.finditer(line):
-            tail = line[set_m.end():]
-            semi = tail.find(";")
-            if semi != -1:
-                tail = tail[:semi]
-            for fm in SQL_FIELD_RE.finditer(tail):
-                candidates.append((KIND_SQL, fm.group(1)))
-        if not candidates:
-            continue
-        symbol = _enclosing_symbol(code_lines, i)
-        snippet = raw_lines[i].strip()[:200]
-        for kind, token in candidates:
-            sites.append(WriteSite(
-                file=path, line=i + 1, text=snippet, symbol=symbol,
-                is_test=is_test, kind=kind, token=token,
-            ))
-    return sites
 
 
 def match_writers(sites: list[WriteSite], invariant: SingleWriterInvariant) -> list[Writer]:
@@ -696,8 +560,46 @@ def _scanner_version() -> str:
     here = Path(__file__).resolve()
     cw_dir = here.parent / "chief_wiggum"
     return scanner_version(
-        here, cw_dir / "annotations.py", cw_dir / "manifest.py", cw_dir / "hashing.py"
+        here,
+        cw_dir / "annotations.py",
+        cw_dir / "manifest.py",
+        cw_dir / "hashing.py",
+        cw_dir / "write_emission.py",
+        cw_dir / "languages.py",
     )
+
+
+def unsupported_extension_counts(
+    source_root: str | Path,
+    exclude: list[str] | None = None,
+    only_files: set[str] | None = None,
+) -> dict[str, int]:
+    """Count files with a RECOGNIZED-but-unsupported extension (#162) — one
+    ``scripts/emitters`` has no emitter for at all (language-specific or
+    generic tier) — among the same candidate set ``scan_writers`` would walk.
+    Never silent: this feeds a ``coverage`` warning in ``check()`` instead of
+    the file simply disappearing from the scan with no trace. Extensions
+    outside the curated ``config/languages.json`` unsupported list (arbitrary
+    non-source files: markdown, images, lockfiles, ...) are not counted —
+    only extensions this repo explicitly recognizes as "a real language we
+    don't scan yet" are worth flagging."""
+    root = Path(source_root)
+    exclude = exclude or []
+    counts: dict[str, int] = {}
+    if not root.exists():
+        return counts
+    candidates = sorted(only_files) if only_files is not None else walk_source_files(root)
+    unsupported = emitters.unsupported_extensions()
+    for rel in candidates:
+        suffix = Path(rel).suffix
+        if suffix not in unsupported:
+            continue
+        if any(part in SKIP_PARTS for part in Path(rel).parts):
+            continue
+        if _excluded(rel, exclude):
+            continue
+        counts[suffix] = counts.get(suffix, 0) + 1
+    return counts
 
 
 # --- top-level check --------------------------------------------------------
@@ -757,6 +659,17 @@ def check(
                         f"{inv.id}: no writer found for {inv.controls_field} — "
                         f"sanctioned writer(s) {inv.sanctioned_writers} may be missing or misnamed"
                     )
+        # Coverage metadata (#162): a recognized-but-unsupported-language file is
+        # NEVER silently dropped — surfaced as an explicit warning, same as any
+        # other coverage gap this checker reports.
+        unsupported = unsupported_extension_counts(source_root, exclude=scan_exclude, only_files=only_files)
+        if unsupported:
+            total = sum(unsupported.values())
+            detail = ", ".join(f"{ext} ({n})" for ext, n in sorted(unsupported.items()))
+            report.warnings.append(
+                f"{total} file(s) skipped: no emitter coverage for recognized-but-unsupported "
+                f"extension(s) {detail} — see config/languages.json"
+            )
     else:
         report.warnings.append("no --source given; parsed invariant metadata only (no repo scan)")
 

--- a/scripts/check_single_writer.py
+++ b/scripts/check_single_writer.py
@@ -500,7 +500,15 @@ def scan_writers(
             text = path.read_text()
         except OSError:
             continue
-        sites = emit_write_sites(rel, text)
+        # Route through the per-language emitter registry (#162) — the gate
+        # consumes the SAME dispatch path scripts/emitters exposes, so a
+        # per-language emitter can never drift from what the gate actually
+        # scans. Every SOURCE_EXTS extension has an emitter (a tier-1 language
+        # module or the generic regex tier), so tier is never "unsupported"
+        # here; genuinely unsupported extensions are counted separately by
+        # unsupported_extension_counts.
+        facts, _tier = emitters.emit(rel, text)
+        sites = emitters.facts_of_kind(facts, "write_site")
         if not sites:
             continue
         # Claim per invariant, then merge preserving the ORIGINAL ordering: line
@@ -543,14 +551,26 @@ def _is_sanctioned(inv: SingleWriterInvariant, rel: str, symbol: str | None) -> 
 def _file_predicate(rel: str) -> bool:
     """The scanner's EXACT file-selection rule (extension allow-list + skipped
     directories) — the same predicate `scan_writers` applies during its own
-    walk, reused to build a manifest whose keys are exactly the files that walk
-    would visit (see ``chief_wiggum.manifest``)."""
+    walk (see ``chief_wiggum.manifest``)."""
     p = Path(rel)
     if p.suffix not in SOURCE_EXTS:
         return False
     if any(part in SKIP_PARTS for part in p.parts):
         return False
     return True
+
+
+def _changed_since_predicate(rel: str) -> bool:
+    """Manifest predicate for ``--changed-since``: the scanner's own rule
+    WIDENED with the recognized-but-unsupported extensions (#162), so a changed
+    ``.php``/``.cpp`` file still reaches ``unsupported_extension_counts`` and
+    triggers the coverage warning in scoped mode — scoping must never make a
+    coverage gap silent. ``scan_writers`` itself still filters candidates to
+    ``SOURCE_EXTS``, so the extra paths never affect the writer scan."""
+    p = Path(rel)
+    if any(part in SKIP_PARTS for part in p.parts):
+        return False
+    return p.suffix in SOURCE_EXTS or p.suffix in emitters.unsupported_extensions()
 
 
 def _scanner_version() -> str:
@@ -642,8 +662,11 @@ def check(
         only_files = None
         if changed_since:
             # Ticket-scoped speed-up ONLY — never used by /close-epic's coverage
-            # gate, which must see the whole repo to be authoritative.
-            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
+            # gate, which must see the whole repo to be authoritative. The
+            # predicate is widened with unsupported extensions so a changed
+            # .php/.cpp still triggers the coverage warning (scan_writers
+            # filters back down to SOURCE_EXTS itself).
+            only_files = changed_paths(source_root, changed_since, predicate=_changed_since_predicate)
         writers = scan_writers(source_root, invariants, exclude=scan_exclude, only_files=only_files)
         report.writers = [w.to_dict() for w in writers]
         report.violations = [w.to_dict() for w in writers if not w.sanctioned]

--- a/scripts/check_traceability.py
+++ b/scripts/check_traceability.py
@@ -36,22 +36,59 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# The ID grammar and verb set are shared with ratchet.py and the TIM schema —
-# a kind added in one place but not the others is silently dropped, so all
-# three build from chief_wiggum.trace_ids (cross-checked in tests).
+# The per-language emitter registry (#162): language-specific emitter -> generic
+# regex tier -> skip-with-warning. Used by scan_source/unsupported_extension_counts
+# below to surface files with NO emitter coverage instead of dropping them silently.
+import emitters  # noqa: E402
+
+# The declared language support matrix (#162) — SOURCE_EXTS below is derived
+# from it (tier-1 + generic-tier extensions) plus this checker's own
+# verification-artifact extensions. The emitter fallback chain (scripts/emitters/)
+# reports files with no coverage at all as an explicit warning rather than a
+# silent skip. See config/languages.json + docs/languages.md.
+from chief_wiggum import languages as cw_languages  # noqa: E402
+
 # Shared with check_single_writer.py: the hash-derived --scanner-version and
 # the git-native manifest helper behind --changed-since (#160). walk_source_files
 # prunes submodules/nested git checkouts from the FULL scan so both scan modes
 # agree on the file universe (the manifest never surfaces submodule blobs).
+# hash_epic_definitions (#169) is the same contract-block hashing ratchet.py
+# uses for weakening detection — one implementation, not a parallel copy.
 from chief_wiggum.hashing import hash_epic_definitions, scanner_version  # noqa: E402
 from chief_wiggum.manifest import ManifestError, changed_paths, walk_source_files  # noqa: E402
-from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE, canonical_id  # noqa: E402
+
+# The @cw-trace annotation emission family (Annotation, classify_source_kind,
+# canonical_id, kind_of, parse_annotations, emit_source_annotations) moved to
+# chief_wiggum.trace_emission (#162) so scripts/emitters/*.py can sit BEHIND
+# the same per-file emission logic this checker uses — re-exported here
+# unchanged so every existing `check_traceability.X` reference keeps working
+# (golden parity; see tests/test_traceability_golden.py). canonical_id's HOME
+# is chief_wiggum.trace_ids (#181: definition-hash keys and annotation targets
+# must join on the same canonical form); trace_emission re-exports it.
+from chief_wiggum.trace_emission import (  # noqa: E402, F401
+    PROBE_DIR_PARTS,
+    Annotation,
+    canonical_id,
+    classify_source_kind,
+    emit_source_annotations,
+    kind_of,
+    parse_annotations,
+)
+
+# The ID grammar and verb set are shared with ratchet.py and the TIM schema —
+# a kind added in one place but not the others is silently dropped, so all
+# three build from chief_wiggum.trace_ids (cross-checked in tests). TRACE_RE
+# isn't called directly by every function here anymore (parse_annotations
+# moved to chief_wiggum.trace_emission, which imports it itself) but stays
+# re-exported as `check_traceability.TRACE_RE` for backward compatibility
+# (see tests/test_trace_ids.py's identity checks).
+from chief_wiggum.trace_ids import DEFINE_RE, ID_RE, TRACE_RE  # noqa: E402, F401
 
 # Suspect-link propagation (#169): a link is SUSPECT when the ID it was
 # verified against has a definition hash that no longer matches the hash
@@ -75,25 +112,12 @@ DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "templates" / "formal-mod
 # Code/test annotations live in code/test files — not markdown. Prose docs
 # (including this checker's own examples and the epic's realizes lines) are
 # handled only by scan_epic_annotations, so they aren't double-counted.
-# .rego/.yaml/.yml are verification artifacts (policy/probe/telemetry — #166).
-SOURCE_EXTS = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java", ".rb", ".rs", ".rego", ".yaml", ".yml"}
-
-# Directory names whose files are verification probes (k6 scenarios, chaos
-# experiments) rather than product code — see classify_source_kind.
-PROBE_DIR_PARTS = {"k6", "chaos", "probe", "probes", "load", "loadtest"}
-
-
-@dataclass
-class Annotation:
-    verb: str
-    target: str
-    file: str
-    line: int
-    source_kind: str  # "code" | "test" | "probe" | "policy" | "telemetry" | a declared ID kind (CTR, INV, BUD, ...)
-    source_id: str | None = None  # for realizes: the declaring contract/invariant ID
-
-    def to_dict(self) -> dict:
-        return asdict(self)
+# .rego/.yaml/.yml are verification artifacts (policy/probe/telemetry — #166),
+# not a programming language in config/languages.json, so they're appended here
+# rather than folded into the shared matrix. Backward-compatible: identical to
+# the pre-#162 hardcoded set.
+VERIFICATION_EXTS = {".rego", ".yaml", ".yml"}
+SOURCE_EXTS = cw_languages.all_known_extensions() | VERIFICATION_EXTS
 
 
 @dataclass
@@ -165,27 +189,6 @@ class TraceReport:
 
 def load_schema(path: Path = DEFAULT_SCHEMA) -> dict:
     return json.loads(Path(path).read_text())
-
-
-def kind_of(node_id: str) -> str:
-    return node_id.split("-", 1)[0].upper()
-
-
-# canonical_id's home is chief_wiggum.trace_ids (shared with the hashing
-# module, so definition-hash keys and annotation targets join on the same
-# canonical form — PR #181 review); imported above, re-exported here for
-# existing callers.
-
-
-def parse_annotations(text: str) -> list[tuple[str, list[str]]]:
-    """Parse ``@cw-trace`` tags from text into (verb, [ids]) pairs."""
-    out: list[tuple[str, list[str]]] = []
-    for m in TRACE_RE.finditer(text):
-        verb = m.group("verb").lower()
-        ids = [canonical_id(i.group(0)) for i in ID_RE.finditer(m.group("ids"))]
-        if ids:
-            out.append((verb, ids))
-    return out
 
 
 def extract_defined_ids(epic_dir: str | Path) -> dict[str, str]:
@@ -309,40 +312,13 @@ def scan_epic_annotations(epic_dir: str | Path) -> list[Annotation]:
     return annotations
 
 
-def classify_source_kind(rel: str, suffix: str) -> str:
-    """Classify a scanned file into a TIM artifact kind.
-
-    ``probe`` (k6/chaos/load scenarios), ``policy`` (rego), and ``telemetry``
-    (SLO/alert/metric YAML) are verification artifacts a ``verifies`` edge may
-    originate from (#166); everything else keeps the original test/code
-    path heuristic.
-    """
-    rel_lower = rel.lower()
-    parts = set(Path(rel_lower).parts)
-    if suffix == ".rego":
-        return "policy"
-    if parts & PROBE_DIR_PARTS:
-        return "probe"
-    if suffix in (".yaml", ".yml"):
-        return "telemetry"
-    # e2e directories are test infrastructure (setup/fixtures/helpers) even when
-    # the filename itself carries no test/spec marker (e.g. ui/e2e/global-setup.ts).
-    is_test = (
-        "test" in rel_lower
-        or "spec" in rel_lower
-        or "e2e" in parts
-    )
-    return "test" if is_test else "code"
-
-
 SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv"}
 
 
 def _file_predicate(rel: str) -> bool:
     """The scanner's EXACT file-selection rule (extension allow-list + skipped
     directories) — the same predicate ``scan_source`` applies during its own
-    walk, reused to build a manifest whose keys are exactly the files that walk
-    would visit (see ``chief_wiggum.manifest``)."""
+    walk (see ``chief_wiggum.manifest``)."""
     p = Path(rel)
     if p.suffix not in SOURCE_EXTS:
         return False
@@ -351,25 +327,54 @@ def _file_predicate(rel: str) -> bool:
     return True
 
 
-def emit_source_annotations(rel: str, text: str, suffix: str) -> list[Annotation]:
-    """Per-file EMISSION: every ``@cw-trace`` annotation in one source/test/
-    verification file's ``text``, classified by this file's source kind. Pure
-    function of file content — no knowledge of the defined-ID set (that join
-    happens in ``build_report``, at query/report time)."""
-    source_kind = classify_source_kind(rel, suffix)
-    annotations: list[Annotation] = []
-    for i, line in enumerate(text.splitlines(), start=1):
-        for verb, ids in parse_annotations(line):
-            for target in ids:
-                annotations.append(Annotation(verb, target, rel, i, source_kind))
-    return annotations
+def _changed_since_predicate(rel: str) -> bool:
+    """Manifest predicate for ``--changed-since``: the scanner's own rule
+    WIDENED with the recognized-but-unsupported extensions (#162), so a changed
+    ``.php``/``.cpp`` file still reaches ``unsupported_extension_counts`` and
+    triggers the coverage warning in scoped mode — scoping must never make a
+    coverage gap silent. ``scan_source`` itself still filters candidates
+    through ``_file_predicate``, so the extra paths never affect the
+    annotation scan."""
+    p = Path(rel)
+    if any(part in SKIP_PARTS for part in p.parts):
+        return False
+    return p.suffix in SOURCE_EXTS or p.suffix in emitters.unsupported_extensions()
+
+
+def unsupported_extension_counts(
+    source_root: str | Path, only_files: set[str] | None = None
+) -> dict[str, int]:
+    """Count files with a RECOGNIZED-but-unsupported extension (#162) — one
+    ``scripts/emitters`` has no emitter for at all (language-specific or
+    generic tier) — among the same candidate set ``scan_source`` would walk.
+    Never silent: this feeds a ``coverage`` warning in ``check()`` instead of
+    the file simply disappearing from the scan with no trace."""
+    root = Path(source_root)
+    counts: dict[str, int] = {}
+    if not root.exists():
+        return counts
+    candidates = sorted(only_files) if only_files is not None else walk_source_files(root)
+    unsupported = emitters.unsupported_extensions()
+    for rel in candidates:
+        suffix = Path(rel).suffix
+        if suffix not in unsupported:
+            continue
+        if any(part in SKIP_PARTS for part in Path(rel).parts):
+            continue
+        counts[suffix] = counts.get(suffix, 0) + 1
+    return counts
 
 
 def scan_source(source_root: str | Path, only_files: set[str] | None = None) -> list[Annotation]:
     """Walk source/test/verification files, emitting ``@cw-trace`` annotations
-    per file via ``emit_source_annotations``. ``only_files`` (repo-relative
-    paths), when given, restricts the walk to that set instead of the whole
-    tree — used by ``--changed-since``."""
+    per file. Language files route through the per-language emitter registry
+    (``scripts/emitters`` — the gate consumes the SAME dispatch path the
+    emitters expose, so a per-language emitter can never drift from what the
+    gate actually scans); verification artifacts (``.rego``/``.yaml``/``.yml``
+    — not a programming language in the matrix) keep the direct
+    ``emit_source_annotations`` path. ``only_files`` (repo-relative paths),
+    when given, restricts the walk to that set instead of the whole tree —
+    used by ``--changed-since``."""
     root = Path(source_root)
     annotations: list[Annotation] = []
     if not root.exists():
@@ -388,7 +393,11 @@ def scan_source(source_root: str | Path, only_files: set[str] | None = None) -> 
             text = path.read_text()
         except OSError:
             continue
-        annotations.extend(emit_source_annotations(rel, text, path.suffix))
+        if path.suffix in VERIFICATION_EXTS:
+            annotations.extend(emit_source_annotations(rel, text, path.suffix))
+        else:
+            facts, _tier = emitters.emit(rel, text)
+            annotations.extend(emitters.facts_of_kind(facts, "trace_annotation"))
     return annotations
 
 
@@ -397,7 +406,14 @@ def _scanner_version() -> str:
     ``chief_wiggum`` dependencies. No hand-bumped constant to forget."""
     here = Path(__file__).resolve()
     cw_dir = here.parent / "chief_wiggum"
-    return scanner_version(here, cw_dir / "trace_ids.py", cw_dir / "manifest.py", cw_dir / "hashing.py")
+    return scanner_version(
+        here,
+        cw_dir / "trace_ids.py",
+        cw_dir / "trace_emission.py",
+        cw_dir / "manifest.py",
+        cw_dir / "hashing.py",
+        cw_dir / "languages.py",
+    )
 
 
 def build_report(
@@ -538,14 +554,29 @@ def check(
     coverage_requirements = extract_coverage_requirements(epic_dir)
     # Contract->BR realizes links live in the epic docs; code/test links in source.
     annotations = scan_epic_annotations(epic_dir)
+    unsupported: dict[str, int] = {}
     if source_root:
         only_files = None
         if changed_since:
             # Ticket-scoped speed-up ONLY — never used by /close-epic's coverage
-            # gate, which must see the whole repo to be authoritative.
-            only_files = changed_paths(source_root, changed_since, predicate=_file_predicate)
+            # gate, which must see the whole repo to be authoritative. The
+            # predicate is widened with unsupported extensions so a changed
+            # .php/.cpp still triggers the coverage warning (scan_source
+            # filters back down through _file_predicate itself).
+            only_files = changed_paths(source_root, changed_since, predicate=_changed_since_predicate)
         annotations += scan_source(source_root, only_files=only_files)
+        unsupported = unsupported_extension_counts(source_root, only_files=only_files)
     report = build_report(defined, annotations, schema, coverage_requirements=coverage_requirements)
+    if unsupported:
+        # Coverage metadata (#162): a recognized-but-unsupported-language file is
+        # NEVER silently dropped — surfaced as an explicit warning, same as any
+        # other coverage gap this checker reports.
+        total = sum(unsupported.values())
+        detail = ", ".join(f"{ext} ({n})" for ext, n in sorted(unsupported.items()))
+        report.warnings.append(
+            f"{total} file(s) skipped: no emitter coverage for recognized-but-unsupported "
+            f"extension(s) {detail} — see config/languages.json"
+        )
 
     if links_path is not None:
         current_hashes = hash_epic_definitions(Path(epic_dir))

--- a/scripts/chief_wiggum/languages.py
+++ b/scripts/chief_wiggum/languages.py
@@ -1,0 +1,124 @@
+"""Loader + helpers for ``config/languages.json`` (#162): the declared
+per-language support matrix.
+
+Three consumers read this single artifact instead of each hand-rolling its
+own idea of "which languages/extensions are supported":
+
+- ``check_single_writer.py`` / ``check_traceability.py`` derive their
+  ``SOURCE_EXTS`` allow-list from :func:`all_known_extensions` and their
+  "recognized but unsupported" coverage warning from
+  :func:`unsupported_extensions` (via ``scripts/emitters``).
+- ``scripts/check_deps.py`` maps a language's ``dep_profile`` to the
+  dependency profile that installs its LSP/toolchain (e.g. Go -> ``go-lsp``).
+- ``scripts/render_languages_doc.py`` renders the whole matrix into
+  ``docs/languages.md`` so the doc can never silently drift from the artifact.
+
+See ``docs/languages.md`` for the rendered, human-readable matrix.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+DEFAULT_PATH = Path(__file__).resolve().parents[2] / "config" / "languages.json"
+
+
+@dataclass(frozen=True)
+class Language:
+    """One entry in ``config/languages.json``'s ``languages`` map."""
+
+    name: str
+    tier: str  # "1" for a built tier-1 emitter, or a maturity label e.g. "designed"
+    status: str
+    extensions: tuple[str, ...]
+    lsp: str | None
+    emitters: tuple[str, ...]
+    test_parser: str | None
+    extractor: str | None
+    func_regex: bool
+    dep_profile: str | None = None
+    trigger: str | None = None
+    requires: tuple[str, ...] = ()
+    note: str | None = None
+
+    @property
+    def built(self) -> bool:
+        """True for an actually-built tier-1 emitter (Go/Python/TypeScript
+        today) — False for a documented-but-unbuilt slot (Rust)."""
+        return self.tier == "1"
+
+
+@lru_cache(maxsize=8)
+def _load_cached(path_str: str) -> dict:
+    return json.loads(Path(path_str).read_text())
+
+
+def load(path: Path | str = DEFAULT_PATH) -> dict:
+    """Raw parsed ``config/languages.json``. Cached per path (the matrix is
+    read-only artifact data, not runtime state)."""
+    return _load_cached(str(path))
+
+
+def languages(path: Path | str = DEFAULT_PATH) -> dict[str, Language]:
+    """``{name: Language}`` for every entry in the matrix, in file order."""
+    data = load(path)
+    out: dict[str, Language] = {}
+    for name, entry in (data.get("languages") or {}).items():
+        out[name] = Language(
+            name=name,
+            tier=str(entry.get("tier", "")),
+            status=str(entry.get("status", "")),
+            extensions=tuple(entry.get("extensions", [])),
+            lsp=entry.get("lsp"),
+            emitters=tuple(entry.get("emitters", [])),
+            test_parser=entry.get("test_parser"),
+            extractor=entry.get("extractor"),
+            func_regex=bool(entry.get("func_regex", False)),
+            dep_profile=entry.get("dep_profile"),
+            trigger=entry.get("trigger"),
+            requires=tuple(entry.get("requires", [])),
+            note=entry.get("note"),
+        )
+    return out
+
+
+def extension_to_language(path: Path | str = DEFAULT_PATH) -> dict[str, str]:
+    """``suffix -> language name`` for BUILT tier-1 languages only (a dedicated
+    ``scripts/emitters/<name>.py`` module exists). A designed-but-unbuilt slot
+    (Rust) is deliberately excluded here — its extension falls through to
+    :func:`generic_tier_extensions` instead, matching current runtime behavior."""
+    out: dict[str, str] = {}
+    for lang in languages(path).values():
+        if not lang.built:
+            continue
+        for ext in lang.extensions:
+            out[ext] = lang.name
+    return out
+
+
+def generic_tier_extensions(path: Path | str = DEFAULT_PATH) -> frozenset[str]:
+    """Extensions scanned by the generic (language-agnostic) regex tier — no
+    dedicated per-language emitter module, but still covered."""
+    data = load(path)
+    return frozenset((data.get("generic_tier") or {}).get("extensions", []))
+
+
+def unsupported_extensions(path: Path | str = DEFAULT_PATH) -> frozenset[str]:
+    """Curated set of recognized programming-language extensions with NO
+    emitter coverage at all — encountering one during a scan must produce an
+    explicit warning, never a silent skip (see check_single_writer.py /
+    check_traceability.py ``unsupported_extension_counts``)."""
+    data = load(path)
+    return frozenset((data.get("unsupported_extensions") or {}).get("extensions", []))
+
+
+def all_known_extensions(path: Path | str = DEFAULT_PATH) -> frozenset[str]:
+    """Union of tier-1 (built) + generic-tier extensions — the full set of
+    extensions a scanner actually walks. This is the single source of truth
+    ``check_single_writer.SOURCE_EXTS`` / ``check_traceability.SOURCE_EXTS``
+    derive from (the latter appends its own non-language verification-artifact
+    extensions on top: ``.rego``/``.yaml``/``.yml``)."""
+    return frozenset(set(extension_to_language(path)) | generic_tier_extensions(path))

--- a/scripts/chief_wiggum/trace_emission.py
+++ b/scripts/chief_wiggum/trace_emission.py
@@ -1,0 +1,99 @@
+"""``@cw-trace`` annotation emission (#162): the per-file parsing that finds
+every ``@cw-trace <verb> <ID>...`` annotation in one file's text.
+
+This is the exact logic that used to live inline in ``check_traceability.py``
+(the emission half of the emission/claim split from #160) — moved here so it
+can sit BEHIND the ``scripts/emitters/`` per-language interface, alongside
+``chief_wiggum.write_emission`` (the single-writer emission family). It shares
+the ID grammar with ``chief_wiggum.trace_ids`` rather than duplicating it.
+``check_traceability.py`` re-exports every name below unchanged, so existing
+imports (``check_traceability.emit_source_annotations``,
+``check_traceability.Annotation``, ``check_traceability.canonical_id``, ...)
+keep working — this is a pure move, not a behavior change (golden parity; see
+``tests/test_traceability_golden.py`` and ``docs/languages.md``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# canonical_id's home is chief_wiggum.trace_ids (#181: shared with the
+# definition-hashing module, so definition-hash keys and annotation targets
+# join on the same canonical form) — imported and re-exported here so
+# emission-side consumers get it from the single home.
+from chief_wiggum.trace_ids import ID_RE, TRACE_RE, canonical_id  # noqa: F401
+
+# Directory names whose files are verification probes (k6/chaos experiments)
+# rather than product code — see classify_source_kind.
+PROBE_DIR_PARTS = {"k6", "chaos", "probe", "probes", "load", "loadtest"}
+
+
+@dataclass
+class Annotation:
+    verb: str
+    target: str
+    file: str
+    line: int
+    source_kind: str  # "code" | "test" | "probe" | "policy" | "telemetry" | a declared ID kind (CTR, INV, BUD, ...)
+    source_id: str | None = None  # for realizes: the declaring contract/invariant ID
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def kind_of(node_id: str) -> str:
+    return node_id.split("-", 1)[0].upper()
+
+
+def parse_annotations(text: str) -> list[tuple[str, list[str]]]:
+    """Parse ``@cw-trace`` tags from text into (verb, [ids]) pairs."""
+    out: list[tuple[str, list[str]]] = []
+    for m in TRACE_RE.finditer(text):
+        verb = m.group("verb").lower()
+        ids = [canonical_id(i.group(0)) for i in ID_RE.finditer(m.group("ids"))]
+        if ids:
+            out.append((verb, ids))
+    return out
+
+
+def classify_source_kind(rel: str, suffix: str) -> str:
+    """Classify a scanned file into a TIM artifact kind.
+
+    ``probe`` (k6/chaos/load scenarios), ``policy`` (rego), and ``telemetry``
+    (SLO/alert/metric YAML) are verification artifacts a ``verifies`` edge may
+    originate from (#166); everything else keeps the original test/code
+    path heuristic.
+    """
+    rel_lower = rel.lower()
+    parts = set(Path(rel_lower).parts)
+    if suffix == ".rego":
+        return "policy"
+    if parts & PROBE_DIR_PARTS:
+        return "probe"
+    if suffix in (".yaml", ".yml"):
+        return "telemetry"
+    # e2e directories are test infrastructure (setup/fixtures/helpers) even when
+    # the filename itself carries no test/spec marker (e.g. ui/e2e/global-setup.ts).
+    is_test = (
+        "test" in rel_lower
+        or "spec" in rel_lower
+        or "e2e" in parts
+    )
+    return "test" if is_test else "code"
+
+
+def emit_source_annotations(rel: str, text: str, suffix: str) -> list[Annotation]:
+    """Per-file EMISSION: every ``@cw-trace`` annotation in one source/test/
+    verification file's ``text``, classified by this file's source kind. Pure
+    function of file content — no knowledge of the defined-ID set (that join
+    happens in ``check_traceability.build_report``, at query/report time).
+    This is the function every trace-annotation emitter (language-specific or
+    generic) under ``scripts/emitters/`` delegates to."""
+    source_kind = classify_source_kind(rel, suffix)
+    annotations: list[Annotation] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for verb, ids in parse_annotations(line):
+            for target in ids:
+                annotations.append(Annotation(verb, target, rel, i, source_kind))
+    return annotations

--- a/scripts/chief_wiggum/write_emission.py
+++ b/scripts/chief_wiggum/write_emission.py
@@ -1,0 +1,202 @@
+"""Field-agnostic write-site emission (#162): the per-file regex family that
+finds candidate write-shaped tokens in one file's text, with NO knowledge of
+any invariant or controlled field.
+
+This is the exact logic that used to live inline in ``check_single_writer.py``
+(the emission half of the emission/claim split from #160) — moved here so it
+can sit BEHIND the ``scripts/emitters/`` per-language interface (one seam,
+reused by the Go/Python/TypeScript/generic emitter modules) instead of being
+private to a single checker. ``check_single_writer.py`` re-exports every name
+below unchanged, so existing imports (``check_single_writer.emit_write_sites``,
+``check_single_writer.KIND_ASSIGN``, ...) keep working — this is a pure move,
+not a behavior change (golden parity; see ``tests/test_single_writer_golden.py``
+and ``docs/languages.md``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# A file is test infrastructure (not a sanctioned/unsanctioned production writer)
+# — same heuristic as check_traceability.py. Test writes of a controlled field
+# are fixtures, not a competing production write path, so they don't violate.
+def _is_test_path(rel: str) -> bool:
+    low = rel.lower()
+    return "test" in low or "spec" in low or any(p == "e2e" for p in Path(low).parts)
+
+
+# Generic (field-agnostic) write-site detectors. Each captures a candidate
+# identifier token; whether that token belongs to any particular invariant's
+# controlled field is a QUERY-TIME decision (match_writers, in
+# check_single_writer.py), not baked into the regex. Kind indices (0-3) mirror
+# the four write shapes documented in check_single_writer's module docstring
+# and drive `persistence_only` filtering in match_writers.
+KIND_ASSIGN, KIND_STRUCT, KIND_QUOTED, KIND_SQL = range(4)
+
+# The token classes are wider than `\w+` on purpose: the pre-split scanner
+# built its regexes from `re.escape(leaf_token)`, so a controlled field whose
+# leaf contains a hyphen (e.g. a Mongo key `plan-tier`) DID match. Emission
+# must cover at least that same token surface or a full scan could silently
+# miss an unsanctioned writer of such a field; over-wide captures are harmless
+# (a token that matches no invariant's field is dropped at claim time).
+# 0. Assignment: `something.Plan =` / `.stripe_plan =` (not ==; `:=` — Go's
+#    declare+assign — IS a write, so it's allowed).
+ASSIGN_RE = re.compile(r"\.([\w-]+)\s*:?=[^=]")
+# 1. Struct-literal / map set: `Plan: value` or `"plan": value` or `Key: "plan"`.
+#    `:(?!=)` so Go's short-var-decl `plan := expr` is NOT read as a field set
+#    (the captured token would be the local var name, and `:` the `:` of `:=`).
+STRUCT_RE = re.compile(r"""(^|[\s,{(])['"]?([\w.-]+)['"]?\s*:(?!=)\s*""")
+# 2. bson/Mongo update key referenced literally in a set expression. `.` is in
+#    the class so a dotted key (`"provider.plan"`) is captured whole — leaf
+#    tokens never contain dots, so it can't claim-match a leaf field, exactly
+#    like the old quote-delimited exact-token match behaved.
+QUOTED_RE = re.compile(r"""['"]([\w.-]+)['"]""")
+# 3. SQL UPDATE ... SET <field> = ...  (multiple fields may be set on one line).
+SQL_SET_KEYWORD_RE = re.compile(r"\bSET\b", re.IGNORECASE)
+SQL_FIELD_RE = re.compile(r"\b([\w-]+)\s*=")
+
+# A bson $set / Mongo update / SQL UPDATE context marker — a bare `"plan":` in a
+# non-mutating context (e.g. a JSON response DTO field) shouldn't count. We only
+# treat KIND_QUOTED (quoted-literal) as a write when the surrounding lines look
+# like a mutation. KIND_ASSIGN and KIND_STRUCT are writes on their own.
+MUTATION_CONTEXT_RE = re.compile(
+    r"\$set|UpdateOne|UpdateMany|UpdateByID|FindOneAndUpdate|bson\.[ME]|SET\b|UPDATE\b",
+    re.IGNORECASE,
+)
+
+# A bson/Mongo QUERY operator on the same line means the `"field":` there is a FILTER
+# clause (which document to match), not a `$set` value (what to write). e.g.
+# `bson.M{"plan": bson.M{"$exists": false}}` selects rows, it doesn't write plan. Skip it.
+FILTER_OPERATOR_RE = re.compile(
+    r"\$(?:exists|in|nin|ne|eq|gt|gte|lt|lte|regex|or|and|not|nor|type|all|elemMatch|size)\b"
+)
+
+# Line-comment markers per language. Used to strip trailing comments before matching,
+# so a field name mentioned in a comment (e.g. `// Free plan: …`) is not read as a write.
+_COMMENT_MARKERS = {
+    ".go": ("//",), ".ts": ("//",), ".tsx": ("//",), ".js": ("//",), ".jsx": ("//",),
+    ".java": ("//",), ".rs": ("//",), ".py": ("#",), ".rb": ("#",),
+}
+
+
+def _strip_line_comment(line: str, suffix: str) -> str:
+    """Drop a trailing line comment, respecting string/char literals so an in-string
+    marker (a URL's `//`, a TS `#private`, a `#` inside a Python string) is preserved.
+    Multi-line strings aren't tracked (per-line scan) — acceptable: at worst a comment
+    marker inside a rare multi-line literal truncates a line we only search for writes."""
+    markers = _COMMENT_MARKERS.get(suffix)
+    if not markers:
+        return line
+    quote: str | None = None
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"', "`"):
+            quote = ch
+            i += 1
+            continue
+        for m in markers:
+            if line.startswith(m, i):
+                return line[:i]
+        i += 1
+    return line
+
+
+GO_FUNC_RE = re.compile(r"^\s*func\s+(?:\([^)]*\)\s*)?([A-Za-z_][A-Za-z0-9_]*)")
+PY_FUNC_RE = re.compile(r"^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)")
+TS_FUNC_RE = re.compile(r"(?:function\s+([A-Za-z_$][\w$]*)|([A-Za-z_$][\w$]*)\s*[:=]\s*(?:async\s*)?\()")
+
+
+def _enclosing_symbol(lines: list[str], idx: int) -> str | None:
+    """Nearest function/method name declared at or above line index ``idx``."""
+    for j in range(idx, -1, -1):
+        line = lines[j]
+        for pat in (GO_FUNC_RE, PY_FUNC_RE):
+            m = pat.match(line)
+            if m:
+                return m.group(1)
+        m = TS_FUNC_RE.search(line)
+        if m:
+            return m.group(1) or m.group(2)
+    return None
+
+
+@dataclass
+class WriteSite:
+    """A FIELD-AGNOSTIC candidate write site: emission time knows nothing about
+    any invariant's controlled field — just "this line assigns/sets/matches an
+    identifier token, in this file, in this enclosing symbol". Whether ``token``
+    belongs to a controlled field is a query-time decision (``match_writers``,
+    in ``check_single_writer.py``).
+    """
+
+    file: str
+    line: int  # 1-indexed
+    text: str  # raw (comment-un-stripped) line, stripped + truncated for display
+    symbol: str | None
+    is_test: bool
+    kind: int  # KIND_ASSIGN | KIND_STRUCT | KIND_QUOTED | KIND_SQL
+    token: str  # the identifier exactly as it appears in source (case preserved)
+
+
+def emit_write_sites(path: str, text: str) -> list[WriteSite]:
+    """Emission: every candidate write site in a single file's ``text``, with NO
+    knowledge of any specific invariant or controlled field (see module +
+    class docstrings). ``path`` is a repo-relative label used only for
+    ``.suffix`` (comment-marker lookup) and the ``file`` attribute — the file
+    is never re-read from disk, so this is safe to call on manifest-sourced
+    content. This is the function every write-site emitter (language-specific
+    or generic) under ``scripts/emitters/`` delegates to."""
+    suffix = Path(path).suffix
+    raw_lines = text.splitlines()
+    code_lines = [_strip_line_comment(rl, suffix) for rl in raw_lines]
+    is_test = _is_test_path(path)
+    sites: list[WriteSite] = []
+    for i, line in enumerate(code_lines):
+        candidates: list[tuple[int, str]] = []  # (kind, token)
+        for m in ASSIGN_RE.finditer(line):
+            candidates.append((KIND_ASSIGN, m.group(1)))
+        for m in STRUCT_RE.finditer(line):
+            candidates.append((KIND_STRUCT, m.group(2)))
+        for m in QUOTED_RE.finditer(line):
+            # A bare quoted literal only counts as a write in a mutation context
+            # (this line or either of the two lines above) and NOT when the same
+            # line carries a query operator (a filter clause, not a $set value).
+            # Both checks are invariant-independent, so resolved once here.
+            if not (
+                MUTATION_CONTEXT_RE.search(line)
+                or (i > 0 and MUTATION_CONTEXT_RE.search(code_lines[i - 1]))
+                or (i > 1 and MUTATION_CONTEXT_RE.search(code_lines[i - 2]))
+            ):
+                continue
+            if FILTER_OPERATOR_RE.search(line):
+                continue
+            candidates.append((KIND_QUOTED, m.group(1)))
+        for set_m in SQL_SET_KEYWORD_RE.finditer(line):
+            tail = line[set_m.end():]
+            semi = tail.find(";")
+            if semi != -1:
+                tail = tail[:semi]
+            for fm in SQL_FIELD_RE.finditer(tail):
+                candidates.append((KIND_SQL, fm.group(1)))
+        if not candidates:
+            continue
+        symbol = _enclosing_symbol(code_lines, i)
+        snippet = raw_lines[i].strip()[:200]
+        for kind, token in candidates:
+            sites.append(WriteSite(
+                file=path, line=i + 1, text=snippet, symbol=symbol,
+                is_test=is_test, kind=kind, token=token,
+            ))
+    return sites

--- a/scripts/emitters/__init__.py
+++ b/scripts/emitters/__init__.py
@@ -78,6 +78,56 @@ def is_recognized_unsupported(suffix: str) -> bool:
     return suffix in unsupported_extensions()
 
 
+def registered_language_extensions() -> dict[str, str]:
+    """``suffix -> language name`` for every REGISTERED tier-1 emitter module.
+    Must equal ``chief_wiggum.languages.extension_to_language()`` — the
+    declared matrix and the actual registry may never drift; validated by
+    :func:`validate_registry_matches_matrix` (and pinned in
+    ``tests/test_emitters.py``)."""
+    return {ext: mod.language for ext, mod in _LANGUAGE_EMITTERS.items()}
+
+
+def validate_registry_matches_matrix() -> list[str]:
+    """Mechanical parity check between ``config/languages.json`` (the declared
+    matrix) and this registry (the actual emitter modules). Returns a list of
+    human-readable problems — empty means the two agree:
+
+    - every BUILT matrix language must have a registered emitter module of the
+      same name covering exactly its declared extensions;
+    - every registered tier-1 extension must be declared by a built matrix
+      language (no undeclared/unregistered strays in either direction);
+    - the generic module's extensions must equal the matrix's generic tier.
+    """
+    problems: list[str] = []
+    declared = cw_languages.extension_to_language()
+    registered = registered_language_extensions()
+    for ext, lang_name in declared.items():
+        got = registered.get(ext)
+        if got is None:
+            problems.append(
+                f"matrix declares built language {lang_name!r} for {ext!r} but no "
+                f"emitter module is registered for it"
+            )
+        elif got != lang_name:
+            problems.append(
+                f"matrix declares {ext!r} -> {lang_name!r} but the registry maps it "
+                f"to emitter {got!r}"
+            )
+    for ext, mod_name in registered.items():
+        if ext not in declared:
+            problems.append(
+                f"emitter {mod_name!r} registers {ext!r} but the matrix does not "
+                f"declare it for any built language"
+            )
+    matrix_generic = cw_languages.generic_tier_extensions()
+    if set(_generic.extensions) != matrix_generic:
+        problems.append(
+            f"generic emitter covers {sorted(_generic.extensions)} but the matrix's "
+            f"generic tier declares {sorted(matrix_generic)}"
+        )
+    return problems
+
+
 __all__ = [
     "Fact",
     "LanguageEmitter",
@@ -85,6 +135,8 @@ __all__ = [
     "emitter_for_suffix",
     "facts_of_kind",
     "is_recognized_unsupported",
+    "registered_language_extensions",
     "tier_for_suffix",
     "unsupported_extensions",
+    "validate_registry_matches_matrix",
 ]

--- a/scripts/emitters/__init__.py
+++ b/scripts/emitters/__init__.py
@@ -1,0 +1,90 @@
+"""Emitter registry + fallback chain (#162).
+
+::
+
+    language-specific emitter  ->  generic regex tier  ->  skip-with-warning
+
+For a given file's extension: use the dedicated tier-1 module
+(go/python/typescript) if one exists; otherwise the generic regex tier
+(java/ruby/rust today — see ``config/languages.json``'s ``generic_tier``);
+otherwise the file is unsupported. "Unsupported" is never silent — callers
+(``check_single_writer.py`` / ``check_traceability.py``) turn
+:func:`unsupported_extensions` into an explicit coverage warning rather than
+letting the file vanish from the scan with no trace.
+
+This module deliberately imports only ``chief_wiggum.*`` and its sibling
+``scripts/emitters/*.py`` modules — never ``check_single_writer`` /
+``check_traceability`` — so those checkers can import ``emitters`` back
+without a circular import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chief_wiggum import languages as cw_languages
+
+from . import generic as _generic
+from . import go as _go
+from . import python as _python
+from . import typescript as _typescript
+from .base import Fact, LanguageEmitter, facts_of_kind  # noqa: F401
+
+# suffix -> emitter module, for every BUILT tier-1 language.
+_LANGUAGE_EMITTERS: dict[str, object] = {}
+for _mod in (_go, _python, _typescript):
+    for _ext in _mod.extensions:
+        _LANGUAGE_EMITTERS[_ext] = _mod
+
+
+def tier_for_suffix(suffix: str) -> str:
+    """"language" | "generic" | "unsupported" — the fallback-chain rung a
+    file's extension lands on. Mirrors ``config/languages.json``'s tiers."""
+    if suffix in _LANGUAGE_EMITTERS:
+        return "language"
+    if suffix in _generic.extensions:
+        return "generic"
+    return "unsupported"
+
+
+def emitter_for_suffix(suffix: str):
+    """The emitter module for ``suffix``, or ``None`` if unsupported."""
+    if suffix in _LANGUAGE_EMITTERS:
+        return _LANGUAGE_EMITTERS[suffix]
+    if suffix in _generic.extensions:
+        return _generic
+    return None
+
+
+def emit(path: str, content: str) -> tuple[list[Fact], str]:
+    """Facts for one file, via the fallback chain, plus the tier that
+    produced them (``"language"``/``"generic"``/``"unsupported"`` — the
+    latter always returns an empty fact list)."""
+    suffix = Path(path).suffix
+    mod = emitter_for_suffix(suffix)
+    if mod is None:
+        return [], "unsupported"
+    tier = "language" if suffix in _LANGUAGE_EMITTERS else "generic"
+    return mod.emit(path, content), tier
+
+
+def unsupported_extensions() -> frozenset[str]:
+    """The curated set of recognized-but-unsupported extensions (#162) —
+    used by the checkers to surface a coverage warning, never a silent skip."""
+    return cw_languages.unsupported_extensions()
+
+
+def is_recognized_unsupported(suffix: str) -> bool:
+    return suffix in unsupported_extensions()
+
+
+__all__ = [
+    "Fact",
+    "LanguageEmitter",
+    "emit",
+    "emitter_for_suffix",
+    "facts_of_kind",
+    "is_recognized_unsupported",
+    "tier_for_suffix",
+    "unsupported_extensions",
+]

--- a/scripts/emitters/base.py
+++ b/scripts/emitters/base.py
@@ -1,0 +1,61 @@
+"""Per-language emitter interface (#162).
+
+A "fact kind" is one of the checkers' field-agnostic emission outputs:
+
+- ``"write_site"`` — a candidate write-shaped token
+  (``chief_wiggum.write_emission.WriteSite``), consumed by
+  ``check_single_writer.py``'s single-write-path audit.
+- ``"trace_annotation"`` — an ``@cw-trace`` annotation
+  (``chief_wiggum.trace_emission.Annotation``), consumed by
+  ``check_traceability.py``'s BR/contract/test coverage graph.
+
+Each language module under ``scripts/emitters/`` implements ``emit(path,
+content) -> list[Fact]`` for whichever fact kind(s) it supports (advertised
+via ``fact_kinds()``), by delegating to the shared regex families in
+``chief_wiggum.write_emission`` / ``chief_wiggum.trace_emission`` — the
+existing, golden-parity-tested logic behind #160's emission/claim split.
+Nothing here re-implements those regexes; the module boundary is the new
+seam #162 asks for, not a rewrite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Fact:
+    """One language-agnostic fact emitted from a single file.
+
+    ``payload`` is the underlying dataclass instance —
+    ``chief_wiggum.write_emission.WriteSite`` for ``kind="write_site"``,
+    ``chief_wiggum.trace_emission.Annotation`` for ``kind="trace_annotation"``.
+    Kept generic (rather than a tagged union) so a future fact kind (e.g. a
+    ``"guard"`` kind for #93's third @cw-* tag family) can be added without
+    changing this dataclass's shape.
+    """
+
+    kind: str
+    payload: object
+
+
+class LanguageEmitter(Protocol):
+    """The per-language emitter interface. A module implementing this
+    protocol need not support every fact kind — ``fact_kinds()`` advertises
+    what ``emit()`` actually produces."""
+
+    language: str
+    extensions: tuple[str, ...]
+
+    def fact_kinds(self) -> tuple[str, ...]:
+        ...
+
+    def emit(self, path: str, content: str) -> list[Fact]:
+        ...
+
+
+def facts_of_kind(facts: list[Fact], kind: str) -> list[object]:
+    """Unwrap the ``payload`` of every fact of ``kind``, preserving order —
+    the common "give me just the WriteSites" / "just the Annotations" query."""
+    return [f.payload for f in facts if f.kind == kind]

--- a/scripts/emitters/generic.py
+++ b/scripts/emitters/generic.py
@@ -1,0 +1,45 @@
+"""Generic (language-agnostic) regex-tier emitter (#162): rung 2 of the
+fallback chain — language-specific emitter -> **generic regex tier** ->
+skip-with-warning.
+
+This is exactly the CURRENT (pre-#162) behavior of
+``check_single_writer.py`` / ``check_traceability.py`` for any extension in
+``config/languages.json``'s ``generic_tier`` (Java, Ruby, and Rust's ``.rs``
+today — see the ``rust`` entry's note: Rust IS scanned by this tier already,
+just without a dedicated func-regex for enclosing-symbol resolution). The
+underlying emission functions are already suffix-driven (comment markers,
+symbol regexes), so this module's ``emit()`` is identical in shape to the
+tier-1 language modules — the only difference is that no dedicated
+``scripts/emitters/<language>.py`` module exists for these extensions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chief_wiggum import languages as cw_languages
+from chief_wiggum.trace_emission import emit_source_annotations
+from chief_wiggum.write_emission import emit_write_sites
+
+from .base import Fact
+
+language = "generic"
+
+# Computed at import time from config/languages.json's generic_tier — a
+# module-level tuple (not a function) so the registry can treat every emitter
+# module (tier-1 or generic) uniformly: `mod.extensions`.
+extensions: tuple[str, ...] = tuple(sorted(cw_languages.generic_tier_extensions()))
+
+
+def fact_kinds() -> tuple[str, ...]:
+    return ("write_site", "trace_annotation")
+
+
+def emit(path: str, content: str) -> list[Fact]:
+    suffix = Path(path).suffix
+    facts: list[Fact] = [Fact("write_site", s) for s in emit_write_sites(path, content)]
+    facts += [
+        Fact("trace_annotation", a)
+        for a in emit_source_annotations(path, content, suffix)
+    ]
+    return facts

--- a/scripts/emitters/go.py
+++ b/scripts/emitters/go.py
@@ -1,0 +1,33 @@
+"""Go emitter (#162): write-site + trace-annotation facts for ``.go`` files.
+
+Delegates to ``chief_wiggum.write_emission.emit_write_sites`` and
+``chief_wiggum.trace_emission.emit_source_annotations`` — the same
+golden-parity-tested regex families ``check_single_writer.py`` and
+``check_traceability.py`` have always used. This module is the per-language
+SEAM (config/languages.json's ``go`` entry -> here), not a reimplementation:
+moving the regex bodies out of the shared modules would risk drift for no
+benefit.
+"""
+
+from __future__ import annotations
+
+from chief_wiggum.trace_emission import emit_source_annotations
+from chief_wiggum.write_emission import emit_write_sites
+
+from .base import Fact
+
+language = "go"
+extensions: tuple[str, ...] = (".go",)
+
+
+def fact_kinds() -> tuple[str, ...]:
+    return ("write_site", "trace_annotation")
+
+
+def emit(path: str, content: str) -> list[Fact]:
+    facts: list[Fact] = [Fact("write_site", s) for s in emit_write_sites(path, content)]
+    facts += [
+        Fact("trace_annotation", a)
+        for a in emit_source_annotations(path, content, ".go")
+    ]
+    return facts

--- a/scripts/emitters/python.py
+++ b/scripts/emitters/python.py
@@ -1,0 +1,28 @@
+"""Python emitter (#162): write-site + trace-annotation facts for ``.py`` files.
+
+See ``scripts/emitters/go.py`` for the delegation rationale — identical
+pattern, just the ``.py`` extension and suffix.
+"""
+
+from __future__ import annotations
+
+from chief_wiggum.trace_emission import emit_source_annotations
+from chief_wiggum.write_emission import emit_write_sites
+
+from .base import Fact
+
+language = "python"
+extensions: tuple[str, ...] = (".py",)
+
+
+def fact_kinds() -> tuple[str, ...]:
+    return ("write_site", "trace_annotation")
+
+
+def emit(path: str, content: str) -> list[Fact]:
+    facts: list[Fact] = [Fact("write_site", s) for s in emit_write_sites(path, content)]
+    facts += [
+        Fact("trace_annotation", a)
+        for a in emit_source_annotations(path, content, ".py")
+    ]
+    return facts

--- a/scripts/emitters/typescript.py
+++ b/scripts/emitters/typescript.py
@@ -1,0 +1,34 @@
+"""TypeScript/JavaScript emitter (#162): write-site + trace-annotation facts
+for ``.ts``/``.tsx``/``.js``/``.jsx`` files.
+
+See ``scripts/emitters/go.py`` for the delegation rationale. One module
+covers all four extensions because the underlying regex families
+(``chief_wiggum.write_emission`` / ``chief_wiggum.trace_emission``) already
+treat them identically (same comment marker, same TS_FUNC_RE for enclosing
+symbols) — splitting them into four modules would add files without adding
+behavior.
+"""
+
+from __future__ import annotations
+
+from chief_wiggum.trace_emission import emit_source_annotations
+from chief_wiggum.write_emission import emit_write_sites
+
+from .base import Fact
+
+language = "typescript"
+extensions: tuple[str, ...] = (".ts", ".tsx", ".js", ".jsx")
+
+
+def fact_kinds() -> tuple[str, ...]:
+    return ("write_site", "trace_annotation")
+
+
+def emit(path: str, content: str) -> list[Fact]:
+    suffix = path[path.rfind("."):] if "." in path else ""
+    facts: list[Fact] = [Fact("write_site", s) for s in emit_write_sites(path, content)]
+    facts += [
+        Fact("trace_annotation", a)
+        for a in emit_source_annotations(path, content, suffix)
+    ]
+    return facts

--- a/scripts/render_languages_doc.py
+++ b/scripts/render_languages_doc.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Render ``config/languages.json`` into ``docs/languages.md`` (#162).
+
+The declared language support matrix is authored once, as data
+(``config/languages.json``); this script is the ONLY thing that turns it into
+prose, so the doc can never silently drift from the artifact both
+``check_deps.py`` and ``scripts/emitters/`` consume — the same
+"mechanical, not trusted" discipline as ``scripts/extract_design.py`` for
+design tokens.
+
+CLI:
+    python3 scripts/render_languages_doc.py            # write docs/languages.md
+    python3 scripts/render_languages_doc.py --check    # verify it's up to date (CI gate)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from chief_wiggum import languages as cw_languages  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "languages.md"
+
+
+def render(path: Path | str = cw_languages.DEFAULT_PATH) -> str:
+    """Render the full markdown doc from the matrix at ``path``."""
+    langs = cw_languages.languages(path)
+    generic = sorted(cw_languages.generic_tier_extensions(path))
+    unsupported = sorted(cw_languages.unsupported_extensions(path))
+
+    lines = [
+        "# Language Support Matrix",
+        "",
+        "Generated from `config/languages.json` by `scripts/render_languages_doc.py` "
+        "(#162) — do not hand-edit this file; edit the config and re-run the script "
+        "(wired into `/update`).",
+        "",
+        "Consumed by `check_deps.py` (`--list-languages`, the `language-tier-1` "
+        "dependency profile) and by `scripts/emitters/` (the per-language emitter "
+        "fallback chain: language-specific emitter -> generic regex tier -> "
+        "skip-with-warning). See `docs/single-writer.md` / `docs/traceability.md` "
+        "for what the emitters feed.",
+        "",
+        "## Languages",
+        "",
+        "| Language | Tier | Status | Extensions | LSP | Emitters | Test parser | "
+        "Extractor | func_regex |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for name, lang in langs.items():
+        exts = ", ".join(f"`{e}`" for e in lang.extensions)
+        lines.append(
+            f"| {name} | {lang.tier} | {lang.status} | {exts} | {lang.lsp or '—'} | "
+            f"{', '.join(lang.emitters) or '—'} | {lang.test_parser or '—'} | "
+            f"{lang.extractor or '—'} | {'yes' if lang.func_regex else 'no'} |"
+        )
+
+    lines += [
+        "",
+        "## Generic regex tier",
+        "",
+        "Extensions with no dedicated per-language emitter module, scanned by the "
+        "generic (language-agnostic) regex tier (`scripts/emitters/generic.py`) — "
+        "the pre-#162 behavior of `check_single_writer.py` / `check_traceability.py`:",
+        "",
+        ", ".join(f"`{e}`" for e in generic) or "(none)",
+    ]
+
+    lines += [
+        "",
+        "## Recognized-but-unsupported extensions",
+        "",
+        "Encountering one of these during a full-repo scan is NEVER a silent skip — "
+        "`check_single_writer.py` / `check_traceability.py` surface an explicit "
+        "coverage warning (`unsupported_extension_counts`) in both `--gate` and "
+        "plain (query) output:",
+        "",
+        ", ".join(f"`{e}`" for e in unsupported) or "(none)",
+    ]
+
+    designed = [lang for lang in langs.values() if not lang.built and lang.requires]
+    if designed:
+        lines += ["", "## Designed, unbuilt slots", ""]
+        for lang in designed:
+            lines += [
+                f"### {lang.name.capitalize()}",
+                "",
+                f"Trigger: {lang.trigger}",
+                "",
+                "Requires when triggered:",
+                "",
+            ]
+            lines += [f"- {r}" for r in lang.requires]
+            if lang.note:
+                lines += ["", lang.note]
+            lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the output file matches the freshly rendered doc; exit 1 if stale "
+        "(no write). For a CI/pre-commit staleness gate.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help=f"Output path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(cw_languages.DEFAULT_PATH),
+        help="Path to languages.json (default: config/languages.json)",
+    )
+    args = parser.parse_args(argv)
+
+    rendered = render(args.config)
+    out_path = Path(args.output)
+
+    if args.check:
+        current = out_path.read_text() if out_path.exists() else None
+        if current != rendered:
+            print(
+                f"Error: {out_path} is stale — run `python3 scripts/render_languages_doc.py` "
+                "to refresh it",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{out_path} is up to date.")
+        return 0
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered)
+    print(f"Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -120,3 +120,27 @@ def test_go_lsp_profile_requires_gopls():
 
 def test_python_lsp_profile_requires_pyright():
     assert check_deps.is_required("cmds", "pyright-langserver", ["python-lsp"])
+
+
+# --- language support matrix consumption (#162) -----------------------------
+
+
+def test_language_tier1_profile_expands_to_built_languages_dep_profiles():
+    """config/languages.json is the source of truth: go/python contribute
+    go-lsp/python-lsp; language-tier-1 requires exactly their tools."""
+    assert check_deps.is_required("cmds", "gopls", ["language-tier-1"])
+    assert check_deps.is_required("cmds", "go", ["language-tier-1"])
+    assert check_deps.is_required("cmds", "pyright-langserver", ["language-tier-1"])
+
+
+def test_language_tier1_profile_is_listed():
+    assert "language-tier-1" in check_deps.WORKFLOW_REQUIREMENTS
+
+
+def test_list_languages_cli_prints_matrix(capsys, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["check_deps.py", "--list-languages"])
+    check_deps.main()
+    out = capsys.readouterr().out
+    assert "go" in out and "python" in out and "typescript" in out and "rust" in out
+    assert "designed" in out  # rust's tier/status shows up
+    assert "docs/languages.md" in out

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -295,6 +295,53 @@ def test_no_writer_found_warns(tmp_path):
     assert report.coverage_ok  # no writer means no violation
 
 
+# --- language coverage metadata (#162) ---------------------------------------
+
+
+def test_unsupported_extension_file_is_not_silently_skipped(tmp_path):
+    """A recognized-but-unsupported-language file (no emitter at all) must
+    surface an explicit coverage warning — never just vanish from the scan."""
+    epic = _write_billing_epic(tmp_path)
+    src = tmp_path / "src"
+    (src / "internal" / "billing").mkdir(parents=True)
+    (src / "internal" / "billing" / "reconcile.go").write_text(
+        "func ReconcileStripe(p *Provider, v string) {\n\tp.StripePlan = v\n}\n"
+    )
+    (src / "legacy.php").write_text("<?php $plan = 'pro';\n")
+    report = sw.check(epic, src)
+    assert any("no emitter coverage" in w and ".php" in w for w in report.warnings)
+    assert report.coverage_ok  # unrelated to the actual single-writer verdict
+
+
+def test_unsupported_extension_counts_are_aggregated_per_extension(tmp_path):
+    (tmp_path / "a.php").write_text("<?php\n")
+    (tmp_path / "b.php").write_text("<?php\n")
+    (tmp_path / "c.cpp").write_text("int main() {}\n")
+    counts = sw.unsupported_extension_counts(tmp_path)
+    assert counts == {".php": 2, ".cpp": 1}
+
+
+def test_unsupported_extension_counts_empty_when_all_supported(tmp_path):
+    (tmp_path / "a.go").write_text("func f() {}\n")
+    (tmp_path / "b.py").write_text("def f(): pass\n")
+    assert sw.unsupported_extension_counts(tmp_path) == {}
+
+
+def test_unsupported_extension_counts_ignores_arbitrary_non_source_files(tmp_path):
+    """Markdown/lockfiles/etc. are not in the curated unsupported list — no
+    coverage-warning noise for ordinary non-source repo content."""
+    (tmp_path / "README.md").write_text("# hi\n")
+    (tmp_path / "package-lock.json").write_text("{}\n")
+    assert sw.unsupported_extension_counts(tmp_path) == {}
+
+
+def test_unsupported_extension_counts_respects_exclude(tmp_path):
+    d = tmp_path / "vendor"
+    d.mkdir()
+    (d / "legacy.php").write_text("<?php\n")
+    assert sw.unsupported_extension_counts(tmp_path, exclude=["vendor"]) == {}
+
+
 # --- CLI --------------------------------------------------------------------
 
 

--- a/tests/test_check_single_writer.py
+++ b/tests/test_check_single_writer.py
@@ -342,6 +342,58 @@ def test_unsupported_extension_counts_respects_exclude(tmp_path):
     assert sw.unsupported_extension_counts(tmp_path, exclude=["vendor"]) == {}
 
 
+def test_scan_writers_routes_through_emitter_registry(tmp_path, monkeypatch):
+    """The gate consumes scripts/emitters' dispatch path — not a private direct
+    call to emit_write_sites — so a per-language emitter can't drift from what
+    the gate actually scans. Regression: fails if scan_writers reverts to
+    calling emit_write_sites directly."""
+    calls: list[str] = []
+    real_emit = sw.emitters.emit
+
+    def spy(path, content):
+        calls.append(path)
+        return real_emit(path, content)
+
+    monkeypatch.setattr(sw.emitters, "emit", spy)
+    (tmp_path / "admin.go").write_text(
+        "func ChangePlan(p *Provider, v string) {\n\tp.StripePlan = v\n}\n"
+    )
+    writers = sw.scan_writers(tmp_path, [_inv()])
+    assert calls == ["admin.go"]
+    assert writers and writers[0].symbol == "ChangePlan"
+
+
+def test_changed_since_scoped_scan_still_warns_on_unsupported_extension(tmp_path, capsys):
+    """A changed .php file must trigger the coverage warning even in
+    --changed-since scoped mode — scoping must never make a coverage gap
+    silent (the changed-path predicate is widened beyond SOURCE_EXTS)."""
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.go").write_text("func A() {}\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    epic = _write_billing_epic(tmp_path)
+    # Added AFTER base: an unsupported-language file (and nothing else changed).
+    (tmp_path / "legacy.php").write_text("<?php $plan = 'pro';\n")
+
+    rc = sw.main([
+        str(epic), "--source", str(tmp_path), "--changed-since", base, "--format", "json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert any("no emitter coverage" in w and ".php" in w for w in data["warnings"])
+
+
 # --- CLI --------------------------------------------------------------------
 
 

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -166,6 +166,40 @@ def test_markdown_docs_not_scanned_as_source(tmp_path):
     assert ct.scan_source(src) == []
 
 
+# --- language coverage metadata (#162) ---------------------------------------
+
+
+def test_unsupported_extension_file_is_not_silently_skipped(tmp_path):
+    epic = _write_epic(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "order.py").write_text("# @cw-trace guards CTR-order-001\n")
+    (src / "test_order.py").write_text("# @cw-trace verifies CTR-order-001\n")
+    (src / "legacy.php").write_text("<?php $x = 1;\n")
+    report = ct.check(epic, src)
+    assert any("no emitter coverage" in w and ".php" in w for w in report.warnings)
+
+
+def test_unsupported_extension_counts_are_aggregated_per_extension(tmp_path):
+    (tmp_path / "a.php").write_text("<?php\n")
+    (tmp_path / "b.php").write_text("<?php\n")
+    (tmp_path / "c.cpp").write_text("int main() {}\n")
+    counts = ct.unsupported_extension_counts(tmp_path)
+    assert counts == {".php": 2, ".cpp": 1}
+
+
+def test_unsupported_extension_counts_empty_when_all_supported(tmp_path):
+    (tmp_path / "a.go").write_text("func f() {}\n")
+    (tmp_path / "b.py").write_text("def f(): pass\n")
+    assert ct.unsupported_extension_counts(tmp_path) == {}
+
+
+def test_unsupported_extension_counts_ignores_arbitrary_non_source_files(tmp_path):
+    (tmp_path / "README.md").write_text("# hi\n")
+    (tmp_path / "package-lock.json").write_text("{}\n")
+    assert ct.unsupported_extension_counts(tmp_path) == {}
+
+
 def test_cli_missing_epic_dir_is_usage_error(tmp_path, capsys):
     rc = ct.main([str(tmp_path / "nope")])
     assert rc == 2

--- a/tests/test_check_traceability.py
+++ b/tests/test_check_traceability.py
@@ -200,6 +200,61 @@ def test_unsupported_extension_counts_ignores_arbitrary_non_source_files(tmp_pat
     assert ct.unsupported_extension_counts(tmp_path) == {}
 
 
+def test_scan_source_routes_language_files_through_emitter_registry(tmp_path, monkeypatch):
+    """The gate consumes scripts/emitters' dispatch path for language files —
+    not a private direct call to emit_source_annotations — so a per-language
+    emitter can't drift from what the gate actually scans. Verification
+    artifacts (.rego/.yaml/.yml — not a language in the matrix) keep the
+    direct path. Regression: fails if scan_source reverts to calling
+    emit_source_annotations directly for language files."""
+    calls: list[str] = []
+    real_emit = ct.emitters.emit
+
+    def spy(path, content):
+        calls.append(path)
+        return real_emit(path, content)
+
+    monkeypatch.setattr(ct.emitters, "emit", spy)
+    (tmp_path / "order.py").write_text("# @cw-trace guards CTR-order-001\n")
+    (tmp_path / "policy.rego").write_text("# @cw-trace verifies CTR-order-001\n")
+    anns = ct.scan_source(tmp_path)
+    assert calls == ["order.py"]  # language file via registry; .rego direct
+    kinds = {(a.file, a.source_kind) for a in anns}
+    assert ("order.py", "code") in kinds
+    assert ("policy.rego", "policy") in kinds  # direct path still scanned
+
+
+def test_changed_since_scoped_scan_still_warns_on_unsupported_extension(tmp_path, capsys):
+    """A changed .php file must trigger the coverage warning even in
+    --changed-since scoped mode — scoping must never make a coverage gap
+    silent (the changed-path predicate is widened beyond SOURCE_EXTS)."""
+    import subprocess
+
+    def _git(*args):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (tmp_path / "a.py").write_text("# @cw-trace guards CTR-x-001\n")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    epic = tmp_path / "epic"
+    epic.mkdir()
+    (epic / "contracts.md").write_text("### CTR-x-001 — x\n")
+    # Added AFTER base: an unsupported-language file (and nothing else changed).
+    (tmp_path / "legacy.php").write_text("<?php $x = 1;\n")
+
+    rc = ct.main([str(epic), "--source", str(tmp_path), "--changed-since", base, "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert any("no emitter coverage" in w and ".php" in w for w in data["warnings"])
+
+
 def test_cli_missing_epic_dir_is_usage_error(tmp_path, capsys):
     rc = ct.main([str(tmp_path / "nope")])
     assert rc == 2

--- a/tests/test_emitters.py
+++ b/tests/test_emitters.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/emitters/ (#162): the per-language emitter interface and
+its fallback chain (language-specific emitter -> generic regex tier ->
+skip-with-warning/unsupported).
+"""
+
+from __future__ import annotations
+
+import emitters
+from chief_wiggum.trace_emission import Annotation
+from chief_wiggum.write_emission import KIND_ASSIGN, WriteSite
+from emitters import base as emitters_base
+from emitters import generic, go, python, typescript
+
+# --- per-language modules: shape + delegation -------------------------------
+
+
+def test_go_module_shape():
+    assert go.language == "go"
+    assert go.extensions == (".go",)
+    assert set(go.fact_kinds()) == {"write_site", "trace_annotation"}
+
+
+def test_python_module_shape():
+    assert python.language == "python"
+    assert python.extensions == (".py",)
+
+
+def test_typescript_module_covers_four_extensions():
+    assert typescript.language == "typescript"
+    assert set(typescript.extensions) == {".ts", ".tsx", ".js", ".jsx"}
+
+
+def test_generic_module_covers_configured_generic_tier():
+    from chief_wiggum import languages as cw_languages
+
+    assert set(generic.extensions) == cw_languages.generic_tier_extensions()
+
+
+def test_go_emit_produces_write_site_fact_matching_direct_call():
+    """The emitter module must be a pure DELEGATION — its write_site facts
+    are byte-identical to calling chief_wiggum.write_emission directly."""
+    content = "func ChangePlan(p *Provider, v string) {\n\tp.StripePlan = v\n}\n"
+    from chief_wiggum.write_emission import emit_write_sites
+
+    direct = emit_write_sites("admin.go", content)
+    facts = go.emit("admin.go", content)
+    write_sites = [f.payload for f in facts if f.kind == "write_site"]
+    assert write_sites == direct
+    assert all(isinstance(s, WriteSite) for s in write_sites)
+
+
+def test_go_emit_produces_trace_annotation_fact_matching_direct_call():
+    content = "// @cw-trace guards CTR-order-001\n"
+    from chief_wiggum.trace_emission import emit_source_annotations
+
+    direct = emit_source_annotations("order.go", content, ".go")
+    facts = go.emit("order.go", content)
+    anns = [f.payload for f in facts if f.kind == "trace_annotation"]
+    assert anns == direct
+    assert all(isinstance(a, Annotation) for a in anns)
+
+
+def test_python_emit_delegates_identically():
+    content = "def f():\n    # plan: the free tier\n    return 1\n"
+    from chief_wiggum.write_emission import emit_write_sites
+
+    facts = python.emit("svc.py", content)
+    direct = emit_write_sites("svc.py", content)
+    assert [f.payload for f in facts if f.kind == "write_site"] == direct
+
+
+def test_typescript_emit_uses_correct_suffix_for_tsx():
+    # A .tsx file's comment-marker/enclosing-symbol handling must match calling
+    # emit_write_sites directly with the .tsx path (suffix-driven).
+    content = "class P {\n  #plan = 'free';\n}\n"
+    from chief_wiggum.write_emission import emit_write_sites
+
+    facts = typescript.emit("m.tsx", content)
+    direct = emit_write_sites("m.tsx", content)
+    assert [f.payload for f in facts if f.kind == "write_site"] == direct
+
+
+# --- fact helpers ------------------------------------------------------------
+
+
+def test_facts_of_kind_unwraps_payloads():
+    facts = go.emit("admin.go", "func F(p *Provider) {\n\tp.Plan = \"x\"\n}\n")
+    sites = emitters_base.facts_of_kind(facts, "write_site")
+    assert sites and all(isinstance(s, WriteSite) for s in sites)
+    assert sites[0].kind == KIND_ASSIGN
+
+
+# --- registry / fallback chain -----------------------------------------------
+
+
+def test_tier_for_suffix_language():
+    assert emitters.tier_for_suffix(".go") == "language"
+    assert emitters.tier_for_suffix(".py") == "language"
+    assert emitters.tier_for_suffix(".ts") == "language"
+
+
+def test_tier_for_suffix_generic():
+    assert emitters.tier_for_suffix(".java") == "generic"
+    assert emitters.tier_for_suffix(".rb") == "generic"
+    # Rust is designed-but-unbuilt at tier-1: it falls to the generic tier.
+    assert emitters.tier_for_suffix(".rs") == "generic"
+
+
+def test_tier_for_suffix_unsupported():
+    assert emitters.tier_for_suffix(".php") == "unsupported"
+    assert emitters.tier_for_suffix(".cpp") == "unsupported"
+
+
+def test_emit_dispatches_to_language_tier():
+    facts, tier = emitters.emit("admin.go", "func F(p *Provider) {\n\tp.Plan = \"x\"\n}\n")
+    assert tier == "language"
+    assert facts and facts[0].kind == "write_site"
+
+
+def test_emit_dispatches_to_generic_tier_for_rust():
+    facts, tier = emitters.emit(
+        "lib.rs", "fn change_plan(p: &mut Provider) {\n\tp.plan = \"x\";\n}\n"
+    )
+    assert tier == "generic"
+    # Struct-field assignment is still caught by the generic regex family.
+    assert any(f.kind == "write_site" for f in facts)
+
+
+def test_emit_returns_empty_for_unsupported():
+    facts, tier = emitters.emit("app.php", "<?php $x = 1;\n")
+    assert facts == []
+    assert tier == "unsupported"
+
+
+def test_emitter_for_suffix_returns_module_or_none():
+    assert emitters.emitter_for_suffix(".go") is go
+    assert emitters.emitter_for_suffix(".java") is generic
+    assert emitters.emitter_for_suffix(".php") is None
+
+
+def test_is_recognized_unsupported():
+    assert emitters.is_recognized_unsupported(".php") is True
+    assert emitters.is_recognized_unsupported(".go") is False
+    # A totally arbitrary/unknown extension is not "recognized" — no
+    # coverage-warning noise for e.g. lockfiles or data files.
+    assert emitters.is_recognized_unsupported(".lock") is False

--- a/tests/test_emitters.py
+++ b/tests/test_emitters.py
@@ -144,3 +144,66 @@ def test_is_recognized_unsupported():
     # A totally arbitrary/unknown extension is not "recognized" — no
     # coverage-warning noise for e.g. lockfiles or data files.
     assert emitters.is_recognized_unsupported(".lock") is False
+
+
+# --- matrix <-> registry parity (#162 review) ---------------------------------
+
+
+def test_registry_matches_declared_matrix():
+    """Mechanical parity: the declared matrix (config/languages.json) and the
+    actual emitter registry may never drift — every built language has a
+    registered emitter of the same name covering exactly its declared
+    extensions, no strays in either direction, and the generic module covers
+    exactly the matrix's generic tier."""
+    assert emitters.validate_registry_matches_matrix() == []
+
+
+def test_registered_language_extensions_equal_matrix_mapping():
+    from chief_wiggum import languages as cw_languages
+
+    assert emitters.registered_language_extensions() == cw_languages.extension_to_language()
+
+
+def test_validator_reports_matrix_extension_with_no_emitter(monkeypatch):
+    # Matrix declares a built language extension the registry doesn't cover.
+    monkeypatch.setattr(
+        emitters.cw_languages,
+        "extension_to_language",
+        lambda path=None: {**emitters.registered_language_extensions(), ".zig": "zig"},
+    )
+    problems = emitters.validate_registry_matches_matrix()
+    assert any(".zig" in p and "no emitter module is registered" in p for p in problems)
+
+
+def test_validator_reports_registered_extension_not_in_matrix(monkeypatch):
+    # Registry covers an extension the matrix doesn't declare for a built language.
+    declared = {
+        ext: lang
+        for ext, lang in emitters.registered_language_extensions().items()
+        if ext != ".go"
+    }
+    monkeypatch.setattr(
+        emitters.cw_languages, "extension_to_language", lambda path=None: declared
+    )
+    problems = emitters.validate_registry_matches_matrix()
+    assert any(".go" in p and "does not" in p and "declare" in p for p in problems)
+
+
+def test_validator_reports_language_name_mismatch(monkeypatch):
+    declared = dict(emitters.registered_language_extensions())
+    declared[".go"] = "golang"  # matrix name diverges from the module's name
+    monkeypatch.setattr(
+        emitters.cw_languages, "extension_to_language", lambda path=None: declared
+    )
+    problems = emitters.validate_registry_matches_matrix()
+    assert any("golang" in p and ".go" in p for p in problems)
+
+
+def test_validator_reports_generic_tier_drift(monkeypatch):
+    monkeypatch.setattr(
+        emitters.cw_languages,
+        "generic_tier_extensions",
+        lambda path=None: frozenset({".java", ".rb", ".rs", ".kt"}),
+    )
+    problems = emitters.validate_registry_matches_matrix()
+    assert any("generic" in p for p in problems)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,107 @@
+"""Tests for chief_wiggum.languages (#162): the config/languages.json loader."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from chief_wiggum import languages as cw_languages
+
+
+def test_load_reads_real_config():
+    data = cw_languages.load()
+    assert "go" in data["languages"]
+    assert "python" in data["languages"]
+    assert "typescript" in data["languages"]
+    assert "rust" in data["languages"]
+
+
+def test_go_python_typescript_are_tier_1_built():
+    langs = cw_languages.languages()
+    assert langs["go"].built is True
+    assert langs["python"].built is True
+    assert langs["typescript"].built is True
+
+
+def test_rust_is_designed_not_built():
+    langs = cw_languages.languages()
+    rust = langs["rust"]
+    assert rust.built is False
+    assert rust.tier == "designed"
+    assert rust.func_regex is False
+    assert rust.trigger == "first real Rust target repo"
+    assert rust.requires  # documents what's needed when triggered
+
+
+def test_extension_to_language_only_includes_built_languages():
+    mapping = cw_languages.extension_to_language()
+    assert mapping[".go"] == "go"
+    assert mapping[".py"] == "python"
+    assert mapping[".ts"] == "typescript"
+    assert mapping[".tsx"] == "typescript"
+    # Rust is designed-but-unbuilt: its extension must NOT resolve to a
+    # tier-1 language module.
+    assert ".rs" not in mapping
+
+
+def test_generic_tier_extensions_include_rust_java_ruby():
+    generic = cw_languages.generic_tier_extensions()
+    assert {".rs", ".java", ".rb"} <= generic
+
+
+def test_all_known_extensions_matches_pre_162_source_exts():
+    """Regression guard: the pre-#162 hardcoded SOURCE_EXTS in
+    check_single_writer.py was exactly this 9-extension set."""
+    expected = {".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".java", ".rb", ".rs"}
+    assert cw_languages.all_known_extensions() == frozenset(expected)
+
+
+def test_unsupported_extensions_are_disjoint_from_known():
+    known = cw_languages.all_known_extensions()
+    unsupported = cw_languages.unsupported_extensions()
+    assert known.isdisjoint(unsupported)
+    assert ".php" in unsupported
+    assert ".cpp" in unsupported
+
+
+def test_config_is_valid_json_with_expected_top_level_keys(tmp_path):
+    # Sanity: the shipped config file itself parses and has the sections the
+    # loader expects (belt-and-suspenders on top of test_load_reads_real_config).
+    data = json.loads(cw_languages.DEFAULT_PATH.read_text())
+    assert set(data) >= {"languages", "generic_tier", "unsupported_extensions"}
+
+
+def test_load_is_cached_per_path(tmp_path):
+    custom = tmp_path / "languages.json"
+    custom.write_text(json.dumps({"languages": {"foo": {"tier": 1, "extensions": [".foo"]}}}))
+    data1 = cw_languages.load(custom)
+    data2 = cw_languages.load(custom)
+    assert data1 is data2  # lru_cache returns the identical object
+
+
+def test_custom_path_round_trips_language_fields(tmp_path):
+    custom = tmp_path / "languages2.json"
+    custom.write_text(json.dumps({
+        "languages": {
+            "elixir": {
+                "tier": "designed",
+                "status": "designed, unbuilt",
+                "extensions": [".ex", ".exs"],
+                "lsp": "elixir-ls",
+                "emitters": [],
+                "func_regex": False,
+            }
+        },
+        "generic_tier": {"extensions": []},
+        "unsupported_extensions": {"extensions": [".ex", ".exs"]},
+    }))
+    langs = cw_languages.languages(custom)
+    assert langs["elixir"].extensions == (".ex", ".exs")
+    assert langs["elixir"].built is False
+    assert cw_languages.unsupported_extensions(custom) == frozenset({".ex", ".exs"})
+
+
+@pytest.mark.parametrize("name", ["go", "python", "typescript", "rust"])
+def test_every_matrix_language_has_extensions(name):
+    lang = cw_languages.languages()[name]
+    assert lang.extensions, f"{name} must declare at least one extension"

--- a/tests/test_render_languages_doc.py
+++ b/tests/test_render_languages_doc.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/render_languages_doc.py (#162): docs/languages.md is
+mechanically rendered from config/languages.json, never hand-edited."""
+
+from __future__ import annotations
+
+import json
+
+import render_languages_doc as rld
+
+
+def test_render_includes_every_language():
+    text = rld.render()
+    assert "| go |" in text
+    assert "| python |" in text
+    assert "| typescript |" in text
+    assert "| rust |" in text
+
+
+def test_render_includes_generic_and_unsupported_sections():
+    text = rld.render()
+    assert "## Generic regex tier" in text
+    assert "`.java`" in text and "`.rb`" in text
+    assert "## Recognized-but-unsupported extensions" in text
+    assert "`.php`" in text
+
+
+def test_render_documents_rust_designed_slot():
+    text = rld.render()
+    assert "## Designed, unbuilt slots" in text
+    assert "### Rust" in text
+    assert "first real Rust target repo" in text
+    assert "rust-analyzer" in text
+
+
+def test_committed_doc_is_up_to_date():
+    """Regression guard: docs/languages.md must always match a fresh render
+    of config/languages.json — the doc is generated, never hand-edited."""
+    rendered = rld.render()
+    committed = rld.DEFAULT_OUTPUT.read_text()
+    assert committed == rendered
+
+
+def test_cli_check_passes_when_up_to_date(capsys):
+    rc = rld.main(["--check"])
+    assert rc == 0
+    assert "up to date" in capsys.readouterr().out
+
+
+def test_cli_check_fails_when_stale(tmp_path, capsys):
+    stale = tmp_path / "languages.md"
+    stale.write_text("stale content\n")
+    rc = rld.main(["--check", "--output", str(stale)])
+    assert rc == 1
+    assert "stale" in capsys.readouterr().err
+
+
+def test_cli_writes_output_file(tmp_path):
+    out = tmp_path / "out.md"
+    rc = rld.main(["--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    assert "# Language Support Matrix" in out.read_text()
+
+
+def test_render_uses_custom_config(tmp_path):
+    custom = tmp_path / "languages.json"
+    custom.write_text(json.dumps({
+        "languages": {
+            "elixir": {
+                "tier": "designed", "status": "designed, unbuilt",
+                "extensions": [".ex"], "lsp": "elixir-ls", "emitters": [],
+                "func_regex": False, "trigger": "first Elixir target repo",
+                "requires": ["placeholder"],
+            }
+        },
+        "generic_tier": {"extensions": []},
+        "unsupported_extensions": {"extensions": [".ex"]},
+    }))
+    text = rld.render(custom)
+    assert "elixir" in text
+    assert "first Elixir target repo" in text


### PR DESCRIPTION
## Summary

- Adds `config/languages.json` — the declared per-language support matrix (per language: `lsp`/`emitters`/`test_parser`/`extractor`/`func_regex` + tier). Consumed by `check_deps.py` (`--list-languages`, the new `language-tier-1` dependency profile, mechanically derived from the matrix's `dep_profile` fields) and rendered into `docs/languages.md` by `scripts/render_languages_doc.py` (never hand-edited — a test pins it to a fresh render, and it's wired into `/update`).
- Introduces `scripts/emitters/` — one module per language (`go.py`/`python.py`/`typescript.py`) implementing `emit(path, content) -> [Fact]`. The underlying regex families are moved UNCHANGED into `chief_wiggum.write_emission` (write-site emission, ex-`check_single_writer.py`) and `chief_wiggum.trace_emission` (`@cw-trace` annotation emission, ex-`check_traceability.py`), both re-exported at the original module paths so every existing `check_single_writer.X` / `check_traceability.X` reference keeps working — golden-parity tests (`tests/test_single_writer_golden.py`, `tests/test_traceability_golden.py`) pass unchanged, plus new tests asserting each emitter module's output is byte-identical to calling the shared emission function directly.
- Fallback chain: language-specific emitter → generic regex tier (`scripts/emitters/generic.py`, the pre-#162 `SOURCE_EXTS` behavior for Java/Ruby/Rust) → skip-with-warning. A file with a recognized-but-unsupported extension (a curated list in `config/languages.json`, e.g. `.php`/`.cpp`/`.rs`... wait `.rs` is generic-tier) is **never silently dropped**: both checkers now aggregate an explicit `"N file(s) skipped: no emitter coverage for recognized-but-unsupported extension(s) ..."` warning into `report.warnings`, surfaced in both `--gate` and plain (query) text/JSON output.
- Rust is documented as a **designed, unbuilt** tier-1 slot in the matrix (rust-analyzer entry in `chief_wiggum/lsp.py` `SERVERS`, `cargo nextest` JUnit XML + `Cargo.toml` autodetect for `ratchet.py`, `fn` regex for enclosing-symbol, sqlx-aware struct-literal writer patterns) — not built, per `docs/gate-rollout.md` doctrine (nothing ships unvalidated ahead of a real Rust target repo). Its `.rs` extension already gets generic-tier coverage today (unchanged from before this PR).

## Test plan

- [x] `make test` — 1181 passed, 4 skipped (same skip count as `main`; no regressions)
- [x] `make lint` — ruff clean, `py_compile` clean (including the new `scripts/emitters/*.py`, added to the Makefile), portability/patterns/cw-standards gates pass
- [x] Golden-parity suites (`test_single_writer_golden.py`, `test_traceability_golden.py`) pass byte-for-byte unchanged
- [x] New suites: `tests/test_languages.py` (config loader), `tests/test_emitters.py` (registry + per-language delegation), `tests/test_render_languages_doc.py` (doc-generation + staleness gate)
- [x] Manual end-to-end check: a `.php` file in a scanned repo produces the coverage warning in both `--gate` and plain text/JSON output for `check_single_writer.py` and `check_traceability.py`
- [x] `python3 scripts/render_languages_doc.py --check` confirms `docs/languages.md` is up to date

## Deviations from the issue as decision-complete

- The issue names one interface, `emit(path, content) -> [facts]`, without specifying whether a single module must cover both fact kinds (write-sites for `check_single_writer.py`, `@cw-trace` annotations for `check_traceability.py`) or split them. I implemented each language module emitting BOTH kinds (tagged `Fact(kind=..., payload=...)`), since a file's language, not its fact kind, determines which regex family applies — this avoids two near-duplicate module trees for the same four languages.
- "Existing regex families moved behind it UNCHANGED" is implemented as a genuine move (not a wrapper-only shim): the regex bodies now live in `chief_wiggum.write_emission` / `chief_wiggum.trace_emission`, imported back into `check_single_writer.py` / `check_traceability.py` for 100% backward-compatible re-export. This was necessary to avoid a circular import (the emitters need the emission logic; the checkers need the emitter registry for coverage metadata).
- The "recognized-but-unsupported" extension list is a curated, non-exhaustive set (`config/languages.json`'s `unsupported_extensions`) rather than an attempt to enumerate every language ever — extending it is a one-line config change, documented in the file itself.
- No changes were made to `check_single_writer.py --gate coverage` / `check_traceability.py --gate coverage` semantics: the new coverage warning is report-only (an addition to `warnings`, never a gate failure), consistent with `docs/gate-rollout.md`'s report-only-first doctrine for anything new.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF