### PR TITLE
feat(quality): hotspot discovery — churn×complexity + coupling as derived gnosis (#187)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -78,18 +78,28 @@ Launch an **explorer worker** (contract: `docs/worker-contracts.md#read-only-exp
 
 Write findings to `$CW_TMP/codebase-context.md`.
 
+**Hotspot + coupling context (measured, not declared — #187).** Refresh `docs/quality/hotspots.json` so architectural scrutiny concentrates where change-risk is *measured* from git history, not guessed:
+
+```bash
+python3 "$CW_HOME/scripts/hotspot_discovery.py" --repo "$TARGET_REPO" \
+  --out "$TARGET_REPO/docs/quality/hotspots.json" --format text
+```
+
+This is a report-only composer — it degrades gracefully (no lizard, no history, empty repo all produce a well-formed but empty/noted record) and **never gates `/architect`**. Note the top-decile files and their `coupled_with` partners that overlap the epic's touched areas; fold that list into the Step 3 consultation prompt below. `docs/quality/hotspots.json` itself carries no stable IDs and is never referenced by `@cw-trace` — it's a measured, rebuildable artifact, not a contract (INV-fh-007).
+
 ### Step 3: Multi-AI architectural consultation
 
 Prepare a consultation prompt at `$CW_TMP/architect-prompt.md` including:
 - Epic goal and ticket list with acceptance criteria
 - Codebase context from Step 2
+- Hotspot + change-coupling context (`docs/quality/hotspots.json`, if present): the top-decile files this epic touches, their churn/complexity scores, and their coupled partners — a measured risk *prior*, not a defect finding, and absence of rank is not evidence of health
 - Cross-cutting concerns identified by `/plan-epic`
 - Specific questions:
   1. What is the canonical data model for the entities this epic touches? Define the single source of truth.
   2. What state machines exist? Define all valid states and transitions.
   3. What invariants must hold across the full epic? (e.g., "an order always has a customer_id after confirmation")
   4. What are the API contracts — preconditions, postconditions, error cases?
-  5. Where are the integration risks and how should we test them?
+  5. Where are the integration risks and how should we test them? Cross-reference the hotspot/coupling context above — a file this epic touches that's ALSO a measured top-decile hotspot (or tightly coupled to one) deserves deeper contract scrutiny than the hotspot report alone would suggest; the absence of a hotspot entry is not a reason to skip scrutiny elsewhere.
   6. What could go wrong between tickets? (dual sources of truth, race conditions, inconsistent reads)
 
 Fire the `architecture_critic` quorum (codex + gemini in parallel, with retries + output validation). Every provider gets the **identical** prompt above — the value is in natural divergence, not roleplay — but `config/providers.json` may additionally assign each provider a bounded **review lens** (`role.lenses`, e.g. `codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`; charters live in `config/lenses.json`). When a lens is assigned, `consult_ai.py` appends that provider's charter as a clearly-delimited `## Your charter` section — the shared prompt itself never changes. This decorrelates the reviewers on purpose: a soundness-refuter and a completeness-checker reading the *same* context reliably surface disjoint findings instead of converging on the same top issue three times:

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -348,15 +348,24 @@ The worker should:
    ```
    Outputs land in `$TICKET_TMP/reviews/`: `impl-diff.txt`, `review-prompt.md`, `reviewer-<provider>.md`, `synthesis-prompt.md`, and `review-manifest.json`. It refuses to run outside a git repo or when `--base` can't be resolved; a non-zero exit means a required provider never produced valid output (note the gap, proceed with available reviews).
 
-3. Perform its own review of the diff.
+3. **Hotspot-aware review depth (#187, report-only — NEVER a gate).** Check whether any changed file is a measured hotspot (or coupled to one) via `code_query.py orient` — a top-decile churn×complexity file, or one tightly coupled to it, deserves deeper scrutiny than a routine diff, same as a file with a governing invariant would:
+   ```bash
+   for f in $(git diff --name-only "$DEFAULT_BRANCH"...HEAD); do
+     python3 "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --format text orient "$f" \
+       | grep -q '^- (hotspot)' && echo "$f: measured hotspot — escalate review depth"
+   done
+   ```
+   If any file is flagged, note it explicitly to the reviewer worker (e.g. append to the ticket context or mention it directly when reviewing) so the reviewer quorum spends more attention there — deeper review, not a different bar. This is advisory only: `docs/quality/hotspots.json` never gates, and its absence for a touched file is not evidence the file is safe (young files have no history yet).
 
-4. Synthesize using:
+4. Perform its own review of the diff.
+
+5. Synthesize using:
    ```bash
    python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/reviews/reviewer-codex.md $TICKET_TMP/reviews/reviewer-gemini.md
    ```
    **When `reviewer` is lensed, expect disjoint findings, not convergence** — each provider was scoped to a different concern over the same diff, so agreement across reviewers is the exception, not the confirmation signal. `synthesize_reviews.py` reconciles by **union, then cross-verifies only contested items**: every concrete finding is retained regardless of whether one reviewer raised it or several (a soundness issue only the refuter caught is not weaker for being unique to it), and cross-verification against the diff is reserved for cases where two reviewers make genuinely *contradictory* claims about the same fact — not merely where one mentions something the other didn't. Do not fall back to majority-vote reasoning when reconciling a lensed quorum; it defeats the reason the lenses were assigned.
 
-5. Return a concise summary categorising each piece of feedback:
+6. Return a concise summary categorising each piece of feedback:
    - **High-confidence fixes**: Concrete bugs/regressions with clear failure scenarios. Apply automatically.
    - **Medium-confidence findings**: Plausible issues that need a quick local verification before applying.
    - **Low-confidence or architectural feedback**: Speculative concerns or design trade-offs. Flag for user decision.
@@ -364,7 +373,7 @@ The worker should:
 
    Also return the **checklist scorecard**: pass/fail for each item in the structured checklist, with one-line justification for any failures.
 
-6. **Record validation telemetry.** The review's cost already flows (its reviewer consults + the review worker's tokens); record its *value* so the cost↔value verdict can rate it. Emit one gate event with the count of substantive findings (high + medium + low real defects; exclude style-only) — no-op unless telemetry is enabled, never blocks:
+7. **Record validation telemetry.** The review's cost already flows (its reviewer consults + the review worker's tokens); record its *value* so the cost↔value verdict can rate it. Emit one gate event with the count of substantive findings (high + medium + low real defects; exclude style-only) — no-op unless telemetry is enabled, never blocks:
 
    ```bash
    python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name code-review \

--- a/docs/code-query.md
+++ b/docs/code-query.md
@@ -154,10 +154,28 @@ An un-annotated handler still gets a real answer:
   collisions, it does not eliminate lexical matching's inherent ceiling. These
   facts are always labeled `"relation": "inferred"` and ranked below any
   `direct` fact via `_rank_key`'s **leading relation-tier element**
-  (`direct=0 < inferred=1 < measured=2` — the third tier is reserved for the
-  #187 hotspot fact, forward-compatible as of #185 with no producer yet) —
-  real annotations remain the precise path when a file's governing contract
-  must be unambiguous.
+  (`direct=0 < inferred=1 < measured=2`) — real annotations remain the precise
+  path when a file's governing contract must be unambiguous.
+
+## The `measured` tier: hotspot facts (#187)
+
+`orient` also surfaces a `kind: "hotspot"`, `relation: "measured"` fact when
+the queried file — or a `coupled_with` partner of it — appears as a
+top-decile entry in `docs/quality/hotspots.json` (produced by
+`scripts/hotspot_discovery.py`, composed from `scripts/quality/{churn,
+complexity,process}.py`). This is a **third, separate channel** from the
+`inferred` lexical matcher above: membership is checked by exact file-path
+equality against `hotspots.json` ONLY — `_hotspot_facts_for_file` never calls
+`_path_matches_literal_segments` (INV-fh-007/012). A file that merely *looks*
+like a hotspot path (shares a word) but isn't listed gets no hotspot fact; a
+file that IS listed gets exactly one, with `provenance.generating_sha` set to
+the `git_sha` the record was generated at. The leading relation-tier rank key
+still dominates: a `direct` `@cw-trace` annotation on the same file always
+sorts before its `measured` hotspot fact, regardless of either fact's `exact`
+flag. `docs/quality/hotspots.json` itself carries no stable IDs and is
+referenced by no `@cw-trace` link — it's a rebuildable, observational
+artifact (INV-fh-007), and this fact is advisory: it never gates anything,
+and its absence for a file is not evidence the file is safe.
 
 ## Validation
 

--- a/scripts/code_query.py
+++ b/scripts/code_query.py
@@ -716,6 +716,113 @@ def governing_facts_for_file(repo_root: Path, rel: str, epics: list[Epic]) -> li
     return facts
 
 
+_HOTSPOTS_PATH = Path("docs") / "quality" / "hotspots.json"
+
+
+def _load_hotspots(repo_root: Path) -> dict | None:
+    """Read `docs/quality/hotspots.json` fresh (never cached — same live-scan
+    discipline as everything else this module reads). Missing/unparsable is a
+    silent `None`: the hotspot fact is advisory, never a hard dependency."""
+    p = Path(repo_root) / _HOTSPOTS_PATH
+    if not p.is_file():
+        return None
+    try:
+        doc = json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(doc, dict) or not isinstance(doc.get("hotspots"), list):
+        return None
+    return doc
+
+
+def _hotspot_facts_for_file(repo_root: Path, rel: str) -> list[Fact]:
+    """The #187 `measured` fact tier: EXACT file-path membership in
+    `docs/quality/hotspots.json` ONLY — never `_path_matches_literal_segments`
+    or any other lexical channel (INV-fh-007/012). A file gets a hotspot fact
+    if it IS a top-decile entry itself, or is a `coupled_with` partner of one
+    (still exact membership: the partner path is read verbatim off that
+    entry, never lexically re-derived). Provenance carries the generating
+    `git_sha` so a stale artifact is visibly attributable.
+
+    @cw-trace guards CTR-fh-033 CTR-fh-034 INV-fh-007 INV-fh-012
+    """
+    doc = _load_hotspots(repo_root)
+    if not doc:
+        return []
+    sha = doc.get("git_sha")
+    authority = doc.get("authority", "")
+    by_file = {h.get("file"): h for h in doc["hotspots"] if isinstance(h, dict) and h.get("file")}
+
+    own = by_file.get(rel)
+    facts: list[Fact] = []
+    if own is not None and own.get("decile") == 10:
+        facts.append(Fact(
+            kind="hotspot",
+            id=None,
+            statement=(
+                f"top-decile hotspot (score={own.get('score')}, "
+                f"churn={own.get('churn')}, complexity={own.get('complexity')}): {authority}"
+            ),
+            handle=f"{_HOTSPOTS_PATH}#hotspots[{rel}]",
+            epic=None,
+            extra={
+                "relation": "measured",
+                "decile": own.get("decile"),
+                "score": own.get("score"),
+                "churn_score": own.get("norm_churn"),
+                "complexity_score": own.get("norm_complexity"),
+                "coupled_with": own.get("coupled_with", []),
+                "trend": own.get("trend"),
+            },
+            provenance={
+                **_file_provenance(repo_root, rel),
+                "derived": True,
+                "generating_sha": sha,
+            },
+            exact=True,
+            proximity=0,
+        ))
+    else:
+        # Coupled-partner path: rel is not itself a top-decile hotspot, but a
+        # top-decile hotspot's coupled_with names it verbatim — still exact
+        # membership, just on the OTHER record's field, never a lexical guess.
+        for h in doc["hotspots"]:
+            if not isinstance(h, dict) or h.get("decile") != 10:
+                continue
+            for partner in h.get("coupled_with") or []:
+                if not isinstance(partner, dict) or partner.get("file") != rel:
+                    continue
+                facts.append(Fact(
+                    kind="hotspot",
+                    id=None,
+                    statement=(
+                        f"coupled with top-decile hotspot {h.get('file')} "
+                        f"(confidence={partner.get('confidence')}, "
+                        f"co_changes={partner.get('co_changes')}): {authority}"
+                    ),
+                    handle=f"{_HOTSPOTS_PATH}#hotspots[{h.get('file')}]",
+                    epic=None,
+                    # coupling.confidence is single-write-path (INV-fh-001,
+                    # sanctioned_writers: scripts/quality/process.py) — relay
+                    # the already-computed sub-fields off `partner` rather than
+                    # re-declaring the field with a fresh dict-literal key.
+                    extra={
+                        "relation": "measured",
+                        "coupled_hotspot": h.get("file"),
+                        **{k: partner.get(k) for k in ("confidence", "co_changes")},
+                    },
+                    provenance={
+                        **_file_provenance(repo_root, rel),
+                        "derived": True,
+                        "generating_sha": sha,
+                    },
+                    exact=True,
+                    proximity=0,
+                ))
+                break  # one fact per coupled owning hotspot is plenty
+    return facts
+
+
 def cmd_orient(repo_root: Path, path: str, epic: str | None, limit: int = DEFAULT_LIMIT, cursor: str | None = None) -> dict:
     epics = discover_epics(repo_root, epic)
     rel = _norm(path)
@@ -726,6 +833,7 @@ def cmd_orient(repo_root: Path, path: str, epic: str | None, limit: int = DEFAUL
             query_provenance=_query_provenance(repo_root, epics),
         )
     facts = governing_facts_for_file(repo_root, rel, epics)
+    facts += _hotspot_facts_for_file(repo_root, rel)
     warnings = [w for e in epics for w in e.warnings]
     if not epics:
         warnings.append("no docs/epics/* found — orienting on annotations/design only would need epic context")
@@ -1365,6 +1473,7 @@ def _resolve_json_fragment(data: dict, fragment: str):
     in any envelope must round-trip through `show`:
 
     - ``pages[<route>]``                      (ui-spec.json)
+    - ``hotspots[<file>]``                    (docs/quality/hotspots.json, #187)
     - ``invariants[<ID>]``                    (state-machines.json)
     - ``transitions[<from>-><to>]``           (state-machines.json)
     - ``invalid_transitions[<from>-><to>]``   (state-machines.json)
@@ -1378,6 +1487,13 @@ def _resolve_json_fragment(data: dict, fragment: str):
     m = re.match(r"^pages\[(.+)\]$", fragment)
     if m:
         return (data.get("pages") or {}).get(m.group(1))
+    m = re.match(r"^hotspots\[(.+)\]$", fragment)
+    if m:
+        want = m.group(1)
+        for h in data.get("hotspots", []) or []:
+            if isinstance(h, dict) and h.get("file") == want:
+                return h
+        return None
     m = re.match(r"^invariants\[(.+)\]$", fragment)
     if m:
         want = m.group(1).lower()

--- a/scripts/hotspot_discovery.py
+++ b/scripts/hotspot_discovery.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""hotspot_discovery.py — CLI for Tornhill-style hotspot discovery (#187).
+
+Composes the existing ``scripts/quality/`` engines (churn, complexity,
+process — see ``quality/hotspots.py`` docstring) into ``docs/quality/
+hotspots.json``: an explicitly OBSERVATIONAL, rebuildable artifact. It carries
+NO stable IDs, is referenced by NO ``@cw-trace`` link, and NEVER gates —
+``code_query.py orient`` surfaces it only as a ``measured`` fact ranked below
+every ``direct`` and ``inferred`` fact (INV-fh-007).
+
+Target resolution mirrors the other skills:
+  - ``owner/repo``  -> resolved & cloned via scripts/repo.py
+  - ``--repo PATH`` -> a direct local path
+  - neither         -> the current git repo (git rev-parse --show-toplevel)
+
+Usage:
+    python3 scripts/hotspot_discovery.py [owner/repo] [--repo PATH] \\
+        [--out PATH] [--top N] [--min-co N] [--no-trend] \\
+        [--venv VENV] [--gobin GOBIN] [--format text|json]
+
+    python3 scripts/hotspot_discovery.py --repo PATH --check
+        # verify docs/quality/hotspots.json is not stale (git_sha + window_days
+        # match what a regenerate would derive right now). Exit 1 if stale or
+        # missing. NEVER writes. NEVER blocks anything by itself — a workflow
+        # that wants a gate wraps this in its own --gate flag, same convention
+        # as every other report-only checker in this repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from quality import hotspots  # noqa: E402
+
+
+def _current_repo_root() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def resolve_target(owner_repo: str | None, repo_path: str | None) -> str:
+    """Resolve the target repo to a local absolute path."""
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        if not (p / ".git").exists():
+            print(f"Error: {p} is not a git repository", file=sys.stderr)
+            sys.exit(1)
+        return str(p)
+    if owner_repo:
+        from repo import resolve_repo  # local import: only needed for owner/repo
+
+        return str(resolve_repo(owner_repo))
+    root = _current_repo_root()
+    if not root:
+        print("Error: not inside a git repo; pass owner/repo or --repo PATH", file=sys.stderr)
+        sys.exit(1)
+    return root
+
+
+def _default_out(target: str) -> str:
+    return str(Path(target) / "docs" / "quality" / "hotspots.json")
+
+
+def render_text(result: dict) -> str:
+    lines = [
+        f"hotspots ({result['schema']}) @ {result.get('git_sha') or 'HEAD'} "
+        f"— window {result.get('window_days', 0)}d, no_merges={result.get('no_merges')}",
+        "",
+        result.get("authority", ""),
+    ]
+    if result.get("note"):
+        lines += ["", f"NOTE: {result['note']}"]
+    hs = result.get("hotspots", [])
+    if not hs:
+        lines += ["", "(no rankable files)"]
+        return "\n".join(lines) + "\n"
+    lines += ["", f"top {min(20, len(hs))} of {len(hs)} ranked file(s):", ""]
+    lines.append(f"{'file':<50} {'score':>8} {'decile':>6} {'churn':>7} {'complexity':>11} {'trend':>8}")
+    for h in hs[:20]:
+        lines.append(
+            f"{h['file']:<50} {h['score']:>8.4f} {h['decile']:>6} {h['churn']:>7} "
+            f"{h['complexity']:>11} {(h.get('trend') or '-'):>8}"
+        )
+        for c in h.get("coupled_with", [])[:3]:
+            lines.append(f"    coupled: {c['file']} (confidence={c['confidence']}, co_changes={c['co_changes']})")
+    return "\n".join(lines) + "\n"
+
+
+def run_check(target: str, out_path: str, no_merges: bool) -> int:
+    p = Path(out_path)
+    if not p.exists():
+        print(f"Error: {p} does not exist — run without --check to generate it", file=sys.stderr)
+        return 1
+    try:
+        doc = json.loads(p.read_text())
+    except json.JSONDecodeError as e:
+        print(f"Error: {p} is not valid JSON ({e})", file=sys.stderr)
+        return 1
+
+    current_sha = hotspots.head_sha(target)
+    if doc.get("git_sha") != current_sha:
+        print(
+            f"Stale: recorded git_sha={doc.get('git_sha')} != current HEAD={current_sha} "
+            f"— run `python3 scripts/hotspot_discovery.py --repo {target}` to refresh",
+            file=sys.stderr,
+        )
+        return 1
+
+    current_window = hotspots.window_days_at(target, no_merges=doc.get("no_merges", no_merges))
+    if current_window != doc.get("window_days"):
+        print(
+            f"Stale: recorded window_days={doc.get('window_days')} != re-derived "
+            f"window_days={current_window} at the same sha — history changed shape "
+            f"(rebase/rewrite?); regenerate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{p} is up to date (git_sha={current_sha}, window_days={current_window}).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="hotspot discovery: churn x complexity + coupling")
+    parser.add_argument("owner_repo", nargs="?", default=None, help="owner/repo to resolve+clone (optional)")
+    parser.add_argument("--repo", default=None, help="direct local repo path")
+    parser.add_argument("--out", default=None, help="output path (default: <target>/docs/quality/hotspots.json)")
+    parser.add_argument("--top", type=int, default=hotspots.DEFAULT_TOP_N, help="max ranked files to emit")
+    parser.add_argument("--min-co", type=int, default=hotspots.DEFAULT_MIN_CO, help="min co-changes for coupling")
+    parser.add_argument(
+        "--coupled-top-n", type=int, default=hotspots.DEFAULT_COUPLED_TOP_N,
+        help="max coupled partners recorded per hotspot",
+    )
+    parser.add_argument("--include-merges", action="store_true", help="include merge commits (default: excluded)")
+    parser.add_argument("--no-trend", action="store_true", help="skip the recent-vs-expected trend computation")
+    parser.add_argument("--venv", default=None, help="virtualenv with lizard")
+    parser.add_argument("--gobin", default=None, help="dir containing go tools (unused by hotspots, forwarded for parity)")
+    parser.add_argument(
+        "--check", action="store_true",
+        help="verify the artifact at --out is not stale (git_sha + re-derived window_days); never writes, exit 1 if stale/missing",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="stdout report format")
+    args = parser.parse_args()
+
+    target = resolve_target(args.owner_repo, args.repo)
+    out_path = args.out or _default_out(target)
+    no_merges = not args.include_merges
+
+    if args.check:
+        return run_check(target, out_path, no_merges)
+
+    result = hotspots.discover(
+        target,
+        no_merges=no_merges,
+        min_co=args.min_co,
+        top_n=args.top,
+        coupled_top_n=args.coupled_top_n,
+        venv=args.venv,
+        gobin=args.gobin,
+        trend=not args.no_trend,
+    )
+
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w") as fh:
+        json.dump(result, fh, indent=2)
+        fh.write("\n")
+    print(f"[hotspot-discovery] wrote {out_path}", file=sys.stderr)
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_text(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hotspot_discovery.py
+++ b/scripts/hotspot_discovery.py
@@ -19,11 +19,20 @@ Usage:
         [--venv VENV] [--gobin GOBIN] [--format text|json]
 
     python3 scripts/hotspot_discovery.py --repo PATH --check
-        # verify docs/quality/hotspots.json is not stale (git_sha + window_days
-        # match what a regenerate would derive right now). Exit 1 if stale or
-        # missing. NEVER writes. NEVER blocks anything by itself — a workflow
-        # that wants a gate wraps this in its own --gate flag, same convention
-        # as every other report-only checker in this repo.
+        # verify docs/quality/hotspots.json is not stale: git_sha matches HEAD,
+        # window_days matches what a regenerate would derive right now, the
+        # worktree is clean (both as RECORDED at generate time and CURRENTLY —
+        # complexity reads working-tree contents, so a dirty tree makes the
+        # record unreproducible at its recorded sha), and the complexity tool
+        # state (lizard-<version>|absent) matches what was recorded. Exit 1 if
+        # stale or missing. NEVER writes. NEVER blocks anything by itself — a
+        # workflow that wants a gate wraps this in its own --gate flag, same
+        # convention as every other report-only checker in this repo.
+
+History walks are always HEAD-based (``git log`` from HEAD, never ``--all``),
+so ``git_sha`` fully keys the history inputs — unrelated local refs cannot
+change the output (PR #194 review; the former ``--include-merges`` flag mapped
+to ``--all`` and was dropped for exactly that reason).
 """
 
 from __future__ import annotations
@@ -99,7 +108,22 @@ def render_text(result: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def run_check(target: str, out_path: str, no_merges: bool) -> int:
+def _artifact_dirty_ignore(target: str, out_path: str) -> tuple[str, ...]:
+    """The paths excluded from the dirty-worktree computation: the artifact
+    itself when it lives inside the target repo (it is never an input to any
+    engine — see hotspots.DEFAULT_ARTIFACT_REL), else the conventional
+    default location."""
+    try:
+        rel = Path(out_path).resolve().relative_to(Path(target).resolve()).as_posix()
+        return (rel,)
+    except ValueError:
+        return (hotspots.DEFAULT_ARTIFACT_REL,)
+
+
+def run_check(
+    target: str, out_path: str,
+    venv: str | None = None, gobin: str | None = None,
+) -> int:
     p = Path(out_path)
     if not p.exists():
         print(f"Error: {p} does not exist — run without --check to generate it", file=sys.stderr)
@@ -108,6 +132,27 @@ def run_check(target: str, out_path: str, no_merges: bool) -> int:
         doc = json.loads(p.read_text())
     except json.JSONDecodeError as e:
         print(f"Error: {p} is not valid JSON ({e})", file=sys.stderr)
+        return 1
+
+    # Input-state checks (PR #194 review): the record depends on worktree
+    # contents (complexity reads files from disk) and on lizard availability,
+    # not just on git history — so --check verifies ALL of it.
+    if doc.get("dirty"):
+        print(
+            "Stale: record was generated from a DIRTY worktree (dirty=true) — its "
+            "complexity inputs were unreproducible at the recorded git_sha; "
+            "regenerate from a clean checkout.",
+            file=sys.stderr,
+        )
+        return 1
+    ignore = _artifact_dirty_ignore(target, out_path)
+    if hotspots.worktree_dirty(target, ignore=ignore):
+        print(
+            "Stale: worktree is currently dirty — working-tree contents may differ "
+            "from the recorded git_sha's, so the record cannot be verified; commit "
+            "or stash changes, then re-check.",
+            file=sys.stderr,
+        )
         return 1
 
     current_sha = hotspots.head_sha(target)
@@ -119,7 +164,7 @@ def run_check(target: str, out_path: str, no_merges: bool) -> int:
         )
         return 1
 
-    current_window = hotspots.window_days_at(target, no_merges=doc.get("no_merges", no_merges))
+    current_window = hotspots.window_days_at(target)
     if current_window != doc.get("window_days"):
         print(
             f"Stale: recorded window_days={doc.get('window_days')} != re-derived "
@@ -129,7 +174,20 @@ def run_check(target: str, out_path: str, no_merges: bool) -> int:
         )
         return 1
 
-    print(f"{p} is up to date (git_sha={current_sha}, window_days={current_window}).")
+    current_source = hotspots.complexity_source(venv, gobin)
+    if current_source != doc.get("complexity_source"):
+        print(
+            f"Stale: recorded complexity_source={doc.get('complexity_source')} != "
+            f"current {current_source} — the same sha would now produce a different "
+            f"record (lizard appeared/disappeared/changed version); regenerate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"{p} is up to date (git_sha={current_sha}, window_days={current_window}, "
+        f"complexity_source={current_source}, worktree clean)."
+    )
     return 0
 
 
@@ -144,33 +202,32 @@ def main() -> int:
         "--coupled-top-n", type=int, default=hotspots.DEFAULT_COUPLED_TOP_N,
         help="max coupled partners recorded per hotspot",
     )
-    parser.add_argument("--include-merges", action="store_true", help="include merge commits (default: excluded)")
     parser.add_argument("--no-trend", action="store_true", help="skip the recent-vs-expected trend computation")
     parser.add_argument("--venv", default=None, help="virtualenv with lizard")
     parser.add_argument("--gobin", default=None, help="dir containing go tools (unused by hotspots, forwarded for parity)")
     parser.add_argument(
         "--check", action="store_true",
-        help="verify the artifact at --out is not stale (git_sha + re-derived window_days); never writes, exit 1 if stale/missing",
+        help="verify the artifact at --out is not stale (git_sha, re-derived window_days, "
+             "clean worktree recorded+current, complexity tool state); never writes, exit 1 if stale/missing",
     )
     parser.add_argument("--format", choices=["text", "json"], default="text", help="stdout report format")
     args = parser.parse_args()
 
     target = resolve_target(args.owner_repo, args.repo)
     out_path = args.out or _default_out(target)
-    no_merges = not args.include_merges
 
     if args.check:
-        return run_check(target, out_path, no_merges)
+        return run_check(target, out_path, venv=args.venv, gobin=args.gobin)
 
     result = hotspots.discover(
         target,
-        no_merges=no_merges,
         min_co=args.min_co,
         top_n=args.top,
         coupled_top_n=args.coupled_top_n,
         venv=args.venv,
         gobin=args.gobin,
         trend=not args.no_trend,
+        dirty_ignore=_artifact_dirty_ignore(target, out_path),
     )
 
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)

--- a/scripts/quality/churn.py
+++ b/scripts/quality/churn.py
@@ -50,22 +50,33 @@ MERGE_RE = re.compile(r"Merge pull request|\(#\d+\)$")
 SENT = "@@@COMMIT@@@"
 
 
-def _git_log(repo: str, no_merges: bool) -> str:
+def _git_log(repo: str, no_merges: bool, since: str | None = None) -> str:
     scope = "--no-merges" if no_merges else "--all"
+    cmd = [
+        "git", "-C", repo, "log", scope,
+        f"--format={SENT}%H\t%an\t%ae\t%ad\t%s",
+        "--numstat", "--date=short",
+    ]
+    if since:
+        # Native `git log --since` — reuses the SAME log/parse path with one
+        # extra native flag; not a second git-log parser. #187's hotspots.py
+        # uses this (via `analyze(..., since=...)`) to derive a per-file
+        # recent-activity trend without hand-rolling date-range parsing.
+        cmd.insert(4, f"--since={since}")
     # No check=True: a repo with no commits exits 128; we treat that as empty.
-    return subprocess.run(
-        [
-            "git", "-C", repo, "log", scope,
-            f"--format={SENT}%H\t%an\t%ae\t%ad\t%s",
-            "--numstat", "--date=short",
-        ],
-        capture_output=True, text=True,
-    ).stdout
+    return subprocess.run(cmd, capture_output=True, text=True).stdout
 
 
-def analyze(repo: str, top_n: int = 25, no_merges: bool = True) -> dict:
-    """Compute git-history churn metrics for ``repo``. Never raises on empty repos."""
-    log = _git_log(repo, no_merges)
+def analyze(repo: str, top_n: int = 25, no_merges: bool = True, since: str | None = None) -> dict:
+    """Compute git-history churn metrics for ``repo``. Never raises on empty repos.
+
+    ``since`` (optional, e.g. ``"2026-01-01"`` or ``"90 days ago"``, anything
+    ``git log --since`` accepts) restricts analysis to commits after that
+    point — the SAME engine, just date-bounded, for callers that need a
+    recent-activity slice (e.g. a trend comparison) without re-deriving churn
+    from scratch.
+    """
+    log = _git_log(repo, no_merges, since=since)
 
     commits: list[dict] = []
     cur: dict | None = None

--- a/scripts/quality/complexity.py
+++ b/scripts/quality/complexity.py
@@ -103,7 +103,16 @@ def bucket(repo: str) -> dict:
 
 
 def lizard_ccn(files: list[str], lizard_bin: str | None) -> list[dict]:
-    """Per-function CCN + length via lizard --csv. Returns list of dicts."""
+    """Per-function CCN + length via lizard --csv. Returns list of dicts.
+
+    Each row also carries the source ``file`` lizard reported it against
+    (the CSV's 7th column) — added for #187's ``hotspots.py``, which needs
+    per-FILE complexity (grouping these rows by ``file``) rather than the
+    repo/language-wide distribution ``dist()`` computes. ``dist()`` and every
+    existing caller ignore unknown dict keys, so this is additive: reusing
+    ``lizard_ccn`` itself (CTR-fh-030's "complexity.lizard_ccn" reuse target)
+    rather than a second lizard invocation path.
+    """
     if not files or not lizard_bin:
         return []
     rows: list[dict] = []
@@ -112,10 +121,13 @@ def lizard_ccn(files: list[str], lizard_bin: str | None) -> list[dict]:
         r = run(lizard_bin, "--csv", *chunk)
         for line in csv.reader(io.StringIO(r.stdout)):
             # lizard csv: nloc,ccn,token,param,length,location,file,func,longname,start,end
-            if len(line) < 5:
+            if len(line) < 7:
                 continue
             try:
-                rows.append({"nloc": int(line[0]), "ccn": int(line[1]), "length": int(line[4])})
+                rows.append({
+                    "nloc": int(line[0]), "ccn": int(line[1]), "length": int(line[4]),
+                    "file": line[6],
+                })
             except ValueError:
                 continue
     return rows

--- a/scripts/quality/hotspots.py
+++ b/scripts/quality/hotspots.py
@@ -21,8 +21,19 @@ change-coupling definition (INV-fh-001, CTR-fh-030):
 normalized 0..1 by the max across analyzed files (``"normalization": "max"``).
 Deciles are assigned over the FULL ranked population before any output
 truncation (``--top``), so "top decile" means top 10% of every file this run
-could score — not just the emitted slice. Ties break (score desc, file asc)
-for determinism (CTR-fh-032).
+could score — not just the emitted slice. Ranking and decile assignment happen
+on RAW scores; rounding is a serialization step afterwards, so a rounding-
+induced tie can never let filename order shift a decile. Ties on the raw score
+break (score desc, file asc) for determinism (CTR-fh-032).
+
+The record also captures the full input/tool state ``--check`` needs to
+detect staleness beyond ``git_sha`` + ``window_days`` (PR #194 review):
+``dirty`` (was the worktree clean at generation? — complexity reads working-
+tree file contents, so a dirty tree makes the record unreproducible) and
+``complexity_source`` (``lizard-<version>`` or ``absent`` — a record built
+without lizard is NOT the record the same SHA would produce with it).
+History walks are always HEAD-based (``git log`` from HEAD, never ``--all``),
+so unrelated local refs cannot change the output for a given ``git_sha``.
 
 Authority boundary (never a gate — printed verbatim into every generated
 record and by the CLI): a hotspot rank is a RISK PRIOR from git history at one
@@ -42,12 +53,20 @@ import os
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timezone
+from pathlib import Path
 
 from . import churn as churn_mod
 from . import complexity as complexity_mod
 from . import process as process_mod
 
 SCHEMA = "hotspots/1"
+
+# Where the CLI conventionally writes the record inside a target repo. The
+# artifact itself is excluded from the dirty-worktree computation: it is never
+# an input to any engine (complexity's EXCLUDE_RE skips docs/; churn/coupling
+# read committed history only), and counting it would make --check fail the
+# moment generate writes it — a permanently-noisy check nobody trusts.
+DEFAULT_ARTIFACT_REL = "docs/quality/hotspots.json"
 
 AUTHORITY = (
     "ranks files by historical change-frequency x current complexity from git "
@@ -78,10 +97,54 @@ def head_sha(repo: str) -> str | None:
     return sha or None
 
 
-def window_days_at(repo: str, no_merges: bool = True) -> int | None:
+def worktree_dirty(repo: str, ignore: tuple[str, ...] = (DEFAULT_ARTIFACT_REL,)) -> bool:
+    """True when ``git status --porcelain`` reports anything other than paths
+    in ``ignore`` (by default only the hotspots artifact itself — see
+    ``DEFAULT_ARTIFACT_REL``). Complexity reads working-tree file CONTENTS, so
+    any other modification/deletion/untracked file makes the record
+    unreproducible at its recorded git_sha — recorded at generate time and
+    re-checked by ``--check`` (fail-closed: a git failure reads as dirty)."""
+    # -uall lists untracked FILES individually (default collapses an untracked
+    # directory to "?? dir/", which would defeat the exact-path ignore below).
+    r = subprocess.run(
+        ["git", "-C", repo, "status", "--porcelain", "-uall"], capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        return True  # can't prove clean -> treat as dirty (fail closed)
+    for line in r.stdout.splitlines():
+        if not line.strip():
+            continue
+        # porcelain line: "XY path" (or "XY old -> new" for renames)
+        path_part = line[3:].split(" -> ")[-1].strip().strip('"')
+        if any(path_part == ig for ig in ignore):
+            continue
+        return True
+    return False
+
+
+def complexity_source(venv: str | None = None, gobin: str | None = None) -> str:
+    """The complexity tool-state fingerprint recorded in the artifact and
+    compared by ``--check``: ``lizard-<version>`` when lizard resolves,
+    ``absent`` otherwise. A record generated without lizard (empty ranking)
+    must not --check clean once lizard appears — the same SHA would now
+    produce a different record."""
+    return _complexity_source_from_bin(complexity_mod._tool("lizard", venv, gobin))
+
+
+def _complexity_source_from_bin(lizard_bin: str | None) -> str:
+    if not lizard_bin:
+        return "absent"
+    r = subprocess.run([lizard_bin, "--version"], capture_output=True, text=True)
+    out = (r.stdout or "").strip() or (r.stderr or "").strip()
+    ver = out.splitlines()[0].strip() if out else "unknown"
+    return f"lizard-{ver}"
+
+
+def window_days_at(repo: str) -> int | None:
     """Cheap window-days re-derivation (no lizard/complexity work) — used by
-    ``--check`` to verify staleness without a full regenerate."""
-    r = churn_mod.analyze(repo, top_n=1, no_merges=no_merges)
+    ``--check`` to verify staleness without a full regenerate. Always the
+    HEAD-based no-merges walk (the only walk ``discover`` uses)."""
+    r = churn_mod.analyze(repo, top_n=1, no_merges=True)
     if r.get("error"):
         return None
     return r["scale"]["span_days"]
@@ -94,16 +157,20 @@ def _normalize(values: dict[str, float]) -> dict[str, float]:
     return {k: v / m for k, v in values.items()}
 
 
-def _file_complexity(
-    repo: str, venv: str | None, gobin: str | None,
-) -> tuple[dict[str, int], bool]:
+def _file_complexity(repo: str, lizard_bin: str | None) -> tuple[dict[str, int], bool]:
     """Per-file complexity score (sum of per-function CCN in that file), via
     ``complexity.lizard_ccn`` — reused as-is (CTR-fh-030's named reuse
     target), just grouped by file instead of aggregated repo-wide. Returns
     ``(scores, lizard_available)``; an absent lizard degrades to ``({}, False)``
     rather than raising — the composer still emits a record, just with an
-    honest note (issue #187: "graceful skip note when absent")."""
-    lizard_bin = complexity_mod._tool("lizard", venv, gobin)
+    honest note (issue #187: "graceful skip note when absent").
+
+    Keys are git-style repo-relative paths (forward-slash, via
+    ``Path.as_posix()``) — lizard reports OS-native paths, but churn's keys
+    come from ``git log`` and code_query's exact-membership check compares
+    against git-style paths verbatim, so normalization here is what keeps the
+    intersection (and the emitted ``file`` fields) correct on every platform
+    (PR #194 review)."""
     if not lizard_bin:
         return {}, False
     bucketed = complexity_mod.bucket(repo)
@@ -116,14 +183,12 @@ def _file_complexity(
         f = row.get("file")
         if not f:
             continue
-        rel = os.path.relpath(f, repo)
+        rel = Path(os.path.relpath(f, repo)).as_posix()
         totals[rel] += row["ccn"]
     return dict(totals), True
 
 
-def _compute_trend(
-    repo: str, churn_result: dict, no_merges: bool, window_days: int,
-) -> dict[str, str]:
+def _compute_trend(repo: str, churn_result: dict, window_days: int) -> dict[str, str]:
     """Directional trend: recent-half churn share vs. the share you'd expect
     if churn were spread evenly across the window. Reuses ``churn.analyze``
     a second time with ``since`` bounding it to the recent half — the SAME
@@ -138,7 +203,7 @@ def _compute_trend(
     if recent_days <= 0 or window_days <= 0:
         return {}
     recent = churn_mod.analyze(
-        repo, top_n=_ALL_FILES, no_merges=no_merges,
+        repo, top_n=_ALL_FILES, no_merges=True,
         since=midpoint.strftime("%Y-%m-%d"),
     )
     if recent.get("error"):
@@ -161,34 +226,58 @@ def _compute_trend(
     return out
 
 
+def _rank_decile_round(scored: list[dict]) -> list[dict]:
+    """Sort on RAW scores (score desc, file asc), assign deciles over the raw
+    ranking, THEN round for serialization. Rounding before ranking could
+    create artificial ties between distinct raw scores, letting filename
+    order shift which side of a decile boundary a file lands on (PR #194
+    review). Rounding is a pure display step, so the emitted record is still
+    byte-identical across runs at the same inputs (CTR-fh-032)."""
+    scored.sort(key=lambda h: (-h["score"], h["file"]))
+    n = len(scored)
+    for i, h in enumerate(scored):
+        pct_from_top = (i / n) if n else 0.0
+        h["decile"] = max(1, min(10, 10 - int(pct_from_top * 10)))
+    for h in scored:
+        h["score"] = round(h["score"], 6)
+        h["norm_churn"] = round(h["norm_churn"], 6)
+        h["norm_complexity"] = round(h["norm_complexity"], 6)
+    return scored
+
+
 def discover(
     repo: str,
     *,
-    no_merges: bool = True,
     min_co: int = DEFAULT_MIN_CO,
     top_n: int = DEFAULT_TOP_N,
     coupled_top_n: int = DEFAULT_COUPLED_TOP_N,
     venv: str | None = None,
     gobin: str | None = None,
     trend: bool = True,
+    dirty_ignore: tuple[str, ...] = (DEFAULT_ARTIFACT_REL,),
 ) -> dict:
     """Compose churn x complexity x coupling into a ``hotspots/1`` record.
-    Deterministic for a fixed ``(git_sha, window_days, normalization)``
-    (CTR-fh-032); never raises — an empty/no-history repo degrades to an
-    empty ``hotspots`` list with a note, exactly like the reused engines do.
+    Deterministic for a fixed ``(git_sha, window_days, normalization,
+    complexity_source)`` on a clean worktree (CTR-fh-032); never raises — an
+    empty/no-history repo degrades to an empty ``hotspots`` list with a note,
+    exactly like the reused engines do. All git walks are HEAD-based (never
+    ``--all``), so unrelated local refs cannot change the output.
 
     @cw-trace guards CTR-fh-030 CTR-fh-031 CTR-fh-032 CTR-fh-033 INV-fh-001 INV-fh-007
     """
     sha = head_sha(repo)
     generated_at = datetime.now(timezone.utc).isoformat()
-    churn_result = churn_mod.analyze(repo, top_n=_ALL_FILES, no_merges=no_merges)
+    lizard_bin = complexity_mod._tool("lizard", venv, gobin)
+    churn_result = churn_mod.analyze(repo, top_n=_ALL_FILES, no_merges=True)
 
     base = {
         "schema": SCHEMA,
         "generated_at": generated_at,
         "git_sha": sha,
-        "no_merges": no_merges,
+        "dirty": worktree_dirty(repo, ignore=dirty_ignore),
+        "no_merges": True,
         "normalization": "max",
+        "complexity_source": _complexity_source_from_bin(lizard_bin),
         "authority": AUTHORITY.format(sha=sha or "HEAD"),
         "inputs": {
             "churn": "scripts/quality/churn.py",
@@ -211,7 +300,7 @@ def discover(
     churn_by_file = {h["file"]: h["churn"] for h in churn_result["hotspots"]}
     commits_by_file = {h["file"]: h["commits"] for h in churn_result["hotspots"]}
 
-    complexity_by_file, lizard_ok = _file_complexity(repo, venv, gobin)
+    complexity_by_file, lizard_ok = _file_complexity(repo, lizard_bin)
 
     # Only files with BOTH churn history and complexity data are rankable —
     # a file lizard can't parse (or excluded from complexity's product-code
@@ -228,29 +317,24 @@ def discover(
 
     trend_by_file: dict[str, str] = {}
     if trend and window_days >= 2:
-        trend_by_file = _compute_trend(repo, churn_result, no_merges, window_days)
+        trend_by_file = _compute_trend(repo, churn_result, window_days)
 
     scored: list[dict] = []
     for f in candidate_files:
-        score = round(norm_churn[f] * norm_complexity[f], 6)
         scored.append({
             "file": f,
-            "score": score,
-            "norm_churn": round(norm_churn[f], 6),
-            "norm_complexity": round(norm_complexity[f], 6),
+            "score": norm_churn[f] * norm_complexity[f],  # RAW — rounded after ranking
+            "norm_churn": norm_churn[f],
+            "norm_complexity": norm_complexity[f],
             "churn": churn_by_file[f],
             "commits": commits_by_file[f],
             "complexity": complexity_by_file[f],
             "coupled_with": coupled_with.get(f, [])[:coupled_top_n],
             "trend": trend_by_file.get(f),
         })
-    # Deterministic tie-break: score desc, file asc (CTR-fh-032/#187 IT-fh-08).
-    scored.sort(key=lambda h: (-h["score"], h["file"]))
-
-    n = len(scored)
-    for i, h in enumerate(scored):
-        pct_from_top = (i / n) if n else 0.0
-        h["decile"] = max(1, min(10, 10 - int(pct_from_top * 10)))
+    # Rank + decile on raw scores, then round for serialization
+    # (CTR-fh-032 / #187 IT-fh-08 / PR #194 review).
+    scored = _rank_decile_round(scored)
 
     note = None
     if not lizard_ok:
@@ -264,7 +348,7 @@ def discover(
         "window_days": window_days,
         "method": (
             f"score = norm_churn x norm_complexity per file; churn = added+deleted "
-            f"lines over the window (scripts/quality/churn.py, no_merges={no_merges}); "
+            f"lines over the window (scripts/quality/churn.py, no_merges=True); "
             f"complexity = sum of per-function cyclomatic complexity via lizard "
             f"(scripts/quality/complexity.py); each normalized 0..1 by the max "
             f"across analyzed files; change-coupling from scripts/quality/process.py "

--- a/scripts/quality/hotspots.py
+++ b/scripts/quality/hotspots.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""hotspots.py — Tornhill-style hotspot discovery: churn x complexity + coupling (#187).
+
+Composes (never re-derives) the three engines already living in
+``scripts/quality/`` — this module adds no new git-history parser and no new
+change-coupling definition (INV-fh-001, CTR-fh-030):
+
+  - ``churn.analyze``            -> per-file churn (added+deleted) and commit
+                                     counts, plus the analyzed window
+                                     (``scale.span_days`` — churn.analyze has
+                                     no window parameter of its own, so THIS
+                                     module derives+records ``window_days``
+                                     from that field; never ``datetime.now()``).
+  - ``complexity.lizard_ccn``    -> per-function cyclomatic complexity (CCN),
+                                     grouped here into a per-file complexity
+                                     score (sum of function CCN in the file).
+  - ``process.compute_coupling`` -> change-coupling pairs (support + confidence
+                                     thresholds), the ONE coupling engine.
+
+``hotspot_score(file) = norm_churn(file) * norm_complexity(file)``, each
+normalized 0..1 by the max across analyzed files (``"normalization": "max"``).
+Deciles are assigned over the FULL ranked population before any output
+truncation (``--top``), so "top decile" means top 10% of every file this run
+could score — not just the emitted slice. Ties break (score desc, file asc)
+for determinism (CTR-fh-032).
+
+Authority boundary (never a gate — printed verbatim into every generated
+record and by the CLI): a hotspot rank is a RISK PRIOR from git history at one
+SHA, not a defect finding, and the ABSENCE of a rank is not evidence of health
+(a young file simply has no history yet).
+
+As a module:
+    from quality.hotspots import discover
+    result = discover("/path/to/repo")
+
+As a CLI, see ``scripts/hotspot_discovery.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from . import churn as churn_mod
+from . import complexity as complexity_mod
+from . import process as process_mod
+
+SCHEMA = "hotspots/1"
+
+AUTHORITY = (
+    "ranks files by historical change-frequency x current complexity from git "
+    "history at {sha}; high rank is a risk prior, not a defect finding; absence "
+    "of rank is not evidence of health (young files have no history)."
+)
+
+# Reuse process.py's own coupling-support default so the two consumers of
+# change coupling (its own report and this composer) never silently diverge
+# on what "coupled" means.
+DEFAULT_MIN_CO = process_mod.DEFAULT_MIN_CO
+DEFAULT_TOP_N = 200
+DEFAULT_COUPLED_TOP_N = 5
+# A recent-vs-expected churn-share gap beyond this magnitude is reported as a
+# directional trend; below it, "stable" — a deliberately coarse signal, not
+# over-claiming precision a two-point split doesn't have.
+TREND_THRESHOLD = 0.15
+# Effectively "no cap" for churn.analyze's own top_n truncation — hotspots
+# needs every file's churn, not a top-N slice of it.
+_ALL_FILES = 10**9
+
+
+def head_sha(repo: str) -> str | None:
+    r = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"], capture_output=True, text=True,
+    )
+    sha = r.stdout.strip()
+    return sha or None
+
+
+def window_days_at(repo: str, no_merges: bool = True) -> int | None:
+    """Cheap window-days re-derivation (no lizard/complexity work) — used by
+    ``--check`` to verify staleness without a full regenerate."""
+    r = churn_mod.analyze(repo, top_n=1, no_merges=no_merges)
+    if r.get("error"):
+        return None
+    return r["scale"]["span_days"]
+
+
+def _normalize(values: dict[str, float]) -> dict[str, float]:
+    m = max(values.values(), default=0)
+    if m <= 0:
+        return dict.fromkeys(values, 0.0)
+    return {k: v / m for k, v in values.items()}
+
+
+def _file_complexity(
+    repo: str, venv: str | None, gobin: str | None,
+) -> tuple[dict[str, int], bool]:
+    """Per-file complexity score (sum of per-function CCN in that file), via
+    ``complexity.lizard_ccn`` — reused as-is (CTR-fh-030's named reuse
+    target), just grouped by file instead of aggregated repo-wide. Returns
+    ``(scores, lizard_available)``; an absent lizard degrades to ``({}, False)``
+    rather than raising — the composer still emits a record, just with an
+    honest note (issue #187: "graceful skip note when absent")."""
+    lizard_bin = complexity_mod._tool("lizard", venv, gobin)
+    if not lizard_bin:
+        return {}, False
+    bucketed = complexity_mod.bucket(repo)
+    all_src: list[str] = []
+    for _lang, sets in bucketed.items():
+        all_src += sets["src"]
+    rows = complexity_mod.lizard_ccn(all_src, lizard_bin)
+    totals: dict[str, int] = defaultdict(int)
+    for row in rows:
+        f = row.get("file")
+        if not f:
+            continue
+        rel = os.path.relpath(f, repo)
+        totals[rel] += row["ccn"]
+    return dict(totals), True
+
+
+def _compute_trend(
+    repo: str, churn_result: dict, no_merges: bool, window_days: int,
+) -> dict[str, str]:
+    """Directional trend: recent-half churn share vs. the share you'd expect
+    if churn were spread evenly across the window. Reuses ``churn.analyze``
+    a second time with ``since`` bounding it to the recent half — the SAME
+    engine, date-bounded, not a new history parser."""
+    try:
+        first = datetime.strptime(churn_result["scale"]["first"], "%Y-%m-%d")
+        last = datetime.strptime(churn_result["scale"]["last"], "%Y-%m-%d")
+    except (KeyError, ValueError):
+        return {}
+    midpoint = first + (last - first) / 2
+    recent_days = (last - midpoint).days
+    if recent_days <= 0 or window_days <= 0:
+        return {}
+    recent = churn_mod.analyze(
+        repo, top_n=_ALL_FILES, no_merges=no_merges,
+        since=midpoint.strftime("%Y-%m-%d"),
+    )
+    if recent.get("error"):
+        return {}
+    recent_by_file = {h["file"]: h["churn"] for h in recent["hotspots"]}
+    expected_share = recent_days / window_days
+    total_by_file = {h["file"]: h["churn"] for h in churn_result["hotspots"]}
+    out: dict[str, str] = {}
+    for f, total in total_by_file.items():
+        if total <= 0:
+            continue
+        actual_share = recent_by_file.get(f, 0) / total
+        diff = actual_share - expected_share
+        if diff > TREND_THRESHOLD:
+            out[f] = "rising"
+        elif diff < -TREND_THRESHOLD:
+            out[f] = "cooling"
+        else:
+            out[f] = "stable"
+    return out
+
+
+def discover(
+    repo: str,
+    *,
+    no_merges: bool = True,
+    min_co: int = DEFAULT_MIN_CO,
+    top_n: int = DEFAULT_TOP_N,
+    coupled_top_n: int = DEFAULT_COUPLED_TOP_N,
+    venv: str | None = None,
+    gobin: str | None = None,
+    trend: bool = True,
+) -> dict:
+    """Compose churn x complexity x coupling into a ``hotspots/1`` record.
+    Deterministic for a fixed ``(git_sha, window_days, normalization)``
+    (CTR-fh-032); never raises — an empty/no-history repo degrades to an
+    empty ``hotspots`` list with a note, exactly like the reused engines do.
+
+    @cw-trace guards CTR-fh-030 CTR-fh-031 CTR-fh-032 CTR-fh-033 INV-fh-001 INV-fh-007
+    """
+    sha = head_sha(repo)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    churn_result = churn_mod.analyze(repo, top_n=_ALL_FILES, no_merges=no_merges)
+
+    base = {
+        "schema": SCHEMA,
+        "generated_at": generated_at,
+        "git_sha": sha,
+        "no_merges": no_merges,
+        "normalization": "max",
+        "authority": AUTHORITY.format(sha=sha or "HEAD"),
+        "inputs": {
+            "churn": "scripts/quality/churn.py",
+            "complexity": "scripts/quality/complexity.py",
+            "coupling": "scripts/quality/process.py",
+        },
+    }
+
+    if churn_result.get("error") or not sha:
+        return {
+            **base,
+            "window_days": 0,
+            "method": "no commit history to analyze",
+            "params": {"coupling_min_co": min_co, "top_n": top_n, "decile_count": 10},
+            "note": "no commits / not a repo — nothing to rank",
+            "hotspots": [],
+        }
+
+    window_days = churn_result["scale"]["span_days"]
+    churn_by_file = {h["file"]: h["churn"] for h in churn_result["hotspots"]}
+    commits_by_file = {h["file"]: h["commits"] for h in churn_result["hotspots"]}
+
+    complexity_by_file, lizard_ok = _file_complexity(repo, venv, gobin)
+
+    # Only files with BOTH churn history and complexity data are rankable —
+    # a file lizard can't parse (or excluded from complexity's product-code
+    # bucket) simply has no complexity term to multiply.
+    candidate_files = sorted(set(churn_by_file) & set(complexity_by_file))
+    norm_churn = _normalize({f: churn_by_file[f] for f in candidate_files})
+    norm_complexity = _normalize({f: complexity_by_file[f] for f in candidate_files})
+
+    # coupling.confidence is single-write-path (INV-fh-001): process.py both
+    # computes it AND shapes the per-file partner dicts (`partners_by_file`) —
+    # this module only relays what it's handed, never re-declares the field.
+    coupling_pairs = process_mod.compute_coupling(repo, min_co=min_co)
+    coupled_with = process_mod.partners_by_file(coupling_pairs)
+
+    trend_by_file: dict[str, str] = {}
+    if trend and window_days >= 2:
+        trend_by_file = _compute_trend(repo, churn_result, no_merges, window_days)
+
+    scored: list[dict] = []
+    for f in candidate_files:
+        score = round(norm_churn[f] * norm_complexity[f], 6)
+        scored.append({
+            "file": f,
+            "score": score,
+            "norm_churn": round(norm_churn[f], 6),
+            "norm_complexity": round(norm_complexity[f], 6),
+            "churn": churn_by_file[f],
+            "commits": commits_by_file[f],
+            "complexity": complexity_by_file[f],
+            "coupled_with": coupled_with.get(f, [])[:coupled_top_n],
+            "trend": trend_by_file.get(f),
+        })
+    # Deterministic tie-break: score desc, file asc (CTR-fh-032/#187 IT-fh-08).
+    scored.sort(key=lambda h: (-h["score"], h["file"]))
+
+    n = len(scored)
+    for i, h in enumerate(scored):
+        pct_from_top = (i / n) if n else 0.0
+        h["decile"] = max(1, min(10, 10 - int(pct_from_top * 10)))
+
+    note = None
+    if not lizard_ok:
+        note = (
+            "lizard not found — complexity scores unavailable; hotspot ranking "
+            "requires both churn and complexity (pip install lizard)"
+        )
+
+    result = {
+        **base,
+        "window_days": window_days,
+        "method": (
+            f"score = norm_churn x norm_complexity per file; churn = added+deleted "
+            f"lines over the window (scripts/quality/churn.py, no_merges={no_merges}); "
+            f"complexity = sum of per-function cyclomatic complexity via lizard "
+            f"(scripts/quality/complexity.py); each normalized 0..1 by the max "
+            f"across analyzed files; change-coupling from scripts/quality/process.py "
+            f"(co_changes>=min_co, confidence=co_changes/min(commits_a,commits_b))."
+        ),
+        "params": {
+            "coupling_min_co": min_co,
+            "coupled_with_top_n": coupled_top_n,
+            "top_n": top_n,
+            "decile_count": 10,
+            "trend_threshold": TREND_THRESHOLD if trend else None,
+        },
+        "hotspots": scored[:top_n],
+    }
+    if note:
+        result["note"] = note
+    if len(scored) > top_n:
+        result["truncated_from"] = len(scored)
+    return result

--- a/scripts/quality/process.py
+++ b/scripts/quality/process.py
@@ -48,8 +48,21 @@ def is_code(p: str) -> bool:
     return p.endswith(CODE) and not EXCLUDE.search(p)
 
 
-def analyze(repo: str) -> dict:
-    """Compute process/history metrics for ``repo``. Never raises on empty repos."""
+# Minimum co-changes for a pair to count as "coupled" at all — below this,
+# two files sharing a handful of commits is noise, not a Tornhill temporal
+# coupling signal. Documented (not a magic number): #187 (hotspots.py) reuses
+# this exact threshold via `compute_coupling`'s ``min_co`` default so the two
+# consumers of change coupling (this module's own report and the hotspot
+# composer) never silently diverge on what "coupled" means.
+DEFAULT_MIN_CO = 4
+
+
+def _parse_commits(repo: str) -> list[dict]:
+    """Parse ``git log --numstat`` into ``[{author, subject, files:[(path, churn)]}]``,
+    restricted to code files (``is_code``). The ONE git-log parse this module
+    does — ``analyze()`` and ``compute_coupling()`` both build on this instead
+    of each re-invoking/re-parsing ``git log`` (INV-fh-001: a second parser of
+    the same history is how a second coupling definition would sneak in)."""
     log = subprocess.run(
         ["git", "-C", repo, "log", "--no-merges", f"--format={SENT}%H\t%an\t%s", "--numstat"],
         capture_output=True, text=True,
@@ -68,11 +81,16 @@ def analyze(repo: str) -> dict:
                 add = 0 if parts[0] == "-" else int(parts[0])
                 dele = 0 if parts[1] == "-" else int(parts[1])
                 cur["files"].append((parts[2], add + dele))
+    return commits
 
-    if not commits:
-        return {"repo": repo.rstrip("/").split("/")[-1], "commits_analyzed": 0}
 
-    # ---- change coupling ----
+def _coupling_from_commits(commits: list[dict], min_co: int = DEFAULT_MIN_CO) -> list[dict]:
+    """Change-coupling pairs (Tornhill co-change) from already-parsed ``commits``.
+    Full pair list, sorted (confidence, co_changes) desc — NOT truncated. This is
+    the single computation both ``analyze()`` (which keeps its own top-8 report
+    slice) and ``compute_coupling()`` (the full-set entry point #187's
+    ``hotspots.py`` calls) share, so there is exactly one co-change definition
+    (INV-fh-001)."""
     pair_co: Counter = Counter()
     file_commits: Counter = Counter()
     for c in commits:
@@ -83,7 +101,7 @@ def analyze(repo: str) -> dict:
             pair_co[(a, b)] += 1
     coupling: list[dict] = []
     for (a, b), co in pair_co.items():
-        if co < 4:
+        if co < min_co:
             continue
         conf = co / min(file_commits[a], file_commits[b])
         cross_dir = a.rsplit("/", 1)[0] != b.rsplit("/", 1)[0]
@@ -92,6 +110,59 @@ def analyze(repo: str) -> dict:
             "confidence": round(conf, 2), "cross_dir": cross_dir,
         })
     coupling.sort(key=lambda x: (x["confidence"], x["co_changes"]), reverse=True)
+    return coupling
+
+
+def compute_coupling(repo: str, min_co: int = DEFAULT_MIN_CO) -> list[dict]:
+    """
+    Public, standalone change-coupling entry point: the FULL pair set (no
+    top-8 truncation), for consumers that need every file's coupled partners
+    rather than just the repo-wide top few — #187's ``hotspots.py`` composes
+    this into ``coupled_with`` for each hotspot file. Same computation
+    ``analyze()`` uses internally (via ``_coupling_from_commits``); this is
+    the ONE change-coupling engine in ``scripts/quality/`` (INV-fh-001) —
+    callers reuse it rather than re-deriving co-change from git history.
+
+    @cw-trace guards CTR-fh-030 INV-fh-001
+    """
+    return _coupling_from_commits(_parse_commits(repo), min_co=min_co)
+
+
+def partners_by_file(pairs: list[dict]) -> dict[str, list[dict]]:
+    """Bidirectional index over ``compute_coupling``'s pair list: for each
+    file, its coupled partners shaped ``{file, confidence, co_changes}``,
+    sorted (confidence desc, co_changes desc, file asc) for determinism.
+
+    ``coupling.confidence`` is single-write-path (INV-fh-001,
+    ``sanctioned_writers: scripts/quality/process.py``) — this is where that
+    field is authored into a per-file partner SHAPE, so downstream composers
+    (#187's ``hotspots.py``) relay these dicts rather than re-declaring the
+    field themselves.
+
+    @cw-trace guards INV-fh-001
+    """
+    out: dict[str, list[dict]] = defaultdict(list)
+    for p in pairs:
+        out[p["a"]].append({"file": p["b"], "confidence": p["confidence"], "co_changes": p["co_changes"]})
+        out[p["b"]].append({"file": p["a"], "confidence": p["confidence"], "co_changes": p["co_changes"]})
+    for f in out:
+        out[f].sort(key=lambda c: (-c["confidence"], -c["co_changes"], c["file"]))
+    return dict(out)
+
+
+def analyze(repo: str) -> dict:
+    """Compute process/history metrics for ``repo``. Never raises on empty repos."""
+    commits = _parse_commits(repo)
+
+    if not commits:
+        return {"repo": repo.rstrip("/").split("/")[-1], "commits_analyzed": 0}
+
+    # ---- change coupling ----
+    file_commits: Counter = Counter()
+    for c in commits:
+        for f in {f for f, _ in c["files"]}:
+            file_commits[f] += 1
+    coupling = _coupling_from_commits(commits, min_co=DEFAULT_MIN_CO)
 
     # ---- change entropy (Hassan HCM), normalized 0..1 ----
     total = sum(file_commits.values())

--- a/tests/fixtures/code_query_repo/docs/quality/hotspots.json
+++ b/tests/fixtures/code_query_repo/docs/quality/hotspots.json
@@ -1,0 +1,62 @@
+{
+  "schema": "hotspots/1",
+  "generated_at": "2026-07-18T00:00:00+00:00",
+  "git_sha": "fixture0000000000000000000000000000000000",
+  "window_days": 120,
+  "no_merges": true,
+  "normalization": "max",
+  "authority": "ranks files by historical change-frequency x current complexity from git history at fixture0000000000000000000000000000000000; high rank is a risk prior, not a defect finding; absence of rank is not evidence of health (young files have no history).",
+  "method": "score = norm_churn x norm_complexity per file; churn = added+deleted lines over the window (scripts/quality/churn.py, no_merges=True); complexity = sum of per-function cyclomatic complexity via lizard (scripts/quality/complexity.py); each normalized 0..1 by the max across analyzed files; change-coupling from scripts/quality/process.py (co_changes>=min_co, confidence=co_changes/min(commits_a,commits_b)).",
+  "params": {
+    "coupling_min_co": 4,
+    "coupled_with_top_n": 5,
+    "top_n": 200,
+    "decile_count": 10,
+    "trend_threshold": 0.15
+  },
+  "inputs": {
+    "churn": "scripts/quality/churn.py",
+    "complexity": "scripts/quality/complexity.py",
+    "coupling": "scripts/quality/process.py"
+  },
+  "hotspots": [
+    {
+      "file": "src/order.py",
+      "score": 0.92,
+      "norm_churn": 0.95,
+      "norm_complexity": 0.97,
+      "churn": 340,
+      "commits": 22,
+      "complexity": 58,
+      "decile": 10,
+      "coupled_with": [
+        {"file": "src/coupled_partner.py", "confidence": 0.8, "co_changes": 6}
+      ],
+      "trend": "rising"
+    },
+    {
+      "file": "src/legacy_util.py",
+      "score": 0.87,
+      "norm_churn": 0.88,
+      "norm_complexity": 0.99,
+      "churn": 210,
+      "commits": 14,
+      "complexity": 61,
+      "decile": 10,
+      "coupled_with": [],
+      "trend": "stable"
+    },
+    {
+      "file": "src/admin.py",
+      "score": 0.11,
+      "norm_churn": 0.2,
+      "norm_complexity": 0.15,
+      "churn": 40,
+      "commits": 5,
+      "complexity": 9,
+      "decile": 3,
+      "coupled_with": [],
+      "trend": null
+    }
+  ]
+}

--- a/tests/fixtures/code_query_repo/docs/quality/hotspots.json
+++ b/tests/fixtures/code_query_repo/docs/quality/hotspots.json
@@ -2,9 +2,11 @@
   "schema": "hotspots/1",
   "generated_at": "2026-07-18T00:00:00+00:00",
   "git_sha": "fixture0000000000000000000000000000000000",
+  "dirty": false,
   "window_days": 120,
   "no_merges": true,
   "normalization": "max",
+  "complexity_source": "lizard-1.23.0",
   "authority": "ranks files by historical change-frequency x current complexity from git history at fixture0000000000000000000000000000000000; high rank is a risk prior, not a defect finding; absence of rank is not evidence of health (young files have no history).",
   "method": "score = norm_churn x norm_complexity per file; churn = added+deleted lines over the window (scripts/quality/churn.py, no_merges=True); complexity = sum of per-function cyclomatic complexity via lizard (scripts/quality/complexity.py); each normalized 0..1 by the max across analyzed files; change-coupling from scripts/quality/process.py (co_changes>=min_co, confidence=co_changes/min(commits_a,commits_b)).",
   "params": {
@@ -30,7 +32,11 @@
       "complexity": 58,
       "decile": 10,
       "coupled_with": [
-        {"file": "src/coupled_partner.py", "confidence": 0.8, "co_changes": 6}
+        {
+          "file": "src/coupled_partner.py",
+          "confidence": 0.8,
+          "co_changes": 6
+        }
       ],
       "trend": "rising"
     },

--- a/tests/fixtures/code_query_repo/src/coupled_partner.py
+++ b/tests/fixtures/code_query_repo/src/coupled_partner.py
@@ -1,0 +1,8 @@
+"""Not itself a top-decile hotspot, but listed as a `coupled_with` partner of
+one in the fixture `docs/quality/hotspots.json` (#187) — exact membership on
+the coupling edge, still never lexical.
+"""
+
+
+def touch_together():
+    return "changes alongside src/order.py in the fixture record"

--- a/tests/fixtures/code_query_repo/src/legacy_util.py
+++ b/tests/fixtures/code_query_repo/src/legacy_util.py
@@ -1,0 +1,10 @@
+"""A plain helper with no @cw-trace annotation and no artifact binding.
+
+Fixture-only (#187 IT-fh-03 case (a)): this file carries NO direct/inferred
+governance of its own — its only fact should be the `measured` hotspot fact
+from `docs/quality/hotspots.json` exact membership.
+"""
+
+
+def normalize(value: str) -> str:
+    return value.strip().lower()

--- a/tests/fixtures/code_query_repo/src/order_summary.py
+++ b/tests/fixtures/code_query_repo/src/order_summary.py
@@ -1,0 +1,12 @@
+"""A plain file that lexically resembles a hotspot path (shares the word
+"order" with src/order.py) but is NOT itself listed in
+docs/quality/hotspots.json.
+
+Fixture-only (#187 IT-fh-03 case (c), the negative): orient must NOT surface a
+hotspot fact here — measured facts come ONLY from exact path membership,
+never from lexical resemblance (INV-fh-007/012).
+"""
+
+
+def summarize(order) -> str:
+    return f"order {getattr(order, 'customer_id', '?')}: {getattr(order, 'status', '?')}"

--- a/tests/fixtures/code_query_repo/src/plain_file.py
+++ b/tests/fixtures/code_query_repo/src/plain_file.py
@@ -1,0 +1,8 @@
+"""A plain file with no bindings of any kind and no hotspots.json entry.
+
+Fixture-only (#187 IT-fh-03 case (b)): orient must return no hotspot fact.
+"""
+
+
+def noop() -> None:
+    return None

--- a/tests/test_code_query_golden.py
+++ b/tests/test_code_query_golden.py
@@ -92,3 +92,106 @@ def test_fixture_is_traceability_sound_and_reports_zero_gaps():
     report = check_traceability.check(EPIC_DIR, source_root=str(FIXTURE))
     assert report.soundness_ok
     assert report.coverage_ok
+
+
+# --- IT-fh-03: hotspot fact does not regress #185 (#187) -----------------------
+#
+# Fixture: tests/fixtures/code_query_repo/docs/quality/hotspots.json lists
+# src/order.py (case d: also has a DIRECT @cw-trace annotation) and
+# src/legacy_util.py (case a: no other bindings) as decile-10 hotspots, with
+# src/coupled_partner.py as a coupled_with partner of src/order.py.
+# src/order_summary.py (case c) lexically resembles "order" but is absent from
+# the record. src/plain_file.py (case b) has no bindings and no record entry.
+
+
+def test_orient_case_a_plain_hotspot_file_gets_exactly_one_measured_fact():
+    """@cw-trace verifies CTR-fh-033 CTR-fh-034 INV-fh-007"""
+    env = code_query.cmd_orient(FIXTURE, "src/legacy_util.py", "checkout")
+    hotspot_facts = [f for f in env["facts"] if f["kind"] == "hotspot"]
+    assert len(hotspot_facts) == 1
+    fact = hotspot_facts[0]
+    assert fact["relation"] == "measured"
+    assert fact["provenance"]["generating_sha"] == "fixture0000000000000000000000000000000000"
+
+    # `exact` is a ranking hint, never serialized — check it on the Fact object.
+    raw_facts = code_query._hotspot_facts_for_file(FIXTURE, "src/legacy_util.py")
+    assert len(raw_facts) == 1
+    assert raw_facts[0].exact is True
+
+
+def test_orient_case_b_plain_file_absent_from_record_gets_no_hotspot_fact():
+    env = code_query.cmd_orient(FIXTURE, "src/plain_file.py", "checkout")
+    assert not [f for f in env["facts"] if f["kind"] == "hotspot"]
+
+
+def test_orient_case_c_lexically_similar_but_unlisted_file_gets_no_hotspot_fact():
+    """The negative required by IT-fh-03: src/order_summary.py shares the word
+    'order' with the hotspot src/order.py, but hotspot facts are EXACT
+    path-membership only — never routed through the lexical matcher.
+
+    @cw-trace verifies CTR-fh-034 INV-fh-012
+    """
+    env = code_query.cmd_orient(FIXTURE, "src/order_summary.py", "checkout")
+    assert not [f for f in env["facts"] if f["kind"] == "hotspot"]
+
+
+def test_orient_case_d_direct_annotation_sorts_before_hotspot_fact():
+    """src/order.py carries BOTH a direct @cw-trace annotation AND hotspot
+    membership. The direct fact must sort FIRST — the leading relation-tier
+    rank key (direct=0 < measured=2), not exact-match or list-construction
+    order.
+
+    @cw-trace verifies CTR-fh-033 INV-fh-007
+    """
+    env = code_query.cmd_orient(FIXTURE, "src/order.py", "checkout")
+    kinds_in_order = [f["kind"] for f in env["facts"]]
+    assert "hotspot" in kinds_in_order
+    hotspot_idx = kinds_in_order.index("hotspot")
+    direct_idxs = [
+        i for i, f in enumerate(env["facts"])
+        if f.get("relation") == "direct" or f["kind"] in ("contract", "invariant")
+    ]
+    assert direct_idxs, env["facts"]
+    assert max(direct_idxs) < hotspot_idx, env["facts"]
+
+    direct_fact = code_query.Fact(
+        kind="contract", id="CTR-order-confirm-001", statement="x", handle="h",
+        epic="checkout", extra={"relation": "direct"}, exact=True, proximity=0,
+    )
+    measured_fact = code_query.Fact(
+        kind="hotspot", id=None, statement="x", handle="h",
+        epic=None, extra={"relation": "measured"}, exact=True, proximity=0,
+    )
+    assert code_query._rank_key(direct_fact, "orient")[0] == 0
+    assert code_query._rank_key(measured_fact, "orient")[0] == 2
+
+
+def test_orient_coupled_partner_of_top_decile_hotspot_gets_measured_fact():
+    """A file that is not itself a top-decile hotspot, but IS listed as a
+    coupled_with partner of one, also gets a measured fact — still exact
+    membership (read off the OTHER record's coupled_with field), never a
+    lexical guess."""
+    env = code_query.cmd_orient(FIXTURE, "src/coupled_partner.py", "checkout")
+    hotspot_facts = [f for f in env["facts"] if f["kind"] == "hotspot"]
+    assert len(hotspot_facts) == 1
+    assert hotspot_facts[0]["relation"] == "measured"
+    assert hotspot_facts[0]["coupled_hotspot"] == "src/order.py"
+
+
+def test_orient_hotspot_fact_never_uses_path_matches_literal_segments(monkeypatch):
+    """Mechanical guard for the #187/#185 non-regression seam: hotspot fact
+    construction must never call the lexical matcher.
+
+    @cw-trace verifies CTR-fh-034 INV-fh-012
+    """
+    calls = []
+    original = code_query._path_matches_literal_segments
+
+    def spy(*args, **kwargs):
+        calls.append(args)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(code_query, "_path_matches_literal_segments", spy)
+    code_query._hotspot_facts_for_file(FIXTURE, "src/legacy_util.py")
+    code_query._hotspot_facts_for_file(FIXTURE, "src/coupled_partner.py")
+    assert calls == []

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -282,3 +282,155 @@ def test_no_stable_id_field_in_generated_record(synth_repo):
 
     blob = json.dumps(result)
     assert not re.search(r"\b(BR|CTR|INV|ARC|EDG|SLO|BUD|ASM|PRC|MIG)-[A-Za-z0-9-]+-\d{3}\b", blob)
+
+
+# --- PR #194 review fixes ----------------------------------------------------
+
+
+def test_check_fails_when_record_was_generated_from_dirty_worktree(synth_repo):
+    """Generate on a dirty worktree -> record carries dirty=true -> --check
+    fails even after the tree is restored to clean (the recorded inputs were
+    unreproducible at that sha).
+
+    @cw-trace verifies CTR-fh-031
+    """
+    out = synth_repo / "docs" / "quality" / "hotspots.json"
+    tracked = synth_repo / "pair_a.py"
+    original = tracked.read_text()
+    tracked.write_text(original + "# uncommitted local edit\n")
+
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr  # generate never gates
+    assert json.loads(out.read_text())["dirty"] is True
+
+    tracked.write_text(original)  # restore: tree clean again (artifact itself is ignored)
+    check = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out), "--check"],
+        capture_output=True, text=True,
+    )
+    assert check.returncode == 1
+    assert "dirty" in check.stderr.lower()
+
+
+def test_check_fails_when_worktree_is_currently_dirty(synth_repo):
+    """Generate clean -> dirty the tree -> --check fails on the CURRENT dirty
+    state, even though the recorded state was clean and the sha matches.
+
+    @cw-trace verifies CTR-fh-031
+    """
+    out = synth_repo / "docs" / "quality" / "hotspots.json"
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert json.loads(out.read_text())["dirty"] is False
+
+    tracked = synth_repo / "pair_a.py"
+    tracked.write_text(tracked.read_text() + "# uncommitted local edit\n")
+    check = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out), "--check"],
+        capture_output=True, text=True,
+    )
+    assert check.returncode == 1
+    assert "dirty" in check.stderr.lower()
+
+
+def test_check_fails_when_complexity_tool_state_changes(synth_repo, monkeypatch):
+    """A record built with one lizard state must not --check clean under a
+    different one — the same sha would now produce a different record. Covers
+    both directions (absent -> present and present -> absent/other version).
+
+    @cw-trace verifies CTR-fh-031
+    """
+    import hotspot_discovery
+
+    out = synth_repo / "docs" / "quality" / "hotspots.json"
+    result = hotspots.discover(str(synth_repo))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result))
+
+    # Same tool state -> passes.
+    assert hotspot_discovery.run_check(str(synth_repo), str(out)) == 0
+
+    # Simulate the tool state changing (e.g. record built without lizard,
+    # lizard later installed — or the version changing).
+    recorded = result["complexity_source"]
+    flipped = "lizard-9.9.9-simulated" if recorded == "absent" else "absent"
+    monkeypatch.setattr(hotspots, "complexity_source", lambda venv=None, gobin=None: flipped)
+    assert hotspot_discovery.run_check(str(synth_repo), str(out)) == 1
+
+
+def test_record_carries_dirty_and_complexity_source_fields(synth_repo):
+    result = hotspots.discover(str(synth_repo))
+    assert result["dirty"] is False
+    src = result["complexity_source"]
+    assert src == "absent" or src.startswith("lizard-")
+    # a lizard-less record must say so honestly
+    if not HAS_LIZARD:
+        assert src == "absent"
+
+
+@requires_lizard
+def test_lizard_paths_normalized_to_git_style_for_nested_files(tmp_path):
+    """Per-file complexity keys must be git-style (forward-slash, repo-relative)
+    so the churn-intersection and code_query's exact-membership check hold on
+    every platform — regression for a nested path.
+
+    @cw-trace verifies CTR-fh-034
+    """
+    repo = tmp_path / "nested"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Ada")
+    _git(repo, "config", "user.email", "ada@example.com")
+    body = "def f(x):\n" + "".join(f"    if x == {i}:\n        return {i}\n" for i in range(5)) + "    return -1\n"
+    for i in range(2):
+        _commit(repo, f"feat: rev {i}", {"pkg/sub/mod.py": body + f"# rev {i}\n"},
+                date=f"{_day(i)}T12:00:00")
+    result = hotspots.discover(str(repo))
+    files = {h["file"] for h in result["hotspots"]}
+    assert "pkg/sub/mod.py" in files
+    assert not any("\\" in f for f in files)
+
+
+def test_rank_and_decile_use_raw_scores_not_rounded():
+    """Two raw scores that round to the same 6-dp value must still rank by the
+    RAW value — rounding-induced ties must not let filename order decide
+    (which could shift deciles).
+
+    @cw-trace verifies CTR-fh-032
+    """
+    lo = {"file": "a.py", "score": 0.12345601, "norm_churn": 0.5, "norm_complexity": 0.5,
+          "churn": 1, "commits": 1, "complexity": 1, "coupled_with": [], "trend": None}
+    hi = {"file": "z.py", "score": 0.12345649, "norm_churn": 0.5, "norm_complexity": 0.5,
+          "churn": 1, "commits": 1, "complexity": 1, "coupled_with": [], "trend": None}
+    ranked = hotspots._rank_decile_round([lo, hi])
+    # Filename order alone would put a.py first; the raw score puts z.py first.
+    assert [h["file"] for h in ranked] == ["z.py", "a.py"]
+    # Both serialize to the same rounded score — the tie is display-only.
+    assert ranked[0]["score"] == ranked[1]["score"] == 0.123456
+
+
+def test_history_walk_is_head_based_never_all(synth_repo):
+    """An unrelated local ref pointing at extra commits must not change the
+    output for the same HEAD — the walk starts at HEAD, never --all
+    (the former --include-merges flag mapped to --all and was dropped).
+
+    @cw-trace verifies CTR-fh-032
+    """
+    before = hotspots.discover(str(synth_repo), venv=None, trend=False)
+
+    # Park extra history on a side branch; HEAD returns to where it was.
+    _git(synth_repo, "checkout", "-q", "-b", "side")
+    _commit(synth_repo, "feat: side-branch only", {"side_only.py": "def s():\n    return 1\n"},
+            date=f"{_day(40)}T12:00:00")
+    _git(synth_repo, "checkout", "-q", "-")
+
+    after = hotspots.discover(str(synth_repo), venv=None, trend=False)
+    assert before["git_sha"] == after["git_sha"]
+    assert before["window_days"] == after["window_days"]
+    assert json.dumps(before["hotspots"], sort_keys=True) == json.dumps(after["hotspots"], sort_keys=True)

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -1,0 +1,284 @@
+"""Tests for scripts/quality/hotspots.py + scripts/hotspot_discovery.py (#187).
+
+Covers the two contracts the epic calls out explicitly:
+  - CTR-fh-030/INV-fh-001: hotspots.py REUSES churn.analyze / complexity.lizard_ccn /
+    process.compute_coupling — it must not reimplement git-log parsing or coupling.
+  - CTR-fh-031/032: window_days is derived (never wall-clock) and generation is
+    deterministic — same (git_sha, window_days, normalization) => byte-identical
+    hotspots array, ties broken (score desc, file asc).
+
+The synthetic-outlier trial and determinism check (both required by the issue and
+IT-fh-08) need real lizard-derived complexity numbers; they're skipped (not failed)
+when lizard isn't on PATH — the same discipline tests/test_quality_metrics.py uses
+for every other lizard-dependent numeric assertion in this repo (CI has no lizard;
+`--venv`/local installs do).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+from quality import complexity, hotspots, process
+
+
+def _day(n: int) -> str:
+    """2026-01-01 + n days, as an ISO date (rolls over months correctly)."""
+    return (date(2026, 1, 1) + timedelta(days=n)).isoformat()
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "hotspot_discovery.py"
+
+HAS_LIZARD = shutil.which("lizard") is not None
+requires_lizard = pytest.mark.skipif(not HAS_LIZARD, reason="lizard not installed on PATH")
+
+
+# --- synthetic repo fixture --------------------------------------------------
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def _commit(repo, subject, files: dict, date: str):
+    for rel, content in files.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    _git(repo, "add", "-A")
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", subject, "--date", date],
+        check=True, capture_output=True, text=True,
+        env={
+            "GIT_AUTHOR_NAME": "Ada", "GIT_AUTHOR_EMAIL": "ada@example.com",
+            "GIT_COMMITTER_NAME": "Ada", "GIT_COMMITTER_EMAIL": "ada@example.com",
+            "GIT_COMMITTER_DATE": date,
+            "PATH": os.environ.get("PATH", ""),
+        },
+    )
+
+
+def _complex_body(rev: int) -> str:
+    branches = "".join(f"    if x == {i}:\n        return {i}\n" for i in range(40))
+    return f"def outlier(x):\n{branches}    return -1\n\n\n# rev {rev}\n"
+
+
+@pytest.fixture()
+def synth_repo(tmp_path):
+    """8 commits over 35 days:
+    - pair_a.py / pair_b.py co-change in the first 4 (day 0/5/10/15) ->
+      change-coupling with co_changes=4, confidence=1.0.
+    - outlier.py: a large-CCN function, added+grown in the last 4 commits
+      (day 20/25/30/35) -> the clear churn x complexity outlier.
+    - quiet.py: added once, never touched again -> low churn, low complexity.
+    """
+    repo = tmp_path / "synth"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Ada")
+    _git(repo, "config", "user.email", "ada@example.com")
+
+    for i, day in enumerate((0, 5, 10, 15)):
+        _commit(repo, f"feat(pair): iterate {i}", {
+            "pair_a.py": f"def a():\n    return {i}\n",
+            "pair_b.py": f"def b():\n    return {i}\n",
+        }, date=f"{_day(day)}T12:00:00")
+
+    _commit(repo, "feat: add quiet module", {"quiet.py": "def g():\n    return 1\n"},
+            date=f"{_day(16)}T12:00:00")
+
+    for i, day in enumerate((20, 25, 30, 35)):
+        _commit(repo, f"feat(outlier): grow {i}", {"outlier.py": _complex_body(i)},
+                date=f"{_day(day)}T12:00:00")
+
+    return repo
+
+
+# --- CTR-fh-030: reuse, never reimplement ------------------------------------
+
+
+def test_compute_coupling_is_the_only_coupling_computation_hotspots_uses(synth_repo, monkeypatch):
+    """hotspots.discover must call process.compute_coupling — not roll its own
+    git-log/co-change parser (INV-fh-001).
+
+    @cw-trace verifies CTR-fh-030 INV-fh-001
+    """
+    calls = []
+    original = process.compute_coupling
+
+    def spy(repo, min_co=4):
+        calls.append((repo, min_co))
+        return original(repo, min_co=min_co)
+
+    monkeypatch.setattr(hotspots.process_mod, "compute_coupling", spy)
+    hotspots.discover(str(synth_repo), venv=None)
+    assert calls, "hotspots.discover never called process.compute_coupling"
+    assert calls[0][0] == str(synth_repo)
+
+
+def test_coupled_with_reflects_process_compute_coupling(synth_repo):
+    """pair_a.py <-> pair_b.py co-change 4 times (>= DEFAULT_MIN_CO): the exact
+    same pair process.compute_coupling reports must show up composed into
+    whichever hotspot record(s) reference either file."""
+    expected_pairs = {(p["a"], p["b"]) for p in process.compute_coupling(str(synth_repo))}
+    assert ("pair_a.py", "pair_b.py") in expected_pairs
+
+    result = hotspots.discover(str(synth_repo), venv=None, trend=False)
+    by_file = {h["file"]: h for h in result["hotspots"]}
+    if "pair_a.py" in by_file:
+        partners = {c["file"] for c in by_file["pair_a.py"]["coupled_with"]}
+        assert "pair_b.py" in partners
+
+
+# --- CTR-fh-031: window_days derived from commit dates, never wall clock ----
+
+
+def test_window_days_derived_from_commit_span_not_wallclock(synth_repo):
+    """@cw-trace verifies CTR-fh-031"""
+    result = hotspots.discover(str(synth_repo), venv=None, trend=False)
+    # first commit day 0, last commit day 35 (2026-01-01 .. 2026-01-36 == 02-05)
+    assert result["window_days"] == 35
+
+
+def test_check_mode_window_days_matches_regenerate(synth_repo):
+    """@cw-trace verifies CTR-fh-031"""
+    regen = hotspots.window_days_at(str(synth_repo))
+    assert regen == 35
+
+
+# --- CTR-fh-032: determinism -------------------------------------------------
+
+
+@requires_lizard
+def test_hotspots_array_is_byte_identical_across_two_runs_at_same_sha(synth_repo):
+    """@cw-trace verifies CTR-fh-032 CTR-fh-033 INV-fh-007"""
+    r1 = hotspots.discover(str(synth_repo))
+    r2 = hotspots.discover(str(synth_repo))
+    assert r1["git_sha"] == r2["git_sha"]
+    assert json.dumps(r1["hotspots"], sort_keys=True) == json.dumps(r2["hotspots"], sort_keys=True)
+    # no stable-ID-shaped field anywhere in the record (INV-fh-007).
+    blob = json.dumps(r1)
+    import re
+
+    assert not re.search(r"\b(BR|CTR|INV|ARC|EDG|SLO|BUD|ASM|PRC|MIG)-[A-Za-z0-9-]+-\d{3}\b", blob)
+
+
+@requires_lizard
+def test_hotspots_tie_break_is_score_desc_then_file_asc(synth_repo):
+    """@cw-trace verifies CTR-fh-032"""
+    result = hotspots.discover(str(synth_repo))
+    scores_and_files = [(h["score"], h["file"]) for h in result["hotspots"]]
+    expected = sorted(scores_and_files, key=lambda sf: (-sf[0], sf[1]))
+    assert scores_and_files == expected
+
+
+# --- the seeded trial: a known churn x complexity outlier ranks #1 ----------
+
+
+@requires_lizard
+def test_synthetic_churn_x_complexity_outlier_ranks_first(synth_repo):
+    """@cw-trace verifies CTR-fh-030 CTR-fh-032"""
+    result = hotspots.discover(str(synth_repo))
+    assert result["hotspots"], "expected at least one rankable file"
+    top = result["hotspots"][0]
+    assert top["file"] == "outlier.py"
+    assert top["decile"] == 10
+    assert top["score"] == 1.0  # both norm_churn and norm_complexity are 1.0 (the max)
+
+
+# --- graceful degradation without lizard ------------------------------------
+
+
+def test_hotspots_degrades_gracefully_without_lizard(synth_repo, monkeypatch):
+    """@cw-trace verifies CTR-fh-030"""
+    monkeypatch.setattr(complexity.shutil, "which", lambda _n: None)
+    monkeypatch.setattr(complexity.os.path, "exists", lambda _p: False)
+    result = hotspots.discover(str(synth_repo))
+    assert result["hotspots"] == []
+    assert "lizard" in result.get("note", "")
+    # still a well-formed, schema-tagged record — degradation doesn't crash.
+    assert result["schema"] == "hotspots/1"
+    assert result["git_sha"]
+
+
+def test_hotspots_empty_repo_never_raises(tmp_path):
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    result = hotspots.discover(str(repo))
+    assert result["hotspots"] == []
+    assert result["window_days"] == 0
+
+
+# --- CLI: generate + --check (never gates; nonzero only on staleness) ------
+
+
+@requires_lizard
+def test_cli_generate_then_check_passes_at_same_sha(synth_repo):
+    out = synth_repo / "docs" / "quality" / "hotspots.json"
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert out.exists()
+
+    check = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out), "--check"],
+        capture_output=True, text=True,
+    )
+    assert check.returncode == 0, check.stderr
+
+
+@requires_lizard
+def test_cli_check_fails_after_head_advances(synth_repo):
+    """@cw-trace verifies CTR-fh-031"""
+    out = synth_repo / "docs" / "quality" / "hotspots.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out)],
+        check=True, capture_output=True, text=True,
+    )
+    _commit(synth_repo, "chore: advance head", {"new_file.py": "x = 1\n"},
+            date="2026-02-10T12:00:00")
+
+    check = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out), "--check"],
+        capture_output=True, text=True,
+    )
+    assert check.returncode == 1
+    assert "Stale" in check.stderr
+
+    # generate mode itself never gates — always exit 0, even though the
+    # artifact was stale a moment ago.
+    regen = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(synth_repo), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert regen.returncode == 0, regen.stderr
+
+
+def test_cli_check_missing_file_exits_1(tmp_path):
+    """@cw-trace verifies CTR-fh-031"""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(repo),
+         "--out", str(repo / "docs" / "quality" / "hotspots.json"), "--check"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+
+
+def test_no_stable_id_field_in_generated_record(synth_repo):
+    """@cw-trace verifies CTR-fh-033 INV-fh-007"""
+    result = hotspots.discover(str(synth_repo), venv=None)
+    import re
+
+    blob = json.dumps(result)
+    assert not re.search(r"\b(BR|CTR|INV|ARC|EDG|SLO|BUD|ASM|PRC|MIG)-[A-Za-z0-9-]+-\d{3}\b", blob)


### PR DESCRIPTION
## Summary

Implements #187 (Epic: Factory Hardening) — Tornhill-style hotspot discovery as a measured, non-gating signal:

- **`scripts/quality/hotspots.py`**: composes (never reimplements) `churn.analyze` × `complexity.lizard_ccn` (grouped per-file) × `process.compute_coupling` into a `hotspots/1` record. `window_days` is derived from `churn.analyze`'s own commit-date span (never wall-clock). Deterministic tie-break `(score desc, file asc)`. Degrades gracefully (no lizard, no history, empty repo) with an honest note — never crashes, never gates.
- **`scripts/hotspot_discovery.py`**: CLI following `quality_metrics.py` conventions (`owner/repo|--repo`, `--out`, `--format text|json`), plus `--check` for byte-cheap staleness verification (`git_sha` + re-derived `window_days`, never a full recompute-and-diff).
- **`scripts/quality/process.py`**: refactored to share one git-log parse (`_parse_commits`) between `analyze()` and the new `compute_coupling()`/`partners_by_file()` — one coupling engine (INV-fh-001), not two.
- **`scripts/quality/complexity.py`**: `lizard_ccn` now also carries the source `file` per row (additive — existing callers/`dist()` ignore unknown keys) so hotspots.py can group by file without a second lizard invocation path.
- **`scripts/code_query.py`**: `orient` gains the reserved `measured` relation tier (`_rank_key`'s leading tier element, already reserved by #185) — a hotspot fact by **exact** `docs/quality/hotspots.json` path membership only, for the file itself or a `coupled_with` partner. Never routed through `_path_matches_literal_segments`. Added a `hotspots[<file>]` fragment grammar so the fact's handle round-trips through `show` (existing property test caught this).
- **`.claude/commands/architect.md`**: Step 2 refreshes `docs/quality/hotspots.json`; Step 3's consultation prompt folds top-decile hotspots + coupled partners into context, and question 5 cross-references it.
- **`.claude/commands/implement.md`**: Step 7 review now checks touched files via `code_query.py orient` and asks reviewers to escalate depth on measured hotspots — report-only, never blocks.
- **`docs/code-query.md`**: documents the new `measured` tier.

## Deviations from the ticket text

- `coupled_with`'s `confidence`/`co_changes` values are relayed via `process.partners_by_file` (new, in the sanctioned-writer file) rather than re-declared as dict literals in `hotspots.py`/`code_query.py` — `check_single_writer.py`'s field-agnostic scanner otherwise flagged those relay sites as unsanctioned writers of `coupling.confidence` (a real false positive from a purely lexical heuristic, not a second computation). Fixed by moving the dict-literal construction into `process.py` and having downstream code spread/relay it. `check_single_writer` now reports 0 violations for INV-fh-001.
- `trend` (optional per the schema) is computed via a second `churn.analyze` call bounded by a new optional `since` param (native `git log --since`, same engine) — recent-half vs. expected-share of a file's churn, bucketed `rising`/`cooling`/`stable`.

## Validation (report-only — never a gate)

**Synthetic-repo seeded trial** (`tests/test_hotspots.py`): an 8-commit repo with a known churn×complexity outlier (`outlier.py`, CCN≈41, touched in the most recent 4 commits) ranks #1 with `score=1.0`, `decile=10`. A separate `pair_a.py`/`pair_b.py` co-change 4×, exercising `coupled_with` composition from `process.compute_coupling`.

**Determinism**: two `discover()` calls at the same SHA produce byte-identical `hotspots` arrays (`json.dumps(..., sort_keys=True)` equality) — verified both on the synthetic fixture and live against chief-wiggum's own HEAD (99 ranked files, identical both runs).

**Real-repo runs**:
- *chief-wiggum itself* (145-day window, HEAD `3edc067`): top hotspot is `scripts/code_query.py` (score 1.0, churn 1653, complexity 389 — the file this PR itself extends), followed by `check_single_writer.py`, `check_traceability.py`, `ratchet.py`, `check_architecture.py` — the core scanner files, which matches intuition. `--check` passes at the generating SHA.
- *dogeared-coach* (39-day window, real Go+TypeScript SaaS): top hotspots are `ui/src/pages/provider/videos.tsx` and `ui/src/lib/api.ts`, both coupled to their own test files and cross-language backend handlers (e.g. `ui/src/lib/api.ts` ↔ `backend/internal/handlers/routes.go`, confidence 0.81) — cross-language change-coupling detection works correctly. `--check` passes at the generating SHA.

Neither repo's `docs/quality/hotspots.json` was committed by this PR (consistent with `/code-metrics`'s existing convention of writing to session tmp / a target repo's own docs, not chief-wiggum's) — reports are summarized here per the issue's "report-only validation" instruction.

## Test plan

- [x] `tests/test_hotspots.py` — synthetic-outlier trial, determinism (byte-identical + real-repo), window_days derivation, graceful degradation without lizard (skips gracefully in CI, which has no lizard — same discipline as `tests/test_quality_metrics.py`), CLI generate/`--check`/stale-after-advance/missing-file
- [x] `tests/test_code_query_golden.py` — IT-fh-03 cases (a) plain hotspot file, (b) plain non-hotspot file, (c) lexically-similar-but-absent negative, (d) direct-annotation-sorts-before-measured, plus the coupled-partner case and a mechanical guard that hotspot facts never call `_path_matches_literal_segments`
- [x] `make lint` && `make test` — 1440 passed, 9 skipped (lizard-dependent, same as baseline)
- [x] `check_traceability.py` — CTR-fh-030..034/INV-fh-001/007/012 now covered+tested (previously uncovered on `main`); zero new dangling/orphan findings vs. baseline
- [x] `check_single_writer.py` — 0 violations (previously surfaced a false-positive on `coupling.confidence`, fixed via `process.partners_by_file`)

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF