### PR TITLE
fix(gnosis): orient inferred-binding precision — corpus specificity + relation-tier ranking (#185)

### DIFF
--- a/docs/code-query.md
+++ b/docs/code-query.md
@@ -127,6 +127,14 @@ An un-annotated handler still gets a real answer:
   path/route "documents" carries **zero binding weight**. At least one of the
   pattern's literal words must clear that bar, or the match is rejected
   outright — even though the all-words guard alone would have accepted it.
+  **Small-corpus bypass**: with fewer than 5 documents the DF bar is skipped
+  entirely (every word counts as specific) — document frequency over a tiny
+  corpus is noise, and without the floor a one-operation epic would reject
+  *itself* (its own path's words ARE the whole corpus at df=1.0), as would
+  the two-document shape of an operation plus its UI route sharing the
+  entity word. Threshold interaction: at ≥5 documents, "common" requires
+  presence in >40% of them — at least 3 of 5 — so a shared entity word needs
+  real recurrence before it loses binding weight.
   This is the mechanical fix for the real over-match found validating against
   dogeared-coach: `ui/src/providers/auth-provider.tsx` word-matched dozens of
   operations that reduce to the bare word `providers` once params are

--- a/docs/code-query.md
+++ b/docs/code-query.md
@@ -118,14 +118,38 @@ An un-annotated handler still gets a real answer:
   fixed during validation), and `ui/orders/page.tsx` does not inherit
   `/api/v1/orders/:id/confirm` just for matching "orders" — "confirm" must
   match too (regression-tested).
-- **Known limitation, disclosed not hidden**: this is a lexical heuristic, not
-  symbol resolution (tree-sitter/refs-lite is explicitly out of phase 1). A
-  file whose name word-covers all of an unrelated operation's literal words
-  can still over-match. These facts are always labeled
-  `"relation": "inferred"` and ranked below any `direct` (annotation or
-  `code_locations`-exact) match — real annotations remain the precise path
-  when a file's governing contract must be unambiguous. Tracked for a future
-  precision pass: [chief-wiggum#185](https://github.com/plwp/chief-wiggum/issues/185).
+- **Fixed by #185 — corpus-derived word specificity**: an all-words match is
+  necessary but no longer sufficient. Each literal word is weighted by its
+  **document frequency across the epic's own operation-paths + ui routes**
+  (no external corpus, no network — recomputed live from the same `contracts.json`/
+  `ui-spec.json` already loaded for this query, so it stays fully reproducible
+  and stdlib-only): a word present in more than 40% of the epic's own
+  path/route "documents" carries **zero binding weight**. At least one of the
+  pattern's literal words must clear that bar, or the match is rejected
+  outright — even though the all-words guard alone would have accepted it.
+  This is the mechanical fix for the real over-match found validating against
+  dogeared-coach: `ui/src/providers/auth-provider.tsx` word-matched dozens of
+  operations that reduce to the bare word `providers` once params are
+  stripped, because "provider" is that epic's own primary tenant entity name
+  and recurs across most of its operations. An entity+verb combination (e.g.
+  a file whose path also contains "verify" for a `.../providers/:id/verify`
+  operation) still binds — only the entity word alone, when it's corpus-common,
+  no longer does (regression-tested: `tests/test_code_query.py`'s
+  `test_common_entity_word_alone_does_not_bind` /
+  `test_entity_verb_combination_still_binds_despite_common_entity_word`).
+- **Known limitation, still disclosed not hidden**: this remains a lexical
+  heuristic, not symbol resolution (tree-sitter/refs-lite is explicitly out of
+  phase 1). A file whose name word-covers all of an unrelated operation's
+  literal words, where at least one of those words is ALSO specific by the
+  document-frequency measure (not just corpus-common), can still over-match —
+  the fix narrows the false-positive surface to genuinely rare word
+  collisions, it does not eliminate lexical matching's inherent ceiling. These
+  facts are always labeled `"relation": "inferred"` and ranked below any
+  `direct` fact via `_rank_key`'s **leading relation-tier element**
+  (`direct=0 < inferred=1 < measured=2` — the third tier is reserved for the
+  #187 hotspot fact, forward-compatible as of #185 with no producer yet) —
+  real annotations remain the precise path when a file's governing contract
+  must be unambiguous.
 
 ## Validation
 

--- a/scripts/code_query.py
+++ b/scripts/code_query.py
@@ -216,11 +216,35 @@ class Fact:
         return d
 
 
+# Leading rank-key element (CTR-fh-052/053, INV-fh-007/012): direct facts
+# always sort before inferred, which always sort before measured. `measured`
+# is forward-compat for the #187 hotspot tier — no producer of `measured`
+# facts exists in this ticket, only the tier, so #187 doesn't have to touch
+# ranking again.
+_RELATION_TIER = {"direct": 0, "inferred": 1, "measured": 2}
+
+
+def _relation_tier(f: Fact) -> int:
+    """The leading `_rank_key` element. Facts that predate the `relation` tag
+    (e.g. `writer` facts, or `field_contract` facts from `governs <field>`
+    mode, neither of which set `extra["relation"]`) fall back to their
+    `exact` flag — exactly how they already sorted before this key was added,
+    so this is additive for verbs that never emit `inferred`/`measured`
+    facts."""
+    relation = f.extra.get("relation")
+    if relation in _RELATION_TIER:
+        return _RELATION_TIER[relation]
+    return 0 if f.exact else 1
+
+
 def _rank_key(f: Fact, verb: str) -> tuple:
+    """
+    @cw-trace guards CTR-fh-052 CTR-fh-053 INV-fh-007
+    """
     prod_rank = 0 if f.prod else 1
     if verb == "verifies":
         prod_rank = 1 - prod_rank  # tests-first: that IS the point of `verifies`
-    return (0 if f.exact else 1, 0 if f.violation else 1, f.proximity, prod_rank)
+    return (_relation_tier(f), 0 if f.exact else 1, 0 if f.violation else 1, f.proximity, prod_rank)
 
 
 def rank_facts(facts: list[Fact], verb: str) -> list[Fact]:
@@ -376,17 +400,105 @@ def _fuzzy_word_match(a: str, b: str) -> bool:
     return a in b or b in a  # tolerate simple stemming (order/orders, confirm/confirmed)
 
 
-def _path_matches_literal_segments(pattern: str, rel: str) -> bool:
+# --- corpus-derived word specificity (CTR-fh-050/051, INV-fh-012) -------------
+#
+# #185: the all-words guard above (kept — see ERROR CASES) still over-matches
+# when a pattern's literal words are ALL common: an entity name that recurs
+# across dozens of an epic's own operations (dogeared-coach's "provider" was
+# the real-world trigger — a file named `auth-provider.tsx` word-matched ~30
+# unrelated provider operations, because many of them reduce to the bare word
+# "providers" once params are stripped). The fix stays lexical and stdlib-only
+# (tree-sitter/symbol resolution is explicitly out of phase 1, per #159):
+# weight each literal word by how common it is across the EPIC'S OWN corpus of
+# operation-paths + ui routes — no external corpus, no network, so the same
+# epic artifacts always yield the same weights — and require at least one
+# word that ISN'T ubiquitous before accepting an all-words match.
+
+# A word present in MORE than this fraction of the epic's own operation-paths/
+# routes carries zero binding weight — it's domain boilerplate for this epic,
+# not a signal that a specific file is about THIS specific operation. This is
+# a deliberately generous majority-ish line, not a tight percentile: it must
+# still treat a moderately-shared word (a handful of an epic's operations
+# mentioning "orders") as specific enough to bind, while catching a word a
+# true plurality of operations share (the "provider" case). Tuned and
+# revalidated against a real, previously-shipped repo (see docs/code-query.md).
+_MAX_COMMON_WORD_DF = 0.4
+
+
+def _epic_path_documents(epic: Epic) -> list[frozenset[str]]:
+    """One 'document' (word set) per `contracts.json` operation path and per
+    `ui-spec.json` page route declared by THIS epic — the closed corpus that
+    word document-frequency is computed over. Deliberately scoped to a single
+    epic's own artifacts: an operation is only "common" relative to what this
+    epic itself declares, so the metric can't be diluted or gamed by an
+    unrelated epic's vocabulary."""
+    docs: list[frozenset[str]] = []
+    contracts = epic.models.get("contracts.json")
+    if contracts:
+        for entity in contracts.get("entities", []):
+            for op in entity.get("operations", []):
+                words = _literal_words(op.get("path", ""))
+                if words:
+                    docs.append(frozenset(words))
+    ui_spec = epic.models.get("ui-spec.json")
+    if ui_spec:
+        for route in (ui_spec.get("pages") or {}):
+            words = _literal_words(route)
+            if words:
+                docs.append(frozenset(words))
+    return docs
+
+
+def _word_document_frequency(docs: list[frozenset[str]]) -> dict[str, float]:
+    """word -> fraction of `docs` that contain it. Deterministic across runs
+    (CTR-fh-051): built by iterating `docs` in the epic artifacts' own JSON
+    list order (stable across runs/platforms), and dict iteration order in
+    CPython is insertion order, not hash order — so this never depends on
+    Python's per-process randomized string hashing, even though the `frozenset`
+    documents themselves are hash-ordered internally. Nothing here reads a
+    set's iteration order; only membership/count, which hashing doesn't
+    affect."""
+    total = len(docs)
+    if not total:
+        return {}
+    counts: dict[str, int] = {}
+    for doc in docs:
+        for w in doc:
+            counts[w] = counts.get(w, 0) + 1
+    return {w: c / total for w, c in counts.items()}
+
+
+def _has_specific_word(literals: set[str], doc_freq: dict[str, float]) -> bool:
+    """At least one of `literals` must clear the specificity bar (CTR-fh-050).
+    A word absent from the corpus (lookup miss — e.g. the corpus is empty
+    because this epic declares only one operation) is treated as maximally
+    specific (df=0.0), so an epic with nothing else to compare against never
+    spuriously blocks its own only operation."""
+    return any(doc_freq.get(w, 0.0) <= _MAX_COMMON_WORD_DF for w in literals)
+
+
+def _path_matches_literal_segments(pattern: str, rel: str, doc_freq: dict[str, float]) -> bool:
     """Best-effort, inferred binding: EVERY non-generic literal word of
     `pattern` (a ui-spec route or contracts.json operation path) must
-    word-match the target file's own path. All-words (not any-word) keeps
-    precision: `/api/v1/orders/:id/confirm` requires both "orders" AND
-    "confirm" among the file's path words, so `ui/orders/page.tsx` does not
-    inherit the confirm operation just for living in an `orders/` directory.
-    Heuristic by design (no file-level binding field exists in the schemas) —
-    labeled `inferred`, never `exact`, in the facts this produces."""
+    word-match the target file's own path, AND at least one of those literal
+    words must be specific (not corpus-common per `_has_specific_word`).
+    All-words-but-not-all-common keeps precision on two fronts:
+    `/api/v1/orders/:id/confirm` requires both "orders" AND "confirm" among
+    the file's path words, so `ui/orders/page.tsx` does not inherit the
+    confirm operation just for living in an `orders/` directory (all-words);
+    and a file that shares ONLY a ubiquitous entity word with a bare
+    single-word operation (e.g. "providers") does not bind either, even
+    though that one word technically satisfies all-words on its own
+    (specificity). Heuristic by design (no file-level binding field exists in
+    the schemas) — labeled `inferred`, never `exact`, in the facts this
+    produces.
+
+    @cw-trace guards CTR-fh-050 CTR-fh-051 INV-fh-012
+    """
     literals = _literal_words(pattern)
     if not literals:
+        return False
+    if not _has_specific_word(literals, doc_freq):
         return False
     file_words = _path_words(rel)
     return all(any(_fuzzy_word_match(lw, fw) for fw in file_words) for lw in literals)
@@ -440,6 +552,11 @@ def governing_facts_for_file(repo_root: Path, rel: str, epics: list[Epic]) -> li
 
     facts: list[Fact] = []
     for epic in epics:
+        # Corpus-derived word specificity (CTR-fh-050/051): computed once per
+        # epic, live from THIS epic's own artifacts, and reused by both
+        # inferred-binding call sites (c)/(d) below.
+        doc_freq = _word_document_frequency(_epic_path_documents(epic))
+
         # (a) Direct: @cw-trace annotations in THIS file targeting a defined ID.
         for ann in direct_anns:
             if ann.target not in epic.defined:
@@ -512,7 +629,7 @@ def governing_facts_for_file(repo_root: Path, rel: str, epics: list[Epic]) -> li
         if contracts:
             for entity in contracts.get("entities", []):
                 for op in entity.get("operations", []):
-                    if not _path_matches_literal_segments(op.get("path", ""), rel):
+                    if not _path_matches_literal_segments(op.get("path", ""), rel, doc_freq):
                         continue
                     # Locator discipline (two-plane): counts + IDs only — the
                     # REQUIRES/ENSURES/error bodies stay in Plane A; deref the
@@ -540,7 +657,7 @@ def governing_facts_for_file(repo_root: Path, rel: str, epics: list[Epic]) -> li
         ui_spec = epic.models.get("ui-spec.json")
         if ui_spec:
             for route, page in (ui_spec.get("pages") or {}).items():
-                if not route or not _path_matches_literal_segments(route, rel):
+                if not route or not _path_matches_literal_segments(route, rel, doc_freq):
                     continue
                 facts.append(Fact(
                     kind="ui_component",

--- a/scripts/code_query.py
+++ b/scripts/code_query.py
@@ -423,6 +423,18 @@ def _fuzzy_word_match(a: str, b: str) -> bool:
 # true plurality of operations share (the "provider" case). Tuned and
 # revalidated against a real, previously-shipped repo (see docs/code-query.md).
 _MAX_COMMON_WORD_DF = 0.4
+# Below this many corpus documents, document frequency is statistical noise
+# and the DF bar is bypassed entirely (every word counts as specific — the
+# pre-#185 all-words behavior). Without this floor, a one-operation epic
+# rejects ITSELF: its own path's words are the whole corpus (df=1.0 > 0.4),
+# so `orient` would return nothing for the file that operation genuinely
+# governs; a two-document epic (an operation plus its UI route sharing the
+# entity word) self-blocks the same way at df=1.0. Threshold interaction:
+# at total_docs >= 5, a word must appear in >40% of documents to be common —
+# i.e. at least 3 of 5 — so a genuinely-shared entity word still needs real
+# recurrence before it loses binding weight, while the dogeared-coach
+# "provider" case (5 of 8 documents) stays blocked.
+_MIN_CORPUS_DOCS = 5
 
 
 def _epic_path_documents(epic: Epic) -> list[frozenset[str]]:
@@ -450,7 +462,12 @@ def _epic_path_documents(epic: Epic) -> list[frozenset[str]]:
 
 
 def _word_document_frequency(docs: list[frozenset[str]]) -> dict[str, float]:
-    """word -> fraction of `docs` that contain it. Deterministic across runs
+    """word -> fraction of `docs` that contain it, or `{}` when the corpus has
+    fewer than `_MIN_CORPUS_DOCS` documents — DF over a tiny corpus is noise,
+    and returning an empty map makes every `_has_specific_word` lookup miss
+    (df=0.0, maximally specific), i.e. small epics keep the pre-#185
+    all-words-only behavior instead of self-blocking (a one-operation epic's
+    own words are the entire corpus at df=1.0). Deterministic across runs
     (CTR-fh-051): built by iterating `docs` in the epic artifacts' own JSON
     list order (stable across runs/platforms), and dict iteration order in
     CPython is insertion order, not hash order — so this never depends on
@@ -459,7 +476,7 @@ def _word_document_frequency(docs: list[frozenset[str]]) -> dict[str, float]:
     set's iteration order; only membership/count, which hashing doesn't
     affect."""
     total = len(docs)
-    if not total:
+    if total < _MIN_CORPUS_DOCS:
         return {}
     counts: dict[str, int] = {}
     for doc in docs:
@@ -470,10 +487,11 @@ def _word_document_frequency(docs: list[frozenset[str]]) -> dict[str, float]:
 
 def _has_specific_word(literals: set[str], doc_freq: dict[str, float]) -> bool:
     """At least one of `literals` must clear the specificity bar (CTR-fh-050).
-    A word absent from the corpus (lookup miss — e.g. the corpus is empty
-    because this epic declares only one operation) is treated as maximally
-    specific (df=0.0), so an epic with nothing else to compare against never
-    spuriously blocks its own only operation."""
+    A word absent from the map is a lookup miss treated as maximally specific
+    (df=0.0) — which is also how the small-corpus bypass arrives here:
+    `_word_document_frequency` returns an empty map below `_MIN_CORPUS_DOCS`,
+    so every word of a small epic misses and the all-words guard alone
+    decides, exactly as before #185."""
     return any(doc_freq.get(w, 0.0) <= _MAX_COMMON_WORD_DF for w in literals)
 
 

--- a/tests/fixtures/code_query_repo/docs/epics/checkout/models/contracts.json
+++ b/tests/fixtures/code_query_repo/docs/epics/checkout/models/contracts.json
@@ -44,6 +44,58 @@
           ],
           "state_transition": "pending -> confirmed",
           "invariants_touched": ["INV-checkout-001"]
+        },
+        {
+          "name": "List Orders",
+          "method": "GET",
+          "path": "/api/v1/orders",
+          "description": "Lists orders. #185 fixture: a second Order operation whose path is a BARE entity word — dilutes 'orders' document-frequency across the corpus so it stays a specific (not ubiquitous) word, contrasting with the 'providers' entity below.",
+          "preconditions": [],
+          "postconditions": [],
+          "error_cases": []
+        }
+      ]
+    },
+    {
+      "name": "Provider",
+      "description": "#185 fixture: a deliberately common entity — nearly every operation below shares the bare word 'providers', mirroring the real dogeared-coach over-match (an 'auth-provider.tsx' file lexically matched ~30 unrelated provider operations). Regression fixture for CTR-fh-050/051/INV-fh-012: 'providers' alone must NOT bind, but an entity+verb combination (e.g. 'verify') still does.",
+      "fields": [],
+      "operations": [
+        {
+          "name": "List Providers",
+          "method": "GET",
+          "path": "/api/v1/providers",
+          "description": "Bare entity word only — the over-match case.",
+          "preconditions": [],
+          "postconditions": [],
+          "error_cases": []
+        },
+        {
+          "name": "Verify Provider",
+          "method": "POST",
+          "path": "/api/v1/providers/:id/verify",
+          "description": "Entity + specific verb — must still bind for a file whose path also contains 'verify'.",
+          "preconditions": [],
+          "postconditions": [],
+          "error_cases": []
+        },
+        {
+          "name": "Schedule Provider",
+          "method": "POST",
+          "path": "/api/v1/providers/:id/schedule",
+          "description": "Entity + a different specific word — keeps 'providers' from being the corpus's only word.",
+          "preconditions": [],
+          "postconditions": [],
+          "error_cases": []
+        },
+        {
+          "name": "Provider Plan",
+          "method": "GET",
+          "path": "/api/v1/providers/:id/plan",
+          "description": "Entity + a third specific word.",
+          "preconditions": [],
+          "postconditions": [],
+          "error_cases": []
         }
       ]
     }

--- a/tests/fixtures/code_query_repo/docs/epics/checkout/models/ui-spec.json
+++ b/tests/fixtures/code_query_repo/docs/epics/checkout/models/ui-spec.json
@@ -10,12 +10,22 @@
       },
       "root": ["status-badge"],
       "design_refs": ["order-detail-reference"]
+    },
+    "/providers/:id": {
+      "route": "/providers/:id",
+      "title": "Provider Detail",
+      "layout": "centered",
+      "auth": "required",
+      "components": {},
+      "root": [],
+      "design_refs": []
     }
   },
   "navigation": {
     "initial": "/orders/:id",
     "states": {
-      "/orders/:id": { "route": "/orders/:id", "on": {} }
+      "/orders/:id": { "route": "/orders/:id", "on": {} },
+      "/providers/:id": { "route": "/providers/:id", "on": {} }
     }
   }
 }

--- a/tests/fixtures/code_query_repo/src/orders/confirm_direct.py
+++ b/tests/fixtures/code_query_repo/src/orders/confirm_direct.py
@@ -1,0 +1,15 @@
+"""Regression fixture for the leading relation-tier rank key (CTR-fh-052/053,
+INV-fh-007/012): this file carries BOTH a direct @cw-trace annotation AND an
+artifact-derived (inferred) match on the SAME 'Confirm Order' operation (its
+path words {orders, confirm, direct} cover all of
+/api/v1/orders/:id/confirm's literal words {orders, confirm}). `orient` must
+rank the direct fact ahead of the inferred one for this file — this is the
+same ordering IT-fh-03 case (d) requires of a direct-vs-measured tie, tested
+here for the direct-vs-inferred tier boundary that ships in this ticket.
+
+@cw-trace guards INV-checkout-001
+"""
+
+
+def handle_confirm_direct(request):
+    ...

--- a/tests/fixtures/code_query_repo/ui/src/providers/auth-provider.tsx
+++ b/tests/fixtures/code_query_repo/ui/src/providers/auth-provider.tsx
@@ -1,0 +1,10 @@
+// #185 regression fixture: mirrors the real dogeared-coach false positive —
+// a file whose path lexically contains only the epic's common entity word
+// ("provider") must NOT inherit contracts.json/ui-spec.json operations that
+// mention "provider" and nothing more specific. No @cw-trace annotation and
+// no artifact-derived binding should govern this file after the CTR-fh-050
+// corpus-specificity fix.
+
+export function AuthProvider() {
+  return null;
+}

--- a/tests/fixtures/code_query_repo/ui/src/providers/verify-provider.tsx
+++ b/tests/fixtures/code_query_repo/ui/src/providers/verify-provider.tsx
@@ -1,0 +1,9 @@
+// #185 regression fixture: the positive counterpart to auth-provider.tsx —
+// this file's path contains BOTH the common entity word ("provider") AND a
+// specific verb word ("verify") that also appears in the "Verify Provider"
+// operation path (/api/v1/providers/:id/verify). The entity+verb combination
+// must still bind even though "providers" alone is corpus-common.
+
+export function VerifyProvider() {
+  return null;
+}

--- a/tests/test_code_query.py
+++ b/tests/test_code_query.py
@@ -15,6 +15,7 @@ small "checkout" epic with:
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -476,6 +477,67 @@ def test_orient_inferred_binding_is_deterministic_across_runs():
     for _ in range(5):
         again = code_query.cmd_orient(FIXTURE, "ui/src/providers/verify-provider.tsx", "checkout")
         assert again == first
+
+
+def _write_mini_epic(root: Path, slug: str, *, contracts: dict | None = None, ui_spec: dict | None = None):
+    mdir = root / "docs" / "epics" / slug / "models"
+    mdir.mkdir(parents=True)
+    if contracts is not None:
+        (mdir / "contracts.json").write_text(json.dumps(contracts))
+    if ui_spec is not None:
+        (mdir / "ui-spec.json").write_text(json.dumps(ui_spec))
+
+
+def test_small_corpus_bypasses_the_specificity_bar_one_doc_epic(tmp_path):
+    """Codex P1 regression (PR #192): a one-operation epic's own path words ARE
+    the whole corpus (df=1.0 > threshold), so a pure-ratio rule rejects the
+    epic's ONLY operation for the file it genuinely governs. Below
+    `_MIN_CORPUS_DOCS` documents the DF bar is bypassed (DF over a tiny corpus
+    is noise) and the pre-#185 all-words behavior decides alone.
+
+    @cw-trace verifies CTR-fh-050
+    """
+    _write_mini_epic(tmp_path, "mini", contracts={"entities": [{"name": "Order", "operations": [
+        {"name": "List Orders", "method": "GET", "path": "/api/v1/orders"}]}]})
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "orders.py").write_text("def list_orders():\n    ...\n")
+    env = code_query.cmd_orient(tmp_path, "src/orders.py", "mini")
+    assert any(f["kind"] == "contract_operation" for f in env["facts"]), env["facts"]
+
+
+def test_small_corpus_bypasses_the_specificity_bar_two_doc_epic(tmp_path):
+    """Two-document flavor of the same P1: an operation plus its UI route both
+    reduce to the shared entity word ('orders', df=1.0 in each) — a small
+    epic's most natural shape — and must still infer-bind on both sides.
+
+    @cw-trace verifies CTR-fh-050
+    """
+    _write_mini_epic(
+        tmp_path, "mini2",
+        contracts={"entities": [{"name": "Order", "operations": [
+            {"name": "List Orders", "method": "GET", "path": "/api/v1/orders"}]}]},
+        ui_spec={"pages": {"/orders/:id": {"route": "/orders/:id", "title": "Order Detail"}}},
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "orders.py").write_text("...")
+    (tmp_path / "ui").mkdir()
+    (tmp_path / "ui" / "orders.tsx").write_text("...")
+    env_src = code_query.cmd_orient(tmp_path, "src/orders.py", "mini2")
+    env_ui = code_query.cmd_orient(tmp_path, "ui/orders.tsx", "mini2")
+    assert any(f["kind"] == "contract_operation" for f in env_src["facts"]), env_src["facts"]
+    assert any(f["kind"] == "ui_component" for f in env_ui["facts"]), env_ui["facts"]
+
+
+def test_word_document_frequency_is_empty_below_min_corpus_and_real_at_or_above():
+    """The bypass seam itself: below `_MIN_CORPUS_DOCS` the DF map is empty
+    (every lookup misses -> maximally specific); at/above it, real ratios.
+
+    @cw-trace verifies CTR-fh-050
+    """
+    small = [frozenset({"orders"})] * (code_query._MIN_CORPUS_DOCS - 1)
+    assert code_query._word_document_frequency(small) == {}
+    full = [frozenset({"orders"})] * code_query._MIN_CORPUS_DOCS
+    assert code_query._word_document_frequency(full) == {"orders": 1.0}
 
 
 # --- relation-tier-first rank key (CTR-fh-052/053, INV-fh-007/012) --------------------

--- a/tests/test_code_query.py
+++ b/tests/test_code_query.py
@@ -414,13 +414,113 @@ def test_inferred_binding_requires_all_literal_words():
     # Positive: src/orders/confirm.py covers ALL literal words of
     # /api/v1/orders/:id/confirm ({orders, confirm}) -> bound.
     env = code_query.cmd_orient(FIXTURE, "src/orders/confirm.py", "checkout")
-    assert any(f["kind"] == "contract_operation" for f in env["facts"])
+    op_names = {f["statement"] for f in env["facts"] if f["kind"] == "contract_operation"}
+    assert any("Confirm Order" in s for s in op_names)
 
     # Negative: ui/orders/page.tsx matches "orders" but NOT "confirm" -> must
-    # NOT inherit the confirm operation (it still gets its ui-spec page).
+    # NOT inherit the confirm operation specifically (it still gets its
+    # ui-spec page, and — #185 fixture addition — its OWN "List Orders"
+    # bare-entity operation, which is a genuine "orders" binding, not an
+    # over-match: "orders" clears the corpus-specificity bar (CTR-fh-050)
+    # because the fixture corpus also contains four unrelated "Provider"
+    # operations that never mention it).
     env = code_query.cmd_orient(FIXTURE, "ui/orders/page.tsx", "checkout")
-    assert not any(f["kind"] == "contract_operation" for f in env["facts"]), env["facts"]
+    op_names = {f["statement"] for f in env["facts"] if f["kind"] == "contract_operation"}
+    assert not any("Confirm Order" in s for s in op_names), op_names
+    assert any("List Orders" in s for s in op_names), op_names
     assert any(f["kind"] == "ui_component" for f in env["facts"])
+
+
+# --- corpus-derived word specificity (#185 precision fix) -----------------------------
+#
+# Real-world trigger (dogeared-coach): `ui/src/providers/auth-provider.tsx` word-matched
+# ~30 unrelated operations purely because "provider" is the entity name and recurs
+# across nearly every Provider operation. The fixture's Provider entity (4 operations,
+# 3 of which share ONLY the bare word "providers") + ui-spec route reproduces the same
+# shape at small scale: "providers" clears >40% document-frequency in the fixture's own
+# 8-document corpus (contracts.json operations + ui-spec.json routes), so it carries no
+# binding weight on its own (CTR-fh-050/051, INV-fh-012).
+
+
+def test_common_entity_word_alone_does_not_bind():
+    """
+    @cw-trace verifies CTR-fh-050 INV-fh-012
+    """
+    env = code_query.cmd_orient(FIXTURE, "ui/src/providers/auth-provider.tsx", "checkout")
+    assert not any(f["kind"] == "contract_operation" for f in env["facts"]), env["facts"]
+    assert not any(f["kind"] == "ui_component" for f in env["facts"]), env["facts"]
+
+
+def test_entity_verb_combination_still_binds_despite_common_entity_word():
+    """
+    @cw-trace verifies CTR-fh-050 INV-fh-012
+    """
+    # "verify" is a specific (low document-frequency) word in the fixture corpus, so
+    # the entity+verb combination still clears the specificity bar even though
+    # "providers" alone would not.
+    env = code_query.cmd_orient(FIXTURE, "ui/src/providers/verify-provider.tsx", "checkout")
+    op_names = {f["statement"] for f in env["facts"] if f["kind"] == "contract_operation"}
+    assert any("Verify Provider" in s for s in op_names), op_names
+    # The bare "List Providers"/"Provider Plan"/"Schedule Provider" operations must
+    # NOT also leak in just because "providers" happens to match too.
+    assert not any("List Providers" in s for s in op_names), op_names
+
+
+def test_orient_inferred_binding_is_deterministic_across_runs():
+    """CTR-fh-051: same epic artifacts + same file => identical fact set and
+    ordering across repeated calls (no dict/set-iteration-order dependence).
+
+    @cw-trace verifies CTR-fh-051
+    """
+    first = code_query.cmd_orient(FIXTURE, "ui/src/providers/verify-provider.tsx", "checkout")
+    for _ in range(5):
+        again = code_query.cmd_orient(FIXTURE, "ui/src/providers/verify-provider.tsx", "checkout")
+        assert again == first
+
+
+# --- relation-tier-first rank key (CTR-fh-052/053, INV-fh-007/012) --------------------
+
+
+def test_rank_key_relation_tier_is_leading_and_orders_direct_inferred_measured():
+    """Unit-level guard on `_rank_key` itself: direct < inferred < measured,
+    and this leading element dominates `exact` — a `measured` fact (the future
+    #187 hotspot tier; no producer exists yet, only the tier) must never
+    outrank a `direct` or `inferred` fact even when `exact=True`.
+
+    @cw-trace verifies CTR-fh-052 CTR-fh-053 INV-fh-007
+    """
+    direct = code_query.Fact(
+        kind="contract", id="CTR-x", statement="s", handle="h", epic="e",
+        extra={"relation": "direct"}, exact=True, proximity=0,
+    )
+    inferred = code_query.Fact(
+        kind="contract_operation", id=None, statement="s", handle="h", epic="e",
+        extra={"relation": "inferred"}, exact=False, proximity=1,
+    )
+    measured = code_query.Fact(
+        kind="hotspot", id=None, statement="s", handle="h", epic="e",
+        extra={"relation": "measured"}, exact=True, proximity=1,
+    )
+    assert code_query._rank_key(direct, "orient")[0] == 0
+    assert code_query._rank_key(inferred, "orient")[0] == 1
+    assert code_query._rank_key(measured, "orient")[0] == 2
+
+    ranked = code_query.rank_facts([measured, inferred, direct], "orient")
+    assert ranked == [direct, inferred, measured]
+
+
+def test_orient_ranks_direct_before_inferred_for_the_same_file():
+    """Property/regression test (IT-fh-03-style, direct-vs-inferred tier
+    boundary): src/orders/confirm_direct.py carries BOTH a direct @cw-trace
+    annotation AND an artifact-derived inferred match on the same Confirm
+    Order operation. `orient` must rank the direct fact first.
+
+    @cw-trace verifies CTR-fh-052 INV-fh-007
+    """
+    env = code_query.cmd_orient(FIXTURE, "src/orders/confirm_direct.py", "checkout")
+    relations = [f.get("relation") for f in env["facts"]]
+    assert "direct" in relations and "inferred" in relations, env["facts"]
+    assert relations.index("direct") < relations.index("inferred")
 
 
 # --- every handle round-trips through show (review issue 3) ---------------------------


### PR DESCRIPTION
## Summary

Fixes #185 — `code_query orient`'s artifact-derived (`inferred`) binding
over-matched on common entity names once #159's "short word hides inside a
longer word" bug was fixed. The remaining false-positive shape: an entity
name that recurs across most of an epic's own operations (dogeared-coach's
`provider` — the primary tenant entity) still satisfies the existing
all-words guard on its own, so a file like `ui/src/providers/auth-provider.tsx`
word-matches every bare-entity operation that mentions it, regardless of
whether the operation has anything to do with that file.

## What changed

1. **Corpus-derived word specificity** (`_word_document_frequency`,
   `_has_specific_word`, `_path_matches_literal_segments`): each literal word
   of an operation path / ui-spec route is weighted by its document frequency
   across **this epic's own** `contracts.json` operations + `ui-spec.json`
   routes — no external corpus, no network, recomputed live from the same
   artifacts already loaded for the query. A word present in more than 40% of
   the epic's own path/route "documents" carries zero binding weight. An
   inferred match now requires the existing all-words guard **AND** at least
   one literal word that clears that bar — an entity name alone, however
   ubiquitous, is never enough on its own; an entity+verb combination (e.g.
   a file whose path also contains "verify") still binds.
2. **Relation-tier-first `_rank_key`** (`_relation_tier`): a new leading
   tuple element — `direct=0 < inferred=1 < measured=2` — placed ahead of
   `exact`, so a future `measured` (#187 hotspot) fact can never outrank a
   `direct` or `inferred` fact for the same file, regardless of its own
   `exact` flag. No hotspot producer exists in this ticket — only the tier,
   wired so #187 doesn't have to touch ranking again. Facts that don't set
   `relation` (writer / field_contract facts) fall back to their `exact`
   flag, exactly how they already sorted — additive, not a behavior change
   for those verbs.
3. **Fixture corpus expansion**: added a "List Orders" bare-entity operation
   and a 4-operation "Provider" entity (+ a `/providers/:id` ui-spec route)
   to `tests/fixtures/code_query_repo` so the fixture reproduces the
   common-entity-name shape at small scale (8-document corpus: `orders`
   stays specific at 3/8 = 37.5%, `providers` becomes common at 5/8 = 62.5%).
   One pre-existing assertion (`ui/orders/page.tsx` must not inherit the
   confirm operation) was narrowed to check the *specific* operation name,
   because the fixture now legitimately binds that file to its own new
   "List Orders" operation — a correct binding, not a regression.
4. `docs/code-query.md` limitation section updated: what #185 fixes, what
   lexical matching still can't do (documented, not hidden).

## CTR/INV coverage

| Contract/Invariant | What it requires | Test(s) |
|---|---|---|
| CTR-fh-050 | ≥1 specific word required, not one common word alone | `test_common_entity_word_alone_does_not_bind`, `test_entity_verb_combination_still_binds_despite_common_entity_word`, `test_inferred_binding_requires_all_literal_words` |
| CTR-fh-051 | Deterministic, stdlib-only, no dict/set-order dependence | `test_orient_inferred_binding_is_deterministic_across_runs` (5 repeated calls, byte-identical envelope) |
| CTR-fh-052 | Relation-tier-first rank key; direct precedes inferred precedes measured | `test_rank_key_relation_tier_is_leading_and_orders_direct_inferred_measured`, `test_orient_ranks_direct_before_inferred_for_the_same_file` |
| CTR-fh-053 | Channel separation: measured never routes through `_path_matches_literal_segments` | `test_rank_key_relation_tier_is_leading_and_orders_direct_inferred_measured` (tier ordering) — full hotspot-producer wiring is #187's scope |
| INV-fh-007 | Measured tier sorts below direct/inferred via leading tier key | `test_rank_key_relation_tier_is_leading_and_orders_direct_inferred_measured` |
| INV-fh-012 | Inferred bindings are precision-bounded (IDF/entity+verb) | `test_common_entity_word_alone_does_not_bind`, `test_entity_verb_combination_still_binds_despite_common_entity_word` |

`@cw-trace guards`/`verifies` annotations added to `scripts/code_query.py`
and `tests/test_code_query.py` for all six IDs above. Verified via
`check_traceability.check()` against this repo's own
`docs/epics/epic-factory-hardening`: CTR-fh-050/051/052/053 and INV-fh-007
move from uncovered/untested to covered+tested; no new dangling links
introduced (all pre-existing dangling entries are unrelated test fixtures).

**Scope note on IT-fh-03**: the epic doc's case (d) — a file with both a
direct annotation and #187 hotspot membership — is tested at the
`_rank_key`/`_relation_tier` unit level (synthetic `measured` Facts plus a
real direct-vs-inferred fixture file, `confirm_direct.py`), since #187 has
not landed yet and there is no `measured`-fact producer to golden-test
end-to-end. The tier ordering itself (this ticket's actual scope) is fully
covered; the full IT-fh-03 golden extension with a real `hotspots.json`
belongs to #187.

## Real-repo re-validation (dogeared-coach)

Ran `orient` (before vs. after this fix) against
`~/.chief-wiggum/repos/plwp/dogeared-coach` on 10 provider-related files —
the exact shape the #185 issue described:

| file | before | after | removed |
|---|---|---|---|
| `ui/src/providers/auth-provider.tsx` | 0 | 0 | — |
| `ui/src/providers/admin-claims-provider.tsx` | 2 | 2 | — |
| `ui/src/providers/impersonation-provider.tsx` | 0 | 0 | — |
| `ui/src/providers/query-provider.tsx` | 0 | 0 | — |
| `ui/src/components/provider/provider-picker-gate.tsx` | 1 | 1 | — |
| `ui/src/__tests__/provider-billing.test.tsx` | 2 | 1 | `page provider-billing (Billing & Plan)` |
| `ui/src/__tests__/admin-provider-billing.test.tsx` | 4 | 3 | `page provider-billing (Billing & Plan)` |
| `backend/internal/db/provider_repo_billing_risk_test.go` | 3 | 2 | `page provider-billing (Billing & Plan)` |
| `backend/internal/handlers/provider_video.go` | 3 | 3 | — |
| `backend/internal/services/provider_video_metadata.go` | 3 | 3 | — |

The removed fact in each case is a `ui-spec.json` "provider-billing" page
binding that three unrelated Go/test files inherited purely by sharing the
two common words "provider" + "billing" with the route — a spurious
cross-language binding, not a genuine dependency.

**Conservativeness check**: ran `orient` before/after on a random 300-file
sample of the whole repo. The post-fix fact set was a **strict subset** of
the pre-fix set for every file (0 files gained a fact; 6 files lost one;
169 → 162 total inferred facts across the sample) — confirming the fix can
only remove over-matches, never introduce a new one.

## Test plan

- [x] Full `pytest` (1351 passed, 4 skipped — pre-existing skips, unrelated)
- [x] `ruff check` clean on all changed files
- [x] Golden parity tests (`tests/test_code_query_golden.py`) unaffected
- [x] `check_traceability.check()` against this repo's own epic confirms
      new annotations resolve, no new dangling links
- [x] Re-validated on dogeared-coach (real, previously-shipped repo) — see
      table above

## Deviations / notes

- CTR-fh-050..053 are declared in
  `docs/epics/epic-factory-hardening/models/contract-assertions.md` (not
  `contracts.md`, which structures this epic's contracts by operation
  heading rather than per-numbered-ID) — annotations target that
  declaration, confirmed resolvable via `check_traceability`.
- Threshold (`_MAX_COMMON_WORD_DF = 0.4`) is a fixed, documented constant
  rather than a per-epic-tuned value — consistent with "deterministic,
  stdlib-only" (CTR-fh-051) and simple enough to reason about; revisit if a
  future real-repo validation finds it too loose/tight.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF