### PR TITLE
feat(system): architecture.json declared model + check_architecture static consistency (#174)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -369,6 +369,26 @@ Maps every acceptance criterion from every ticket to the test(s) that will verif
 
 Each row's "Status" column starts as `pending` and is updated to `covered` when `/implement` writes the test, then `passing` when `/close-epic` verifies it.
 
+#### 4i. System Architecture Model (`docs/system/architecture.json`) — once per product
+
+Unlike 4a–4h, this artifact is **system-level, not epic-level**: it lives at `docs/system/architecture.json` in the target repo (schema: `$CW_HOME/templates/formal-models/architecture-schema.json`) and is authored **once per product**, then updated only when an epic adds/removes/retires a deployable or connector — most epics touching an existing product will find it already present and just extend it.
+
+**Check first**: `test -f "$TARGET_REPO/docs/system/architecture.json"`.
+- **Absent** (first epic that touches system architecture, or a product that has never modeled it): author it fresh. Include `$CW_HOME/templates/formal-models/examples/voice-agent-architecture.json` in the worker prompt as a worked example (client → gateway → STT/LLM/TTS externals with `ASM-` refs) — a concrete template for the node/edge shape, not a fixture to copy verbatim.
+- **Present**: read it, and only add/amend the `ARC-`/`EDG-` nodes and edges THIS epic actually introduces (a new service, a new external vendor call, a connector being retired). Leave everything else untouched — this file is a standing product model, not a per-epic scratchpad.
+
+For every deployable and connector this epic's tickets introduce or change, define:
+- **Nodes** (`ARC-`): `id`, `name`, `kind` (`service`|`worker`|`db`|`queue`|`bucket`|`cron`|`external`), `repo` (URN/path, or `null` for external), `external`, `trust_zone` (`public`|`dmz`|`internal`|`restricted`), `region`, `failure_domain`, `criticality_tier` (`tier-1`|`tier-2`|`tier-3` — **never omit this**: a missing tier is reported as a finding by the checker, not silently skipped, so leaving it out just defers the problem), `emits` (telemetry binding names — bind these to the same names used in `docs/system/system-contracts.json` budget nodes' `telemetry_ref`, if that artifact exists, so the cross-artifact check in 5a has something to verify), `status` (`active`|`deprecated`|`retired`), `asm_refs` (REQUIRED, non-empty, when `external: true` and the node is reached by a `hard` edge — vendor SLA/assumption references, `ASM-` ids).
+- **Edges** (`EDG-`): `from`/`to` (must resolve to declared `ARC-` node ids), `protocol`, `mode` (`sync`|`async`), `criticality` (`hard`|`soft` — an AVAILABILITY dependency only, distinct from `carries` and from a trust-zone crossing: a low-tier logging sink may carry sensitive data without being availability-critical, and a low-tier auth provider may be availability-critical without carrying any payload), `on_failure` (`fallback`/`degrade_to`), `carries` (data-class labels, the monotone lattice `public < internal < pii < secret < official-sensitive`), `auth`, `timeout_ms`, `ordering`, `dlq`, `active`. **Never author `trust_zone_crossing`/`region_crossing`** — those two fields are computed ONLY by `check_architecture.py` from the node attributes; leave them `null` (or omit them) and let the checker derive them. An authored non-null value is itself a finding (INV-fh-006) — a hand-written "safe" crossing label is exactly the kind of thing that could mask a real trust-zone violation.
+
+**Verifier-in-the-loop**: validate against the schema as soon as the worker produces it:
+```bash
+python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/architecture.json" --type architecture
+```
+Fix and re-validate until clean. The deeper consistency checks (dangling endpoints, retired-node edges, unlabelled externals, tier inversion, label propagation, cross-artifact drift) run in Step 5a below — schema validity here is necessary but not sufficient.
+
+**What this proves, and what it doesn't.** `check_architecture.py` proves the DECLARED model in `architecture.json` is internally consistent. It does **not** prove the running code matches this model — that conformance/reflexion question is deliberately deferred (`#171`; see `docs/system-layer.md`). Declaring the model is cheap; treat it as a design-time contract the epic's `contracts.md`/`ui-spec.json` may reference by `ARC-`/`EDG-` id, not as a guarantee about deployed reality.
+
 ### Step 5: Formal model validation + multi-AI review
 
 The synthesised artifacts are the most critical output in the pipeline — every ticket inherits them. Validate mechanically first, then get a second opinion from external AIs.
@@ -404,6 +424,15 @@ python3 "$CW_HOME/scripts/check_traceability.py" "$CW_TMP" --gate soundness --fo
 # docs/single-writer.md). Degrades gracefully when no such invariant exists.
 python3 "$CW_HOME/scripts/check_single_writer.py" "$CW_TMP" --source "$TARGET_REPO" --gate soundness --format text
 ```
+
+**Architecture model consistency (`docs/system/architecture.json`, when 4i produced or updated one).** Report-only — this checker is NOT gated in `/architect` yet (ADR-fh-07: gating requires the #168 gate-validation protocol plus a passing `#184` validation record for `check_architecture`, which freezes its `CHECKS` inventory as a prerequisite). Run it so findings are visible at design time even though they don't block:
+
+```bash
+python3 "$CW_HOME/scripts/check_architecture.py" "$CW_TMP/architecture.json" \
+  --system-contracts "$TARGET_REPO/docs/system/system-contracts.json" --format text
+```
+
+(Omit `--system-contracts` if the target repo has no budget-tree doc yet — the checker reports that cross-artifact leg as "not checked", distinct from "passed", never silently skipped.) The authority line is printed every run: *"proves the DECLARED model is internally consistent; does not prove the code matches the model."* Fix any dangling endpoints, retired-node edges, unlabelled externals, tier inversions, label-propagation violations, or authored (non-null) crossing labels before proceeding — these are cheap to fix now and expensive to discover once tickets have started referencing the wrong `ARC-`/`EDG-` ids.
 
 Any invariant that says "single write path" or "single source of truth" for a field/state MUST name its `controls_field` and `sanctioned_writers` — either as arrays on the structured `state-machines.json` invariant, or via a `<!-- @cw-writes INV-... controls_field=a.b sanctioned_writers=Sym,path.go -->` tag next to its `**INV-...**` label in `invariants.md`. Without this metadata the invariant is prose only and a second mutator (e.g. a legacy admin control) can silently violate it. Review the surfaced writer inventory: if the gate lists a writer outside the sanctioned set, that is a pre-existing violation to fix or explicitly sanction before the epic builds on the invariant.
 
@@ -476,6 +505,7 @@ python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name architect-rev
 - **Open unknowns**: every surviving `TBD:`/`UNRESOLVED:` marker, which tickets each one blocks, and the plan to resolve it (who/what/when)
 - **Test coverage preview**: number of test paths that will be mechanically generated (from the test view)
 - **DST readiness** (new products only): the INV-dst-001/002/003 invariants stamped, the clock/random/IO seam packages named in the ADR, and `check_dst_readiness.py`'s baseline finding counts
+- **System architecture model** (when 4i produced/updated one): node/edge counts, any `check_architecture.py` findings (report-only — never blocks here), and which `ARC-`/`EDG-` ids this epic's contracts reference
 - ADR: key decisions with trade-offs
 - Integration tests: what will be validated at epic close
 - Traceability: coverage gaps (any AC without a planned test)
@@ -504,6 +534,15 @@ git push
 ```
 
 The transition-map baseline marks existing-code transitions `covered` and new model transitions `planned`; it evolves as tickets are implemented. Use `--dry-run` to preview what would be installed (and the issue-comment body) without writing, and `--no-commit` to install without committing. The JSON output lists `copied`, `generated`, `transition_map`, `issue_comment`, and any `warnings`.
+
+**If Step 4i produced or updated `architecture.json`**, commit it separately to `docs/system/` — it is a system-level, once-per-product artifact and does NOT belong under `docs/epics/$EPIC_SLUG/`:
+```bash
+mkdir -p "$TARGET_REPO/docs/system"
+cp "$CW_TMP/architecture.json" "$TARGET_REPO/docs/system/architecture.json"
+git -C "$TARGET_REPO" add docs/system/architecture.json
+git -C "$TARGET_REPO" commit -m "arch: update docs/system/architecture.json for $EPIC_SLUG"
+```
+(This can be folded into the same commit/push as the epic artifacts above if the installer step hasn't pushed yet.)
 
 **If `git push` fails** (e.g., branch protection rules forbid direct pushes to the default branch), fall back to creating a PR:
 ```bash

--- a/docs/system-layer.md
+++ b/docs/system-layer.md
@@ -1,0 +1,148 @@
+# System layer: the declared architecture model (and what it doesn't prove)
+
+Chief Wiggum can check that a *declared* system architecture is internally
+consistent — mechanically, instead of trusting a hand-drawn C4 diagram nobody
+re-derives once it drifts. This is `#174`'s contribution to the system layer
+that `#164` (budget trees) and `#165` (infra drift) started: `docs/system/architecture.json`,
+checked by `scripts/check_architecture.py`.
+
+## The model: nodes and edges, C4-flavored
+
+`architecture.json` (schema: `templates/formal-models/architecture-schema.json`)
+declares two things:
+
+- **Nodes** (`ARC-` stable IDs) — deployables (`service`/`worker`/`db`/`queue`/`bucket`/`cron`)
+  and external/vendor dependencies (`external: true`, e.g. an LLM API, a TTS
+  vendor, Stripe). Each node carries a `trust_zone`, an optional `region`, a
+  `failure_domain`, a `criticality_tier` (`tier-1`/`tier-2`/`tier-3`), the
+  telemetry bindings it `emits`, and a `status` (`active`/`deprecated`/`retired`).
+- **Edges** (`EDG-` stable IDs) — connectors between declared nodes: `protocol`,
+  `mode` (`sync`/`async`), `criticality` (`hard`/`soft`), `on_failure`, `carries`
+  (data-class labels), `auth`, `timeout_ms`, `ordering`, `dlq`.
+
+The worked example — a voice agent (`client → gateway → STT/LLM/TTS externals`,
+each vendor carrying an `ASM-` assumption reference) — lives at
+`templates/formal-models/examples/voice-agent-architecture.json`, alongside a
+companion `voice-agent-system-contracts.json` for the cross-artifact check
+below. Both check clean.
+
+## Three edge meanings that are NOT the same thing
+
+A single edge has three logically independent properties, read by three
+different checks. Conflating any two of them is a common design-review bug
+this model exists to catch mechanically:
+
+1. **`criticality` (hard/soft)** — an AVAILABILITY dependency only: `hard`
+   means the caller fails if the callee is down. A low-tier logging sink may
+   `carries: [pii]` without being availability-critical; a low-tier auth
+   provider may be `hard` (availability-critical) without carrying any
+   payload at all.
+2. **`carries`** — a data-class label, from the monotone lattice
+   `public < internal < pii < secret < official-sensitive`. This is a
+   classification of *what flows*, independent of whether the edge is a hard
+   dependency.
+3. **`trust_zone_crossing` / `region_crossing`** — whether the edge crosses a
+   trust boundary or a data-residency boundary. These two fields are
+   **COMPUTED ONLY**, never authored: the schema permits the `null`
+   placeholder, but any authored non-null value is itself a finding
+   (`INV-fh-006`) — a hand-written "safe" crossing label is exactly the kind
+   of thing that could mask a real trust-zone violation.
+
+## What `check_architecture.py` proves — and what it deliberately doesn't
+
+Every report — text or JSON — states this verbatim, every run:
+
+> proves the DECLARED model is internally consistent; does not prove the code
+> matches the model
+
+**Declaring** a system model is cheap. Only the **extraction/reflexion**
+machinery — actually inspecting running code or infrastructure and comparing
+it against the declaration — is expensive, and that work is *deliberately
+deferred* to `#171`. This checker never reads source code, containers, or
+infra state; it only reasons over `architecture.json` (and, optionally,
+`system-contracts.json` for cross-artifact checks). A clean `check_architecture.py`
+run tells you the *design* hangs together — it says nothing about whether the
+*deployed system* still matches that design. Treat a clean report as "the
+blueprint is sound", not as "the building matches the blueprint".
+
+## The eight consistency checks (`CHECKS` — frozen per ADR-fh-06)
+
+`check_architecture.CHECKS` is a **frozen tuple**, one canonical seed class
+per consistency rule. It freezes BEFORE `#184` authors this gate's
+validation record (a retroactive test asserts one genuinely-passing `fire`
+trial per entry — closing the gap where a check-specific omission could slip
+past `#184`'s only-generic `required_seed_classes` set). Adding a new rule
+means adding a new tuple entry, never silently folding it into an existing
+one.
+
+| Check | What it catches |
+| --- | --- |
+| `dangling-endpoint` | An edge's `from`/`to` does not resolve to a declared node. |
+| `retired-node-edge` | An ACTIVE edge still touches a `retired` node. |
+| `unlabelled-external` | An `external: true` node reached by a `hard` edge has no `asm_refs`. |
+| `tier-inversion` | A tier-1 node's hard-availability-dependency path reaches (directly, or by passing THROUGH) a lower-criticality node. |
+| `label-propagation` | An edge `carries` a data class into a `trust_zone`/`region` its target forbids — declared-graph only, NO taint analysis. A valid `asm_refs` waiver on the same edge downgrades this to a documented waiver, not a silent pass. |
+| `undeclared-cross-ref` | `system-contracts.json` budget-tree `chains`/`telemetry_ref`s name an `ARC-`/`EDG-`/binding this model never declared (`INV-fh-008`). |
+| `missing-tier` | A node has no `criticality_tier` — reported as a FINDING, never a silently-skipped node (else a node could opt itself out of the tier-inversion check by omission). |
+| `authored-crossing-label` | `trust_zone_crossing`/`region_crossing` was authored non-null instead of left for the checker to derive (`INV-fh-006`). |
+
+## Cross-artifact consistency with `system-contracts.json` (`INV-fh-008`)
+
+Every node/connector `system-contracts.json`'s budget-tree `chains` and
+telemetry bindings reference must name a declared `ARC-`/`EDG-` in
+`architecture.json`, and vice versa where declared — neither model may
+silently invent the other's nodes. Pass the budget-tree doc with
+`--system-contracts`:
+
+```bash
+python3 scripts/check_architecture.py docs/system/architecture.json \
+  --system-contracts docs/system/system-contracts.json --format json
+```
+
+Without `--system-contracts`, this leg is reported `not_checked` — **never**
+conflated with "passed". The same distinction applies to the model itself:
+an absent `architecture.json` exits `0` with a "no architecture model found"
+note, so `/architect` can adopt this incrementally without retroactively
+failing every existing product.
+
+## Report-only by default; exit-code semantics
+
+```bash
+python3 scripts/check_architecture.py docs/system/architecture.json --format text
+python3 scripts/check_architecture.py docs/system/architecture.json --gate   # hard-fail on findings
+python3 scripts/check_architecture.py --scanner-version                     # hash-derived version, no other action
+```
+
+- Exit `0`: report-only default (findings printed, never blocks) — this
+  includes a malformed/unparseable `architecture.json`: a parse or schema
+  error is a FINDING, not a usage error.
+- Exit `1`: `--gate` was passed AND findings exist.
+- Exit `2`: reserved for genuine USAGE errors (bad flags, an unreadable
+  `--schema` path). Never for a property of the model being checked.
+
+Per `docs/gate-rollout.md`, `check_architecture.py` ships report-only and is
+**not yet wired as a blocker** into `/architect` or `/close-epic` — per
+ADR-fh-07, gating requires the `#168` gate-validation protocol plus a passing
+`#184` validation record, which in turn requires this checker's `CHECKS`
+inventory to have frozen first (ADR-fh-06). `/architect` runs it for
+visibility at design time only.
+
+## `--scanner-version`
+
+Hash-derived (`chief_wiggum.hashing.scanner_version`) over this module's
+source plus every `chief_wiggum` dependency whose logic affects findings —
+never a hand-set constant (`INV-fh-005`). This is what makes
+`check_architecture` the fifth `#184` gate whose validation record can be
+mechanically staleness-checked once that record exists.
+
+## Deferred: reflexion / conformance (`#171`)
+
+The declared-vs-declared consistency this checker proves is a different,
+cheaper question than declared-vs-**code**. Whether the code actually
+implements the edges and nodes this file declares — via static extraction
+(imports, RPC clients, queue producers/consumers) or dynamic reflexion
+(observed call graphs vs. declared graph) — is `#171`'s deliberately deferred
+scope. Nothing in `check_architecture.py` reads source, containers, or infra
+state; building that extraction/comparison machinery is real, separate work,
+and the authority line above exists specifically so a clean report is never
+mistaken for that stronger guarantee.

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+"""Architecture model checker (#174): STATIC consistency of the DECLARED system model.
+
+``docs/system/architecture.json`` (schema:
+``templates/formal-models/architecture-schema.json``) declares a C4-flavored
+system model: ``ARC-`` deployables/externals (nodes) and ``EDG-`` connectors
+(edges) between them. This checker proves the declaration is INTERNALLY
+CONSISTENT — it never inspects running code. Whether the code actually matches
+the declared model is a separate, deliberately deferred question (the
+reflexion/extraction conformance gate, #171). Every report — text or JSON —
+states this boundary verbatim::
+
+    proves the DECLARED model is internally consistent; does not prove the
+    code matches the model
+
+Declaring a system model is cheap; only the extraction/reflexion conformance
+machinery is expensive, and that stays out of scope here (ADR-fh-07).
+
+**Three distinct edge meanings** (ADR-fh-01/07), read separately by different
+checks: ``criticality`` (hard/soft) is specifically an AVAILABILITY
+dependency — a low-tier logging sink may carry sensitive data without being an
+availability dependency, and a low-tier auth provider may be
+availability-critical without carrying any payload. ``carries`` is a data
+class. ``trust_zone_crossing``/``region_crossing`` are a zone/locality
+crossing. None of the three implies another.
+
+**CHECKS — frozen inventory (ADR-fh-06).** ``check_architecture`` is the FIFTH
+#184 gate. Per ADR-fh-06, its check set freezes as a module-level tuple BEFORE
+#184 authors this gate's validation record — a retroactive test
+(``tests/test_check_architecture.py`` today; #184's table-driven test later)
+asserts one genuinely-passing ``fire`` trial per entry in ``CHECKS``, closing
+the gap where a check-specific omission could slip past #184's only-generic
+``required_seed_classes`` set. Adding a NEW rule means adding a new entry here
+— never silently folding it into an existing one.
+
+**Report-only by default.** Exit ``0`` even WITH findings; ``--gate`` opts
+into blocking (exit ``1`` on findings); ``2`` is reserved for genuine USAGE
+errors (bad flags/paths) — a malformed/unparseable ``architecture.json``, or
+any other consistency-rule violation, is a FINDING (exit 0 report-only / 1
+under ``--gate``), never a usage error. Absent ``architecture.json`` exits 0
+with a distinct "no architecture model found" note — "not checked" is never
+conflated with "passed", so ``/architect`` can adopt this incrementally.
+Absent optional cross-artifacts (``--system-contracts``) degrade the same way:
+reported ``not_checked``, never silently "passed".
+
+``--scanner-version`` prints a hash-derived version
+(``chief_wiggum.hashing.scanner_version``) covering this module and every
+``chief_wiggum`` dependency whose logic affects findings, and exits — this is
+what makes a stale #184 validation record structurally detectable (INV-fh-005).
+
+Follows ``check_budget_tree.py``'s bespoke, stdlib-only ``_validate_value``
+schema walker (no ``jsonschema`` dependency in gate scripts) so every schema
+finding carries a JSON path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum.hashing import scanner_version  # noqa: E402
+
+DEFAULT_SCHEMA = (
+    Path(__file__).resolve().parents[1] / "templates" / "formal-models" / "architecture-schema.json"
+)
+
+AUTHORITY = (
+    "proves the DECLARED model is internally consistent; does not prove the "
+    "code matches the model"
+)
+
+# --- CHECKS: frozen inventory (ADR-fh-06) -----------------------------------
+# One canonical seed class per entry, in the order ADR-fh-06 lists them. This
+# tuple is the contract #184 tests against — do not reorder/rename entries
+# once a #184 validation record exists; add a NEW entry for a new rule.
+# @cw-trace guards CTR-fh-026
+CHECKS = (
+    "dangling-endpoint",        # edge.from/to does not resolve to a declared node
+    "retired-node-edge",        # an ACTIVE edge touches a retired node
+    "unlabelled-external",      # external node reached by a hard edge has no asm_refs
+    "tier-inversion",           # a tier-1 hard-availability path reaches a lower tier
+    "label-propagation",        # carries x trust_zone/region rule violated, unwaived
+    "undeclared-cross-ref",     # system-contracts.json names an undeclared ARC-/EDG-/binding
+    "missing-tier",             # node has no criticality_tier
+    "authored-crossing-label",  # trust_zone_crossing/region_crossing authored non-null
+)
+
+# Data-class lattice (contracts.md ArchitectureModel entity): a MONOTONE
+# comparison, never string equality — public < internal < pii < secret <
+# official-sensitive.
+DATA_CLASS_RANK = {"public": 0, "internal": 1, "pii": 2, "secret": 3, "official-sensitive": 4}
+# The highest data-class rank a trust_zone may legitimately RECEIVE. A
+# `carries` label whose rank exceeds the target edge's `to` zone's ceiling is
+# a label-propagation finding (declared-graph only — NO taint analysis).
+# 'dmz' (a public-facing ingest/gateway) may legitimately see PII in transit
+# (that's normal for any TLS-terminating ingest) but never secret/
+# official-sensitive without stepping into a more trusted zone first.
+TRUST_ZONE_CEILING = {"public": 0, "dmz": 2, "internal": 3, "restricted": 4}
+EVIDENCE_CHOICES = ("sla-doc", "live-probe", "justified")
+TIER_RANK = {"tier-1": 1, "tier-2": 2, "tier-3": 3}
+ASM_ID_RE = re.compile(r"^ASM-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$")
+CROSS_REF_ID_RE = re.compile(r"^(ARC|EDG)-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$")
+
+
+# --- report data model -------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    check: str  # one of CHECKS, or "schema" for a structural/schema violation
+    id: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Waiver:
+    check: str
+    id: str
+    asm_id: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class NotChecked:
+    artifact: str
+    reason: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class DerivedLabel:
+    edge: str
+    trust_zone_crossing: str | None
+    region_crossing: bool | None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ArchitectureReport:
+    model_present: bool = True
+    nodes: int = 0
+    edges: int = 0
+    findings: list[Finding] = field(default_factory=list)
+    waivers: list[Waiver] = field(default_factory=list)
+    not_checked: list[NotChecked] = field(default_factory=list)
+    derived_labels: list[DerivedLabel] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Gateable status: no findings. Waivers, not_checked notes, and
+        derived-label bookkeeping never affect this."""
+        return not self.findings
+
+    @property
+    def authority(self) -> str:
+        return AUTHORITY
+
+    @property
+    def counts(self) -> dict:
+        by_check: dict[str, int] = {}
+        for f in self.findings:
+            by_check[f.check] = by_check.get(f.check, 0) + 1
+        return {
+            "nodes": self.nodes,
+            "edges": self.edges,
+            "findings": len(self.findings),
+            "by_check": by_check,
+            "waivers": len(self.waivers),
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            "model_present": self.model_present,
+            "authority": self.authority,
+            "ok": self.ok,
+            "counts": self.counts,
+            "findings": [f.to_dict() for f in self.findings],
+            "waivers": [w.to_dict() for w in self.waivers],
+            "not_checked": [n.to_dict() for n in self.not_checked],
+            "derived_labels": [d.to_dict() for d in self.derived_labels],
+        }
+
+
+# --- loading ------------------------------------------------------------------
+
+
+def load_schema(path: Path = DEFAULT_SCHEMA) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def load_doc(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+# --- schema validation --------------------------------------------------------
+#
+# Bespoke, stdlib-only structural validator (mirrors check_budget_tree.py):
+# walks the schema's $ref/type/required/properties/additionalProperties/
+# enum/pattern/minimum/maximum/items keywords against the document. Violations
+# are "schema"-category findings, gateable like any other finding.
+
+
+def _resolve_ref(schema_node: dict, root_schema: dict) -> dict:
+    while isinstance(schema_node, dict) and "$ref" in schema_node:
+        target: object = root_schema
+        for part in schema_node["$ref"].lstrip("#/").split("/"):
+            target = target[part]  # type: ignore[index]
+        schema_node = target  # type: ignore[assignment]
+    return schema_node
+
+
+def _validate_value(value, schema_node: dict, path: str, root_schema: dict, errors: list[tuple[str, str]]) -> None:
+    schema_node = _resolve_ref(schema_node, root_schema)
+    expected = schema_node.get("type")
+
+    if "enum" in schema_node and value not in schema_node["enum"]:
+        errors.append((path, f"value {value!r} not in allowed set {schema_node['enum']}"))
+        return
+
+    if isinstance(expected, list):
+        # e.g. ["string", "null"] — accept if value matches any listed type.
+        if value is None and "null" in expected:
+            return
+        expected = next((t for t in expected if t != "null"), None)
+
+    if expected == "object":
+        if not isinstance(value, dict):
+            errors.append((path, f"expected object, got {type(value).__name__}"))
+            return
+        for req in schema_node.get("required", []):
+            if req not in value:
+                errors.append((path, f"missing required field '{req}'"))
+        props = schema_node.get("properties", {})
+        if schema_node.get("additionalProperties") is False:
+            for key in value:
+                if key not in props:
+                    errors.append((path, f"unknown field '{key}'"))
+        for key, sub in value.items():
+            if key in props:
+                _validate_value(sub, props[key], f"{path}.{key}", root_schema, errors)
+    elif expected == "array":
+        if not isinstance(value, list):
+            errors.append((path, f"expected array, got {type(value).__name__}"))
+            return
+        min_items = schema_node.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            errors.append((path, f"expected at least {min_items} item(s), got {len(value)}"))
+        item_schema = schema_node.get("items")
+        if item_schema:
+            for i, item in enumerate(value):
+                _validate_value(item, item_schema, f"{path}[{i}]", root_schema, errors)
+    elif expected == "string":
+        if not isinstance(value, str):
+            errors.append((path, f"expected string, got {type(value).__name__}"))
+            return
+        pattern = schema_node.get("pattern")
+        if pattern and not re.search(pattern, value):
+            errors.append((path, f"value {value!r} does not match pattern {pattern}"))
+    elif expected == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            errors.append((path, f"expected number, got {type(value).__name__}"))
+            return
+        minimum, maximum = schema_node.get("minimum"), schema_node.get("maximum")
+        if minimum is not None and value < minimum:
+            errors.append((path, f"value {value} below minimum {minimum}"))
+        if maximum is not None and value > maximum:
+            errors.append((path, f"value {value} above maximum {maximum}"))
+    elif expected == "boolean":
+        if not isinstance(value, bool):
+            errors.append((path, f"expected boolean, got {type(value).__name__}"))
+
+
+def validate_doc(doc, schema: dict) -> list[Finding]:
+    """Structurally validate an architecture document against the JSON schema.
+
+    Returns ``schema``-category findings for every violation — a malformed or
+    unparseable document is a FINDING (report-only exit 0 / --gate exit 1),
+    never a usage error.
+    @cw-trace guards CTR-fh-020"""
+    errors: list[tuple[str, str]] = []
+    _validate_value(doc, schema, "$", schema, errors)
+    return [Finding("schema", path, f"{path}: {msg}") for path, msg in errors]
+
+
+# --- consistency checks (CHECKS) ----------------------------------------------
+
+
+def _check_missing_tier(nodes: dict, report: ArchitectureReport) -> None:
+    """A node with no criticality_tier is a FINDING, never a silently-skipped
+    node — else a node could opt itself out of the tier-inversion check by
+    simply omitting its tier.
+    @cw-trace guards CTR-fh-022"""
+    for nid, node in nodes.items():
+        if not node.get("criticality_tier"):
+            report.findings.append(
+                Finding("missing-tier", nid or "<node>", f"node {nid}: no criticality_tier declared")
+            )
+
+
+def _check_dangling_endpoints(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """@cw-trace guards CTR-fh-021"""
+    for e in edges:
+        eid = e.get("id", "<edge>")
+        missing = [end for end in ("from", "to") if e.get(end) not in nodes]
+        if missing:
+            bad = ", ".join(f"{end}={e.get(end)!r}" for end in missing)
+            report.findings.append(
+                Finding("dangling-endpoint", eid, f"edge {eid}: {bad} does not resolve to a declared node")
+            )
+
+
+def _check_retired_node_edges(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """No ACTIVE edge may reference a retired node — a declared-but-inactive
+    edge (``active: false``) is exempt (a documented, retired path)."""
+    for e in edges:
+        eid = e.get("id", "<edge>")
+        if e.get("active", True) is False:
+            continue
+        for end in ("from", "to"):
+            node = nodes.get(e.get(end))
+            if node is not None and node.get("status") == "retired":
+                report.findings.append(
+                    Finding(
+                        "retired-node-edge",
+                        eid,
+                        f"edge {eid}: ACTIVE edge references retired node {node.get('id')} ({end})",
+                    )
+                )
+
+
+def _check_unlabelled_external(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """An external node reached by a HARD (availability) edge is the whole
+    point of an ASM reference — an unlabelled vendor dependency is a
+    finding."""
+    flagged: set[str] = set()
+    for e in edges:
+        if e.get("criticality") != "hard":
+            continue
+        eid = e.get("id", "<edge>")
+        for end in ("from", "to"):
+            node = nodes.get(e.get(end))
+            if node is None:
+                continue
+            node_id = node.get("id")
+            if node_id in flagged:
+                continue
+            if node.get("external") and not node.get("asm_refs"):
+                flagged.add(node_id)
+                report.findings.append(
+                    Finding(
+                        "unlabelled-external",
+                        node_id,
+                        f"external node {node_id} is reached by hard edge {eid} but declares no asm_refs",
+                    )
+                )
+
+
+def _check_tier_inversion(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """No hard-availability-dependency path may run from a tier-1 node through
+    a lower-criticality node. Modeled as reachability over the ACTIVE, HARD
+    edge subgraph starting at every tier-1 node: any node reached with a
+    lower tier (tier-2/tier-3) is a violation, whether it is the final hop or
+    an intermediate one the path merely passes 'through' — both make the
+    tier-1 node's availability transitively depend on a lower-tier
+    component."""
+    adjacency: dict[str, list[tuple[str, str]]] = {}
+    for e in edges:
+        if e.get("criticality") != "hard" or e.get("active", True) is False:
+            continue
+        frm, to = e.get("from"), e.get("to")
+        if frm in nodes and to in nodes:
+            adjacency.setdefault(frm, []).append((to, e.get("id", "<edge>")))
+
+    tier1_roots = [nid for nid, n in nodes.items() if TIER_RANK.get(n.get("criticality_tier")) == 1]
+    flagged: set[tuple[str, str]] = set()
+    for root in tier1_roots:
+        visited = {root}
+        queue = [root]
+        while queue:
+            cur = queue.pop(0)
+            for nxt, eid in adjacency.get(cur, []):
+                if nxt in visited:
+                    continue
+                visited.add(nxt)
+                queue.append(nxt)
+                rank = TIER_RANK.get(nodes[nxt].get("criticality_tier"))
+                if rank is not None and rank > 1 and (root, nxt) not in flagged:
+                    flagged.add((root, nxt))
+                    report.findings.append(
+                        Finding(
+                            "tier-inversion",
+                            nxt,
+                            f"tier-1 node {root} has a hard-availability-dependency path (via {eid}) "
+                            f"reaching lower-tier node {nxt} ({nodes[nxt].get('criticality_tier')})",
+                        )
+                    )
+
+
+def _valid_asm(ref) -> bool:
+    return (
+        isinstance(ref, dict)
+        and bool(ASM_ID_RE.match(str(ref.get("id", ""))))
+        and ref.get("evidence") in EVIDENCE_CHOICES
+        and bool(ref.get("ref"))
+    )
+
+
+def _check_label_propagation(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """Declared-graph-only label propagation (NO taint analysis): a connector
+    must not `carries` a data class into a trust_zone/region the target's
+    labels forbid. A violation with a valid `asm_refs` waiver on the SAME
+    edge is recorded as a documented waiver, not a silent pass and not a hard
+    finding (mirrors check_budget_tree.py's covered/waived/missing ASM
+    statuses)."""
+    for e in edges:
+        eid = e.get("id", "<edge>")
+        frm, to = nodes.get(e.get("from")), nodes.get(e.get("to"))
+        if frm is None or to is None:
+            continue  # already reported by dangling-endpoint
+        carries = e.get("carries") or []
+        if not carries:
+            continue
+        max_class = max(carries, key=lambda c: DATA_CLASS_RANK.get(c, 0))
+        max_rank = DATA_CLASS_RANK.get(max_class, 0)
+
+        violations = []
+        to_zone = to.get("trust_zone")
+        ceiling = TRUST_ZONE_CEILING.get(to_zone)
+        if ceiling is not None and max_rank > ceiling:
+            violations.append(f"carries {max_class!r} into trust_zone {to_zone!r} which forbids it")
+
+        from_region, to_region = frm.get("region"), to.get("region")
+        region_crossing = from_region is not None and to_region is not None and from_region != to_region
+        if region_crossing and max_rank >= DATA_CLASS_RANK["secret"]:
+            violations.append(f"carries {max_class!r} across a region boundary ({from_region} -> {to_region})")
+
+        if not violations:
+            continue
+
+        asm_refs = e.get("asm_refs") or []
+        waiver_ref = next((a for a in asm_refs if _valid_asm(a)), None)
+        message = f"edge {eid}: " + "; ".join(violations)
+        if waiver_ref is not None:
+            report.waivers.append(Waiver("label-propagation", eid, waiver_ref.get("id"), message))
+        else:
+            report.findings.append(Finding("label-propagation", eid, message + " (no valid asm_refs waiver)"))
+
+
+def _check_authored_crossing_labels(edges: list[dict], report: ArchitectureReport) -> None:
+    """trust_zone_crossing/region_crossing are COMPUTED-ONLY. The schema
+    permits the null placeholder; ANY authored non-null value is itself a
+    finding — a hand-authored 'safe' label could otherwise mask a real
+    trust-zone violation (INV-fh-006).
+    @cw-trace ensures INV-fh-006 CTR-fh-025"""
+    for e in edges:
+        eid = e.get("id", "<edge>")
+        if e.get("trust_zone_crossing") is not None:
+            report.findings.append(
+                Finding(
+                    "authored-crossing-label",
+                    eid,
+                    f"edge {eid}: trust_zone_crossing is AUTHORED ({e.get('trust_zone_crossing')!r}) — "
+                    "this field is computed-only, never authored",
+                )
+            )
+        if e.get("region_crossing") is not None:
+            report.findings.append(
+                Finding(
+                    "authored-crossing-label",
+                    eid,
+                    f"edge {eid}: region_crossing is AUTHORED ({e.get('region_crossing')!r}) — "
+                    "this field is computed-only, never authored",
+                )
+            )
+
+
+def _compute_derived_labels(nodes: dict, edges: list[dict], report: ArchitectureReport) -> None:
+    """Always computes trust_zone_crossing/region_crossing for every
+    resolvable edge — informational, reports-never-mutates (the checker opens
+    architecture.json read-only; it never writes the authored file).
+    @cw-trace ensures INV-fh-006 CTR-fh-025 CTR-fh-023"""
+    for e in edges:
+        eid = e.get("id", "<edge>")
+        frm, to = nodes.get(e.get("from")), nodes.get(e.get("to"))
+        if frm is None or to is None:
+            continue
+        tz_crossing = None
+        if frm.get("trust_zone") != to.get("trust_zone"):
+            tz_crossing = f"{frm.get('trust_zone')}->{to.get('trust_zone')}"
+        region_crossing = None
+        if frm.get("region") is not None and to.get("region") is not None:
+            region_crossing = frm.get("region") != to.get("region")
+        report.derived_labels.append(DerivedLabel(eid, tz_crossing, region_crossing))
+
+
+def _walk_budget_nodes(node, telemetry_refs: set) -> None:
+    if not isinstance(node, dict):
+        return
+    ref = node.get("telemetry_ref")
+    if ref:
+        telemetry_refs.add(ref)
+    for child in node.get("children") or []:
+        _walk_budget_nodes(child, telemetry_refs)
+    residual = node.get("residual")
+    if residual:
+        _walk_budget_nodes(residual, telemetry_refs)
+
+
+def _check_cross_artifact(nodes: dict, edges: list[dict], system_contracts: dict, report: ArchitectureReport) -> None:
+    """Every node/connector referenced by system-contracts.json budget-tree
+    `chains` and telemetry bindings must name a declared ARC-/EDG- in
+    architecture.json (INV-fh-008) — neither model may silently invent the
+    other's nodes.
+    @cw-trace guards INV-fh-008"""
+    if not isinstance(system_contracts, dict):
+        return
+    edge_ids = set(edges and [e.get("id") for e in edges] or [])
+    node_ids = set(nodes.keys())
+
+    for chain in system_contracts.get("chains") or []:
+        cid = chain.get("id", "<chain>")
+        for hop in chain.get("hops") or []:
+            for role in ("caller", "callee"):
+                token = hop.get(role)
+                if not token or not CROSS_REF_ID_RE.match(str(token)):
+                    continue  # legacy plain service-name hops are not ID-shaped; not applicable
+                kind = token.split("-", 1)[0]
+                pool = node_ids if kind == "ARC" else edge_ids
+                if token not in pool:
+                    report.findings.append(
+                        Finding(
+                            "undeclared-cross-ref",
+                            token,
+                            f"system-contracts.json chain {cid} hop.{role}={token} is not a declared "
+                            f"{kind}- node/edge in architecture.json",
+                        )
+                    )
+
+    declared_emits: set = set()
+    for n in nodes.values():
+        declared_emits.update(n.get("emits") or [])
+    if declared_emits:
+        telemetry_refs: set = set()
+        for tree in system_contracts.get("trees") or []:
+            _walk_budget_nodes(tree.get("root") or {}, telemetry_refs)
+        for ref in sorted(telemetry_refs):
+            if ref not in declared_emits:
+                report.findings.append(
+                    Finding(
+                        "undeclared-cross-ref",
+                        ref,
+                        f"system-contracts.json telemetry_ref={ref!r} is not declared in any "
+                        "architecture.json node's emits[]",
+                    )
+                )
+
+
+# --- top-level check ----------------------------------------------------------
+
+
+def check_static(
+    doc,
+    schema: dict | None = None,
+    system_contracts: dict | None = None,
+    system_contracts_path: str | None = None,
+    system_contracts_error: str | None = None,
+) -> ArchitectureReport:
+    report = ArchitectureReport()
+    schema = schema if schema is not None else load_schema()
+    report.findings.extend(validate_doc(doc, schema))
+
+    if not isinstance(doc, dict):
+        return report
+
+    raw_nodes = doc.get("nodes")
+    raw_edges = doc.get("edges")
+    node_list = raw_nodes if isinstance(raw_nodes, list) else []
+    edges = raw_edges if isinstance(raw_edges, list) else []
+    nodes = {n.get("id"): n for n in node_list if isinstance(n, dict) and n.get("id")}
+    report.nodes = len(nodes)
+    report.edges = len(edges)
+
+    _check_missing_tier(nodes, report)
+    _check_dangling_endpoints(nodes, edges, report)
+    _check_retired_node_edges(nodes, edges, report)
+    _check_unlabelled_external(nodes, edges, report)
+    _check_tier_inversion(nodes, edges, report)
+    _check_label_propagation(nodes, edges, report)
+    _check_authored_crossing_labels(edges, report)
+    _compute_derived_labels(nodes, edges, report)
+
+    if system_contracts is not None:
+        _check_cross_artifact(nodes, edges, system_contracts, report)
+    else:
+        report.not_checked.append(
+            NotChecked(
+                artifact=system_contracts_path or "system-contracts.json",
+                reason=system_contracts_error
+                or "no --system-contracts given — cross-artifact consistency not checked "
+                "(never reported as passed)",
+            )
+        )
+
+    return report
+
+
+# --- rendering / CLI --------------------------------------------------------
+
+
+def render_text(report: ArchitectureReport, note: str | None = None) -> str:
+    lines = ["# Architecture Model Report", "", f"Authority: {AUTHORITY}", ""]
+
+    if not report.model_present:
+        lines.append(f"Status: NOT CHECKED — {note or 'no architecture model found'}")
+        return "\n".join(lines) + "\n"
+
+    c = report.counts
+    lines.append(f"Nodes: {c['nodes']}  Edges: {c['edges']}  Findings: {c['findings']}  Waivers: {c['waivers']}")
+    lines.append(f"Status: {'OK' if report.ok else 'FINDINGS'}")
+
+    if report.findings:
+        lines += ["", "## Findings (gateable under --gate)"]
+        lines += [f"- [{f.check}] {f.message}" for f in report.findings]
+    if report.waivers:
+        lines += ["", "## Waivers (documented ASM evidence, never a finding)"]
+        lines += [f"- [{w.check}] {w.message} (waived by {w.asm_id})" for w in report.waivers]
+    if report.not_checked:
+        lines += ["", "## Not checked (absent optional artifact — never reported as 'passed')"]
+        lines += [f"- {n.artifact}: {n.reason}" for n in report.not_checked]
+    if report.derived_labels:
+        lines += ["", "## Derived crossing labels (computed, never authored)"]
+        for d in report.derived_labels:
+            lines.append(
+                f"- {d.edge}: trust_zone_crossing={d.trust_zone_crossing!r} region_crossing={d.region_crossing!r}"
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def _scanner_version() -> str:
+    """Hash-derived ``--scanner-version``: the source of this module plus its
+    ``chief_wiggum`` dependencies. No hand-bumped constant to forget
+    (INV-fh-005). Makes check_architecture the fifth #184 gate whose
+    validation record can be staleness-checked.
+    @cw-trace guards CTR-fh-026"""
+    here = Path(__file__).resolve()
+    cw_dir = here.parent / "chief_wiggum"
+    return scanner_version(here, cw_dir / "hashing.py")
+
+
+def _emit(report: ArchitectureReport) -> None:
+    try:  # factory telemetry; no-op unless enabled, never breaks the gate
+        import os
+
+        _here = os.path.dirname(os.path.abspath(__file__))
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        from factory_log import emit_gate
+
+        emit_gate("check_architecture", "fail" if report.findings else "pass", caught=len(report.findings))
+    except Exception:
+        pass
+
+
+def _print(report: ArchitectureReport, fmt: str, note: str | None = None) -> None:
+    if fmt == "json":
+        out = report.to_dict()
+        if note:
+            out["note"] = note
+        print(json.dumps(out, indent=2))
+    else:
+        print(render_text(report, note=note))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Architecture model checker: STATIC consistency of the declared system model (#174)"
+    )
+    parser.add_argument(
+        "architecture_file",
+        nargs="?",
+        default=None,
+        help="Path to architecture.json; not required with --scanner-version",
+    )
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    parser.add_argument(
+        "--system-contracts",
+        help="Optional docs/system/system-contracts.json for cross-artifact consistency (INV-fh-008); "
+        "absent -> reported 'not checked', never 'passed'",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit 1 on findings (report-only default: exit 0 with findings printed)",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument(
+        "--scanner-version",
+        action="store_true",
+        help="Print the hash-derived scanner version (source hash of this module + its "
+        "chief_wiggum deps) and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.scanner_version:
+        print(_scanner_version())
+        return 0
+
+    if not args.architecture_file:
+        print("Error: architecture_file is required unless --scanner-version is given", file=sys.stderr)
+        return 2
+
+    path = Path(args.architecture_file)
+    if not path.exists():
+        # @cw-trace guards CTR-fh-023 CTR-fh-024
+        report = ArchitectureReport(model_present=False)
+        _print(report, args.format, note="no architecture model found")
+        _emit(report)
+        return 0
+
+    try:
+        schema = load_schema(Path(args.schema))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error: cannot load schema: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        raw_text = path.read_text()
+    except OSError as exc:
+        print(f"Error: cannot read architecture file: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        doc = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        # A malformed document is a FINDING (report-only 0 / --gate 1), never
+        # a usage error — only bad CLI flags/paths are usage errors (2).
+        # @cw-trace guards CTR-fh-020
+        report = ArchitectureReport()
+        report.findings.append(Finding("schema", str(path), f"invalid JSON in {path}: {exc}"))
+        _print(report, args.format)
+        _emit(report)
+        return 1 if args.gate else 0
+
+    system_contracts = None
+    system_contracts_error = None
+    if args.system_contracts:
+        try:
+            system_contracts = load_doc(args.system_contracts)
+        except (OSError, json.JSONDecodeError) as exc:
+            system_contracts_error = f"cannot load {args.system_contracts}: {exc}"
+
+    report = check_static(
+        doc,
+        schema=schema,
+        system_contracts=system_contracts,
+        system_contracts_path=args.system_contracts,
+        system_contracts_error=system_contracts_error,
+    )
+
+    _print(report, args.format)
+    _emit(report)
+
+    if args.gate and not report.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -272,6 +272,9 @@ def _validate_value(value, schema_node: dict, path: str, root_schema: dict, erro
         pattern = schema_node.get("pattern")
         if pattern and not re.search(pattern, value):
             errors.append((path, f"value {value!r} does not match pattern {pattern}"))
+        min_length = schema_node.get("minLength")
+        if min_length is not None and len(value) < min_length:
+            errors.append((path, f"string {value!r} shorter than minLength {min_length}"))
     elif expected == "number":
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             errors.append((path, f"expected number, got {type(value).__name__}"))
@@ -536,10 +539,29 @@ def _check_cross_artifact(nodes: dict, edges: list[dict], system_contracts: dict
     for chain in system_contracts.get("chains") or []:
         cid = chain.get("id", "<chain>")
         for hop in chain.get("hops") or []:
+            if not isinstance(hop, dict):
+                continue  # malformed hop shape is check_budget_tree's schema concern
             for role in ("caller", "callee"):
                 token = hop.get(role)
-                if not token or not CROSS_REF_ID_RE.match(str(token)):
-                    continue  # legacy plain service-name hops are not ID-shaped; not applicable
+                if not token:
+                    continue  # absent endpoint is check_budget_tree's schema concern
+                token = str(token)
+                if not CROSS_REF_ID_RE.match(token):
+                    # A legacy plain service-name hop ("gateway", "billing-api")
+                    # cannot be cross-checked against the declared model at all —
+                    # silently skipping it would recreate exactly the INV-fh-008
+                    # blind spot this check exists to close. Visible finding:
+                    # declare the node/edge and reference its ARC-/EDG- id.
+                    report.findings.append(
+                        Finding(
+                            "undeclared-cross-ref",
+                            token,
+                            f"system-contracts.json chain {cid} hop.{role}={token!r} is not an "
+                            "ARC-/EDG- id — a plain service name cannot be resolved against "
+                            "architecture.json; declare the node/edge and reference its id",
+                        )
+                    )
+                    continue
                 kind = token.split("-", 1)[0]
                 pool = node_ids if kind == "ARC" else edge_ids
                 if token not in pool:
@@ -590,9 +612,39 @@ def check_static(
 
     raw_nodes = doc.get("nodes")
     raw_edges = doc.get("edges")
-    node_list = raw_nodes if isinstance(raw_nodes, list) else []
-    edges = raw_edges if isinstance(raw_edges, list) else []
-    nodes = {n.get("id"): n for n in node_list if isinstance(n, dict) and n.get("id")}
+    # Normalize to dict-only items: a non-dict node/edge already produced a
+    # "schema"-category finding via validate_doc above; the graph checks must
+    # then run over the well-shaped remainder instead of crashing (a malformed
+    # model must ALWAYS end as findings, never a traceback).
+    node_list = [n for n in raw_nodes if isinstance(n, dict)] if isinstance(raw_nodes, list) else []
+    edges = [e for e in raw_edges if isinstance(e, dict)] if isinstance(raw_edges, list) else []
+
+    # Duplicate stable IDs must be a finding BEFORE dict construction: the
+    # last-wins dict below would otherwise silently collapse duplicates (e.g.
+    # an active node shadowing a retired duplicate, hiding its retired-edge
+    # findings).
+    seen_node_ids: set[str] = set()
+    for n in node_list:
+        nid = n.get("id")
+        if not nid:
+            continue
+        if nid in seen_node_ids:
+            report.findings.append(
+                Finding("schema", nid, f"duplicate node id {nid}: declared more than once in nodes[]")
+            )
+        seen_node_ids.add(nid)
+    seen_edge_ids: set[str] = set()
+    for e in edges:
+        eid = e.get("id")
+        if not eid:
+            continue
+        if eid in seen_edge_ids:
+            report.findings.append(
+                Finding("schema", eid, f"duplicate edge id {eid}: declared more than once in edges[]")
+            )
+        seen_edge_ids.add(eid)
+
+    nodes = {n.get("id"): n for n in node_list if n.get("id")}
     report.nodes = len(nodes)
     report.edges = len(edges)
 

--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -45,6 +45,7 @@ SCHEMAS = {
     "gap": SCHEMA_DIR / "gap-classification.json",
     "transition-map": SCHEMA_DIR / "transition-map-schema.json",
     "ui-spec": SCHEMA_DIR / "ui-spec-schema.json",
+    "architecture": SCHEMA_DIR / "architecture-schema.json",
 }
 
 
@@ -64,6 +65,8 @@ def _load_schema(name: str) -> dict:
 
 def detect_schema_type(data: dict) -> str:
     """Heuristic detection of which schema a JSON document conforms to."""
+    if "nodes" in data and "edges" in data:
+        return "architecture"
     if "states" in data and "transitions" in data:
         return "state-machine"
     if "entities" in data and "summary" in data:

--- a/templates/formal-models/architecture-schema.json
+++ b/templates/formal-models/architecture-schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/architecture.json",
+  "title": "Declared System Architecture Model",
+  "description": "A C4-flavored DECLARED system model (#174): ARC- deployables/externals and EDG- connectors between them, checked for STATIC internal consistency by scripts/check_architecture.py. Declaring this model is cheap; it does NOT prove the running code matches it (that conformance/reflexion check is deferred to #171). See docs/system-layer.md.",
+  "type": "object",
+  "required": ["nodes", "edges"],
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "description": "Deployables (service|worker|db|queue|bucket|cron) and external/vendor nodes.",
+      "items": { "$ref": "#/$defs/node" },
+      "minItems": 1
+    },
+    "edges": {
+      "type": "array",
+      "description": "Connectors between declared nodes.",
+      "items": { "$ref": "#/$defs/edge" }
+    },
+    "derived_from": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/provenance" }
+    }
+  },
+  "$defs": {
+    "node": {
+      "type": "object",
+      "required": ["id", "name", "kind", "external", "trust_zone", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ARC-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$",
+          "description": "Stable ID, e.g. ARC-gateway-001"
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "type": "string",
+          "enum": ["service", "worker", "db", "queue", "bucket", "cron", "external"],
+          "description": "Deployable kind. 'external' is available for a vendor node with no more specific kind."
+        },
+        "repo": {
+          "type": ["string", "null"],
+          "description": "URN/path of the owning repo, or null for an external/no-repo node."
+        },
+        "external": {
+          "type": "boolean",
+          "description": "True for a vendor/third-party node outside this system's own deployables. External nodes reached by a hard (availability) edge MUST carry non-empty asm_refs."
+        },
+        "trust_zone": {
+          "type": "string",
+          "enum": ["public", "dmz", "internal", "restricted"]
+        },
+        "region": {
+          "type": ["string", "null"],
+          "description": "Deployment region/locality, or null when not meaningful (e.g. a global CDN)."
+        },
+        "failure_domain": {
+          "type": "string",
+          "description": "Independent-failure grouping (e.g. an AZ, a vendor account, a cluster) — free text."
+        },
+        "criticality_tier": {
+          "type": "string",
+          "enum": ["tier-1", "tier-2", "tier-3"],
+          "description": "REQUIRED in practice, but deliberately NOT schema-required: an omitted tier must surface as the checker's own 'missing-tier' FINDING, never a silently-skipped node (else a node could opt itself out of the tier-inversion check by omission)."
+        },
+        "emits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Telemetry binding names this node emits (cross-checked against system-contracts.json telemetry_ref usage)."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "deprecated", "retired"]
+        },
+        "asm_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/asm_ref" }
+        }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "required": ["id", "from", "to", "protocol", "mode", "criticality"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^EDG-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$",
+          "description": "Stable ID, e.g. EDG-gateway-stt-001"
+        },
+        "from": { "type": "string", "description": "Caller node id (must resolve to a declared ARC- node)." },
+        "to": { "type": "string", "description": "Callee node id (must resolve to a declared ARC- node)." },
+        "protocol": { "type": "string" },
+        "mode": {
+          "type": "string",
+          "enum": ["sync", "async"]
+        },
+        "criticality": {
+          "type": "string",
+          "enum": ["hard", "soft"],
+          "description": "'hard' is SPECIFICALLY an AVAILABILITY dependency (caller fails if callee is down) — distinct from what the edge carries (data class) and from a trust-zone crossing. 'soft' means the caller degrades gracefully if the callee is unavailable."
+        },
+        "on_failure": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fallback": { "type": ["string", "null"] },
+            "degrade_to": { "type": ["string", "null"] }
+          }
+        },
+        "carries": {
+          "type": "array",
+          "description": "Data-class labels this edge carries, from the monotone lattice public < internal < pii < secret < official-sensitive.",
+          "items": {
+            "type": "string",
+            "enum": ["public", "internal", "pii", "secret", "official-sensitive"]
+          }
+        },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mechanism": { "type": "string" },
+            "tenant_scoped": { "type": "boolean" }
+          }
+        },
+        "timeout_ms": { "type": "number", "minimum": 0 },
+        "ordering": { "type": "string" },
+        "dlq": { "type": "boolean" },
+        "active": {
+          "type": "boolean",
+          "default": true,
+          "description": "False marks a declared-but-inactive edge (e.g. retired-but-documented path). An ACTIVE edge referencing a retired node is a finding."
+        },
+        "asm_refs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/asm_ref" },
+          "description": "Optional waiver evidence for this edge's label-propagation (carries x trust_zone x region) — an edge with a valid asm_ref is reported as a documented waiver, not a silent pass and not a hard finding."
+        },
+        "trust_zone_crossing": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "NEVER authored. COMPUTED by check_architecture.py from from.trust_zone -> to.trust_zone. The schema permits the null placeholder; ANY authored non-null value is itself a finding (INV-fh-006)."
+        },
+        "region_crossing": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": "NEVER authored. COMPUTED by check_architecture.py from from.region != to.region. ANY authored non-null value is itself a finding (INV-fh-006)."
+        }
+      }
+    },
+    "asm_ref": {
+      "type": "object",
+      "required": ["id", "evidence", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ASM-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$"
+        },
+        "evidence": {
+          "type": "string",
+          "enum": ["sla-doc", "live-probe", "justified"]
+        },
+        "ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["type", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+        },
+        "ref": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/templates/formal-models/examples/voice-agent-architecture.json
+++ b/templates/formal-models/examples/voice-agent-architecture.json
@@ -1,0 +1,157 @@
+{
+  "nodes": [
+    {
+      "id": "ARC-client-001",
+      "name": "Client (browser/mobile app)",
+      "kind": "external",
+      "repo": null,
+      "external": true,
+      "trust_zone": "public",
+      "region": null,
+      "failure_domain": "n/a",
+      "criticality_tier": "tier-3",
+      "emits": [],
+      "status": "active"
+    },
+    {
+      "id": "ARC-gateway-001",
+      "name": "Voice Gateway",
+      "kind": "service",
+      "repo": "org/voice-gateway",
+      "external": false,
+      "trust_zone": "dmz",
+      "region": "us-east-1",
+      "failure_domain": "us-east-1a",
+      "criticality_tier": "tier-1",
+      "emits": ["endpointing_latency_ms", "asr_latency_ms", "llm_ttft_ms", "tts_ttfb_ms"],
+      "status": "active"
+    },
+    {
+      "id": "ARC-stt-001",
+      "name": "Speech-to-Text vendor",
+      "kind": "external",
+      "repo": null,
+      "external": true,
+      "trust_zone": "restricted",
+      "region": "us-east-1",
+      "failure_domain": "vendor:stt",
+      "criticality_tier": "tier-1",
+      "emits": [],
+      "status": "active",
+      "asm_refs": [
+        { "id": "ASM-stt-latency-001", "evidence": "sla-doc", "ref": "https://vendor.example/stt/sla" }
+      ]
+    },
+    {
+      "id": "ARC-llm-001",
+      "name": "LLM provider",
+      "kind": "external",
+      "repo": null,
+      "external": true,
+      "trust_zone": "restricted",
+      "region": "us-east-1",
+      "failure_domain": "vendor:llm",
+      "criticality_tier": "tier-1",
+      "emits": [],
+      "status": "active",
+      "asm_refs": [
+        { "id": "ASM-llm-latency-001", "evidence": "sla-doc", "ref": "https://vendor.example/llm/sla" }
+      ]
+    },
+    {
+      "id": "ARC-tts-001",
+      "name": "Text-to-Speech vendor",
+      "kind": "external",
+      "repo": null,
+      "external": true,
+      "trust_zone": "restricted",
+      "region": "us-east-1",
+      "failure_domain": "vendor:tts",
+      "criticality_tier": "tier-1",
+      "emits": [],
+      "status": "active",
+      "asm_refs": [
+        { "id": "ASM-tts-latency-001", "evidence": "sla-doc", "ref": "https://vendor.example/tts/sla" }
+      ]
+    },
+    {
+      "id": "ARC-analytics-001",
+      "name": "Analytics event queue",
+      "kind": "queue",
+      "repo": "org/voice-analytics",
+      "external": false,
+      "trust_zone": "internal",
+      "region": "us-east-1",
+      "failure_domain": "us-east-1a",
+      "criticality_tier": "tier-3",
+      "emits": [],
+      "status": "active"
+    }
+  ],
+  "edges": [
+    {
+      "id": "EDG-client-gateway-001",
+      "from": "ARC-client-001",
+      "to": "ARC-gateway-001",
+      "protocol": "webrtc",
+      "mode": "sync",
+      "criticality": "soft",
+      "carries": ["pii"],
+      "auth": { "mechanism": "session-token", "tenant_scoped": false },
+      "timeout_ms": 5000,
+      "active": true
+    },
+    {
+      "id": "EDG-gateway-stt-001",
+      "from": "ARC-gateway-001",
+      "to": "ARC-stt-001",
+      "protocol": "grpc",
+      "mode": "sync",
+      "criticality": "hard",
+      "on_failure": { "fallback": null, "degrade_to": "text-input-fallback" },
+      "carries": ["pii"],
+      "auth": { "mechanism": "api-key", "tenant_scoped": false },
+      "timeout_ms": 800,
+      "active": true
+    },
+    {
+      "id": "EDG-gateway-llm-001",
+      "from": "ARC-gateway-001",
+      "to": "ARC-llm-001",
+      "protocol": "https",
+      "mode": "sync",
+      "criticality": "hard",
+      "on_failure": { "fallback": null, "degrade_to": null },
+      "carries": ["pii"],
+      "auth": { "mechanism": "api-key", "tenant_scoped": false },
+      "timeout_ms": 1500,
+      "active": true
+    },
+    {
+      "id": "EDG-gateway-tts-001",
+      "from": "ARC-gateway-001",
+      "to": "ARC-tts-001",
+      "protocol": "https",
+      "mode": "sync",
+      "criticality": "hard",
+      "on_failure": { "fallback": null, "degrade_to": "text-only-response" },
+      "carries": ["pii"],
+      "auth": { "mechanism": "api-key", "tenant_scoped": false },
+      "timeout_ms": 500,
+      "active": true
+    },
+    {
+      "id": "EDG-gateway-analytics-001",
+      "from": "ARC-gateway-001",
+      "to": "ARC-analytics-001",
+      "protocol": "kafka",
+      "mode": "async",
+      "criticality": "soft",
+      "carries": ["internal"],
+      "auth": { "mechanism": "mtls", "tenant_scoped": true },
+      "ordering": "none",
+      "dlq": true,
+      "active": true
+    }
+  ]
+}

--- a/templates/formal-models/examples/voice-agent-system-contracts.json
+++ b/templates/formal-models/examples/voice-agent-system-contracts.json
@@ -1,0 +1,27 @@
+{
+  "trees": [
+    {
+      "root": {
+        "id": "BUD-voice-agent-001",
+        "kind": "latency",
+        "unit": "ms",
+        "bound": 800,
+        "alpha": 0.05,
+        "children": [
+          { "id": "BUD-voice-agent-002", "kind": "latency", "unit": "ms", "bound": 300, "alpha": 0.02, "telemetry_ref": "asr_latency_ms" },
+          { "id": "BUD-voice-agent-003", "kind": "latency", "unit": "ms", "bound": 300, "alpha": 0.02, "telemetry_ref": "llm_ttft_ms" }
+        ],
+        "residual": { "id": "BUD-voice-agent-004", "kind": "latency", "unit": "ms", "bound": 150, "alpha": 0.01, "telemetry_ref": "tts_ttfb_ms" }
+      }
+    }
+  ],
+  "chains": [
+    {
+      "id": "voice-chain-001",
+      "hops": [
+        { "caller": "ARC-client-001", "callee": "ARC-gateway-001", "timeout_ms": 5000 },
+        { "caller": "ARC-gateway-001", "callee": "ARC-stt-001", "timeout_ms": 800 }
+      ]
+    }
+  ]
+}

--- a/tests/test_check_architecture.py
+++ b/tests/test_check_architecture.py
@@ -115,15 +115,22 @@ def test_cross_artifact_undeclared_telemetry_ref_is_finding():
     )
 
 
-def test_cross_artifact_non_id_shaped_hop_is_skipped_not_flagged():
-    """Legacy plain-service-name hops (not ARC-/EDG- shaped) are not treated
-    as an undeclared reference — they predate this cross-ref convention."""
+def test_cross_artifact_non_id_shaped_hop_is_a_finding():
+    """A legacy plain-service-name hop ("gateway", "billing-api") cannot be
+    resolved against the declared model at all — silently skipping it would
+    recreate exactly the INV-fh-008 blind spot this check closes, so it is a
+    visible undeclared-cross-ref finding, never a silent pass."""
+    # @cw-trace verifies INV-fh-008
     arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
     sc["chains"][0]["hops"][0]["callee"] = "some-legacy-service-name"
     report = ca.check_static(arch, system_contracts=sc)
-    assert not any(
-        f.check == "undeclared-cross-ref" and "some-legacy-service-name" in f.message for f in report.findings
-    )
+    assert not report.ok
+    hits = [
+        f for f in report.findings
+        if f.check == "undeclared-cross-ref" and "some-legacy-service-name" in f.message
+    ]
+    assert hits, "legacy non-ID hop endpoint must produce a visible finding"
+    assert "not an ARC-/EDG- id" in hits[0].message
 
 
 def test_absent_system_contracts_is_not_checked_never_passed():
@@ -387,6 +394,106 @@ def test_non_dict_document_reports_schema_finding_and_does_not_crash():
     report = ca.check_static(["oops", "not", "an", "object"])
     assert not report.ok
     assert any(f.check == "schema" for f in report.findings)
+
+
+def test_non_dict_edge_item_is_a_schema_finding_never_a_crash():
+    """Codex review regression: {"edges": ["bad"]} previously yielded a schema
+    finding and then an AttributeError inside _check_dangling_endpoints. The
+    graph checks must run over the well-shaped remainder — a malformed model
+    ALWAYS ends as findings, never a traceback."""
+    # @cw-trace verifies CTR-fh-020
+    report = ca.check_static({"edges": ["bad"]})  # the exact reviewed document
+    assert not report.ok
+    assert any(f.check == "schema" for f in report.findings)
+
+    # A mixed doc: the bad item is a finding, the good edge is still checked.
+    report = ca.check_static(
+        {
+            "nodes": [_node("ARC-a-001")],
+            "edges": ["bad", _edge("EDG-a-b-001", "ARC-a-001", "ARC-ghost-999")],
+        }
+    )
+    assert any(f.check == "schema" for f in report.findings)
+    assert any(f.check == "dangling-endpoint" for f in report.findings)
+
+
+def test_non_dict_node_item_is_a_schema_finding_never_a_crash():
+    report = ca.check_static({"nodes": ["bad", _node("ARC-a-001")], "edges": []})
+    assert not report.ok
+    assert any(f.check == "schema" for f in report.findings)
+    assert report.nodes == 1  # the well-shaped node is still counted and checked
+
+
+def test_non_dict_edge_item_renders_as_findings_in_json_format(tmp_path, capsys):
+    """The malformed-edge document must also survive the CLI end-to-end,
+    including --format json (never a traceback)."""
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps({"edges": ["bad"]}))
+    rc = ca.main([str(p), "--format", "json"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0  # report-only
+    assert out["ok"] is False
+    assert any(f["check"] == "schema" for f in out["findings"])
+    assert ca.main([str(p), "--gate"]) == 1
+
+
+def test_duplicate_node_id_is_a_schema_finding_not_last_wins():
+    """Codex review regression: duplicate ARC- ids previously collapsed
+    last-wins in the node dict — an active node shadowing a retired duplicate
+    hid the retired-node-edge finding entirely. Duplicates are a schema
+    finding BEFORE dict construction."""
+    # @cw-trace verifies CTR-fh-020
+    doc = {
+        "nodes": [
+            _node("ARC-a-001"),
+            _node("ARC-b-001", status="retired"),
+            _node("ARC-b-001", status="active"),  # shadows the retired duplicate
+        ],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", active=True)],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    dup = [f for f in report.findings if f.check == "schema" and "duplicate node id" in f.message]
+    assert dup and dup[0].id == "ARC-b-001"
+
+
+def test_duplicate_edge_id_is_a_schema_finding():
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001")],
+        "edges": [
+            _edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001"),
+            _edge("EDG-a-b-001", "ARC-b-001", "ARC-a-001"),
+        ],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(
+        f.check == "schema" and "duplicate edge id" in f.message and f.id == "EDG-a-b-001"
+        for f in report.findings
+    )
+
+
+def test_min_length_is_enforced_by_the_walker_empty_asm_ref():
+    """Codex review regression: the walker ignored minLength while the schema
+    uses it — an empty-string asm ref passed the checker but failed
+    formal_models.py. The two validators must agree."""
+    # @cw-trace verifies CTR-fh-020
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node(
+                "ARC-vendor-001",
+                external=True,
+                trust_zone="restricted",
+                criticality_tier="tier-1",
+                asm_refs=[{"id": "ASM-vendor-001", "evidence": "sla-doc", "ref": ""}],
+            ),
+        ],
+        "edges": [_edge("EDG-a-vendor-001", "ARC-a-001", "ARC-vendor-001", criticality="hard")],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "schema" and "minLength" in f.message for f in report.findings)
 
 
 # --- IT-fh-09: report-only vs --gate exit-mode semantics ---------------------

--- a/tests/test_check_architecture.py
+++ b/tests/test_check_architecture.py
@@ -1,0 +1,504 @@
+"""Tests for the architecture model checker (#174).
+
+Mirrors tests/test_check_budget_tree.py's shape: builder helpers construct a
+minimal valid document, then mutate for negative cases. One test per CHECKS
+entry (ADR-fh-06's frozen inventory) plus the voice-agent worked example
+(clean), IT-fh-07 (cross-artifact resolution) and IT-fh-09 (report-only vs
+--gate exit semantics).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import check_architecture as ca
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = REPO_ROOT / "templates" / "formal-models" / "examples"
+EXAMPLE_ARCH = EXAMPLES_DIR / "voice-agent-architecture.json"
+EXAMPLE_SC = EXAMPLES_DIR / "voice-agent-system-contracts.json"
+
+
+def _load(path) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _node(id_, **overrides) -> dict:
+    node = {
+        "id": id_,
+        "name": id_,
+        "kind": "service",
+        "external": False,
+        "trust_zone": "internal",
+        "status": "active",
+        "criticality_tier": "tier-2",
+    }
+    node.update(overrides)
+    return node
+
+
+def _edge(id_, frm, to, **overrides) -> dict:
+    edge = {"id": id_, "from": frm, "to": to, "protocol": "https", "mode": "sync", "criticality": "soft"}
+    edge.update(overrides)
+    return edge
+
+
+# --- CHECKS inventory is frozen (ADR-fh-06) ----------------------------------
+
+
+def test_checks_inventory_is_frozen_and_matches_adr_fh_06():
+    assert ca.CHECKS == (
+        "dangling-endpoint",
+        "retired-node-edge",
+        "unlabelled-external",
+        "tier-inversion",
+        "label-propagation",
+        "undeclared-cross-ref",
+        "missing-tier",
+        "authored-crossing-label",
+    )
+
+
+# --- worked example (voice agent): checks clean ------------------------------
+
+
+def test_voice_agent_example_checks_clean():
+    doc = _load(EXAMPLE_ARCH)
+    report = ca.check_static(doc)
+    assert report.ok
+    assert report.findings == []
+
+
+def test_voice_agent_example_is_schema_valid():
+    doc = _load(EXAMPLE_ARCH)
+    assert ca.validate_doc(doc, ca.load_schema()) == []
+
+
+# --- IT-fh-07: architecture <-> system-contracts cross-ref resolution -------
+
+
+def test_cross_artifact_clean_pair_passes():
+    arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
+    report = ca.check_static(arch, system_contracts=sc)
+    assert report.ok
+    assert not report.not_checked
+
+
+def test_cross_artifact_undeclared_arc_reference_is_finding():
+    # @cw-trace verifies INV-fh-008
+    arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
+    sc["chains"][0]["hops"][0]["callee"] = "ARC-does-not-exist-999"
+    report = ca.check_static(arch, system_contracts=sc)
+    assert not report.ok
+    hits = [f for f in report.findings if f.check == "undeclared-cross-ref"]
+    assert any("ARC-does-not-exist-999" in f.message for f in hits)
+
+
+def test_cross_artifact_undeclared_edg_reference_is_finding():
+    arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
+    sc["chains"][0]["hops"].append({"caller": "EDG-nonexistent-001", "callee": "ARC-gateway-001", "timeout_ms": 100})
+    report = ca.check_static(arch, system_contracts=sc)
+    assert not report.ok
+    assert any(
+        f.check == "undeclared-cross-ref" and "EDG-nonexistent-001" in f.message for f in report.findings
+    )
+
+
+def test_cross_artifact_undeclared_telemetry_ref_is_finding():
+    arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
+    sc["trees"][0]["root"]["children"][0]["telemetry_ref"] = "nonexistent_binding_ms"
+    report = ca.check_static(arch, system_contracts=sc)
+    assert not report.ok
+    assert any(
+        f.check == "undeclared-cross-ref" and "nonexistent_binding_ms" in f.message for f in report.findings
+    )
+
+
+def test_cross_artifact_non_id_shaped_hop_is_skipped_not_flagged():
+    """Legacy plain-service-name hops (not ARC-/EDG- shaped) are not treated
+    as an undeclared reference — they predate this cross-ref convention."""
+    arch, sc = _load(EXAMPLE_ARCH), _load(EXAMPLE_SC)
+    sc["chains"][0]["hops"][0]["callee"] = "some-legacy-service-name"
+    report = ca.check_static(arch, system_contracts=sc)
+    assert not any(
+        f.check == "undeclared-cross-ref" and "some-legacy-service-name" in f.message for f in report.findings
+    )
+
+
+def test_absent_system_contracts_is_not_checked_never_passed():
+    arch = _load(EXAMPLE_ARCH)
+    report = ca.check_static(arch)  # no --system-contracts given
+    assert report.ok  # architecture-only checks are still clean
+    assert len(report.not_checked) == 1
+    assert "not_checked" not in [f.check for f in report.findings]
+
+
+# --- one seeded violation per CHECKS entry ------------------------------------
+
+
+def test_dangling_endpoint_caught():
+    # @cw-trace verifies CTR-fh-021
+    doc = {"nodes": [_node("ARC-a-001")], "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-ghost-999")]}
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "dangling-endpoint" for f in report.findings)
+
+
+def test_retired_node_active_edge_caught():
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001", status="retired")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", active=True)],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "retired-node-edge" for f in report.findings)
+
+
+def test_retired_node_inactive_edge_is_not_flagged():
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001", status="retired")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", active=False)],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "retired-node-edge" for f in report.findings)
+
+
+def test_unlabelled_external_on_hard_edge_caught():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node("ARC-vendor-001", external=True, trust_zone="restricted", criticality_tier="tier-1"),
+        ],
+        "edges": [_edge("EDG-a-vendor-001", "ARC-a-001", "ARC-vendor-001", criticality="hard")],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "unlabelled-external" for f in report.findings)
+
+
+def test_external_with_valid_asm_refs_on_hard_edge_is_clean():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node(
+                "ARC-vendor-001",
+                external=True,
+                trust_zone="restricted",
+                criticality_tier="tier-1",
+                asm_refs=[{"id": "ASM-vendor-001", "evidence": "sla-doc", "ref": "https://vendor.example/sla"}],
+            ),
+        ],
+        "edges": [_edge("EDG-a-vendor-001", "ARC-a-001", "ARC-vendor-001", criticality="hard")],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "unlabelled-external" for f in report.findings)
+
+
+def test_unlabelled_external_not_triggered_by_soft_edge():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node("ARC-vendor-001", external=True, trust_zone="restricted", criticality_tier="tier-3"),
+        ],
+        "edges": [_edge("EDG-a-vendor-001", "ARC-a-001", "ARC-vendor-001", criticality="soft")],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "unlabelled-external" for f in report.findings)
+
+
+def test_tier_inversion_caught():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node("ARC-b-001", criticality_tier="tier-2"),
+        ],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", criticality="hard")],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "tier-inversion" and f.id == "ARC-b-001" for f in report.findings)
+
+
+def test_tier_inversion_through_intermediate_node_caught():
+    """tier-1 -> tier-1 -> tier-3: the hard-dependency path passes THROUGH a
+    lower-tier node even though the first hop looks tier-1-to-tier-1 — this is
+    still a violation because the tier-1 root's availability now transitively
+    depends on the lower-tier node."""
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node("ARC-b-001", criticality_tier="tier-1"),
+            _node("ARC-c-001", criticality_tier="tier-3"),
+        ],
+        "edges": [
+            _edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", criticality="hard"),
+            _edge("EDG-b-c-001", "ARC-b-001", "ARC-c-001", criticality="hard"),
+        ],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    hits = [f for f in report.findings if f.check == "tier-inversion"]
+    assert any(f.id == "ARC-c-001" for f in hits)
+
+
+def test_tier_inversion_not_triggered_by_soft_edge():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", criticality_tier="tier-1"),
+            _node("ARC-b-001", criticality_tier="tier-2"),
+        ],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", criticality="soft")],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "tier-inversion" for f in report.findings)
+
+
+def test_label_propagation_violation_caught_without_waiver():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", trust_zone="restricted"),
+            _node("ARC-b-001", trust_zone="public"),
+        ],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", carries=["secret"])],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "label-propagation" for f in report.findings)
+    assert not report.waivers
+
+
+def test_label_propagation_violation_waived_by_valid_asm_ref():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", trust_zone="restricted"),
+            _node("ARC-b-001", trust_zone="public"),
+        ],
+        "edges": [
+            _edge(
+                "EDG-a-b-001",
+                "ARC-a-001",
+                "ARC-b-001",
+                carries=["secret"],
+                asm_refs=[{"id": "ASM-waiver-001", "evidence": "justified", "ref": "documented exception: see runbook"}],
+            )
+        ],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "label-propagation" for f in report.findings)
+    assert len(report.waivers) == 1
+    assert report.waivers[0].asm_id == "ASM-waiver-001"
+
+
+def test_label_propagation_not_triggered_for_permitted_class():
+    doc = {
+        "nodes": [
+            _node("ARC-a-001", trust_zone="internal"),
+            _node("ARC-b-001", trust_zone="restricted"),
+        ],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", carries=["pii"])],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "label-propagation" for f in report.findings)
+
+
+def test_missing_tier_caught():
+    # @cw-trace verifies CTR-fh-022
+    node = _node("ARC-a-001")
+    del node["criticality_tier"]
+    doc = {"nodes": [node], "edges": []}
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "missing-tier" for f in report.findings)
+
+
+def test_missing_tier_node_is_not_skipped_from_the_model():
+    """A node missing its tier still counts in nodes/edges accounting and
+    still participates in every other check — it is a FINDING, never a
+    silently-removed node (else it could opt itself out of tier-inversion)."""
+    node_no_tier = _node("ARC-a-001")
+    del node_no_tier["criticality_tier"]
+    doc = {
+        "nodes": [node_no_tier, _node("ARC-b-001", status="retired")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", active=True)],
+    }
+    report = ca.check_static(doc)
+    assert report.nodes == 2
+    assert any(f.check == "missing-tier" for f in report.findings)
+    assert any(f.check == "retired-node-edge" for f in report.findings)
+
+
+def test_authored_trust_zone_crossing_caught():
+    # @cw-trace verifies INV-fh-006 CTR-fh-025
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", trust_zone_crossing="internal->public")],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "authored-crossing-label" for f in report.findings)
+
+
+def test_authored_region_crossing_caught():
+    # @cw-trace verifies INV-fh-006 CTR-fh-025
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", region_crossing=True)],
+    }
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "authored-crossing-label" for f in report.findings)
+
+
+def test_null_crossing_labels_are_not_findings():
+    doc = {
+        "nodes": [_node("ARC-a-001"), _node("ARC-b-001")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001", trust_zone_crossing=None, region_crossing=None)],
+    }
+    report = ca.check_static(doc)
+    assert not any(f.check == "authored-crossing-label" for f in report.findings)
+
+
+def test_derived_labels_are_computed_and_input_is_never_mutated():
+    # @cw-trace verifies INV-fh-006 CTR-fh-025 CTR-fh-023
+    doc = {
+        "nodes": [_node("ARC-a-001", trust_zone="internal"), _node("ARC-b-001", trust_zone="public")],
+        "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-b-001")],
+    }
+    before = json.dumps(doc, sort_keys=True)
+    report = ca.check_static(doc)
+    after = json.dumps(doc, sort_keys=True)
+    assert before == after  # read-only: the checker never mutates the input
+    assert report.derived_labels[0].trust_zone_crossing == "internal->public"
+
+
+# --- schema-category findings (malformed doc never crashes) -----------------
+
+
+def test_schema_violation_is_a_finding_not_a_crash():
+    # @cw-trace verifies CTR-fh-020
+    doc = {"nodes": "not-a-list", "edges": []}
+    report = ca.check_static(doc)
+    assert not report.ok
+    assert any(f.check == "schema" for f in report.findings)
+
+
+def test_non_dict_document_reports_schema_finding_and_does_not_crash():
+    report = ca.check_static(["oops", "not", "an", "object"])
+    assert not report.ok
+    assert any(f.check == "schema" for f in report.findings)
+
+
+# --- IT-fh-09: report-only vs --gate exit-mode semantics ---------------------
+
+
+def test_cli_report_only_exits_zero_with_findings(tmp_path, capsys):
+    bad = {"nodes": [_node("ARC-a-001")], "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-ghost-999")]}
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps(bad))
+    rc = ca.main([str(p)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "dangling-endpoint" in out
+    assert ca.AUTHORITY in out
+
+
+def test_cli_gate_exits_one_on_same_findings(tmp_path):
+    bad = {"nodes": [_node("ARC-a-001")], "edges": [_edge("EDG-a-b-001", "ARC-a-001", "ARC-ghost-999")]}
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps(bad))
+    rc = ca.main([str(p), "--gate"])
+    assert rc == 1
+
+
+def test_cli_gate_exits_zero_on_clean_model(tmp_path):
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps(_load(EXAMPLE_ARCH)))
+    assert ca.main([str(p)]) == 0
+    assert ca.main([str(p), "--gate"]) == 0
+
+
+def test_cli_usage_error_exits_two(capsys):
+    rc = ca.main([])
+    assert rc == 2
+    assert "architecture_file is required" in capsys.readouterr().err
+
+
+def test_cli_absent_model_exits_zero_and_reports_not_checked_never_passed(tmp_path, capsys):
+    # @cw-trace verifies CTR-fh-024
+    rc = ca.main([str(tmp_path / "does-not-exist.json")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "NOT CHECKED" in out
+    assert ca.AUTHORITY in out
+
+
+def test_cli_absent_model_exits_zero_even_under_gate(tmp_path):
+    rc = ca.main([str(tmp_path / "does-not-exist.json"), "--gate"])
+    assert rc == 0
+
+
+def test_cli_malformed_json_is_a_finding_never_a_usage_error(tmp_path, capsys):
+    # @cw-trace verifies CTR-fh-020
+    p = tmp_path / "architecture.json"
+    p.write_text("{not valid json")
+    rc = ca.main([str(p)])
+    out = capsys.readouterr().out
+    assert rc == 0  # report-only: a parse error is a finding, never exit 2
+    assert "schema" in out.lower()
+
+    rc_gate = ca.main([str(p), "--gate"])
+    assert rc_gate == 1
+
+
+def test_cli_authority_line_present_in_every_mode(tmp_path):
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps(_load(EXAMPLE_ARCH)))
+    for extra in ([], ["--gate"], ["--format", "json"]):
+        rc = ca.main([str(p), *extra])
+        assert rc == 0
+
+
+def test_json_format_includes_authority_field(tmp_path, capsys):
+    p = tmp_path / "architecture.json"
+    p.write_text(json.dumps(_load(EXAMPLE_ARCH)))
+    ca.main([str(p), "--format", "json"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["authority"] == ca.AUTHORITY
+    assert out["ok"] is True
+
+
+# --- --scanner-version (fifth #184 gate, ADR-fh-06 / INV-fh-005) -------------
+
+
+def test_scanner_version_is_deterministic_and_stable_across_calls():
+    rc1 = ca.main(["--scanner-version"])
+    assert rc1 == 0
+
+
+def test_cli_scanner_version_prints_hex_digest(capsys):
+    # @cw-trace verifies CTR-fh-026
+    rc = ca.main(["--scanner-version"])
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert len(out) == 64  # sha256 hex digest
+    int(out, 16)  # valid hex
+
+
+def test_scanner_version_changes_if_module_source_changes(tmp_path):
+    """scanner_version hashes THIS module's live source (INV-fh-005) — a copy
+    with one byte changed must hash differently, proving it is not a
+    hand-set constant nobody remembers to bump."""
+    import shutil
+
+    from chief_wiggum.hashing import scanner_version as sv
+
+    src = Path(ca.__file__).resolve()
+    cw_dir = src.parent / "chief_wiggum"
+    copy = tmp_path / "check_architecture_copy.py"
+    shutil.copy(src, copy)
+    copy.write_text(copy.read_text() + "\n# a harmless trailing comment\n")
+
+    original = sv(src, cw_dir / "hashing.py")
+    modified = sv(copy, cw_dir / "hashing.py")
+    assert original != modified


### PR DESCRIPTION
## Summary

Ships `docs/system/architecture.json` (a C4-flavored DECLARED system model — `ARC-` deployables/externals + `EDG-` connectors) and `scripts/check_architecture.py`, the checker that proves that declared model is **internally consistent**. It never inspects running code — whether the code matches the declaration is the deliberately deferred reflexion/extraction question (`#171`, ADR-fh-07).

- **Schema**: `templates/formal-models/architecture-schema.json` (2020-12, `additionalProperties: false`, `$defs`, `ARC-`/`EDG-`/`ASM-` id patterns). Registered as `"architecture"` in `scripts/formal_models.py`'s `SCHEMAS` + `detect_schema_type`.
- **Checker**: `scripts/check_architecture.py` with a frozen, module-level `CHECKS` tuple (ADR-fh-06 — one canonical seed class per consistency rule, ordered exactly as the ADR lists them): `dangling-endpoint`, `retired-node-edge`, `unlabelled-external`, `tier-inversion`, `label-propagation`, `undeclared-cross-ref`, `missing-tier`, `authored-crossing-label`. This is the fifth `#184` gate — `CHECKS` must freeze before that ticket authors this gate's validation record.
  - Report-only by default: exit `0` even with findings, **including a malformed/unparseable `architecture.json`** (a parse/schema error is a FINDING, never a usage error). `--gate` exits `1` on findings. Exit `2` is reserved for genuine usage errors (bad flags/paths).
  - Absent `architecture.json` → exit `0` with a distinct "no architecture model found" note — "not checked" is never conflated with "passed", so `/architect` can adopt this incrementally. The same distinction applies to the optional `--system-contracts` cross-artifact leg.
  - `--scanner-version` is hash-derived (`chief_wiggum.hashing.scanner_version`) over the module + its `chief_wiggum` deps (INV-fh-005).
  - Cross-artifact consistency against `system-contracts.json` `chains`/telemetry bindings (INV-fh-008).
  - `trust_zone_crossing`/`region_crossing` are computed-only; an authored non-null value is itself a finding (INV-fh-006).
- **Worked example**: `templates/formal-models/examples/voice-agent-architecture.json` (+ companion `voice-agent-system-contracts.json`) — client → gateway → STT/LLM/TTS externals with `ASM-` refs, doubling as the `#164` pilot's model. Checks clean, cross-artifact clean.
- **`/architect` integration**: new step 4i (author/update `architecture.json` once per product, or when an epic adds a deployable/connector) and a report-only Step 5a invocation. Not wired as a blocker anywhere yet (ADR-fh-07: gating requires the `#168` protocol + a `#184` validation record).
- **`docs/system-layer.md`**: explains the model, the three distinct edge meanings (`criticality` vs `carries` vs crossing labels), the eight `CHECKS`, and the model-vs-reflexion authority boundary.
- `@cw-trace guards`/`ensures` annotations link `CTR-fh-020..026` and `INV-fh-006`/`INV-fh-008` to the checker; `check_traceability.py` confirms zero uncovered/untested/invalid links for these ids and no regression vs. `main` (identical `defined`/`uncovered`/`dangling`/`invalid_links` counts).

## Test plan

- [x] `tests/test_check_architecture.py` — 41 tests: `CHECKS` inventory frozen and matches ADR-fh-06; worked example checks clean + is schema-valid; cross-artifact resolution (IT-fh-07: clean pair passes, undeclared `ARC-`/`EDG-`/telemetry-ref each caught, non-ID-shaped legacy hops skipped, absent `--system-contracts` reported not-checked); one seeded violation per `CHECKS` entry (+ negative controls: inactive-edge exemption, soft-edge exemption, ASM-waived label-propagation, null crossing labels, missing-tier node still fully participates in other checks); schema/malformed-doc findings never crash; report-only vs `--gate` vs usage-error exit semantics (IT-fh-09); authority line present every run/mode; `--scanner-version` hex digest + changes when source changes.
- [x] `make lint` (ruff + py_compile + check_portability/patterns/cw_standards) — clean.
- [x] `make test` — full suite: **1387 passed, 4 skipped** (pre-existing skips; no regressions).
- [x] `python3 scripts/check_traceability.py docs/epics/epic-factory-hardening --source . --format json` — `CTR-fh-020..026` all covered/tested, zero invalid links from `check_architecture.py`, and identical repo-wide `defined`/`uncovered`/`dangling`/`invalid_links` counts vs. `main`.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF