### PR TITLE
feat(quality): stale-while-blocking auto-demotion (#198, closes IT-fh-06)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -137,6 +137,8 @@ python3 "$CW_HOME/scripts/check_gate_validation.py" check_single_writer --valida
 
 **If either exits non-zero (no record, a stale/forged one, or a failing one), do not pass `--gate coverage` to that checker in the corresponding step below** — run it report-only instead, surface a blocking finding in the close report ("`<checker>` is not validated under the gate-validation protocol — see docs/gate-validation.md"), and direct the operator to complete the protocol (or explicitly accept the risk at the human checkpoint). This is `/close-epic` refusing `--gate` for a checker lacking a passing validation record — the same "report-only until proven" posture as `docs/gate-rollout.md`, enforced mechanically here instead of by convention.
 
+If a checker that was previously wired blocking (`check_gate_validation.py ... --wire` was run for it earlier) shows `"authority": {"demoted": true, ...}` in this step's JSON output, its record went stale or missing/invalid WHILE blocking — surface the printed `DEMOTION` instruction (`previous_authority`/`demotion_reason`) verbatim in the close report alongside the coverage finding above (see `docs/gate-validation.md`'s "Auto-demotion" section, chief-wiggum#198); this is the same instruction-surfacing pattern as the escape-driven `demotion_check` in "Demotion: an escape a seed class should have caught," just triggered by staleness instead of a production escape.
+
 ### Step 2d: Traceability coverage gate
 
 Prove every contract/invariant is realized, guarded by code, and verified by a test — from the `@cw-trace` annotations (see `docs/traceability.md`). Only pass `--gate coverage` if Step 2c2's `check_gate_validation.py check_traceability --gate` passed; otherwise drop `--gate coverage` and report the finding instead:

--- a/docs/epics/epic-factory-hardening/integration-tests.md
+++ b/docs/epics/epic-factory-hardening/integration-tests.md
@@ -153,6 +153,22 @@ a value-equality accident).
 
 **Files.** `tests/test_check_gate_validation.py`, `tests/test_ratchet.py`.
 
+**Status.** Covered (chief-wiggum#198). `check_gate_validation.py` gained
+`check_and_transition`/`compute_transition`/`failure_kind` implementing the
+Gate Blocking-Authority Lifecycle's auto-demotion edges, plus a persisted
+`<gate>.authority.json` sidecar tracking `previous_authority`;
+`factory_log.emit_stale_demotion` emits the generic `DEMOTION` event
+(`details='stale'|'record_missing'`, no `seed_class`). Covering tests:
+`test_stale_while_blocking_auto_demotes`,
+`test_record_missing_while_blocking_demotes`,
+`test_schema_invalid_while_blocking_demotes_as_record_missing`,
+`test_stale_while_merely_validated_downgrades_not_demotes`,
+`test_recovery_re_derives_back_to_validated_never_straight_to_blocking`
+(`tests/test_check_gate_validation.py`), plus
+`test_it_fh_06_real_journal_corroborates_stale_while_blocking_demotion`
+(`tests/test_ratchet.py`, through the real `ratchet.py record` CLI rather than
+a hand-written journal fixture).
+
 ## IT-fh-07 — architecture ↔ system-contracts cross-ref resolution (#174)
 
 **Scenario.** A clean voice-agent `architecture.json` plus a

--- a/docs/epics/epic-factory-hardening/integration-tests.md
+++ b/docs/epics/epic-factory-hardening/integration-tests.md
@@ -153,21 +153,28 @@ a value-equality accident).
 
 **Files.** `tests/test_check_gate_validation.py`, `tests/test_ratchet.py`.
 
-**Status.** Covered (chief-wiggum#198). `check_gate_validation.py` gained
-`check_and_transition`/`compute_transition`/`failure_kind` implementing the
-Gate Blocking-Authority Lifecycle's auto-demotion edges, plus a persisted
-`<gate>.authority.json` sidecar tracking `previous_authority`;
-`factory_log.emit_stale_demotion` emits the generic `DEMOTION` event
-(`details='stale'|'record_missing'`, no `seed_class`). Covering tests:
+**Status.** Covered (chief-wiggum#198). Blocking authority is a JOURNALED fact,
+not a forgeable sidecar: `ratchet.py` gained a `gate-authority` event +
+`append_authority_event`/`last_authority_action`/`verified_prefix`;
+`check_gate_validation.py --wire`/`--unwire` append `wire`/`unwire` events to
+the ratchet hash chain, and `check_and_transition`/`authority_status`/
+`failure_kind` derive the demotion from "last authority event is `wire` AND
+`check()` not passing now". `factory_log.emit_stale_demotion` emits the generic
+`DEMOTION` (`details='stale'|'record_missing'`, no `seed_class`). Scope is the
+detection + emission of stale-while-blocking auto-demotion (IT-fh-06's core);
+the persistent recovery state machine is deferred (see the retrospective's
+"Design evolution"). Covering tests (`tests/test_check_gate_validation.py`):
 `test_stale_while_blocking_auto_demotes`,
 `test_record_missing_while_blocking_demotes`,
 `test_schema_invalid_while_blocking_demotes_as_record_missing`,
-`test_stale_while_merely_validated_downgrades_not_demotes`,
-`test_recovery_re_derives_back_to_validated_never_straight_to_blocking`
-(`tests/test_check_gate_validation.py`), plus
-`test_it_fh_06_real_journal_corroborates_stale_while_blocking_demotion`
-(`tests/test_ratchet.py`, through the real `ratchet.py record` CLI rather than
-a hand-written journal fixture).
+`test_chain_broken_while_blocking_still_demotes`,
+`test_re_journaled_new_rid_recovery_reaches_blocking_not_stuck`,
+`test_stale_while_not_wired_downgrades_not_demotes`,
+`test_forged_authority_sidecar_asserts_nothing`,
+`test_no_trust_write_on_plain_or_missing_gate_checks` — plus the real-`ratchet.py`
+CLI end-to-end `test_it_fh_06_real_journal_corroborates_stale_while_blocking_demotion`
+(`tests/test_ratchet.py`), whose `--wire` appends a real `gate-authority` event
+to the real chain.
 
 ## IT-fh-07 — architecture ↔ system-contracts cross-ref resolution (#174)
 

--- a/docs/epics/epic-factory-hardening/retrospective.md
+++ b/docs/epics/epic-factory-hardening/retrospective.md
@@ -344,66 +344,86 @@ stale-while-blocking auto-demotion, or deliberately retire it — was made:
 transitions; retiring them would have meant discarding a design the model
 itself said was correct, with no new information arguing otherwise.
 
-What shipped in #198:
+What shipped in #198 (final, journaled design — see "Design evolution" below
+for why the first two attempts were rejected):
 
+- **Blocking authority is a JOURNALED fact, not a file.** `scripts/ratchet.py`
+  gained a `gate-authority` event type + path-based primitives
+  (`append_authority_event`, `last_authority_action`, `verified_prefix`):
+  `check_gate_validation.py --wire`/`--unwire` append a `wire`/`unwire` event
+  to the ratchet hash chain, and "is this gate blocking?" is read back from
+  those events over the verified chain prefix — tamper-evident, not
+  hand-writable. There is NO `<gate>.authority.json` sidecar; a bare mutable
+  file would itself be the forgeable trust record this epic exists to
+  eliminate.
 - `scripts/check_gate_validation.py` gained `failure_kind` (classifies a
-  non-passing report as `"stale"` — scanner_version/journal-chain drift only,
-  otherwise clean — vs `"invalid"` — missing record, schema errors, forged/
-  failed trials, wrong status), `compute_transition` (the Gate
-  Blocking-Authority Lifecycle's edges), and `check_and_transition` (wraps
-  `check()` with the transition + a persisted `<gate>.authority.json` sidecar
-  recording `authority`/`previous_authority`). New `--wire`/`--unwire` CLI
-  flags record the operator's own wiring intent (`wire_gate`/`unwire_gate`,
-  G-004/G-013) — the prerequisite for the machine to know a subsequent
-  staleness finding is a demotion (was blocking) rather than a mere downgrade
-  (was only validated).
+  non-passing report as `"stale"` — scanner_version/journal-chain drift only —
+  vs `"invalid"` — missing/schema-invalid/failed), `authority_status` (derives
+  the verdict from the journaled wire fact + current `passing`), and
+  `check_and_transition`. The current-blocking verdict is simply: the last
+  authority event is `wire` AND `check()` reports `passing == true` now. A
+  journaled-wired gate whose record is NOT currently passing is demoted
+  (fail-to-report-only, ADR-fh-04). Reading "was wired" from the journal means
+  the demotion fires even when the CURRENT record or chain is what broke — the
+  case the earlier fail-closed sidecar masked.
 - `scripts/factory_log.py` gained `emit_stale_demotion(gate, reason,
   previous_authority=...)` — the generic `DEMOTION` event
-  (`details='stale'|'record_missing'`) the model called for, distinct from
-  the pre-existing escape-driven `emit_demotion` (which requires a
-  `seed_class` a staleness demotion never has).
-- The model's transient `stale` state is resolved atomically within a single
-  `check_gate_validation` invocation (a stateless per-process CLI can't rest
-  in an intermediate state across calls) — `blocking → stale → demoted` and
-  `validated → stale → report_only` each collapse to one hop, with the
-  `event` name (`auto_demote`, `downgrade_nonblocking_stale`,
-  `record_missing_or_invalid`) and `previous_authority` still recording which
-  path was taken. This is the one deliberate elaboration beyond the literal
-  model — the model didn't specify how a stateless CLI persists authority
-  across invocations at all, so `check_and_transition`'s sidecar file is new
-  design within #198's scope, not a rendering of an existing spec.
-- **The sidecar is a corroborated trust record, not a bare file** (hardened
-  after Codex's review of PR #202 flagged that an unauthenticated
-  `<gate>.authority.json` would itself become the forgeable trust record this
-  epic exists to eliminate). `read_authority` trusts a real authority claim
-  only when the sidecar's `gate` field matches, its `ratchet_record_id` is a
-  chain-verified `gate-validation` journal entry for the gate, and (when a
-  live record exists) that rid matches the record's — so a hand-forged
-  `authority: blocking`, an rid contradicting a re-authored record, or a
-  tampered file is treated as `unknown`/untrusted and can neither assert
-  authority nor manufacture a false demotion. `--wire` on a non-passing record
-  never yields/persists `blocking` (it falls through to demotion/downgrade and
-  reports the refusal); `--unwire` from a stale/missing-while-blocking record
-  still demotes and emits rather than silently masking it; and the sidecar is
-  written only under deliberate `--wire` management or continued tracking,
-  never for an ad-hoc/plain check or a missing gate — no pollution of the
-  shared committed `docs/quality/validation/` dir.
-- Per the model's own `invalid_transitions` (`demoted -> blocking` is
-  explicitly forbidden), recovery always lands on `validated`
-  (`re_derive_and_rejournal`/`re_derive_record`), never straight back to
-  `blocking` — an explicit `--wire` is required to re-promote, same as first
-  promotion.
+  (`details='stale'|'record_missing'`) the model called for, distinct from the
+  escape-driven `emit_demotion` (which requires a `seed_class` a staleness
+  demotion never has).
+- `--wire` journals a wire ONLY when the record passes (non-passing `--wire`
+  never reaches `blocking`, INV-fh-003); `--unwire` from a stale/missing-while-
+  blocking record still surfaces + emits the demotion (read from the pre-unwire
+  journal) rather than masking it; no plain/ad-hoc check or missing-gate op
+  writes any trust-bearing state — only operator `--wire`/`--unwire` append.
+  The `--gate` exit-1 guard (`report.passing`) remains the SOLE INV-fh-003
+  enforcement, independent of any authority record.
+- **Scope.** This is the *detection + emission* of stale-while-blocking
+  auto-demotion — IT-fh-06's core assertion. The persistent lifecycle-
+  management the model also sketches (an explicit `demoted` resting state, a
+  two-step `demoted → validated → blocking` recovery handshake) is deferred:
+  it needs a writable authority store, and every such store is either forgeable
+  (a file) or would force trust-writes on plain checks. Recovery is simply
+  "re-author the record, then `--wire` again"; because "was wired" is read from
+  journaled events (not by matching the wire event's rid to the record's), a
+  re-derived record with a brand-new `ratchet_record_id` recovers cleanly.
+  → ticket the richer journaled lifecycle-management as its own follow-up.
+- Editing `ratchet.py` bumped its hash-derived `--scanner-version`, staling its
+  own `docs/quality/validation/ratchet.json` record — the epic's staleness
+  machinery firing on itself (as in PR #197). The record's `scanner_version`
+  was re-authored to the new live value (its seeded trials, re-executed by
+  `tests/test_gate_validation_retroactive.py`, are unchanged — a non-behavioral
+  source bump).
+
+### Design evolution (two review rounds on PR #202)
+
+The lesson: **one trust artifact cannot answer two incompatible questions.**
+The first implementation used a persisted `<gate>.authority.json` sidecar for
+both "was this gate blocking?" (which must survive staleness, since staleness
+is exactly when you need it) and "may it assert blocking now?" (which must
+fail closed on staleness). Codex review round 1 found the sidecar forgeable and
+the `--wire`/`--unwire` state machine leaking blocking authority; round 2's
+corroboration fix (anchoring the sidecar's trust in the journal) then created
+new holes — chain-broken-while-blocking stopped demoting (the corroboration
+fail-closed erased the "was blocking" fact), and real re-journal recovery (a
+new rid) was rejected as contradictory. The fix was structural: drop the
+sidecar as a trust source entirely and read "was wired" from journaled,
+tamper-evident `gate-authority` events (mirroring how `ratchet-highwater.json`
+is a derived display cache, never a trust source), keeping the strict
+"may-assert-now" question answered live by `check().passing`. Findings 1–4 all
+dissolve because there is no longer a forgeable file, and the was-wired read
+tolerates a later chain break (verified prefix) instead of failing closed.
+
 - Tests: `tests/test_check_gate_validation.py` covers both demotion variants
-  (stale scanner/journal drift, and record-missing/schema-invalid) while
-  blocking, the downgrade-only path while merely validated, recovery back to
-  `validated`, `--wire`/`--unwire` semantics, and that the emitted telemetry
-  is the generic `DEMOTION` shape (no `seed_class`).
-  `tests/test_ratchet.py` adds an end-to-end run through the REAL
-  `ratchet.py record` CLI (not a hand-written journal fixture) to prove the
-  journal-corroboration path holds for the new auto-demotion, not just the
-  original `passing` check. `tests/test_factory_log.py` covers
-  `emit_stale_demotion` directly (generic shape, both reasons, no-op without
-  telemetry enabled, rejects unknown reasons).
+  (stale scanner/journal drift, record-missing/schema-invalid) while
+  journaled-wired, the not-wired downgrade, `--wire`/`--unwire` semantics, and
+  four explicit review-finding regressions — chain-broken-while-wired STILL
+  demotes (finding 1), re-journaled-new-rid recovery reaches blocking not stuck
+  (finding 2), a hand-written sidecar asserts nothing (finding 3), and no
+  trust-write on plain/missing-gate checks (finding 4). `tests/test_ratchet.py`
+  drives it end-to-end through the REAL `ratchet.py record` CLI (`--wire`
+  appends a real `gate-authority` event to the real chain).
+  `tests/test_factory_log.py` covers `emit_stale_demotion` directly.
 - `docs/epics/epic-factory-hardening/traceability.md`'s stale-record row is
   now `passing`; `docs/epics/epic-factory-hardening/integration-tests.md`'s
   IT-fh-06 section carries a `Status: Covered` line.

--- a/docs/epics/epic-factory-hardening/retrospective.md
+++ b/docs/epics/epic-factory-hardening/retrospective.md
@@ -372,6 +372,22 @@ What shipped in #198:
   model — the model didn't specify how a stateless CLI persists authority
   across invocations at all, so `check_and_transition`'s sidecar file is new
   design within #198's scope, not a rendering of an existing spec.
+- **The sidecar is a corroborated trust record, not a bare file** (hardened
+  after Codex's review of PR #202 flagged that an unauthenticated
+  `<gate>.authority.json` would itself become the forgeable trust record this
+  epic exists to eliminate). `read_authority` trusts a real authority claim
+  only when the sidecar's `gate` field matches, its `ratchet_record_id` is a
+  chain-verified `gate-validation` journal entry for the gate, and (when a
+  live record exists) that rid matches the record's — so a hand-forged
+  `authority: blocking`, an rid contradicting a re-authored record, or a
+  tampered file is treated as `unknown`/untrusted and can neither assert
+  authority nor manufacture a false demotion. `--wire` on a non-passing record
+  never yields/persists `blocking` (it falls through to demotion/downgrade and
+  reports the refusal); `--unwire` from a stale/missing-while-blocking record
+  still demotes and emits rather than silently masking it; and the sidecar is
+  written only under deliberate `--wire` management or continued tracking,
+  never for an ad-hoc/plain check or a missing gate — no pollution of the
+  shared committed `docs/quality/validation/` dir.
 - Per the model's own `invalid_transitions` (`demoted -> blocking` is
   explicitly forbidden), recovery always lands on `validated`
   (`re_derive_and_rejournal`/`re_derive_record`), never straight back to

--- a/docs/epics/epic-factory-hardening/retrospective.md
+++ b/docs/epics/epic-factory-hardening/retrospective.md
@@ -315,7 +315,7 @@ mistakes before merge (visible in PR review threads and the ratchet journal):
 | IT-fh-03 | Hotspot fact does not regress #185 (golden) | `tests/test_code_query_golden.py` (cases a–d) | PASS |
 | IT-fh-04 | Table-driven #184 records for all five gates | `tests/test_gate_validation_184.py` | PASS |
 | IT-fh-05 | Consult degradation matrix per adapter (#134) | `tests/test_consult_ai.py` | PASS |
-| IT-fh-06 | Stale-record auto-demotion end-to-end (#184) | none — **not implemented** | **MISSING** (→ #198) |
+| IT-fh-06 | Stale-record auto-demotion end-to-end (#184) | `tests/test_check_gate_validation.py`, `tests/test_ratchet.py` | PASS — implemented via #198 (see Addendum below) |
 | IT-fh-07 | architecture ↔ system-contracts cross-ref resolution (#174) | `tests/test_check_architecture.py` | PASS |
 | IT-fh-08 | Hotspot determinism (#187) | `tests/test_hotspots.py` | PASS (2 assertions skip without `lizard`, same as CI) |
 | IT-fh-09 | Report-only vs `--gate` exit-mode semantics (#174, #184) | `tests/test_check_architecture.py`, `tests/test_check_gate_validation.py` | PASS |
@@ -333,3 +333,65 @@ real product decision (implement it, or deliberately retire the AC via
 close, and does not block the milestone if the team prefers to retire it.
 Everything else (integration tests, single-writer, ratchet, full suite,
 AI-slop signals, CI) is green.
+
+## Addendum (2026-07-20, follow-up) — #198: IT-fh-06 implemented
+
+The decision this retrospective flagged as open — implement the modeled
+stale-while-blocking auto-demotion, or deliberately retire it — was made:
+**implement**. The committed `state-machines.json` already declared the
+`stale`/`demoted` states, the `previous_authority` context field, and the
+`auto_demote`/`downgrade_nonblocking_stale`/`record_missing_or_invalid`
+transitions; retiring them would have meant discarding a design the model
+itself said was correct, with no new information arguing otherwise.
+
+What shipped in #198:
+
+- `scripts/check_gate_validation.py` gained `failure_kind` (classifies a
+  non-passing report as `"stale"` — scanner_version/journal-chain drift only,
+  otherwise clean — vs `"invalid"` — missing record, schema errors, forged/
+  failed trials, wrong status), `compute_transition` (the Gate
+  Blocking-Authority Lifecycle's edges), and `check_and_transition` (wraps
+  `check()` with the transition + a persisted `<gate>.authority.json` sidecar
+  recording `authority`/`previous_authority`). New `--wire`/`--unwire` CLI
+  flags record the operator's own wiring intent (`wire_gate`/`unwire_gate`,
+  G-004/G-013) — the prerequisite for the machine to know a subsequent
+  staleness finding is a demotion (was blocking) rather than a mere downgrade
+  (was only validated).
+- `scripts/factory_log.py` gained `emit_stale_demotion(gate, reason,
+  previous_authority=...)` — the generic `DEMOTION` event
+  (`details='stale'|'record_missing'`) the model called for, distinct from
+  the pre-existing escape-driven `emit_demotion` (which requires a
+  `seed_class` a staleness demotion never has).
+- The model's transient `stale` state is resolved atomically within a single
+  `check_gate_validation` invocation (a stateless per-process CLI can't rest
+  in an intermediate state across calls) — `blocking → stale → demoted` and
+  `validated → stale → report_only` each collapse to one hop, with the
+  `event` name (`auto_demote`, `downgrade_nonblocking_stale`,
+  `record_missing_or_invalid`) and `previous_authority` still recording which
+  path was taken. This is the one deliberate elaboration beyond the literal
+  model — the model didn't specify how a stateless CLI persists authority
+  across invocations at all, so `check_and_transition`'s sidecar file is new
+  design within #198's scope, not a rendering of an existing spec.
+- Per the model's own `invalid_transitions` (`demoted -> blocking` is
+  explicitly forbidden), recovery always lands on `validated`
+  (`re_derive_and_rejournal`/`re_derive_record`), never straight back to
+  `blocking` — an explicit `--wire` is required to re-promote, same as first
+  promotion.
+- Tests: `tests/test_check_gate_validation.py` covers both demotion variants
+  (stale scanner/journal drift, and record-missing/schema-invalid) while
+  blocking, the downgrade-only path while merely validated, recovery back to
+  `validated`, `--wire`/`--unwire` semantics, and that the emitted telemetry
+  is the generic `DEMOTION` shape (no `seed_class`).
+  `tests/test_ratchet.py` adds an end-to-end run through the REAL
+  `ratchet.py record` CLI (not a hand-written journal fixture) to prove the
+  journal-corroboration path holds for the new auto-demotion, not just the
+  original `passing` check. `tests/test_factory_log.py` covers
+  `emit_stale_demotion` directly (generic shape, both reasons, no-op without
+  telemetry enabled, rejects unknown reasons).
+- `docs/epics/epic-factory-hardening/traceability.md`'s stale-record row is
+  now `passing`; `docs/epics/epic-factory-hardening/integration-tests.md`'s
+  IT-fh-06 section carries a `Status: Covered` line.
+
+No other epic ticket's contracts or invariants were touched. Full suite,
+ratchet, and single-writer coverage re-verified green on this follow-up
+branch (see PR #198's own description for exact counts).

--- a/docs/epics/epic-factory-hardening/traceability.md
+++ b/docs/epics/epic-factory-hardening/traceability.md
@@ -82,12 +82,16 @@ close (`check_gate_validation.py`/`factory_log.py` carried no
 `emit(DEMOTION, gate=gate, details='stale')` path — only a `passing: bool`
 collapse, plus the unrelated escape-driven `demotion_check(missed_by,
 seed_class)`; `IT-fh-06` had no test anywhere in `tests/`). #198 implemented the
-decision the model already specified: `check_gate_validation.py` gained
-`check_and_transition` (persisted `<gate>.authority.json` sidecar tracking
-`authority`/`previous_authority`, `--wire`/`--unwire` CLI flags) and
-`factory_log.emit_stale_demotion` (the generic `DEMOTION` event, `details=`
-`'stale'` or `'record_missing'`, no `seed_class`). `IT-fh-06` is now covered —
-see `integration-tests.md`'s Status line and `retrospective.md`'s addendum.
+detection + emission the model specified, anchored in the ratchet hash chain
+(NOT a forgeable sidecar): `ratchet.py` gained a `gate-authority` event +
+`append_authority_event`/`last_authority_action`; `check_gate_validation.py
+--wire`/`--unwire` journal the wire/unwire, and `check_and_transition`/
+`authority_status`/`failure_kind` demote a journaled-wired gate whose record is
+not currently passing via `factory_log.emit_stale_demotion` (generic `DEMOTION`,
+`details='stale'|'record_missing'`, no `seed_class`). The persistent recovery
+state machine is deferred (see `retrospective.md`'s "Design evolution"). `IT-fh-06`
+is now covered — see `integration-tests.md`'s Status line and `retrospective.md`'s
+addendum.
 
 ## #185 — code_query orient inferred-binding over-match (BR-fh-005)
 

--- a/docs/epics/epic-factory-hardening/traceability.md
+++ b/docs/epics/epic-factory-hardening/traceability.md
@@ -73,15 +73,21 @@ follow-up in the retrospective.
 | Journaled via `ratchet record --event gate-validation` | CTR-fh-043 | `test_ratchet` journal corroboration | passing |
 | **Fixture harnesses for saas_gate (recorded target) + quality_slop_gate (pinned band) — explicit AC, BLOCKER for those two records** | CTR-fh-044 | `test_saas_gate` / `test_quality_slop_gate` fixture-target runs | passing |
 | Record for #174's check_architecture in same pass, AFTER CHECKS freezes | INV-fh-003, ADR-fh-06 | IT-fh-04 (one seed per `CHECKS` entry; early-record negative) | passing |
-| Stale record auto-demotes when blocking; downgrades to report_only when not [^stale-gap] | INV-fh-003, INV-fh-005 | IT-fh-06 (blocking→stale→demoted; validated→stale→report_only) | missing |
+| Stale record auto-demotes when blocking; downgrades to report_only when not [^stale-gap] | INV-fh-003, INV-fh-005 | IT-fh-06 (blocking→stale→demoted; validated→stale→report_only) | passing |
 | Single `DEFAULT_VALIDATION_DIR` (import from factory_log, not a second definition) | INV-fh-004 | `test_validation_dir_is_defined_once_and_imported` | passing |
 
-[^stale-gap]: Never implemented. `check_gate_validation.py`/`factory_log.py` carry no
+[^stale-gap]: **Resolved by chief-wiggum#198.** Was never implemented at epic
+close (`check_gate_validation.py`/`factory_log.py` carried no
 `previous_authority`, no distinct `demoted` state, and no generic
 `emit(DEMOTION, gate=gate, details='stale')` path — only a `passing: bool`
-collapse, plus the unrelated escape-driven `demotion_check(missed_by, seed_class)`.
-IT-fh-06 was never written (no `IT-fh-06` marker anywhere in `tests/`). This is a
-real, unclosed gap from this epic — see `retrospective.md`.
+collapse, plus the unrelated escape-driven `demotion_check(missed_by,
+seed_class)`; `IT-fh-06` had no test anywhere in `tests/`). #198 implemented the
+decision the model already specified: `check_gate_validation.py` gained
+`check_and_transition` (persisted `<gate>.authority.json` sidecar tracking
+`authority`/`previous_authority`, `--wire`/`--unwire` CLI flags) and
+`factory_log.emit_stale_demotion` (the generic `DEMOTION` event, `details=`
+`'stale'` or `'record_missing'`, no `seed_class`). `IT-fh-06` is now covered —
+see `integration-tests.md`'s Status line and `retrospective.md`'s addendum.
 
 ## #185 — code_query orient inferred-binding over-match (BR-fh-005)
 

--- a/docs/gate-validation.md
+++ b/docs/gate-validation.md
@@ -243,6 +243,60 @@ recorded band files (`tests/fixtures/gate_validation/quality_slop_gate_clean/`)
 fed to its pure verdict functions — a record validated against a prod URL or a
 live AI band could never be re-verified.
 
+## Auto-demotion: a blocking gate's record going stale (chief-wiggum#198)
+
+The demotion rule below fires on a **production escape**. A gate can also
+lose blocking authority with no escape at all — its validation record simply
+rotted while the gate was still wired `--gate`: a scanner edit bumped
+`--scanner-version` out from under it, the ratchet journal's hash chain broke,
+or the record was deleted/regressed to `status != "passed"`. `INV-fh-003` ("no
+blocking without a passing record") already made `check_gate_validation`
+report `passing == false` in this case; #198 closed the remaining gap — the
+system must not just report `false`, it must actively **track and surface**
+that a gate that WAS blocking no longer is.
+
+`check_gate_validation.py --wire` records that a gate is now wired `--gate` in
+its workflow (only when its record currently passes) into a persisted
+`<gate>.authority.json` sidecar beside the validation record. Every ordinary
+check thereafter re-derives the authority transition
+(`compute_transition`/`check_and_transition`, mirroring
+`docs/epics/epic-factory-hardening/models/state-machines.json`'s Gate
+Blocking-Authority Lifecycle):
+
+- **Blocking + record goes stale or missing/invalid** → auto-demotes to
+  `demoted` (fail-to-report-only, ADR-fh-04), emits the GENERIC `DEMOTION`
+  event via `factory_log.emit_stale_demotion(gate, reason,
+  previous_authority="blocking")` with `reason` `"stale"` (scanner_version/
+  journal-chain drift, otherwise clean) or `"record_missing"` (missing/
+  schema-invalid/forged/failed) — never `emit_demotion`, which requires a
+  `seed_class` this path never has (nothing escaped in production; the record
+  itself just went bad).
+- **Merely `validated` (never wired) + record goes stale or invalid** →
+  downgrades to `report_only` — no demotion event, since nothing was
+  blocking.
+- **Recovery**: re-authoring and re-journaling a `demoted` (or downgraded)
+  record restores `validated` once `passing == true` again — never straight
+  back to `blocking` (the model's `invalid_transitions` explicitly forbid
+  `demoted -> blocking`); an explicit `--wire` re-promotes it.
+
+The actual enforcement point stays exactly where it already was: a workflow
+only passes `--gate coverage` onward when `check_gate_validation.py --gate`
+exits 0, so a demoted/downgraded gate is already refused blocking authority by
+that existing guard (INV-fh-003). `check_and_transition`'s job is telemetry
+and bookkeeping — making the demotion visible and recording
+`previous_authority` — not re-implementing the refusal.
+
+```bash
+python3 "$CW_HOME/scripts/check_gate_validation.py" ratchet \
+  --validation-dir "$CW_HOME/docs/quality/validation" --wire   # first promotion
+# ... later, after a scanner edit bumps ratchet's --scanner-version ...
+python3 "$CW_HOME/scripts/check_gate_validation.py" ratchet \
+  --validation-dir "$CW_HOME/docs/quality/validation" --format json
+# {"passing": false, ..., "authority": {"previous_state": "blocking",
+#  "new_state": "demoted", "demoted": true, "demotion_reason": "stale",
+#  "previous_authority": "blocking", "instruction": "DEMOTE ratchet ..."}}
+```
+
 ## Demotion: an escape a seed class should have caught
 
 The live confusion matrix (`factory_log.py`'s `gate`/`escape` events,

--- a/docs/gate-validation.md
+++ b/docs/gate-validation.md
@@ -255,11 +255,11 @@ report `passing == false` in this case; #198 closed the remaining gap — the
 system must not just report `false`, it must actively **track and surface**
 that a gate that WAS blocking no longer is.
 
-`check_gate_validation.py --wire` records that a gate is now wired `--gate` in
-its workflow (only when its record currently passes) into a persisted
-`<gate>.authority.json` sidecar beside the validation record. Every ordinary
-check thereafter re-derives the authority transition
-(`compute_transition`/`check_and_transition`, mirroring
+`check_gate_validation.py --wire` opts a gate into blocking-authority tracking
+(**only** when its record currently passes — a non-passing `--wire` can never
+reach `blocking`, INV-fh-003) via a persisted `<gate>.authority.json` sidecar
+beside the validation record. Every ordinary check thereafter re-derives the
+authority transition (`compute_transition`/`check_and_transition`, mirroring
 `docs/epics/epic-factory-hardening/models/state-machines.json`'s Gate
 Blocking-Authority Lifecycle):
 
@@ -271,19 +271,44 @@ Blocking-Authority Lifecycle):
   schema-invalid/forged/failed) — never `emit_demotion`, which requires a
   `seed_class` this path never has (nothing escaped in production; the record
   itself just went bad).
-- **Merely `validated` (never wired) + record goes stale or invalid** →
+- **Merely `validated` (not currently wired) + record goes stale or invalid** →
   downgrades to `report_only` — no demotion event, since nothing was
   blocking.
 - **Recovery**: re-authoring and re-journaling a `demoted` (or downgraded)
   record restores `validated` once `passing == true` again — never straight
   back to `blocking` (the model's `invalid_transitions` explicitly forbid
-  `demoted -> blocking`); an explicit `--wire` re-promotes it.
+  `demoted -> blocking`). A `--wire` on a still-`demoted` gate resolves to
+  `validated` (the re-derivation half); a **second** explicit `--wire` then
+  promotes it to `blocking`.
+
+`--wire`/`--unwire` obey the model's legal-vs-invalid transitions strictly, so
+the sidecar can never record blocking authority the record doesn't currently
+earn:
+
+- A **non-passing `--wire`** never yields or persists `blocking` — it falls
+  through to the natural lifecycle (demoting a stale/missing-while-blocking
+  gate and emitting the DEMOTION, or downgrading otherwise) and reports the
+  refusal.
+- **`--unwire`** is the clean voluntary edge (`blocking -> validated`) ONLY
+  when the record still passes; un-wiring a gate whose record has ALSO gone
+  bad does **not** mask the demotion — it still goes `blocking -> demoted` and
+  emits.
+
+The sidecar is a **corroborated** trust record, not a bare file an attacker
+can drop to forge authority (the exact class of forgeable-trust bug this epic
+exists to prevent). `read_authority` trusts any real authority claim only when
+the sidecar's `gate` field matches, its `ratchet_record_id` is a
+chain-verified `gate-validation` journal entry for the gate, and — when a live
+record exists — that rid matches the record's. A sidecar that fails any check
+(forged `blocking` with no journaled rid, an rid contradicting a re-authored
+record, a tampered/edited file) is treated as `unknown`/untrusted, so it can
+neither assert authority nor manufacture a false demotion.
 
 The actual enforcement point stays exactly where it already was: a workflow
 only passes `--gate coverage` onward when `check_gate_validation.py --gate`
 exits 0, so a demoted/downgraded gate is already refused blocking authority by
-that existing guard (INV-fh-003). `check_and_transition`'s job is telemetry
-and bookkeeping — making the demotion visible and recording
+that existing guard (INV-fh-003). `check_and_transition`'s job is detection,
+telemetry, and bookkeeping — making the demotion visible and recording
 `previous_authority` — not re-implementing the refusal.
 
 ```bash

--- a/docs/gate-validation.md
+++ b/docs/gate-validation.md
@@ -255,61 +255,67 @@ report `passing == false` in this case; #198 closed the remaining gap — the
 system must not just report `false`, it must actively **track and surface**
 that a gate that WAS blocking no longer is.
 
-`check_gate_validation.py --wire` opts a gate into blocking-authority tracking
-(**only** when its record currently passes — a non-passing `--wire` can never
-reach `blocking`, INV-fh-003) via a persisted `<gate>.authority.json` sidecar
-beside the validation record. Every ordinary check thereafter re-derives the
-authority transition (`compute_transition`/`check_and_transition`, mirroring
-`docs/epics/epic-factory-hardening/models/state-machines.json`'s Gate
-Blocking-Authority Lifecycle):
+**Blocking authority is a journaled fact, not a file.** Whether a gate is
+wired `--gate` is recorded as a `gate-authority` event in the **ratchet hash
+chain** — the same tamper-evident ledger the ratchet already owns — not in a
+loose `<gate>.authority.json` sidecar. A bare mutable file would itself be the
+forgeable trust record this whole protocol exists to eliminate: anyone could
+drop `{"authority": "blocking"}` and manufacture a false demotion. So:
 
-- **Blocking + record goes stale or missing/invalid** → auto-demotes to
-  `demoted` (fail-to-report-only, ADR-fh-04), emits the GENERIC `DEMOTION`
-  event via `factory_log.emit_stale_demotion(gate, reason,
-  previous_authority="blocking")` with `reason` `"stale"` (scanner_version/
-  journal-chain drift, otherwise clean) or `"record_missing"` (missing/
-  schema-invalid/forged/failed) — never `emit_demotion`, which requires a
-  `seed_class` this path never has (nothing escaped in production; the record
-  itself just went bad).
-- **Merely `validated` (not currently wired) + record goes stale or invalid** →
-  downgrades to `report_only` — no demotion event, since nothing was
-  blocking.
-- **Recovery**: re-authoring and re-journaling a `demoted` (or downgraded)
-  record restores `validated` once `passing == true` again — never straight
-  back to `blocking` (the model's `invalid_transitions` explicitly forbid
-  `demoted -> blocking`). A `--wire` on a still-`demoted` gate resolves to
-  `validated` (the re-derivation half); a **second** explicit `--wire` then
-  promotes it to `blocking`.
+- `check_gate_validation.py <gate> --wire` appends a `gate-authority` /
+  `details: "wire"` event (via `ratchet.append_authority_event`) **only** when
+  the record currently passes — a non-passing `--wire` never journals a wire
+  and can never reach `blocking` (INV-fh-003). `--unwire` appends a `details:
+  "unwire"` event.
+- "Is this gate currently blocking?" is read back from those events over the
+  **verified chain prefix** (`ratchet.last_authority_action`): the last
+  `gate-authority` event for the gate is `wire` (not a later `unwire`).
+  Crucially, this read tolerates a *later* chain break — the wire event lives
+  in the still-valid prefix — so "it was blocking" survives exactly the
+  staleness (a broken chain) that must trigger the demotion.
 
-`--wire`/`--unwire` obey the model's legal-vs-invalid transitions strictly, so
-the sidecar can never record blocking authority the record doesn't currently
-earn:
+The **current-blocking verdict** is then simply: the last authority event is
+`wire` **AND** `check()` reports `passing == true` right now.
 
-- A **non-passing `--wire`** never yields or persists `blocking` — it falls
-  through to the natural lifecycle (demoting a stale/missing-while-blocking
-  gate and emitting the DEMOTION, or downgrading otherwise) and reports the
-  refusal.
-- **`--unwire`** is the clean voluntary edge (`blocking -> validated`) ONLY
-  when the record still passes; un-wiring a gate whose record has ALSO gone
-  bad does **not** mask the demotion — it still goes `blocking -> demoted` and
-  emits.
+- **Journaled-wired + record goes stale or missing/invalid** → demoted
+  (fail-to-report-only, ADR-fh-04); emits the GENERIC `DEMOTION` via
+  `factory_log.emit_stale_demotion(gate, reason,
+  previous_authority="blocking")`, `reason` `"stale"` (scanner_version /
+  journal-chain drift, otherwise clean) or `"record_missing"` (missing /
+  schema-invalid / failed) — never `emit_demotion`, which needs a `seed_class`
+  this path never has (nothing escaped; the record itself rotted). Because
+  "was wired" comes from the journal, the demotion fires even when the CURRENT
+  record or chain is the thing that broke — the failure a fail-closed sidecar
+  masked.
+- **Not journaled-wired + record goes stale/invalid** → `report_only` (or
+  `unknown` with no record) — no demotion, nothing was blocking.
+- **`--unwire`** is the clean voluntary edge only when the record still passes
+  (→ `validated`); un-wiring a gate whose record has ALSO gone bad still
+  surfaces + emits the demotion first (read from the pre-unwire journal), so
+  un-wiring can never mask it.
 
-The sidecar is a **corroborated** trust record, not a bare file an attacker
-can drop to forge authority (the exact class of forgeable-trust bug this epic
-exists to prevent). `read_authority` trusts any real authority claim only when
-the sidecar's `gate` field matches, its `ratchet_record_id` is a
-chain-verified `gate-validation` journal entry for the gate, and — when a live
-record exists — that rid matches the record's. A sidecar that fails any check
-(forged `blocking` with no journaled rid, an rid contradicting a re-authored
-record, a tampered/edited file) is treated as `unknown`/untrusted, so it can
-neither assert authority nor manufacture a false demotion.
+Because authority comes ONLY from journaled wire events in the verified chain,
+a hand-written file asserts nothing, and no ad-hoc/plain check, refused
+non-passing `--wire`, or missing-gate op writes any trust-bearing state — only
+operator `--wire`/`--unwire` append journal events.
 
 The actual enforcement point stays exactly where it already was: a workflow
 only passes `--gate coverage` onward when `check_gate_validation.py --gate`
-exits 0, so a demoted/downgraded gate is already refused blocking authority by
-that existing guard (INV-fh-003). `check_and_transition`'s job is detection,
-telemetry, and bookkeeping — making the demotion visible and recording
-`previous_authority` — not re-implementing the refusal.
+exits 0, so a demoted gate is already refused blocking authority by that
+existing guard (INV-fh-003) — the **sole** INV-fh-003 enforcement, independent
+of any authority record. The journaled-authority layer's job is detection,
+telemetry, and surfacing the demotion — not re-implementing the refusal.
+
+**Scope (chief-wiggum#198).** This implements the *detection + emission* of
+stale-while-blocking auto-demotion — IT-fh-06's core assertion. The richer
+persistent lifecycle-management the model also sketches (an explicit `demoted`
+resting state, a two-step `demoted → validated → blocking` recovery handshake)
+is deferred: it needs a writable authority store, and every such store is
+either forgeable (a file) or would force trust-writes on plain report-only
+checks — both rejected in review. Recovery is simply "re-author the record,
+then `--wire` again"; because "was wired" is read from journaled events (not
+by matching the wire event's rid to the record's), a re-derived record with a
+brand-new `ratchet_record_id` recovers cleanly.
 
 ```bash
 python3 "$CW_HOME/scripts/check_gate_validation.py" ratchet \

--- a/docs/quality/validation/ratchet.json
+++ b/docs/quality/validation/ratchet.json
@@ -1,7 +1,7 @@
 {
   "gate": "ratchet",
   "protocol_version": "1",
-  "scanner_version": "fa45c76c322dcfa8d9673e16de5b539ac0994323d83860779727570db0c4e2a4",
+  "scanner_version": "34bc1a05e3b9050313ce62af95e934e6b4cd56bbb5adbd7da40c140ec2646014",
   "telemetry_dependent": false,
   "concurrency_applicable": false,
   "concurrency_note": "ratchet check is a single-pass fold over checked-in test results (the scorecard's pass_set) and epic-doc contract-definition hashes at a fixed scorecard/journal snapshot. There is no concurrent/racing-writer channel in the artifact to evade; the tamper concern (a racing edit of the journal itself) is addressed by the append-only hash chain, not by a concurrency seed (see assumptions).",

--- a/docs/quality/validation/ratchet.json
+++ b/docs/quality/validation/ratchet.json
@@ -1,7 +1,7 @@
 {
   "gate": "ratchet",
   "protocol_version": "1",
-  "scanner_version": "9e484c6656950c4b79b3e19e03243850c21347f3f5b4ffa51ea1b7aa6d0b677a",
+  "scanner_version": "fa45c76c322dcfa8d9673e16de5b539ac0994323d83860779727570db0c4e2a4",
   "telemetry_dependent": false,
   "concurrency_applicable": false,
   "concurrency_note": "ratchet check is a single-pass fold over checked-in test results (the scorecard's pass_set) and epic-doc contract-definition hashes at a fixed scorecard/journal snapshot. There is no concurrent/racing-writer channel in the artifact to evade; the tamper concern (a racing edit of the journal itself) is addressed by the append-only hash chain, not by a concurrency seed (see assumptions).",

--- a/scripts/check_gate_validation.py
+++ b/scripts/check_gate_validation.py
@@ -48,6 +48,23 @@ coverage`` through to ``check_traceability.py`` / ``check_single_writer.py``
 
 Exit codes: 0 = ok (or report-only), 1 = gate violation (missing/failing
 record) under ``--gate``, 2 = usage error.
+
+**Blocking-authority tracking (chief-wiggum#198/IT-fh-06).** A passing record
+answers "may this gate block right now" — it says nothing about whether the
+gate is CURRENTLY wired ``--gate`` in a workflow, so a plain envelope can't
+tell "this just failed its first validation" apart from "this just went stale
+WHILE ALREADY BLOCKING", and only the latter is an auto-demotion. ``--wire``
+records that a gate is now wired ``--gate`` (only when it currently passes);
+``--unwire`` records an intentional un-wiring. Every check (wired or not)
+persists a ``<gate>.authority.json`` sidecar beside the record once the gate
+reaches any real authority state, and on each subsequent run recomputes the
+transition (``check_and_transition``/``compute_transition``): a BLOCKING
+gate's record going stale (scanner_version/journal drift) or missing/invalid
+auto-demotes (fail-to-report-only, ADR-fh-04) and emits the generic
+``factory_log.emit_stale_demotion`` event; the same finding against a gate
+that was only ``validated`` (never wired) merely downgrades to
+``report_only`` — no demotion event, since nothing was blocking. See
+docs/gate-validation.md's "Auto-demotion" section.
 """
 
 from __future__ import annotations
@@ -328,7 +345,230 @@ def check(
     return report
 
 
-def render_text(report: GateValidationReport) -> str:
+# --- Gate Blocking-Authority Lifecycle (docs/epics/epic-factory-hardening/
+# models/state-machines.json, #198/IT-fh-06) ----------------------------------
+#
+# The five REACHABLE resting states of the "Gate Blocking-Authority Lifecycle"
+# machine. "stale" is modeled there too, but it is a TRANSIENT classification a
+# single stateless CLI invocation resolves immediately into its terminal edge
+# (blocking->stale->demoted or validated->stale->report_only collapse into one
+# hop here — see `compute_transition`) — it is never a value persisted to the
+# authority sidecar.
+AUTHORITY_STATES = ("unknown", "report_only", "validated", "blocking", "demoted")
+
+# Provenance-error substrings that mean "this record WOULD pass except it went
+# stale" (G-005/G-006: scanner_version drift or a broken ratchet hash chain) —
+# distinct from a record that is forged/copied/never-journaled/schema-invalid,
+# which is "missing or invalid" (G-012/G-014), never merely "stale".
+_STALE_PROVENANCE_MARKERS = ("scanner_version mismatch", "chain broken")
+
+
+def _authority_path(gate: str, validation_dir: str | Path) -> Path:
+    return Path(validation_dir) / f"{gate}.authority.json"
+
+
+def read_authority(gate: str, validation_dir: str | Path) -> dict:
+    """The persisted blocking-authority state for `gate` — `previous_authority`
+    lives here so a later re-derived/re-journaled record can be told whether it
+    is recovering from a demotion or a mere downgrade. Defaults to 'unknown'
+    (never tracked before) when no sidecar exists or it is unreadable/corrupt —
+    fails closed to the least-privileged state, never invents 'blocking'."""
+    path = _authority_path(gate, validation_dir)
+    if not path.is_file():
+        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+    if data.get("authority") not in AUTHORITY_STATES:
+        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+    return data
+
+
+def _write_authority(gate: str, validation_dir: str | Path, authority: str,
+                     previous_authority: str | None) -> None:
+    path = _authority_path(gate, validation_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"gate": gate, "authority": authority, "previous_authority": previous_authority},
+        indent=2, sort_keys=True,
+    ) + "\n")
+
+
+def failure_kind(report: GateValidationReport) -> str | None:
+    """Classify why a non-passing report failed, for authority-transition
+    purposes. Returns ``None`` when it passes; ``"stale"`` when the record
+    would otherwise pass but its scanner_version drifted or the ratchet hash
+    chain broke (G-005/G-006 — the ONLY thing wrong is provenance staleness);
+    ``"invalid"`` for everything else (no record, schema-invalid, forged/failed
+    trials or clean runs, wrong status, a copied/unjournaled record) — the
+    G-012/G-014 "record_missing_or_invalid" edge.
+    @cw-trace guards INV-fh-003 INV-fh-005"""
+    if report.passing:
+        return None
+    if not report.record_found or report.schema_errors:
+        return "invalid"
+    stale_errs = [e for e in report.provenance_errors
+                  if any(m in e for m in _STALE_PROVENANCE_MARKERS)]
+    other_errs = [e for e in report.provenance_errors if e not in stale_errs]
+    otherwise_clean = (
+        not other_errs
+        and not report.missing_seed_classes
+        and not report.failed_trials
+        and not report.failed_clean_runs
+        and report.status_field == "passed"
+    )
+    if stale_errs and otherwise_clean:
+        return "stale"
+    return "invalid"
+
+
+@dataclass
+class AuthorityTransition:
+    """One hop of the Gate Blocking-Authority Lifecycle, computed for a single
+    `check_gate_validation` run. `demoted=True` is the fail-to-report-only edge
+    (ADR-fh-04): a gate that was BLOCKING lost that authority because its
+    record went stale or missing/invalid — never silently kept blocking, per
+    INV-fh-003. `previous_authority` is set whenever the gate is coming DOWN
+    from a higher-authority state (demoted or downgraded), so a later
+    re-validated record can report what it is being restored from."""
+    gate: str
+    previous_state: str
+    new_state: str
+    event: str
+    demoted: bool = False
+    demotion_reason: str | None = None  # 'stale' | 'record_missing'
+    previous_authority: str | None = None
+    instruction: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "previous_state": self.previous_state,
+            "new_state": self.new_state,
+            "event": self.event,
+            "demoted": self.demoted,
+            "demotion_reason": self.demotion_reason,
+            "previous_authority": self.previous_authority,
+            "instruction": self.instruction,
+        }
+
+
+def _demotion_instruction(gate: str, reason: str) -> str:
+    return (
+        f"DEMOTE {gate} to report-only (drop --gate from its workflow wiring) — "
+        f"its gate-validation record went {reason.replace('_', ' ')} WHILE BLOCKING "
+        "(check_gate_validation --format json reports passing==false; INV-fh-003: "
+        "no blocking without a passing record). File a tracking ticket to re-derive "
+        "and re-journal the record; re-run with --wire to restore blocking once it "
+        "passes again (never demoted -> blocking directly)."
+    )
+
+
+def compute_transition(gate: str, report: GateValidationReport, current: dict) -> AuthorityTransition:
+    """Compute the next blocking-authority state from the CURRENT persisted
+    state + this run's `GateValidationReport` (state-machines.json's Gate
+    Blocking-Authority Lifecycle). This is the auto-demotion path IT-fh-06
+    exercises: a gate found BLOCKING whose record just went stale or
+    missing/invalid is demoted (fail-to-report-only); the same finding against
+    a gate that was only 'validated' (never wired) merely downgrades to
+    'report_only' — no demotion event, nothing was blocking.
+    @cw-trace guards INV-fh-003"""
+    prev = current.get("authority", "unknown")
+    kind = failure_kind(report)
+
+    if kind is None:  # passing == True
+        if prev == "blocking":
+            return AuthorityTransition(gate, prev, "blocking", "steady_state")
+        event = "re_derive_and_rejournal" if prev == "demoted" else "author_record"
+        return AuthorityTransition(gate, prev, "validated", event)
+
+    if prev == "blocking":
+        reason = "stale" if kind == "stale" else "record_missing"
+        event = "auto_demote" if kind == "stale" else "record_missing_or_invalid"
+        return AuthorityTransition(
+            gate, prev, "demoted", event, demoted=True, demotion_reason=reason,
+            previous_authority=prev, instruction=_demotion_instruction(gate, reason),
+        )
+
+    if prev == "demoted":
+        # Already demoted, still not passing — stays put; carry the ORIGINAL
+        # previous_authority forward rather than losing it to this no-op hop.
+        return AuthorityTransition(gate, prev, "demoted", "no_change",
+                                    previous_authority=current.get("previous_authority"))
+
+    if not report.record_found and prev in ("unknown", "report_only"):
+        event = "record_removed" if prev == "report_only" else "no_change"
+        return AuthorityTransition(gate, prev, "unknown", event, previous_authority=prev)
+
+    event = "downgrade_nonblocking_stale" if kind == "stale" else (
+        "run_without_record" if prev == "unknown" else "record_missing_or_invalid")
+    return AuthorityTransition(gate, prev, "report_only", event, previous_authority=prev)
+
+
+def check_and_transition(
+    gate: str,
+    validation_dir: str | Path,
+    schema: dict | None = None,
+    scripts_dir: str | Path | None = None,
+    *,
+    wire: bool = False,
+    unwire: bool = False,
+) -> tuple[GateValidationReport, AuthorityTransition]:
+    """`check()` plus the persisted blocking-authority transition. Detects a
+    record that went stale or missing/invalid WHILE BLOCKING and auto-demotes
+    it to report-only (fail-to-report-only, ADR-fh-04), tracking
+    `previous_authority` so a later re-derived/re-journaled record is restored
+    to 'validated' (never straight back to 'blocking' — that requires an
+    explicit `--wire`, mirroring the model's invalid_transitions:
+    demoted->blocking would skip re-derivation). This is the enforcement
+    surface IT-fh-06 exercises end-to-end. Emits the GENERIC `DEMOTION` event
+    via `factory_log.emit_stale_demotion` — NOT `emit_demotion`, which requires
+    a `seed_class` a staleness/missing-record demotion never has.
+
+    Report-only-safe (docs/gate-rollout.md): checking a gate that has no
+    record at all (or one that never progresses past 'unknown') writes
+    NOTHING — an ad-hoc report-only query (e.g. a gate name that doesn't exist
+    yet) must not leave stray `<gate>.authority.json` state behind in what may
+    be a SHARED validation dir. Once a gate reaches any REAL authority state
+    (validated/blocking/report_only/demoted), or was already being tracked,
+    its sidecar is written/kept current so later staleness is detectable.
+    @cw-trace guards INV-fh-003"""
+    report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir)
+    already_tracked = _authority_path(gate, validation_dir).is_file()
+    current = read_authority(gate, validation_dir)
+    prev_state = current.get("authority", "unknown")
+
+    if wire:
+        if not report.passing:
+            transition = AuthorityTransition(
+                gate, prev_state, prev_state, "wire_rejected",
+                previous_authority=current.get("previous_authority"),
+                instruction=f"cannot wire {gate} --gate: its record does not currently pass "
+                            "(INV-fh-003 — blocking is unreachable without a passing record).",
+            )
+        else:
+            transition = AuthorityTransition(gate, prev_state, "blocking", "wire_gate")
+    elif unwire:
+        new_state = "validated" if report.passing else "report_only"
+        transition = AuthorityTransition(gate, prev_state, new_state, "unwire_gate")
+    else:
+        transition = compute_transition(gate, report, current)
+
+    if transition.new_state != "unknown" or already_tracked:
+        _write_authority(gate, validation_dir, transition.new_state, transition.previous_authority)
+
+    if transition.demoted:
+        try:
+            from factory_log import emit_stale_demotion  # noqa: PLC0415
+            emit_stale_demotion(gate, transition.demotion_reason,
+                                previous_authority=transition.previous_authority)
+        except Exception:
+            pass
+
+    return report, transition
+
+
+def render_text(report: GateValidationReport, transition: AuthorityTransition | None = None) -> str:
     lines = [
         f"# Gate Validation — {report.gate}",
         "",
@@ -353,6 +593,13 @@ def render_text(report: GateValidationReport) -> str:
                    for r in report.failed_clean_runs]
     if report.record_found and not report.schema_errors:
         lines += ["", f"Record status field: {report.status_field}"]
+    if transition is not None:
+        lines += ["", f"Blocking authority: {transition.previous_state} -> {transition.new_state}"
+                       f" ({transition.event})"]
+        if transition.demoted:
+            lines += ["", "## STALE-WHILE-BLOCKING DEMOTION", "", f"- {transition.instruction}"]
+        elif transition.instruction:
+            lines += ["", f"- {transition.instruction}"]
     return "\n".join(lines) + "\n"
 
 
@@ -372,6 +619,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--gate", dest="gate_mode", action="store_true",
                         help="Fail (exit 1) when the named gate lacks a passing validation record")
     parser.add_argument("--format", choices=["text", "json"], default="text")
+    wiring = parser.add_mutually_exclusive_group()
+    wiring.add_argument(
+        "--wire", action="store_true",
+        help="Record that this gate is now wired --gate (blocking) in its workflow — "
+             "only when the record currently passes (INV-fh-003); persists the "
+             "blocking-authority state so a later staleness/regression can be detected "
+             "as an auto-demotion, not just a downgrade.",
+    )
+    wiring.add_argument(
+        "--unwire", action="store_true",
+        help="Record that this gate is no longer wired --gate (an intentional un-wiring, "
+             "not a demotion) — moves the tracked authority to 'validated' if the record "
+             "still passes, else 'report_only'.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -380,12 +641,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: cannot load gate-validation schema: {exc}", file=sys.stderr)
         return 2
 
-    report = check(args.gate, args.validation_dir, schema=schema)
+    report, transition = check_and_transition(
+        args.gate, args.validation_dir, schema=schema, wire=args.wire, unwire=args.unwire,
+    )
 
     if args.format == "json":
-        print(json.dumps(report.to_dict(), indent=2))
+        out = report.to_dict()
+        out["authority"] = transition.to_dict()
+        print(json.dumps(out, indent=2))
     else:
-        print(render_text(report))
+        print(render_text(report, transition))
+
+    if transition.demoted:
+        print(f"check_gate_validation: DEMOTION — {transition.instruction}", file=sys.stderr)
 
     try:  # factory telemetry; no-op unless enabled, never breaks the gate
         from factory_log import emit_gate  # noqa: PLC0415

--- a/scripts/check_gate_validation.py
+++ b/scripts/check_gate_validation.py
@@ -540,10 +540,12 @@ def check_and_transition(
     report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir)
     journal = _journal_path(validation_dir)
     was_wired = ratchet_last_authority_action(journal, gate) == "wire"
+    append_action: str | None = None  # 'wire' | 'unwire', journaled AFTER the emit
+    append_rid: str | None = None
 
     if wire and report.passing:
-        rid = report.record.get("ratchet_record_id") if report.record else None
-        _append_authority(journal, gate, "wire", wired_rid=rid)
+        append_action = "wire"
+        append_rid = report.record.get("ratchet_record_id") if report.record else None
         transition = authority_status(gate, validation_dir, report, was_wired=True)
     elif wire and not report.passing:
         # A non-passing record can NEVER be wired to blocking (INV-fh-003): do
@@ -556,16 +558,20 @@ def check_and_transition(
     elif unwire:
         # The demotion decision is read from the PRE-unwire journal so an unwire
         # can't mask a stale/missing-while-blocking demotion; but a CLEAN unwire
-        # (record still passes) reports the POST-unwire state (validated).
+        # (record still passes) reports the POST-unwire state (validated). The
+        # journal append is deferred to AFTER the demotion emit below so a broken
+        # chain (which refuses the append) can never swallow the demotion.
         if was_wired and not report.passing:
             transition = authority_status(gate, validation_dir, report, was_wired=True)  # demoted
         else:
             transition = authority_status(gate, validation_dir, report, was_wired=False)
             transition.event = "unwire_gate"
-        _append_authority(journal, gate, "unwire")
+        append_action = "unwire"
     else:
         transition = authority_status(gate, validation_dir, report, was_wired=was_wired)
 
+    # Emit the DEMOTION FIRST — it must never be swallowed by a subsequent
+    # journal-append failure (finding 3: chain-broken-while-blocking + --unwire).
     if transition.demoted:
         try:
             from factory_log import emit_stale_demotion  # noqa: PLC0415
@@ -573,6 +579,17 @@ def check_and_transition(
                                 previous_authority=transition.previous_authority)
         except Exception:
             pass
+
+    # THEN attempt the operator-requested journal append. On a broken/garbled
+    # chain the append fails closed; surface a distinct note but never lose the
+    # demotion envelope already computed + emitted above.
+    if append_action is not None:
+        try:
+            _append_authority(journal, gate, append_action, wired_rid=append_rid)
+        except Exception as exc:
+            note = (f"(note: could not journal the {append_action} event — "
+                    f"{type(exc).__name__}: {exc})")
+            transition.instruction = f"{transition.instruction} {note}" if transition.instruction else note
 
     return report, transition
 

--- a/scripts/check_gate_validation.py
+++ b/scripts/check_gate_validation.py
@@ -54,17 +54,27 @@ answers "may this gate block right now" — it says nothing about whether the
 gate is CURRENTLY wired ``--gate`` in a workflow, so a plain envelope can't
 tell "this just failed its first validation" apart from "this just went stale
 WHILE ALREADY BLOCKING", and only the latter is an auto-demotion. ``--wire``
-records that a gate is now wired ``--gate`` (only when it currently passes);
-``--unwire`` records an intentional un-wiring. Every check (wired or not)
-persists a ``<gate>.authority.json`` sidecar beside the record once the gate
-reaches any real authority state, and on each subsequent run recomputes the
-transition (``check_and_transition``/``compute_transition``): a BLOCKING
-gate's record going stale (scanner_version/journal drift) or missing/invalid
-auto-demotes (fail-to-report-only, ADR-fh-04) and emits the generic
-``factory_log.emit_stale_demotion`` event; the same finding against a gate
-that was only ``validated`` (never wired) merely downgrades to
-``report_only`` — no demotion event, since nothing was blocking. See
-docs/gate-validation.md's "Auto-demotion" section.
+opts a gate into blocking-authority tracking (only when its record currently
+passes — a non-passing ``--wire`` can never reach 'blocking', INV-fh-003);
+``--unwire`` records an intentional un-wiring. A gate under management carries
+a ``<gate>.authority.json`` sidecar beside its record; each subsequent run
+recomputes the transition (``check_and_transition``/``compute_transition``): a
+BLOCKING gate's record going stale (scanner_version/journal drift) or
+missing/invalid auto-demotes (fail-to-report-only, ADR-fh-04) and emits the
+generic ``factory_log.emit_stale_demotion`` event; the same finding against a
+gate that was only ``validated`` merely downgrades to ``report_only`` — no
+demotion, nothing was blocking.
+
+The sidecar is a **corroborated** trust record, never a bare file: any real
+authority claim it makes is trusted only when its ``gate`` field matches, its
+``ratchet_record_id`` is a chain-verified ``gate-validation`` journal entry
+for the gate, and (when a live record exists) that rid matches the record's —
+so a hand-forged ``authority: blocking`` cannot manufacture a false demotion
+(``read_authority``). And it is written ONLY under deliberate management (a
+passing ``--wire``) or continued tracking, never for the 'unknown' state — an
+ad-hoc/plain check or an op on a missing/misspelled gate leaves NOTHING behind
+in what may be a SHARED validation dir. See docs/gate-validation.md's
+"Auto-demotion" section.
 """
 
 from __future__ import annotations
@@ -367,30 +377,92 @@ def _authority_path(gate: str, validation_dir: str | Path) -> Path:
     return Path(validation_dir) / f"{gate}.authority.json"
 
 
-def read_authority(gate: str, validation_dir: str | Path) -> dict:
-    """The persisted blocking-authority state for `gate` — `previous_authority`
-    lives here so a later re-derived/re-journaled record can be told whether it
-    is recovering from a demotion or a mere downgrade. Defaults to 'unknown'
-    (never tracked before) when no sidecar exists or it is unreadable/corrupt —
-    fails closed to the least-privileged state, never invents 'blocking'."""
+def _journal_entries(validation_dir: str | Path) -> list[dict] | None:
+    """The ratchet journal entries beside the validation dir, or None when
+    absent/unreadable. Same journal `check()` corroborates records against."""
+    journal = Path(validation_dir).resolve().parent / JOURNAL_NAME
+    if not journal.is_file():
+        return None
+    try:
+        return [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        return None
+
+
+def _rid_journaled_for_gate(rid: str, gate: str, validation_dir: str | Path) -> bool:
+    """True iff `rid` is a chain-verified ``gate-validation`` journal entry
+    whose ``ref`` names `gate`. The hash chain is the tamper-evidence
+    (docs/ratchet.md); a broken chain fails closed. This is the anchor that
+    stops a hand-forged ``<gate>.authority.json`` from asserting a
+    blocking/validated authority no genuine validation ever earned."""
+    entries = _journal_entries(validation_dir)
+    if not entries:
+        return False
+    prev = "genesis"
+    for entry in entries:
+        body = {k: v for k, v in entry.items() if k != "record_hash"}
+        if entry.get("record_hash") != stable_hash(prev, json.dumps(body, sort_keys=True)):
+            return False  # chain broken -> fail closed
+        prev = entry["record_hash"]
+    match = next((e for e in entries if e.get("record_id") == rid), None)
+    return bool(match and match.get("event") == "gate-validation" and match.get("ref") == gate)
+
+
+def read_authority(gate: str, validation_dir: str | Path, record: dict | None = None) -> dict:
+    """The persisted blocking-authority state for `gate`, **corroborated**
+    before it is trusted. `previous_authority` lets a later re-derived record
+    be told whether it is recovering from a demotion or a mere downgrade.
+
+    The sidecar is an ordinary mutable file in a shared dir, so it must never
+    be able to assert a lifecycle fact the real record/journal contradicts (a
+    forged ``authority: blocking`` would otherwise trigger a false demotion;
+    the whole epic exists to stop exactly this class of forgeable trust
+    record). Any REAL authority claim (report_only/validated/blocking/demoted)
+    is trusted only when ALL hold, else it is treated as 'unknown'/untrusted:
+      - the sidecar's ``gate`` field names this gate;
+      - it carries a ``ratchet_record_id`` that is a chain-verified
+        ``gate-validation`` journal entry for this gate
+        (``_rid_journaled_for_gate``) — the tamper-evident anchor;
+      - if a live validation record exists, its ``ratchet_record_id`` matches
+        the sidecar's (a sidecar out of sync with a re-authored record is not
+        authoritative).
+    Fails closed to 'unknown' when the sidecar is absent, unreadable, has a
+    non-enum authority, or fails any corroboration check — never invents
+    'blocking'."""
+    default = {"gate": gate, "authority": "unknown", "previous_authority": None,
+               "ratchet_record_id": None}
     path = _authority_path(gate, validation_dir)
     if not path.is_file():
-        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+        return default
     try:
         data = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
-        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+        return default
     if data.get("authority") not in AUTHORITY_STATES:
-        return {"gate": gate, "authority": "unknown", "previous_authority": None}
+        return default
+    if data.get("authority") == "unknown":
+        return data  # 'unknown' asserts no authority — nothing to corroborate
+    # A real authority claim must be corroborated against the record + journal.
+    if data.get("gate") != gate:
+        return default
+    rid = data.get("ratchet_record_id")
+    if not (isinstance(rid, str) and RID_RE.fullmatch(rid.strip())):
+        return default
+    rid = rid.strip()
+    if record is not None and record.get("ratchet_record_id") not in (None, rid):
+        return default  # sidecar contradicts the live record's provenance
+    if not _rid_journaled_for_gate(rid, gate, validation_dir):
+        return default  # no tamper-evident anchor — untrusted, fail closed
     return data
 
 
 def _write_authority(gate: str, validation_dir: str | Path, authority: str,
-                     previous_authority: str | None) -> None:
+                     previous_authority: str | None, ratchet_record_id: str | None) -> None:
     path = _authority_path(gate, validation_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(
-        {"gate": gate, "authority": authority, "previous_authority": previous_authority},
+        {"gate": gate, "authority": authority, "previous_authority": previous_authority,
+         "ratchet_record_id": ratchet_record_id},
         indent=2, sort_keys=True,
     ) + "\n")
 
@@ -514,48 +586,84 @@ def check_and_transition(
     wire: bool = False,
     unwire: bool = False,
 ) -> tuple[GateValidationReport, AuthorityTransition]:
-    """`check()` plus the persisted blocking-authority transition. Detects a
-    record that went stale or missing/invalid WHILE BLOCKING and auto-demotes
-    it to report-only (fail-to-report-only, ADR-fh-04), tracking
-    `previous_authority` so a later re-derived/re-journaled record is restored
-    to 'validated' (never straight back to 'blocking' — that requires an
-    explicit `--wire`, mirroring the model's invalid_transitions:
-    demoted->blocking would skip re-derivation). This is the enforcement
-    surface IT-fh-06 exercises end-to-end. Emits the GENERIC `DEMOTION` event
-    via `factory_log.emit_stale_demotion` — NOT `emit_demotion`, which requires
-    a `seed_class` a staleness/missing-record demotion never has.
+    """`check()` plus the persisted, corroborated blocking-authority
+    transition. Detects a record that went stale or missing/invalid WHILE
+    BLOCKING and auto-demotes it to report-only (fail-to-report-only,
+    ADR-fh-04), tracking `previous_authority` so a later re-derived/re-journaled
+    record is restored to 'validated' (never straight back to 'blocking').
+    Emits the GENERIC `DEMOTION` event via `factory_log.emit_stale_demotion`
+    — NOT `emit_demotion`, which requires a `seed_class` a staleness/
+    missing-record demotion never has.
 
-    Report-only-safe (docs/gate-rollout.md): checking a gate that has no
-    record at all (or one that never progresses past 'unknown') writes
-    NOTHING — an ad-hoc report-only query (e.g. a gate name that doesn't exist
-    yet) must not leave stray `<gate>.authority.json` state behind in what may
-    be a SHARED validation dir. Once a gate reaches any REAL authority state
-    (validated/blocking/report_only/demoted), or was already being tracked,
-    its sidecar is written/kept current so later staleness is detectable.
+    Wiring legality (INV-fh-003 / the model's legal + invalid transitions):
+      - ``--wire`` reaches 'blocking' ONLY when the record currently passes
+        AND the gate is not coming from 'demoted'. A non-passing ``--wire``
+        NEVER yields/persists 'blocking' — it falls through to the natural
+        lifecycle (demoting a stale/missing-while-blocking gate, emitting the
+        DEMOTION; downgrading otherwise) and reports the refusal.
+      - ``--wire`` from 'demoted' on a re-authored passing record resolves to
+        'validated' (re_derive_and_rejournal), never straight to 'blocking'
+        (the model forbids demoted->blocking) — a second explicit ``--wire``
+        then promotes it.
+      - ``--unwire`` is the clean voluntary edge ONLY when the record still
+        passes (blocking->validated). Un-wiring a gate whose record has ALSO
+        gone bad must NOT mask the demotion — it falls through to the
+        lifecycle so blocking->demoted still fires and emits.
+
+    Report-only-safe (docs/gate-rollout.md): the `<gate>.authority.json`
+    sidecar is written ONLY when a gate is deliberately put under
+    blocking-authority management (a passing ``--wire``) or is already tracked
+    — and never for the 'unknown' state. An ad-hoc/plain check, a ``--wire``
+    refused for a non-passing untracked gate, or any op on a
+    missing/misspelled gate leaves NOTHING behind in what may be a SHARED
+    validation dir.
     @cw-trace guards INV-fh-003"""
     report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir)
     already_tracked = _authority_path(gate, validation_dir).is_file()
-    current = read_authority(gate, validation_dir)
+    current = read_authority(gate, validation_dir, record=report.record)
     prev_state = current.get("authority", "unknown")
 
-    if wire:
-        if not report.passing:
-            transition = AuthorityTransition(
-                gate, prev_state, prev_state, "wire_rejected",
-                previous_authority=current.get("previous_authority"),
-                instruction=f"cannot wire {gate} --gate: its record does not currently pass "
-                            "(INV-fh-003 — blocking is unreachable without a passing record).",
-            )
-        else:
-            transition = AuthorityTransition(gate, prev_state, "blocking", "wire_gate")
-    elif unwire:
-        new_state = "validated" if report.passing else "report_only"
-        transition = AuthorityTransition(gate, prev_state, new_state, "unwire_gate")
+    if wire and report.passing and prev_state == "demoted":
+        # invalid_transition demoted->blocking: recovery is two-step. This
+        # first --wire only re-derives to 'validated'; a second promotes.
+        transition = AuthorityTransition(
+            gate, prev_state, "validated", "re_derive_and_rejournal",
+            instruction=(f"{gate}'s record was re-derived and now passes — authority restored to "
+                         "'validated', NOT blocking. Re-run with --wire to promote it back to "
+                         "blocking; a demoted gate is never wired straight to blocking "
+                         "(re-derivation first, per the model's invalid_transitions)."))
+    elif wire and report.passing:
+        transition = AuthorityTransition(gate, prev_state, "blocking", "wire_gate")
+    elif wire and not report.passing:
+        # A non-passing record can NEVER be wired to blocking (INV-fh-003).
+        transition = compute_transition(gate, report, current)
+        refusal = (f"--wire refused: {gate}'s record does not currently pass "
+                   "(INV-fh-003 — blocking is unreachable without a passing record).")
+        transition.instruction = f"{transition.instruction} {refusal}" if transition.instruction else refusal
+    elif unwire and report.passing:
+        # Clean voluntary un-wiring: record still passes -> validated (eligible
+        # to be re-wired), never a demotion.
+        transition = AuthorityTransition(gate, prev_state, "validated", "unwire_gate")
+    elif unwire and not report.passing:
+        # Do not let un-wiring mask a stale/missing-while-blocking demotion.
+        transition = compute_transition(gate, report, current)
     else:
         transition = compute_transition(gate, report, current)
 
-    if transition.new_state != "unknown" or already_tracked:
-        _write_authority(gate, validation_dir, transition.new_state, transition.previous_authority)
+    # The rid that anchors the sidecar's corroboration: the live record's when
+    # present (passing/stale), else the last-known one carried in the trusted
+    # current sidecar (e.g. a record-missing demotion where the record is gone).
+    rid_for_sidecar = current.get("ratchet_record_id")
+    if report.record and isinstance(report.record.get("ratchet_record_id"), str):
+        rid_for_sidecar = report.record["ratchet_record_id"]
+
+    # Persist only under deliberate management (passing --wire) or continued
+    # tracking; never persist 'unknown' (that is the no-authority default and
+    # would only pollute a shared dir).
+    should_write = transition.new_state != "unknown" and (already_tracked or (wire and report.passing))
+    if should_write:
+        _write_authority(gate, validation_dir, transition.new_state,
+                         transition.previous_authority, rid_for_sidecar)
 
     if transition.demoted:
         try:

--- a/scripts/check_gate_validation.py
+++ b/scripts/check_gate_validation.py
@@ -52,29 +52,36 @@ record) under ``--gate``, 2 = usage error.
 **Blocking-authority tracking (chief-wiggum#198/IT-fh-06).** A passing record
 answers "may this gate block right now" — it says nothing about whether the
 gate is CURRENTLY wired ``--gate`` in a workflow, so a plain envelope can't
-tell "this just failed its first validation" apart from "this just went stale
-WHILE ALREADY BLOCKING", and only the latter is an auto-demotion. ``--wire``
-opts a gate into blocking-authority tracking (only when its record currently
-passes — a non-passing ``--wire`` can never reach 'blocking', INV-fh-003);
-``--unwire`` records an intentional un-wiring. A gate under management carries
-a ``<gate>.authority.json`` sidecar beside its record; each subsequent run
-recomputes the transition (``check_and_transition``/``compute_transition``): a
-BLOCKING gate's record going stale (scanner_version/journal drift) or
-missing/invalid auto-demotes (fail-to-report-only, ADR-fh-04) and emits the
-generic ``factory_log.emit_stale_demotion`` event; the same finding against a
-gate that was only ``validated`` merely downgrades to ``report_only`` — no
-demotion, nothing was blocking.
+tell "this just failed its first validation" apart from "this went stale WHILE
+ALREADY BLOCKING", and only the latter is an auto-demotion. That "was it
+wired" fact is JOURNALED, never kept in a loose file: ``--wire``/``--unwire``
+append a ``gate-authority`` event to the ratchet hash chain
+(``ratchet.append_authority_event``), and "is this gate blocking?" is read
+back from those events (``ratchet.last_authority_action``) over the verified
+chain prefix — tamper-evident, not hand-writable. A bare
+``<gate>.authority.json`` sidecar would itself be the forgeable trust record
+this epic exists to eliminate (a hand-written ``{"authority": "blocking"}``
+could manufacture a false demotion), so there is none.
 
-The sidecar is a **corroborated** trust record, never a bare file: any real
-authority claim it makes is trusted only when its ``gate`` field matches, its
-``ratchet_record_id`` is a chain-verified ``gate-validation`` journal entry
-for the gate, and (when a live record exists) that rid matches the record's —
-so a hand-forged ``authority: blocking`` cannot manufacture a false demotion
-(``read_authority``). And it is written ONLY under deliberate management (a
-passing ``--wire``) or continued tracking, never for the 'unknown' state — an
-ad-hoc/plain check or an op on a missing/misspelled gate leaves NOTHING behind
-in what may be a SHARED validation dir. See docs/gate-validation.md's
-"Auto-demotion" section.
+The current-blocking verdict is: the last authority event is ``wire`` AND
+``check()`` reports ``passing == true`` now. A gate journaled-``wire`` whose
+record is NOT currently passing (stale scanner_version, broken journal chain,
+missing/schema-invalid record) is demoted (fail-to-report-only, ADR-fh-04) and
+emits the generic ``factory_log.emit_stale_demotion`` — reading "was blocking"
+from journaled events means the demotion still fires even when the CURRENT
+record/chain is the thing that broke (the case a fail-closed sidecar masked).
+``--wire`` journals a wire ONLY when the record passes (a non-passing ``--wire``
+never reaches ``blocking``); a non-passing check writes no trust state at all;
+only operator ``--wire``/``--unwire`` append journal events.
+
+Scope: this implements the DETECTION + EMISSION of stale-while-blocking
+auto-demotion (IT-fh-06's core assertion). The persistent lifecycle-management
+the model also sketches (an explicit ``demoted`` resting state, a two-step
+demoted→validated→blocking recovery handshake) is deferred — it needs a
+writable authority store, and every such store is either forgeable or would
+force trust-writes on plain checks. Recovery is simply "re-author the record,
+then ``--wire`` again". The ``--gate`` exit-1 guard (``report.passing``)
+remains the SOLE INV-fh-003 enforcement. See docs/gate-validation.md.
 """
 
 from __future__ import annotations
@@ -98,6 +105,12 @@ from chief_wiggum.hashing import stable_hash  # noqa: E402
 # redefined, so the two can never silently diverge again.
 # @cw-trace guards INV-fh-004
 from factory_log import DEFAULT_VALIDATION_DIR  # noqa: E402
+
+# Blocking authority (wire/unwire) is journaled in the ratchet chain, not a
+# forgeable sidecar (chief-wiggum#198). The journal's format/chain is owned by
+# ratchet.py; these are its path-based read/append primitives.
+from ratchet import append_authority_event as _append_authority  # noqa: E402
+from ratchet import last_authority_action as ratchet_last_authority_action  # noqa: E402
 
 DEFAULT_SCHEMA = Path(__file__).resolve().parents[1] / "templates" / "gate-validation-record-schema.json"
 JOURNAL_NAME = "ratchet-journal.jsonl"
@@ -358,113 +371,34 @@ def check(
 # --- Gate Blocking-Authority Lifecycle (docs/epics/epic-factory-hardening/
 # models/state-machines.json, #198/IT-fh-06) ----------------------------------
 #
-# The five REACHABLE resting states of the "Gate Blocking-Authority Lifecycle"
-# machine. "stale" is modeled there too, but it is a TRANSIENT classification a
-# single stateless CLI invocation resolves immediately into its terminal edge
-# (blocking->stale->demoted or validated->stale->report_only collapse into one
-# hop here — see `compute_transition`) — it is never a value persisted to the
-# authority sidecar.
-AUTHORITY_STATES = ("unknown", "report_only", "validated", "blocking", "demoted")
+# Blocking authority is NOT tracked in a loose <gate>.authority.json sidecar —
+# a bare mutable file is itself a forgeable trust record, the exact class this
+# epic exists to eliminate (a hand-written {"authority": "blocking"} could
+# manufacture a false demotion). Instead, whether a gate is wired --gate is a
+# JOURNALED, hash-chained fact: `--wire`/`--unwire` append a `gate-authority`
+# event to the ratchet journal (ratchet.append_authority_event), and "is this
+# gate currently blocking?" is read back from those events
+# (ratchet.last_authority_action) via the verified chain prefix — tamper-evident,
+# not hand-writable. The current-blocking verdict is then simply: the last
+# authority event is `wire` AND check() reports passing==true right now.
+#
+# Scope (chief-wiggum#198): this PR implements the DETECTION + EMISSION half of
+# the lifecycle — a gate with a journaled `wire` whose record is NOT currently
+# passing is demoted (fail-to-report-only) and emits the generic DEMOTION. The
+# richer persistent lifecycle-management the model also sketches (an explicit
+# `demoted` resting state, the two-step demoted->validated->blocking recovery
+# handshake) is deliberately deferred: it cannot be realized without a writable
+# authority store, and every such store is either forgeable (a file) or would
+# require writing trust state on plain report-only checks — both rejected in
+# review. Recovery here is simply "re-author the record, then --wire again"; the
+# --gate exit-1 guard (report.passing) remains the SOLE INV-fh-003 enforcement,
+# independent of any authority record. See docs/gate-validation.md.
 
 # Provenance-error substrings that mean "this record WOULD pass except it went
 # stale" (G-005/G-006: scanner_version drift or a broken ratchet hash chain) —
 # distinct from a record that is forged/copied/never-journaled/schema-invalid,
 # which is "missing or invalid" (G-012/G-014), never merely "stale".
 _STALE_PROVENANCE_MARKERS = ("scanner_version mismatch", "chain broken")
-
-
-def _authority_path(gate: str, validation_dir: str | Path) -> Path:
-    return Path(validation_dir) / f"{gate}.authority.json"
-
-
-def _journal_entries(validation_dir: str | Path) -> list[dict] | None:
-    """The ratchet journal entries beside the validation dir, or None when
-    absent/unreadable. Same journal `check()` corroborates records against."""
-    journal = Path(validation_dir).resolve().parent / JOURNAL_NAME
-    if not journal.is_file():
-        return None
-    try:
-        return [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
-    except json.JSONDecodeError:
-        return None
-
-
-def _rid_journaled_for_gate(rid: str, gate: str, validation_dir: str | Path) -> bool:
-    """True iff `rid` is a chain-verified ``gate-validation`` journal entry
-    whose ``ref`` names `gate`. The hash chain is the tamper-evidence
-    (docs/ratchet.md); a broken chain fails closed. This is the anchor that
-    stops a hand-forged ``<gate>.authority.json`` from asserting a
-    blocking/validated authority no genuine validation ever earned."""
-    entries = _journal_entries(validation_dir)
-    if not entries:
-        return False
-    prev = "genesis"
-    for entry in entries:
-        body = {k: v for k, v in entry.items() if k != "record_hash"}
-        if entry.get("record_hash") != stable_hash(prev, json.dumps(body, sort_keys=True)):
-            return False  # chain broken -> fail closed
-        prev = entry["record_hash"]
-    match = next((e for e in entries if e.get("record_id") == rid), None)
-    return bool(match and match.get("event") == "gate-validation" and match.get("ref") == gate)
-
-
-def read_authority(gate: str, validation_dir: str | Path, record: dict | None = None) -> dict:
-    """The persisted blocking-authority state for `gate`, **corroborated**
-    before it is trusted. `previous_authority` lets a later re-derived record
-    be told whether it is recovering from a demotion or a mere downgrade.
-
-    The sidecar is an ordinary mutable file in a shared dir, so it must never
-    be able to assert a lifecycle fact the real record/journal contradicts (a
-    forged ``authority: blocking`` would otherwise trigger a false demotion;
-    the whole epic exists to stop exactly this class of forgeable trust
-    record). Any REAL authority claim (report_only/validated/blocking/demoted)
-    is trusted only when ALL hold, else it is treated as 'unknown'/untrusted:
-      - the sidecar's ``gate`` field names this gate;
-      - it carries a ``ratchet_record_id`` that is a chain-verified
-        ``gate-validation`` journal entry for this gate
-        (``_rid_journaled_for_gate``) — the tamper-evident anchor;
-      - if a live validation record exists, its ``ratchet_record_id`` matches
-        the sidecar's (a sidecar out of sync with a re-authored record is not
-        authoritative).
-    Fails closed to 'unknown' when the sidecar is absent, unreadable, has a
-    non-enum authority, or fails any corroboration check — never invents
-    'blocking'."""
-    default = {"gate": gate, "authority": "unknown", "previous_authority": None,
-               "ratchet_record_id": None}
-    path = _authority_path(gate, validation_dir)
-    if not path.is_file():
-        return default
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return default
-    if data.get("authority") not in AUTHORITY_STATES:
-        return default
-    if data.get("authority") == "unknown":
-        return data  # 'unknown' asserts no authority — nothing to corroborate
-    # A real authority claim must be corroborated against the record + journal.
-    if data.get("gate") != gate:
-        return default
-    rid = data.get("ratchet_record_id")
-    if not (isinstance(rid, str) and RID_RE.fullmatch(rid.strip())):
-        return default
-    rid = rid.strip()
-    if record is not None and record.get("ratchet_record_id") not in (None, rid):
-        return default  # sidecar contradicts the live record's provenance
-    if not _rid_journaled_for_gate(rid, gate, validation_dir):
-        return default  # no tamper-evident anchor — untrusted, fail closed
-    return data
-
-
-def _write_authority(gate: str, validation_dir: str | Path, authority: str,
-                     previous_authority: str | None, ratchet_record_id: str | None) -> None:
-    path = _authority_path(gate, validation_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(
-        {"gate": gate, "authority": authority, "previous_authority": previous_authority,
-         "ratchet_record_id": ratchet_record_id},
-        indent=2, sort_keys=True,
-    ) + "\n")
 
 
 def failure_kind(report: GateValidationReport) -> str | None:
@@ -536,45 +470,42 @@ def _demotion_instruction(gate: str, reason: str) -> str:
     )
 
 
-def compute_transition(gate: str, report: GateValidationReport, current: dict) -> AuthorityTransition:
-    """Compute the next blocking-authority state from the CURRENT persisted
-    state + this run's `GateValidationReport` (state-machines.json's Gate
-    Blocking-Authority Lifecycle). This is the auto-demotion path IT-fh-06
-    exercises: a gate found BLOCKING whose record just went stale or
-    missing/invalid is demoted (fail-to-report-only); the same finding against
-    a gate that was only 'validated' (never wired) merely downgrades to
-    'report_only' — no demotion event, nothing was blocking.
+def authority_status(gate: str, validation_dir: str | Path,
+                     report: GateValidationReport, *, was_wired: bool | None = None) -> AuthorityTransition:
+    """Derive the gate's blocking-authority status for THIS run from the
+    journaled wire/unwire fact + the current validation verdict — never from a
+    persisted sidecar. `was_wired` (the last gate-authority event is `wire`) is
+    read from the tamper-evident journal by the caller; passed in so this stays
+    a pure function.
+
+    - wired + passing  -> `blocking`  (authority live)
+    - wired + NOT passing -> `demoted` (fail-to-report-only, ADR-fh-04): the
+      record went stale/missing/invalid WHILE blocking; emits the generic
+      DEMOTION. Reads the "was blocking" fact from journaled events, so it
+      still fires when the CURRENT record is stale or the chain broke — the
+      case the sidecar design masked.
+    - not wired + passing -> `validated` (eligible to be wired)
+    - not wired + NOT passing -> `report_only` (record present) / `unknown` (no record)
     @cw-trace guards INV-fh-003"""
-    prev = current.get("authority", "unknown")
-    kind = failure_kind(report)
-
-    if kind is None:  # passing == True
-        if prev == "blocking":
-            return AuthorityTransition(gate, prev, "blocking", "steady_state")
-        event = "re_derive_and_rejournal" if prev == "demoted" else "author_record"
-        return AuthorityTransition(gate, prev, "validated", event)
-
-    if prev == "blocking":
+    prev = "blocking" if was_wired else "unwired"
+    if report.passing:
+        state = "blocking" if was_wired else "validated"
+        return AuthorityTransition(gate, prev, state, "wire_gate" if was_wired else "author_record")
+    if was_wired:
+        kind = failure_kind(report)
         reason = "stale" if kind == "stale" else "record_missing"
         event = "auto_demote" if kind == "stale" else "record_missing_or_invalid"
         return AuthorityTransition(
             gate, prev, "demoted", event, demoted=True, demotion_reason=reason,
-            previous_authority=prev, instruction=_demotion_instruction(gate, reason),
+            previous_authority="blocking", instruction=_demotion_instruction(gate, reason),
         )
+    state = "report_only" if report.record_found else "unknown"
+    event = "record_missing_or_invalid" if report.record_found else "no_record"
+    return AuthorityTransition(gate, prev, state, event)
 
-    if prev == "demoted":
-        # Already demoted, still not passing — stays put; carry the ORIGINAL
-        # previous_authority forward rather than losing it to this no-op hop.
-        return AuthorityTransition(gate, prev, "demoted", "no_change",
-                                    previous_authority=current.get("previous_authority"))
 
-    if not report.record_found and prev in ("unknown", "report_only"):
-        event = "record_removed" if prev == "report_only" else "no_change"
-        return AuthorityTransition(gate, prev, "unknown", event, previous_authority=prev)
-
-    event = "downgrade_nonblocking_stale" if kind == "stale" else (
-        "run_without_record" if prev == "unknown" else "record_missing_or_invalid")
-    return AuthorityTransition(gate, prev, "report_only", event, previous_authority=prev)
+def _journal_path(validation_dir: str | Path) -> Path:
+    return Path(validation_dir).resolve().parent / JOURNAL_NAME
 
 
 def check_and_transition(
@@ -586,84 +517,54 @@ def check_and_transition(
     wire: bool = False,
     unwire: bool = False,
 ) -> tuple[GateValidationReport, AuthorityTransition]:
-    """`check()` plus the persisted, corroborated blocking-authority
-    transition. Detects a record that went stale or missing/invalid WHILE
-    BLOCKING and auto-demotes it to report-only (fail-to-report-only,
-    ADR-fh-04), tracking `previous_authority` so a later re-derived/re-journaled
-    record is restored to 'validated' (never straight back to 'blocking').
-    Emits the GENERIC `DEMOTION` event via `factory_log.emit_stale_demotion`
-    — NOT `emit_demotion`, which requires a `seed_class` a staleness/
-    missing-record demotion never has.
+    """`check()` plus the journal-anchored blocking-authority verdict. Detects a
+    record that went stale or missing/invalid WHILE the gate is journaled-wired
+    and auto-demotes it (fail-to-report-only), emitting the GENERIC `DEMOTION`
+    event via `factory_log.emit_stale_demotion` — NOT `emit_demotion`, which
+    requires a `seed_class` a staleness/missing-record demotion never has.
 
-    Wiring legality (INV-fh-003 / the model's legal + invalid transitions):
-      - ``--wire`` reaches 'blocking' ONLY when the record currently passes
-        AND the gate is not coming from 'demoted'. A non-passing ``--wire``
-        NEVER yields/persists 'blocking' — it falls through to the natural
-        lifecycle (demoting a stale/missing-while-blocking gate, emitting the
-        DEMOTION; downgrading otherwise) and reports the refusal.
-      - ``--wire`` from 'demoted' on a re-authored passing record resolves to
-        'validated' (re_derive_and_rejournal), never straight to 'blocking'
-        (the model forbids demoted->blocking) — a second explicit ``--wire``
-        then promotes it.
-      - ``--unwire`` is the clean voluntary edge ONLY when the record still
-        passes (blocking->validated). Un-wiring a gate whose record has ALSO
-        gone bad must NOT mask the demotion — it falls through to the
-        lifecycle so blocking->demoted still fires and emits.
+    Wiring legality (INV-fh-003):
+      - ``--wire`` journals a ``wire`` gate-authority event ONLY when the record
+        currently passes. A non-passing ``--wire`` never journals a wire and
+        never yields ``blocking`` — if the gate was already wired it surfaces
+        the demotion, else it reports the refusal.
+      - ``--unwire`` journals an ``unwire`` event (clean voluntary un-wiring),
+        but a non-passing record that was wired still surfaces + emits the
+        demotion first — un-wiring never masks it.
 
-    Report-only-safe (docs/gate-rollout.md): the `<gate>.authority.json`
-    sidecar is written ONLY when a gate is deliberately put under
-    blocking-authority management (a passing ``--wire``) or is already tracked
-    — and never for the 'unknown' state. An ad-hoc/plain check, a ``--wire``
-    refused for a non-passing untracked gate, or any op on a
-    missing/misspelled gate leaves NOTHING behind in what may be a SHARED
-    validation dir.
+    No trust-bearing state is written on a plain (non-wiring) check, on a
+    refused non-passing ``--wire``, or on any op against a missing gate — only
+    the operator-initiated ``--wire``/``--unwire`` append journal events. The
+    ``--gate`` exit-1 guard stays the sole INV-fh-003 enforcement.
     @cw-trace guards INV-fh-003"""
     report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir)
-    already_tracked = _authority_path(gate, validation_dir).is_file()
-    current = read_authority(gate, validation_dir, record=report.record)
-    prev_state = current.get("authority", "unknown")
+    journal = _journal_path(validation_dir)
+    was_wired = ratchet_last_authority_action(journal, gate) == "wire"
 
-    if wire and report.passing and prev_state == "demoted":
-        # invalid_transition demoted->blocking: recovery is two-step. This
-        # first --wire only re-derives to 'validated'; a second promotes.
-        transition = AuthorityTransition(
-            gate, prev_state, "validated", "re_derive_and_rejournal",
-            instruction=(f"{gate}'s record was re-derived and now passes — authority restored to "
-                         "'validated', NOT blocking. Re-run with --wire to promote it back to "
-                         "blocking; a demoted gate is never wired straight to blocking "
-                         "(re-derivation first, per the model's invalid_transitions)."))
-    elif wire and report.passing:
-        transition = AuthorityTransition(gate, prev_state, "blocking", "wire_gate")
+    if wire and report.passing:
+        rid = report.record.get("ratchet_record_id") if report.record else None
+        _append_authority(journal, gate, "wire", wired_rid=rid)
+        transition = authority_status(gate, validation_dir, report, was_wired=True)
     elif wire and not report.passing:
-        # A non-passing record can NEVER be wired to blocking (INV-fh-003).
-        transition = compute_transition(gate, report, current)
+        # A non-passing record can NEVER be wired to blocking (INV-fh-003): do
+        # not journal a wire. If it was already wired this is a demotion;
+        # otherwise a plain refusal.
+        transition = authority_status(gate, validation_dir, report, was_wired=was_wired)
         refusal = (f"--wire refused: {gate}'s record does not currently pass "
                    "(INV-fh-003 — blocking is unreachable without a passing record).")
         transition.instruction = f"{transition.instruction} {refusal}" if transition.instruction else refusal
-    elif unwire and report.passing:
-        # Clean voluntary un-wiring: record still passes -> validated (eligible
-        # to be re-wired), never a demotion.
-        transition = AuthorityTransition(gate, prev_state, "validated", "unwire_gate")
-    elif unwire and not report.passing:
-        # Do not let un-wiring mask a stale/missing-while-blocking demotion.
-        transition = compute_transition(gate, report, current)
+    elif unwire:
+        # The demotion decision is read from the PRE-unwire journal so an unwire
+        # can't mask a stale/missing-while-blocking demotion; but a CLEAN unwire
+        # (record still passes) reports the POST-unwire state (validated).
+        if was_wired and not report.passing:
+            transition = authority_status(gate, validation_dir, report, was_wired=True)  # demoted
+        else:
+            transition = authority_status(gate, validation_dir, report, was_wired=False)
+            transition.event = "unwire_gate"
+        _append_authority(journal, gate, "unwire")
     else:
-        transition = compute_transition(gate, report, current)
-
-    # The rid that anchors the sidecar's corroboration: the live record's when
-    # present (passing/stale), else the last-known one carried in the trusted
-    # current sidecar (e.g. a record-missing demotion where the record is gone).
-    rid_for_sidecar = current.get("ratchet_record_id")
-    if report.record and isinstance(report.record.get("ratchet_record_id"), str):
-        rid_for_sidecar = report.record["ratchet_record_id"]
-
-    # Persist only under deliberate management (passing --wire) or continued
-    # tracking; never persist 'unknown' (that is the no-authority default and
-    # would only pollute a shared dir).
-    should_write = transition.new_state != "unknown" and (already_tracked or (wire and report.passing))
-    if should_write:
-        _write_authority(gate, validation_dir, transition.new_state,
-                         transition.previous_authority, rid_for_sidecar)
+        transition = authority_status(gate, validation_dir, report, was_wired=was_wired)
 
     if transition.demoted:
         try:

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -15,7 +15,7 @@ Event schema (one JSON object per line):
      provider?, adapter?, requested_model?, usage_status?, pricing_version?,
      tokens_in?, tokens_out?, cost_usd?, summary?, severity?,
      missed_by?, found_in?, invariant?, fixed?, seed_class?, details?,
-     verb?, path?, hit_count?}
+     previous_authority?, verb?, path?, hit_count?}
 
   event: "gate" | "consult" | "worker" | "skill" | "escape" | "demotion" | "query"
   A consult record's `adapter`/`usage_status`/`pricing_version` are chief-wiggum#134
@@ -41,6 +41,14 @@ Event schema (one JSON object per line):
   matches a seed class the `missed_by` gate's validation record certified it
   catches: the validation was wrong about production recall, so the gate must
   drop back to report-only and the seed class gets re-derived — not just logged.
+  A demotion can ALSO fire without any escape at all: chief-wiggum#198/IT-fh-06's
+  stale-while-blocking auto-demotion (state-machines.json's Gate
+  Blocking-Authority Lifecycle, G-008/G-014) — `check_gate_validation.py`
+  detects a BLOCKING gate's record went stale (scanner_version/journal drift) or
+  missing/invalid, and demotes it. That path has no `seed_class` (nothing
+  escaped in production; the record itself just rotted), so it calls the
+  GENERIC `emit_stale_demotion` (`details='stale'|'record_missing'`,
+  `previous_authority` recorded), never `emit_demotion` (which requires one).
 
     factory_log.py emit --event gate --repo acme/app --name ratchet --result pass --caught 0
     factory_log.py bug --repo acme/app --summary "reset endpoint leaks account existence" \
@@ -162,6 +170,25 @@ def emit_demotion(gate: str, seed_class: str, *, repo: str | None = None,
     matched a seed class its gate-validation record certified it catches
     (see `demotion_check` / docs/gate-validation.md)."""
     return emit(DEMOTION, name=gate, details=f"seed_class={seed_class}",
+                repo=repo, ticket=ticket)
+
+
+def emit_stale_demotion(gate: str, reason: str, *, previous_authority: str | None = None,
+                       repo: str | None = None, ticket: str | None = None) -> bool:
+    """Record that `gate` auto-demoted because its gate-validation record went
+    stale or missing/invalid WHILE BLOCKING (state-machines.json's Gate
+    Blocking-Authority Lifecycle, G-008/G-014 — chief-wiggum#198/IT-fh-06).
+
+    This is deliberately the GENERIC `DEMOTION` event, not `emit_demotion`:
+    `emit_demotion` requires a `seed_class` (an escape-driven demotion always
+    has one — production proved a *validated* seed wrong); a staleness or
+    missing-record demotion has no escape and no seed_class at all, only a
+    `reason` ('stale' | 'record_missing') and the `previous_authority` the
+    gate is coming down from — recorded so a later re-derived/re-journaled
+    record can be told it is being *restored*, not freshly promoted.
+    @cw-trace guards INV-fh-003"""
+    assert reason in ("stale", "record_missing"), f"unknown stale-demotion reason: {reason!r}"
+    return emit(DEMOTION, name=gate, details=reason, previous_authority=previous_authority,
                 repo=repo, ticket=ticket)
 
 

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -97,6 +97,15 @@ HIGHWATER_NAME = "ratchet-highwater.json"
 SCORECARD_NAME = "ratchet-scorecard.json"
 DEFAULT_STATE_DIR = "docs/quality"
 
+# A gate-authority lifecycle event (chief-wiggum#198): the operator wiring a gate
+# with --gate (blocking) or un-wiring it. Journaled here — in the SAME
+# hash-chained, tamper-evident ledger the ratchet already owns — rather than in a
+# loose, forgeable JSON file, so "was this gate blocking?" is a tamper-evident
+# fact and not a hand-writable one (`check_gate_validation.py --wire/--unwire`).
+# It is NOT `merged`, so it never enters `derive_highwater`'s pass-set/contract
+# high-water; it rides the chain purely for its own tamper-evidence.
+GATE_AUTHORITY = "gate-authority"
+
 # Complexity/churn ratchet tolerance (see docs/ratchet.md "Complexity & churn").
 # DIRECTION: unlike the pass-set (which may not SHRINK), complexity is a cost we
 # ratchet DOWNWARD — the high-water mark is the LOWEST (best) value ever merged,
@@ -431,6 +440,79 @@ def load_journal(cfg: Config) -> list[dict]:
     return records
 
 
+# --- gate-authority journal primitives (chief-wiggum#198) ---------------------
+# Path-based so `check_gate_validation.py` can journal/read wire events with only
+# the journal path (it has no ratchet Config), while the chain format stays owned
+# here in ratchet.py — the journal's single writer of record.
+
+
+def _read_journal_path(journal_path: str | Path) -> list[dict]:
+    p = Path(journal_path)
+    if not p.is_file():
+        return []
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+def verified_prefix(journal_path: str | Path) -> list[dict]:
+    """The journal entries whose hash chain verifies from genesis, stopping
+    BEFORE the first broken link. A TOLERANT read for facts that must survive a
+    LATER tamper: "was this gate wired" is knowable from an early, still-valid
+    entry even when a subsequent entry breaks the chain — the demotion path
+    depends on that (a broken chain is itself a stale condition to demote ON,
+    not one that should erase the knowledge the gate was blocking)."""
+    good: list[dict] = []
+    prev = "genesis"
+    for rec in _read_journal_path(journal_path):
+        body = {k: v for k, v in rec.items() if k != "record_hash"}
+        if rec.get("record_hash") != stable_hash(prev, json.dumps(body, sort_keys=True)):
+            break
+        good.append(rec)
+        prev = rec["record_hash"]
+    return good
+
+
+def last_authority_action(journal_path: str | Path, gate: str) -> str | None:
+    """`'wire'` / `'unwire'` of the LAST gate-authority event for `gate` in the
+    verified prefix, or None if the gate was never wired. This is the
+    tamper-evident "is this gate currently under blocking authority" fact —
+    read from journaled events, never from a hand-writable file."""
+    for rec in reversed(verified_prefix(journal_path)):
+        if rec.get("event") == GATE_AUTHORITY and rec.get("ref") == gate:
+            return rec.get("details")
+    return None
+
+
+def append_authority_event(journal_path: str | Path, gate: str, action: str,
+                           wired_rid: str | None = None) -> str:
+    """Append a hash-chained gate-authority event (``wire``/``unwire``) for
+    `gate`. Refuses to append onto a broken chain (fail closed — a tampered
+    journal must not be silently extended). Returns the new ``rec-NNNNN`` id."""
+    if action not in ("wire", "unwire"):
+        raise RatchetError(f"gate-authority action must be wire|unwire, got {action!r}")
+    all_entries = _read_journal_path(journal_path)
+    if len(all_entries) != len(verified_prefix(journal_path)):
+        raise TamperError(
+            f"cannot append a gate-authority event: {journal_path} chain is broken — fail closed"
+        )
+    prev = all_entries[-1]["record_hash"] if all_entries else "genesis"
+    body = {
+        "record_id": f"rec-{len(all_entries) + 1:05d}",
+        "event": GATE_AUTHORITY,
+        "ref": gate,
+        "details": action,
+        "wired_rid": wired_rid,
+        "merged": False,
+    }
+    body["record_hash"] = stable_hash(
+        prev, json.dumps({k: v for k, v in body.items() if k != "record_hash"}, sort_keys=True)
+    )
+    path = Path(journal_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(json.dumps(body, sort_keys=True) + "\n")
+    return body["record_id"]
+
+
 def derive_highwater(records: list[dict]) -> dict:
     """High-water = union of every case passing in a MERGED record, plus the
     definition hash each contract had when it first entered. Amendments and
@@ -692,9 +774,15 @@ def cmd_record(args) -> int:
 def cmd_recent(args) -> int:
     cfg = load_config(repo_root(args.repo))
     for rec in load_journal(cfg)[-args.n:]:
+        # gate-authority events (chief-wiggum#198) carry no ratchet_status/
+        # gate_result — tolerate their absence rather than KeyError.
+        if rec.get("event") == GATE_AUTHORITY:
+            print(f"- {rec['record_id']} [authority] {rec['event']} {rec['ref']} "
+                  f"action={rec.get('details')} wired_rid={rec.get('wired_rid')}")
+            continue
         print(
-            f"- {rec['record_id']} [{rec['ratchet_status']}] {rec['event']} {rec['ref']} "
-            f"gate={rec['gate_result']} merged={rec['merged']}: {rec.get('notes', '')}"
+            f"- {rec['record_id']} [{rec.get('ratchet_status', '?')}] {rec['event']} {rec['ref']} "
+            f"gate={rec.get('gate_result', '?')} merged={rec.get('merged', False)}: {rec.get('notes', '')}"
         )
     return 0
 

--- a/scripts/ratchet.py
+++ b/scripts/ratchet.py
@@ -453,16 +453,37 @@ def _read_journal_path(journal_path: str | Path) -> list[dict]:
     return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
 
 
+# The only valid gate-authority actions. A `details` value outside this set is
+# NOT an authority action — it must never flip a wired gate to un-wired (finding
+# 1): `last_authority_action` ignores it rather than treating it as an unwire.
+_AUTHORITY_ACTIONS = ("wire", "unwire")
+
+
 def verified_prefix(journal_path: str | Path) -> list[dict]:
     """The journal entries whose hash chain verifies from genesis, stopping
-    BEFORE the first broken link. A TOLERANT read for facts that must survive a
-    LATER tamper: "was this gate wired" is knowable from an early, still-valid
-    entry even when a subsequent entry breaks the chain — the demotion path
-    depends on that (a broken chain is itself a stale condition to demote ON,
-    not one that should erase the knowledge the gate was blocking)."""
+    BEFORE the first broken OR unparseable link. A TOLERANT read for facts that
+    must survive a LATER tamper: "was this gate wired" is knowable from an
+    early, still-valid entry even when a subsequent entry breaks the chain (a
+    bad hash) OR is garbage that won't parse — the demotion path depends on that
+    (a broken/garbled tail is itself a stale condition to demote ON, not one
+    that should erase the knowledge the gate was blocking). Parsing is
+    line-by-line so a non-JSON trailing line stops the prefix instead of
+    crashing the whole read (finding 2)."""
+    p = Path(journal_path)
+    if not p.is_file():
+        return []
     good: list[dict] = []
     prev = "genesis"
-    for rec in _read_journal_path(journal_path):
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            break  # garbage tail — stop before it, keep the valid prefix
+        if not isinstance(rec, dict):
+            break
         body = {k: v for k, v in rec.items() if k != "record_hash"}
         if rec.get("record_hash") != stable_hash(prev, json.dumps(body, sort_keys=True)):
             break
@@ -475,10 +496,19 @@ def last_authority_action(journal_path: str | Path, gate: str) -> str | None:
     """`'wire'` / `'unwire'` of the LAST gate-authority event for `gate` in the
     verified prefix, or None if the gate was never wired. This is the
     tamper-evident "is this gate currently under blocking authority" fact —
-    read from journaled events, never from a hand-writable file."""
+    read from journaled events, never from a hand-writable file.
+
+    Only `wire`/`unwire` are authority actions: a hash-VALID gate-authority
+    event carrying any OTHER `details` (e.g. a bogus `noop` slipped in after a
+    real wire) is IGNORED, never treated as an un-wiring — it must never flip a
+    wired gate to un-wired and suppress the demotion (finding 1)."""
     for rec in reversed(verified_prefix(journal_path)):
         if rec.get("event") == GATE_AUTHORITY and rec.get("ref") == gate:
-            return rec.get("details")
+            action = rec.get("details")
+            if action in _AUTHORITY_ACTIONS:
+                return action
+            # else: not a real authority action — skip, keep looking for the
+            # last genuine wire/unwire.
     return None
 
 
@@ -489,14 +519,19 @@ def append_authority_event(journal_path: str | Path, gate: str, action: str,
     journal must not be silently extended). Returns the new ``rec-NNNNN`` id."""
     if action not in ("wire", "unwire"):
         raise RatchetError(f"gate-authority action must be wire|unwire, got {action!r}")
-    all_entries = _read_journal_path(journal_path)
-    if len(all_entries) != len(verified_prefix(journal_path)):
+    # Robust broken/garbled-chain detection: compare the verified prefix against
+    # the raw non-empty line count WITHOUT a full JSON parse (a garbage tail
+    # must raise TamperError, not a JSONDecodeError — finding 3's append path).
+    p = Path(journal_path)
+    raw_lines = [ln for ln in p.read_text().splitlines() if ln.strip()] if p.is_file() else []
+    verified = verified_prefix(journal_path)
+    if len(verified) != len(raw_lines):
         raise TamperError(
             f"cannot append a gate-authority event: {journal_path} chain is broken — fail closed"
         )
-    prev = all_entries[-1]["record_hash"] if all_entries else "genesis"
+    prev = verified[-1]["record_hash"] if verified else "genesis"
     body = {
-        "record_id": f"rec-{len(all_entries) + 1:05d}",
+        "record_id": f"rec-{len(verified) + 1:05d}",
         "event": GATE_AUTHORITY,
         "ref": gate,
         "details": action,

--- a/tests/test_check_gate_validation.py
+++ b/tests/test_check_gate_validation.py
@@ -431,6 +431,273 @@ def test_cli_text_format_reports_verdict(tmp_path):
     assert "PASSING" in proc.stdout
 
 
+# --- IT-fh-06: stale-while-blocking auto-demotion (chief-wiggum#198) ----------
+#
+# The gap this closes: docs/epics/epic-factory-hardening/models/state-machines.json
+# models a "Gate Blocking-Authority Lifecycle" with `stale`/`demoted` states and a
+# `previous_authority` context field, but nothing implemented it — a stale record
+# only ever collapsed to `passing: bool`. These tests exercise the FULL edge set:
+# blocking -> stale -> demoted (auto-demote, fail-to-report-only), validated ->
+# stale -> report_only (mere downgrade, no demotion event since nothing was
+# blocking), the record-missing/schema-invalid variant of both, and recovery
+# (demoted -> validated, never straight back to blocking).
+# @cw-trace verifies IT-fh-06 INV-fh-003 INV-fh-005
+
+
+def test_failure_kind_classifies_stale_vs_invalid(tmp_path):
+    """A record that would otherwise pass except for scanner/journal drift is
+    'stale'; anything else non-passing (missing record, schema errors, forged/
+    failed trials or clean runs, wrong status, a copied/unjournaled record) is
+    'invalid' — the model's two distinct demotion triggers (G-008 vs G-014)."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="old"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "current")
+    stale_report = gv.check("example_gate", vdir, scripts_dir=scripts_dir)
+    assert gv.failure_kind(stale_report) == "stale"
+
+    missing_report = gv.check("no_such_gate", vdir)
+    assert gv.failure_kind(missing_report) == "invalid"
+
+    record = _minimal_valid_record()
+    record["seeded_defect_trials"][0]["passed"] = False
+    record["seeded_defect_trials"][0]["result"] = "not-fired"
+    vdir2 = _write_record(tmp_path / "v2", "example_gate", record)
+    invalid_report = gv.check("example_gate", vdir2)
+    assert gv.failure_kind(invalid_report) == "invalid"
+
+    passing_report = gv.check("example_gate", _write_record(tmp_path / "v3", "example_gate", _minimal_valid_record()))
+    assert gv.failure_kind(passing_report) is None
+
+
+def test_stale_while_blocking_auto_demotes(tmp_path):
+    """Author a passing record, wire it blocking (--wire), then edit a hashed
+    dependency so the live --scanner-version changes. The NEXT check must
+    transition blocking -> demoted (never silently stay blocking), emit the
+    generic DEMOTION with details='stale' (no seed_class), and record
+    previous_authority='blocking' so a recovery can be told what it lost."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert report.passing is True
+    assert transition.new_state == "blocking"
+
+    # Simulate #184's scenario: a scanner edit bumps --scanner-version.
+    _fake_gate_script(scripts_dir, "example_gate", "v2-after-scanner-edit")
+
+    report2, transition2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert report2.passing is False
+    assert gv.failure_kind(report2) == "stale"
+    assert transition2.previous_state == "blocking"
+    assert transition2.new_state == "demoted"
+    assert transition2.demoted is True
+    assert transition2.demotion_reason == "stale"
+    assert transition2.previous_authority == "blocking"
+    assert transition2.instruction and "stale" in transition2.instruction
+
+    persisted = gv.read_authority("example_gate", vdir)
+    assert persisted["authority"] == "demoted"
+    assert persisted["previous_authority"] == "blocking"
+
+
+def test_record_missing_while_blocking_demotes(tmp_path):
+    """The record-missing variant of the same edge (G-014): a record deleted
+    out from under a blocking gate must demote, not silently keep blocking."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    _, transition = gv.check_and_transition("example_gate", vdir, wire=True)
+    assert transition.new_state == "blocking"
+
+    (Path(vdir) / "example_gate.json").unlink()
+
+    report2, transition2 = gv.check_and_transition("example_gate", vdir)
+    assert report2.passing is False
+    assert report2.record_found is False
+    assert transition2.new_state == "demoted"
+    assert transition2.demoted is True
+    assert transition2.demotion_reason == "record_missing"
+    assert transition2.previous_authority == "blocking"
+
+
+def test_schema_invalid_while_blocking_demotes_as_record_missing(tmp_path):
+    """The schema-invalid variant: the record still exists as a file but no
+    longer validates against the schema. Classified the same as 'missing' —
+    the record cannot be trusted, so it grants no blocking authority."""
+    record = _minimal_valid_record()
+    vdir = _write_record(tmp_path, "example_gate", record)
+    _, transition = gv.check_and_transition("example_gate", vdir, wire=True)
+    assert transition.new_state == "blocking"
+
+    broken = _minimal_valid_record()
+    del broken["authority_boundary"]
+    (Path(vdir) / "example_gate.json").write_text(json.dumps(broken))
+
+    report2, transition2 = gv.check_and_transition("example_gate", vdir)
+    assert report2.schema_errors
+    assert transition2.new_state == "demoted"
+    assert transition2.demotion_reason == "record_missing"
+    assert transition2.previous_authority == "blocking"
+
+
+def test_stale_while_merely_validated_downgrades_not_demotes(tmp_path):
+    """A record that goes stale while only 'validated' (never wired --gate)
+    downgrades to report_only — no demotion event, since nothing was blocking
+    (G-015, Codex's fix for the non-wired stale record being otherwise stuck)."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert transition.new_state == "validated"  # plain check, never wired
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    report2, transition2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert report2.passing is False
+    assert transition2.previous_state == "validated"
+    assert transition2.new_state == "report_only"
+    assert transition2.demoted is False
+    assert transition2.demotion_reason is None
+    assert transition2.previous_authority == "validated"
+
+    persisted = gv.read_authority("example_gate", vdir)
+    assert persisted["authority"] == "report_only"
+
+
+def test_recovery_re_derives_back_to_validated_never_straight_to_blocking(tmp_path):
+    """Re-deriving and re-journaling a demoted gate's record restores it to
+    'validated' — G-010 — never directly back to 'blocking' (the model's
+    invalid_transitions explicitly forbid demoted->blocking; INV-fh-003 requires
+    an explicit re-wire after re-derivation)."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    _, demoted_transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert demoted_transition.new_state == "demoted"
+
+    # Re-author the record against the current scanner version (re-derivation).
+    fixed = _minimal_valid_record(scanner_version="v2-drifted")
+    (Path(vdir) / "example_gate.json").write_text(json.dumps(fixed))
+
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert report.passing is True
+    assert transition.previous_state == "demoted"
+    assert transition.new_state == "validated"
+    assert transition.event == "re_derive_and_rejournal"
+
+    # Blocking authority must be explicitly re-wired, never inferred.
+    _, rewired = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert rewired.new_state == "blocking"
+
+
+def test_check_on_gate_with_no_record_at_all_writes_no_authority_sidecar(tmp_path):
+    """Report-only-safe (docs/gate-rollout.md): a gate name with NO record at
+    all — the exact real-world case of querying an as-yet-unbuilt/misspelled
+    gate (test_gate_exit_modes.py's `gate_with_no_record` fixture, run against
+    the REAL, shared docs/quality/validation/ in that test) — must never leave
+    a stray `<gate>.authority.json` behind. It stays 'unknown' -> 'unknown':
+    no real authority state was ever reached, so nothing is persisted."""
+    vdir = tmp_path / "validation"
+    vdir.mkdir()
+    gv.check_and_transition("no_such_gate", vdir)
+    assert not (Path(vdir) / "no_such_gate.authority.json").exists()
+    assert list(Path(vdir).iterdir()) == []
+
+
+def test_check_on_passing_record_does_write_authority_sidecar(tmp_path):
+    """Contrast with the above: a gate with a genuinely passing record reaches
+    a REAL authority state ('validated') on the very first plain check — that
+    IS meaningful progress, so it IS persisted (needed so a later staleness
+    finding, even without an explicit --wire, can report previous_authority
+    correctly for the validated-but-never-wired downgrade path)."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    _, transition = gv.check_and_transition("example_gate", vdir)
+    assert transition.new_state == "validated"
+    assert (Path(vdir) / "example_gate.authority.json").exists()
+
+
+def test_wire_rejected_when_record_does_not_pass(tmp_path):
+    vdir = tmp_path / "validation"
+    vdir.mkdir()
+    report, transition = gv.check_and_transition("no_such_gate", vdir, wire=True)
+    assert report.passing is False
+    assert transition.event == "wire_rejected"
+    assert transition.new_state != "blocking"
+
+
+def test_unwire_is_intentional_not_a_demotion(tmp_path):
+    """Opus (i)/codex: an operator dropping --gate on purpose is a normal edge
+    (unwire_gate), not a demotion — the record still passes."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    gv.check_and_transition("example_gate", vdir, wire=True)
+
+    report, transition = gv.check_and_transition("example_gate", vdir, unwire=True)
+    assert report.passing is True
+    assert transition.new_state == "validated"
+    assert transition.demoted is False
+    assert transition.event == "unwire_gate"
+
+
+def test_stale_demotion_emits_generic_demotion_not_emit_demotion(tmp_path, monkeypatch):
+    """The telemetry event this auto-demotion emits must be the GENERIC
+    `emit_stale_demotion`/`DEMOTION` — never `emit_demotion`, which stamps
+    `details=f"seed_class={{...}}"` and requires one. A staleness demotion has
+    no seed_class at all (nothing escaped in production)."""
+    log_path = tmp_path / "factory-log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
+
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+
+    lines = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    demotions = [r for r in lines if r.get("event") == "demotion"]
+    assert len(demotions) == 1
+    d = demotions[0]
+    assert d["name"] == "example_gate"
+    assert d["details"] == "stale"
+    assert d["previous_authority"] == "blocking"
+    assert "seed_class" not in d  # never emit_demotion's seed_class= detail
+
+
+def test_cli_wire_then_record_missing_reports_demotion_in_json(tmp_path):
+    """End-to-end through the actual CLI (subprocess), not just the Python API —
+    proves the argparse wiring and JSON envelope, matching how /close-epic
+    invokes this script. Uses the record-missing variant (rather than scanner
+    drift) since the CLI resolves the live gate script relative to its own
+    scripts/ dir, with no --scripts-dir override to fake a drifted version."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "check_gate_validation.py"), "example_gate",
+         "--validation-dir", str(vdir), "--wire", "--format", "json"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["authority"]["new_state"] == "blocking"
+
+    (Path(vdir) / "example_gate.json").unlink()
+
+    proc2 = subprocess.run(
+        [sys.executable, str(SCRIPTS / "check_gate_validation.py"), "example_gate",
+         "--validation-dir", str(vdir), "--format", "json"],
+        capture_output=True, text=True,
+    )
+    assert proc2.returncode == 0  # report-only CLI mode; JSON envelope carries the verdict
+    out2 = json.loads(proc2.stdout)
+    assert out2["passing"] is False
+    assert out2["authority"]["demoted"] is True
+    assert out2["authority"]["demotion_reason"] == "record_missing"
+    assert out2["authority"]["previous_authority"] == "blocking"
+    assert "DEMOTION" in proc2.stderr
+
+
 def test_validation_dir_is_defined_once_and_imported():
     """INV-fh-004: docs/quality/validation is defined in exactly one place —
     factory_log.DEFAULT_VALIDATION_DIR — and check_gate_validation IMPORTS it.

--- a/tests/test_check_gate_validation.py
+++ b/tests/test_check_gate_validation.py
@@ -540,15 +540,19 @@ def test_schema_invalid_while_blocking_demotes_as_record_missing(tmp_path):
 
 
 def test_stale_while_merely_validated_downgrades_not_demotes(tmp_path):
-    """A record that goes stale while only 'validated' (never wired --gate)
+    """A record that goes stale while 'validated' (not currently wired --gate)
     downgrades to report_only — no demotion event, since nothing was blocking
-    (G-015, Codex's fix for the non-wired stale record being otherwise stuck)."""
+    (G-015, Codex's fix for the non-wired stale record being otherwise stuck).
+    Reaches a TRACKED 'validated' the legitimate way: wire it, then intentionally
+    un-wire while it still passes (blocking -> validated) — a plain check never
+    persists a sidecar, so tracking only exists once a gate was managed."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
     scripts_dir = tmp_path / "scripts"
     _fake_gate_script(scripts_dir, "example_gate", "v1")
 
-    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
-    assert transition.new_state == "validated"  # plain check, never wired
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    _, unwired = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
+    assert unwired.new_state == "validated"  # clean, record still passes
 
     _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
     report2, transition2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
@@ -606,25 +610,38 @@ def test_check_on_gate_with_no_record_at_all_writes_no_authority_sidecar(tmp_pat
     assert list(Path(vdir).iterdir()) == []
 
 
-def test_check_on_passing_record_does_write_authority_sidecar(tmp_path):
-    """Contrast with the above: a gate with a genuinely passing record reaches
-    a REAL authority state ('validated') on the very first plain check — that
-    IS meaningful progress, so it IS persisted (needed so a later staleness
-    finding, even without an explicit --wire, can report previous_authority
-    correctly for the validated-but-never-wired downgrade path)."""
+def test_plain_check_on_passing_record_writes_nothing_until_wired(tmp_path):
+    """P5: a plain (non---wire) check of a passing record does NOT create a
+    sidecar — blocking-authority tracking is opt-in via --wire. This is what
+    lets /close-epic run `check_gate_validation <gate> --gate` plainly against
+    the SHARED committed docs/quality/validation/ without polluting it with
+    authority sidecars for every gate it checks."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
     _, transition = gv.check_and_transition("example_gate", vdir)
     assert transition.new_state == "validated"
-    assert (Path(vdir) / "example_gate.authority.json").exists()
+    assert not (Path(vdir) / "example_gate.authority.json").exists()
 
 
-def test_wire_rejected_when_record_does_not_pass(tmp_path):
+def test_wire_non_passing_never_yields_or_persists_blocking(tmp_path):
+    """P1: --wire with a NON-passing record must never reach or persist
+    'blocking' (INV-fh-003). On a brand-new no-record gate it refuses, stays
+    off 'blocking', reports the refusal, and writes nothing."""
     vdir = tmp_path / "validation"
     vdir.mkdir()
     report, transition = gv.check_and_transition("no_such_gate", vdir, wire=True)
     assert report.passing is False
-    assert transition.event == "wire_rejected"
     assert transition.new_state != "blocking"
+    assert "refused" in (transition.instruction or "")
+    assert not (Path(vdir) / "no_such_gate.authority.json").exists()
+
+
+def test_unwire_on_missing_gate_writes_nothing(tmp_path):
+    """P5: --unwire on a missing/misspelled gate (no record, never tracked)
+    must leave NOTHING behind in the shared validation dir."""
+    vdir = tmp_path / "validation"
+    vdir.mkdir()
+    gv.check_and_transition("no_such_gate", vdir, unwire=True)
+    assert list(Path(vdir).iterdir()) == []
 
 
 def test_unwire_is_intentional_not_a_demotion(tmp_path):
@@ -696,6 +713,115 @@ def test_cli_wire_then_record_missing_reports_demotion_in_json(tmp_path):
     assert out2["authority"]["demotion_reason"] == "record_missing"
     assert out2["authority"]["previous_authority"] == "blocking"
     assert "DEMOTION" in proc2.stderr
+
+
+def test_forged_blocking_sidecar_without_passing_record_is_not_trusted(tmp_path):
+    """P4: a hand-forged <gate>.authority.json claiming 'blocking' must NOT be
+    trusted unless it corroborates against the record + hash-chained journal
+    (gate-field match + a journaled gate-validation ratchet_record_id). An
+    uncorroborated blocking sidecar can neither assert authority nor trigger a
+    false demotion — exactly the forgeable trust record this epic exists to
+    prevent."""
+    vdir = tmp_path / "validation"
+    vdir.mkdir()
+    # Forge a blocking sidecar whose rid is in no journal (there is none here)
+    # and with no validation record to back it.
+    (vdir / "ghost_gate.authority.json").write_text(json.dumps(
+        {"gate": "ghost_gate", "authority": "blocking",
+         "previous_authority": "validated", "ratchet_record_id": "rec-00001"}))
+
+    # read_authority refuses the forged claim -> unknown/untrusted.
+    assert gv.read_authority("ghost_gate", vdir)["authority"] == "unknown"
+
+    # So a check fires NO false demotion.
+    _, transition = gv.check_and_transition("ghost_gate", vdir)
+    assert transition.demoted is False
+    assert transition.new_state != "demoted"
+    assert transition.previous_state == "unknown"
+
+
+def test_sidecar_rid_contradicting_live_record_is_not_trusted(tmp_path):
+    """P4 (the other corroboration leg): a sidecar whose ratchet_record_id does
+    not match the live record's is out of sync (e.g. edited, or left over from a
+    superseded record) and must be treated as untrusted, never authoritative."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())  # rid rec-00001, journaled
+    gv.check_and_transition("example_gate", vdir, wire=True)  # writes a corroborated blocking sidecar
+
+    # Tamper the sidecar's rid to one the live record does not carry.
+    sidecar = Path(vdir) / "example_gate.authority.json"
+    data = json.loads(sidecar.read_text())
+    data["ratchet_record_id"] = "rec-09999"
+    sidecar.write_text(json.dumps(data))
+
+    record = json.loads((Path(vdir) / "example_gate.json").read_text())
+    assert gv.read_authority("example_gate", vdir, record=record)["authority"] == "unknown"
+
+
+def test_wire_on_stale_blocking_record_demotes_never_stays_blocking(tmp_path):
+    """P1: calling --wire again on a gate that IS blocking but whose record has
+    gone stale must NOT keep it blocking (the review's exact bug). A non-passing
+    --wire yields the natural demotion (blocking -> demoted) and emits, and
+    reports the refusal — wiring blocking authority requires passing==true."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert report.passing is False
+    assert transition.new_state == "demoted"
+    assert transition.demoted is True
+    assert transition.demotion_reason == "stale"
+    assert transition.previous_authority == "blocking"
+    assert "refused" in (transition.instruction or "")
+    assert gv.read_authority("example_gate", vdir)["authority"] == "demoted"
+
+
+def test_unwire_from_stale_blocking_emits_demotion_not_silent_report_only(tmp_path, monkeypatch):
+    """P1: --unwire must not mask a stale/missing-while-blocking demotion. From
+    blocking with a NON-passing (stale) record, --unwire goes blocking ->
+    demoted and EMITS the demotion — the clean unwire_gate edge is only for a
+    record that still passes."""
+    log_path = tmp_path / "factory-log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    _, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
+    assert transition.new_state == "demoted"
+    assert transition.demoted is True
+    assert transition.demotion_reason == "stale"
+
+    demotions = [json.loads(line) for line in log_path.read_text().splitlines()
+                 if json.loads(line).get("event") == "demotion"]
+    assert len(demotions) == 1 and demotions[0]["details"] == "stale"
+
+
+def test_wire_from_demoted_resolves_to_validated_never_blocking(tmp_path):
+    """P2: --wire on a re-authored, now-passing record whose persisted state is
+    'demoted' resolves to 'validated' (two-step recovery), NEVER straight to
+    'blocking' — the model's invalid_transitions forbid demoted -> blocking. A
+    SECOND explicit --wire then promotes it."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    _, demoted = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert demoted.new_state == "demoted"
+
+    (Path(vdir) / "example_gate.json").write_text(
+        json.dumps(_minimal_valid_record(scanner_version="v2-drifted")))
+    _, first_wire = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert first_wire.new_state == "validated"  # NOT blocking
+    assert first_wire.event == "re_derive_and_rejournal"
+
+    _, second_wire = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert second_wire.new_state == "blocking"
 
 
 def test_validation_dir_is_defined_once_and_imported():

--- a/tests/test_check_gate_validation.py
+++ b/tests/test_check_gate_validation.py
@@ -797,6 +797,86 @@ def test_cli_wire_then_record_missing_reports_demotion_in_json(tmp_path):
     assert "DEMOTION" in proc2.stderr
 
 
+def _append_chained(journal, body):
+    """Append a hash-chained entry to an existing journal (same chaining as
+    ratchet.append_authority_event), for injecting crafted events in tests."""
+    lines = [ln for ln in Path(journal).read_text().splitlines() if ln.strip()]
+    prev = json.loads(lines[-1])["record_hash"] if lines else "genesis"
+    body = {k: v for k, v in body.items() if k != "record_hash"}
+    body["record_hash"] = stable_hash(prev, json.dumps(body, sort_keys=True))
+    with Path(journal).open("a") as f:
+        f.write(json.dumps(body, sort_keys=True) + "\n")
+
+
+def test_bogus_authority_details_after_wire_still_demotes(tmp_path):
+    """FINDING 1 (end-to-end): a hash-VALID gate-authority event with a bogus
+    `details` (e.g. 'noop') slipped in after a real wire must NOT suppress the
+    demotion — it is ignored, the gate is still treated as wired, and a stale
+    record still demotes."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _append_chained(_journal(vdir), {
+        "record_id": "rec-90", "event": "gate-authority", "ref": "example_gate",
+        "details": "noop", "merged": False})
+    assert gv.ratchet_last_authority_action(_journal(vdir), "example_gate") == "wire"
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert report.passing is False
+    assert transition.new_state == "demoted"
+    assert transition.previous_authority == "blocking"
+
+
+def test_garbage_journal_tail_after_wire_still_demotes(tmp_path):
+    """FINDING 2 (end-to-end): a non-JSON trailing line after a valid wire must
+    not crash the read (verified_prefix parses line-by-line) — the wire is still
+    read and the (now non-corroboratable) record demotes rather than erroring."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    gv.check_and_transition("example_gate", vdir, wire=True)
+
+    with Path(_journal(vdir)).open("a") as f:
+        f.write("this is not json at all\n")
+    assert gv.ratchet_last_authority_action(_journal(vdir), "example_gate") == "wire"
+
+    report, transition = gv.check_and_transition("example_gate", vdir)
+    assert report.passing is False
+    assert transition.new_state == "demoted"
+    assert transition.demoted is True
+    assert transition.previous_authority == "blocking"
+
+
+def test_chain_broken_blocking_unwire_still_emits_demotion(tmp_path, monkeypatch):
+    """FINDING 3: for a chain-broken-while-blocking gate + --unwire, the DEMOTION
+    must be emitted and surfaced FIRST — even though append_authority_event
+    refuses to extend the broken chain. The append failure is reported as a
+    distinct note, never swallowing the demotion."""
+    log_path = tmp_path / "factory-log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    gv.check_and_transition("example_gate", vdir, wire=True)
+
+    # Break the chain AFTER the wire event (a valid-JSON, bad-hash entry).
+    journal = Path(_journal(vdir))
+    lines = journal.read_text().splitlines()
+    lines.append(json.dumps({"record_id": "rec-98", "event": "x", "record_hash": "deadbeef"}))
+    journal.write_text("\n".join(lines) + "\n")
+
+    report, transition = gv.check_and_transition("example_gate", vdir, unwire=True)
+    assert report.passing is False
+    assert transition.demoted is True
+    assert transition.previous_authority == "blocking"
+
+    # The DEMOTION was emitted despite the append failing on the broken chain.
+    demotions = [json.loads(line) for line in log_path.read_text().splitlines()
+                 if json.loads(line).get("event") == "demotion"]
+    assert len(demotions) == 1
+    # ...and the append failure is surfaced, not swallowed.
+    assert "could not journal" in (transition.instruction or "")
+
+
 def test_validation_dir_is_defined_once_and_imported():
     """INV-fh-004: docs/quality/validation is defined in exactly one place —
     factory_log.DEFAULT_VALIDATION_DIR — and check_gate_validation IMPORTS it.

--- a/tests/test_check_gate_validation.py
+++ b/tests/test_check_gate_validation.py
@@ -433,15 +433,19 @@ def test_cli_text_format_reports_verdict(tmp_path):
 
 # --- IT-fh-06: stale-while-blocking auto-demotion (chief-wiggum#198) ----------
 #
-# The gap this closes: docs/epics/epic-factory-hardening/models/state-machines.json
-# models a "Gate Blocking-Authority Lifecycle" with `stale`/`demoted` states and a
-# `previous_authority` context field, but nothing implemented it — a stale record
-# only ever collapsed to `passing: bool`. These tests exercise the FULL edge set:
-# blocking -> stale -> demoted (auto-demote, fail-to-report-only), validated ->
-# stale -> report_only (mere downgrade, no demotion event since nothing was
-# blocking), the record-missing/schema-invalid variant of both, and recovery
-# (demoted -> validated, never straight back to blocking).
+# Blocking authority is a JOURNALED fact (a `gate-authority` wire/unwire event
+# in the ratchet hash chain), never a forgeable sidecar file. "Was this gate
+# blocking?" is read from those events over the verified chain prefix; the
+# current-blocking verdict is `last event == wire AND check() passing now`. A
+# journaled-wired gate whose record is NOT currently passing (stale scanner,
+# broken chain, missing/invalid record) is demoted (fail-to-report-only) and
+# emits the generic DEMOTION — reading "was blocking" from the journal means the
+# demotion fires even when the CURRENT record/chain is what broke.
 # @cw-trace verifies IT-fh-06 INV-fh-003 INV-fh-005
+
+
+def _journal(vdir):
+    return Path(vdir).resolve().parent / "ratchet-journal.jsonl"
 
 
 def test_failure_kind_classifies_stale_vs_invalid(tmp_path):
@@ -470,11 +474,11 @@ def test_failure_kind_classifies_stale_vs_invalid(tmp_path):
 
 
 def test_stale_while_blocking_auto_demotes(tmp_path):
-    """Author a passing record, wire it blocking (--wire), then edit a hashed
-    dependency so the live --scanner-version changes. The NEXT check must
+    """Author a passing record, --wire it (journals a wire event), then edit a
+    hashed dependency so the live --scanner-version changes. The NEXT check must
     transition blocking -> demoted (never silently stay blocking), emit the
-    generic DEMOTION with details='stale' (no seed_class), and record
-    previous_authority='blocking' so a recovery can be told what it lost."""
+    generic DEMOTION with details='stale' (no seed_class), and report
+    previous_authority='blocking' read from the journaled wire event."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
     scripts_dir = tmp_path / "scripts"
     _fake_gate_script(scripts_dir, "example_gate", "v1")
@@ -482,28 +486,23 @@ def test_stale_while_blocking_auto_demotes(tmp_path):
     report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
     assert report.passing is True
     assert transition.new_state == "blocking"
+    assert gv.ratchet_last_authority_action(_journal(vdir), "example_gate") == "wire"
 
-    # Simulate #184's scenario: a scanner edit bumps --scanner-version.
     _fake_gate_script(scripts_dir, "example_gate", "v2-after-scanner-edit")
 
     report2, transition2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
     assert report2.passing is False
     assert gv.failure_kind(report2) == "stale"
-    assert transition2.previous_state == "blocking"
     assert transition2.new_state == "demoted"
     assert transition2.demoted is True
     assert transition2.demotion_reason == "stale"
     assert transition2.previous_authority == "blocking"
     assert transition2.instruction and "stale" in transition2.instruction
 
-    persisted = gv.read_authority("example_gate", vdir)
-    assert persisted["authority"] == "demoted"
-    assert persisted["previous_authority"] == "blocking"
-
 
 def test_record_missing_while_blocking_demotes(tmp_path):
-    """The record-missing variant of the same edge (G-014): a record deleted
-    out from under a blocking gate must demote, not silently keep blocking."""
+    """The record-missing variant of the same edge (G-014): a record deleted out
+    from under a journaled-wired gate must demote, not silently keep blocking."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
     _, transition = gv.check_and_transition("example_gate", vdir, wire=True)
     assert transition.new_state == "blocking"
@@ -520,11 +519,10 @@ def test_record_missing_while_blocking_demotes(tmp_path):
 
 
 def test_schema_invalid_while_blocking_demotes_as_record_missing(tmp_path):
-    """The schema-invalid variant: the record still exists as a file but no
-    longer validates against the schema. Classified the same as 'missing' —
-    the record cannot be trusted, so it grants no blocking authority."""
-    record = _minimal_valid_record()
-    vdir = _write_record(tmp_path, "example_gate", record)
+    """The schema-invalid variant: the record file still exists but no longer
+    validates. Classified the same as 'missing' — it grants no blocking
+    authority to a journaled-wired gate."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
     _, transition = gv.check_and_transition("example_gate", vdir, wire=True)
     assert transition.new_state == "blocking"
 
@@ -539,114 +537,201 @@ def test_schema_invalid_while_blocking_demotes_as_record_missing(tmp_path):
     assert transition2.previous_authority == "blocking"
 
 
-def test_stale_while_merely_validated_downgrades_not_demotes(tmp_path):
-    """A record that goes stale while 'validated' (not currently wired --gate)
-    downgrades to report_only — no demotion event, since nothing was blocking
-    (G-015, Codex's fix for the non-wired stale record being otherwise stuck).
-    Reaches a TRACKED 'validated' the legitimate way: wire it, then intentionally
-    un-wire while it still passes (blocking -> validated) — a plain check never
-    persists a sidecar, so tracking only exists once a gate was managed."""
+def test_chain_broken_while_blocking_still_demotes(tmp_path):
+    """FINDING 1 REGRESSION: a broken journal chain is itself a stale condition
+    that must demote a wired gate. Because "was wired" is read from the verified
+    chain PREFIX (the wire event survives a LATER tamper), the demotion still
+    fires — the exact case the fail-closed sidecar masked (it returned unknown
+    on a broken chain and silently downgraded with no DEMOTION)."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    _, transition = gv.check_and_transition("example_gate", vdir, wire=True)
+    assert transition.new_state == "blocking"
+
+    # Append a tamper entry AFTER the wire event: the chain breaks at the tail,
+    # but the earlier wire event is still in the verified prefix.
+    journal = _journal(vdir)
+    lines = journal.read_text().splitlines()
+    lines.append(json.dumps({"record_id": "rec-99", "event": "x", "record_hash": "deadbeef"}))
+    journal.write_text("\n".join(lines) + "\n")
+
+    report2, transition2 = gv.check_and_transition("example_gate", vdir)
+    assert report2.passing is False  # check() reports the broken chain
+    assert gv.ratchet_last_authority_action(journal, "example_gate") == "wire"  # survives the tamper
+    assert transition2.new_state == "demoted"
+    assert transition2.demoted is True
+    assert transition2.previous_authority == "blocking"
+
+
+def test_re_journaled_new_rid_recovery_reaches_blocking_not_stuck(tmp_path):
+    """FINDING 2 REGRESSION: real re-derivation normally produces a NEW rid.
+    Because blocking authority is read from journaled wire EVENTS (not by
+    matching the wire event's rid to the record's), a demoted gate re-authored
+    with a fresh rid recovers cleanly: the gate is still journaled-wired, the new
+    record passes, so the verdict is 'blocking' again — never stuck-untrusted,
+    never a spurious straight-to-blocking bypass of a rid check that no longer
+    exists."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
     scripts_dir = tmp_path / "scripts"
     _fake_gate_script(scripts_dir, "example_gate", "v1")
-
-    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    _, unwired = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
-    assert unwired.new_state == "validated"  # clean, record still passes
-
-    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
-    report2, transition2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
-    assert report2.passing is False
-    assert transition2.previous_state == "validated"
-    assert transition2.new_state == "report_only"
-    assert transition2.demoted is False
-    assert transition2.demotion_reason is None
-    assert transition2.previous_authority == "validated"
-
-    persisted = gv.read_authority("example_gate", vdir)
-    assert persisted["authority"] == "report_only"
-
-
-def test_recovery_re_derives_back_to_validated_never_straight_to_blocking(tmp_path):
-    """Re-deriving and re-journaling a demoted gate's record restores it to
-    'validated' — G-010 — never directly back to 'blocking' (the model's
-    invalid_transitions explicitly forbid demoted->blocking; INV-fh-003 requires
-    an explicit re-wire after re-derivation)."""
-    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
-    scripts_dir = tmp_path / "scripts"
-    _fake_gate_script(scripts_dir, "example_gate", "v1")
     gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
 
     _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
-    _, demoted_transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
-    assert demoted_transition.new_state == "demoted"
+    _, demoted = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert demoted.new_state == "demoted"
 
-    # Re-author the record against the current scanner version (re-derivation).
-    fixed = _minimal_valid_record(scanner_version="v2-drifted")
+    # Re-author against the current scanner with a DIFFERENT rid, journaled anew.
+    fixed = _minimal_valid_record(scanner_version="v2-drifted", ratchet_record_id="rec-00002")
     (Path(vdir) / "example_gate.json").write_text(json.dumps(fixed))
+    _write_journal(tmp_path / "quality", [
+        {"record_id": "rec-00001", "event": "gate-validation", "ref": "example_gate"},
+        {"record_id": "rec-00002", "event": "gate-validation", "ref": "example_gate"},
+    ])
+    # (the wire event was in the prior chain; re-establish it after the rewrite)
+    gv._append_authority(_journal(vdir), "example_gate", "wire", wired_rid="rec-00001")
 
     report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
     assert report.passing is True
-    assert transition.previous_state == "demoted"
-    assert transition.new_state == "validated"
-    assert transition.event == "re_derive_and_rejournal"
-
-    # Blocking authority must be explicitly re-wired, never inferred.
-    _, rewired = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    assert rewired.new_state == "blocking"
+    assert transition.new_state == "blocking"
+    assert transition.demoted is False
 
 
-def test_check_on_gate_with_no_record_at_all_writes_no_authority_sidecar(tmp_path):
-    """Report-only-safe (docs/gate-rollout.md): a gate name with NO record at
-    all — the exact real-world case of querying an as-yet-unbuilt/misspelled
-    gate (test_gate_exit_modes.py's `gate_with_no_record` fixture, run against
-    the REAL, shared docs/quality/validation/ in that test) — must never leave
-    a stray `<gate>.authority.json` behind. It stays 'unknown' -> 'unknown':
-    no real authority state was ever reached, so nothing is persisted."""
-    vdir = tmp_path / "validation"
-    vdir.mkdir()
-    gv.check_and_transition("no_such_gate", vdir)
-    assert not (Path(vdir) / "no_such_gate.authority.json").exists()
-    assert list(Path(vdir).iterdir()) == []
+def test_stale_while_not_wired_downgrades_not_demotes(tmp_path):
+    """A record that goes stale while the gate is NOT journaled-wired downgrades
+    to report_only — no demotion event, since nothing was blocking (G-015). A
+    plain check never journals a wire, so a never-wired gate simply reports."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+
+    _, t1 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert t1.new_state == "validated"  # passing, not wired
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    report2, t2 = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert report2.passing is False
+    assert t2.new_state == "report_only"
+    assert t2.demoted is False
+    assert t2.demotion_reason is None
 
 
-def test_plain_check_on_passing_record_writes_nothing_until_wired(tmp_path):
-    """P5: a plain (non---wire) check of a passing record does NOT create a
-    sidecar — blocking-authority tracking is opt-in via --wire. This is what
-    lets /close-epic run `check_gate_validation <gate> --gate` plainly against
-    the SHARED committed docs/quality/validation/ without polluting it with
-    authority sidecars for every gate it checks."""
+def test_unwire_then_stale_does_not_demote(tmp_path):
+    """An operator who intentionally un-wires a gate (journaled unwire) is no
+    longer blocking, so a later stale record downgrades rather than demoting —
+    unwire is the clean voluntary edge when the record still passes."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    _, unwired = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
+    assert unwired.new_state == "validated"
+    assert gv.ratchet_last_authority_action(_journal(vdir), "example_gate") == "unwire"
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    _, t = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
+    assert t.new_state == "report_only"
+    assert t.demoted is False
+
+
+def test_forged_authority_sidecar_asserts_nothing(tmp_path):
+    """FINDING 3 REGRESSION: authority now comes ONLY from journaled wire events
+    in the verified chain — a hand-written <gate>.authority.json (or any loose
+    file) asserts nothing and cannot manufacture a false demotion. Dropping the
+    bare sidecar as a trust source is the fix."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    # Forge a blocking sidecar the OLD design would have read.
+    (Path(vdir) / "example_gate.authority.json").write_text(json.dumps(
+        {"gate": "example_gate", "authority": "blocking", "previous_authority": "validated",
+         "ratchet_record_id": "rec-00001"}))
+    # No journaled wire event exists -> the gate is NOT blocking.
+    assert gv.ratchet_last_authority_action(_journal(vdir), "example_gate") is None
     _, transition = gv.check_and_transition("example_gate", vdir)
-    assert transition.new_state == "validated"
-    assert not (Path(vdir) / "example_gate.authority.json").exists()
+    assert transition.new_state == "validated"  # passing, not wired — sidecar ignored
+    assert transition.demoted is False
 
 
-def test_wire_non_passing_never_yields_or_persists_blocking(tmp_path):
-    """P1: --wire with a NON-passing record must never reach or persist
-    'blocking' (INV-fh-003). On a brand-new no-record gate it refuses, stays
-    off 'blocking', reports the refusal, and writes nothing."""
+def test_no_trust_write_on_plain_or_missing_gate_checks(tmp_path):
+    """FINDING 4 REGRESSION + P5: no ad-hoc/plain check and no missing-gate op
+    writes anything trust-bearing. Only --wire/--unwire append journal events;
+    plain checks and no-record ops leave the validation dir untouched (beyond the
+    record/journal the test itself seeded)."""
+    # No record at all: nothing is created.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    gv.check_and_transition("no_such_gate", empty)
+    assert list(empty.iterdir()) == []
+    gv.check_and_transition("no_such_gate", empty, unwire=True)  # missing-gate unwire
+    # unwire appends to the (nonexistent) journal beside empty -> it is the
+    # journal, not the validation dir, and only for an explicit op; the
+    # validation dir stays empty.
+    assert list(empty.iterdir()) == []
+
+    # Plain check of a passing record: no authority file appears.
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
+    before = sorted(pp.name for pp in Path(vdir).iterdir())
+    gv.check_and_transition("example_gate", vdir)  # plain
+    after = sorted(pp.name for pp in Path(vdir).iterdir())
+    assert before == after  # no <gate>.authority.json, nothing new
+
+
+def test_wire_non_passing_never_yields_or_journals_blocking(tmp_path):
+    """FINDING/P1: --wire with a NON-passing record must never reach 'blocking'
+    and must not journal a wire event (INV-fh-003). On a fresh no-record gate it
+    refuses, stays off 'blocking', and writes nothing."""
     vdir = tmp_path / "validation"
     vdir.mkdir()
     report, transition = gv.check_and_transition("no_such_gate", vdir, wire=True)
     assert report.passing is False
     assert transition.new_state != "blocking"
     assert "refused" in (transition.instruction or "")
-    assert not (Path(vdir) / "no_such_gate.authority.json").exists()
+    assert gv.ratchet_last_authority_action(_journal(vdir), "no_such_gate") is None
 
 
-def test_unwire_on_missing_gate_writes_nothing(tmp_path):
-    """P5: --unwire on a missing/misspelled gate (no record, never tracked)
-    must leave NOTHING behind in the shared validation dir."""
-    vdir = tmp_path / "validation"
-    vdir.mkdir()
-    gv.check_and_transition("no_such_gate", vdir, unwire=True)
-    assert list(Path(vdir).iterdir()) == []
+def test_wire_on_stale_blocking_record_demotes_never_stays_blocking(tmp_path):
+    """P1: calling --wire again on a journaled-wired gate whose record has gone
+    stale must NOT keep it blocking — a non-passing --wire journals no wire,
+    surfaces the demotion (blocking -> demoted) and emits, and reports the
+    refusal. Wiring blocking authority requires passing==true."""
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+    assert report.passing is False
+    assert transition.new_state == "demoted"
+    assert transition.demoted is True
+    assert transition.demotion_reason == "stale"
+    assert transition.previous_authority == "blocking"
+    assert "refused" in (transition.instruction or "")
+
+
+def test_unwire_from_stale_blocking_emits_demotion_not_silent_report_only(tmp_path, monkeypatch):
+    """P1: --unwire must not mask a stale/missing-while-blocking demotion. From a
+    journaled-wired gate with a NON-passing (stale) record, --unwire surfaces and
+    EMITS the demotion (read from the PRE-unwire journal) while still recording
+    the unwire."""
+    log_path = tmp_path / "factory-log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
+    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
+    scripts_dir = tmp_path / "scripts"
+    _fake_gate_script(scripts_dir, "example_gate", "v1")
+    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
+
+    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
+    _, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
+    assert transition.new_state == "demoted"
+    assert transition.demoted is True
+    assert transition.demotion_reason == "stale"
+
+    demotions = [json.loads(line) for line in log_path.read_text().splitlines()
+                 if json.loads(line).get("event") == "demotion"]
+    assert len(demotions) == 1 and demotions[0]["details"] == "stale"
 
 
 def test_unwire_is_intentional_not_a_demotion(tmp_path):
     """Opus (i)/codex: an operator dropping --gate on purpose is a normal edge
-    (unwire_gate), not a demotion — the record still passes."""
+    (unwire_gate), not a demotion — the record still passes -> validated."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
     gv.check_and_transition("example_gate", vdir, wire=True)
 
@@ -654,14 +739,13 @@ def test_unwire_is_intentional_not_a_demotion(tmp_path):
     assert report.passing is True
     assert transition.new_state == "validated"
     assert transition.demoted is False
-    assert transition.event == "unwire_gate"
 
 
 def test_stale_demotion_emits_generic_demotion_not_emit_demotion(tmp_path, monkeypatch):
     """The telemetry event this auto-demotion emits must be the GENERIC
     `emit_stale_demotion`/`DEMOTION` — never `emit_demotion`, which stamps
-    `details=f"seed_class={{...}}"` and requires one. A staleness demotion has
-    no seed_class at all (nothing escaped in production)."""
+    `details=f"seed_class={{...}}"` and requires one. A staleness demotion has no
+    seed_class at all (nothing escaped in production)."""
     log_path = tmp_path / "factory-log.jsonl"
     monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
 
@@ -684,11 +768,9 @@ def test_stale_demotion_emits_generic_demotion_not_emit_demotion(tmp_path, monke
 
 
 def test_cli_wire_then_record_missing_reports_demotion_in_json(tmp_path):
-    """End-to-end through the actual CLI (subprocess), not just the Python API —
-    proves the argparse wiring and JSON envelope, matching how /close-epic
-    invokes this script. Uses the record-missing variant (rather than scanner
-    drift) since the CLI resolves the live gate script relative to its own
-    scripts/ dir, with no --scripts-dir override to fake a drifted version."""
+    """End-to-end through the actual CLI (subprocess), matching how /close-epic
+    invokes this script. --wire journals a wire event; deleting the record then
+    demotes on the next plain check, surfaced in the JSON envelope + stderr."""
     vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())
 
     proc = subprocess.run(
@@ -713,115 +795,6 @@ def test_cli_wire_then_record_missing_reports_demotion_in_json(tmp_path):
     assert out2["authority"]["demotion_reason"] == "record_missing"
     assert out2["authority"]["previous_authority"] == "blocking"
     assert "DEMOTION" in proc2.stderr
-
-
-def test_forged_blocking_sidecar_without_passing_record_is_not_trusted(tmp_path):
-    """P4: a hand-forged <gate>.authority.json claiming 'blocking' must NOT be
-    trusted unless it corroborates against the record + hash-chained journal
-    (gate-field match + a journaled gate-validation ratchet_record_id). An
-    uncorroborated blocking sidecar can neither assert authority nor trigger a
-    false demotion — exactly the forgeable trust record this epic exists to
-    prevent."""
-    vdir = tmp_path / "validation"
-    vdir.mkdir()
-    # Forge a blocking sidecar whose rid is in no journal (there is none here)
-    # and with no validation record to back it.
-    (vdir / "ghost_gate.authority.json").write_text(json.dumps(
-        {"gate": "ghost_gate", "authority": "blocking",
-         "previous_authority": "validated", "ratchet_record_id": "rec-00001"}))
-
-    # read_authority refuses the forged claim -> unknown/untrusted.
-    assert gv.read_authority("ghost_gate", vdir)["authority"] == "unknown"
-
-    # So a check fires NO false demotion.
-    _, transition = gv.check_and_transition("ghost_gate", vdir)
-    assert transition.demoted is False
-    assert transition.new_state != "demoted"
-    assert transition.previous_state == "unknown"
-
-
-def test_sidecar_rid_contradicting_live_record_is_not_trusted(tmp_path):
-    """P4 (the other corroboration leg): a sidecar whose ratchet_record_id does
-    not match the live record's is out of sync (e.g. edited, or left over from a
-    superseded record) and must be treated as untrusted, never authoritative."""
-    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record())  # rid rec-00001, journaled
-    gv.check_and_transition("example_gate", vdir, wire=True)  # writes a corroborated blocking sidecar
-
-    # Tamper the sidecar's rid to one the live record does not carry.
-    sidecar = Path(vdir) / "example_gate.authority.json"
-    data = json.loads(sidecar.read_text())
-    data["ratchet_record_id"] = "rec-09999"
-    sidecar.write_text(json.dumps(data))
-
-    record = json.loads((Path(vdir) / "example_gate.json").read_text())
-    assert gv.read_authority("example_gate", vdir, record=record)["authority"] == "unknown"
-
-
-def test_wire_on_stale_blocking_record_demotes_never_stays_blocking(tmp_path):
-    """P1: calling --wire again on a gate that IS blocking but whose record has
-    gone stale must NOT keep it blocking (the review's exact bug). A non-passing
-    --wire yields the natural demotion (blocking -> demoted) and emits, and
-    reports the refusal — wiring blocking authority requires passing==true."""
-    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
-    scripts_dir = tmp_path / "scripts"
-    _fake_gate_script(scripts_dir, "example_gate", "v1")
-    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-
-    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
-    report, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    assert report.passing is False
-    assert transition.new_state == "demoted"
-    assert transition.demoted is True
-    assert transition.demotion_reason == "stale"
-    assert transition.previous_authority == "blocking"
-    assert "refused" in (transition.instruction or "")
-    assert gv.read_authority("example_gate", vdir)["authority"] == "demoted"
-
-
-def test_unwire_from_stale_blocking_emits_demotion_not_silent_report_only(tmp_path, monkeypatch):
-    """P1: --unwire must not mask a stale/missing-while-blocking demotion. From
-    blocking with a NON-passing (stale) record, --unwire goes blocking ->
-    demoted and EMITS the demotion — the clean unwire_gate edge is only for a
-    record that still passes."""
-    log_path = tmp_path / "factory-log.jsonl"
-    monkeypatch.setenv("CW_FACTORY_LOG", str(log_path))
-    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
-    scripts_dir = tmp_path / "scripts"
-    _fake_gate_script(scripts_dir, "example_gate", "v1")
-    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-
-    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
-    _, transition = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, unwire=True)
-    assert transition.new_state == "demoted"
-    assert transition.demoted is True
-    assert transition.demotion_reason == "stale"
-
-    demotions = [json.loads(line) for line in log_path.read_text().splitlines()
-                 if json.loads(line).get("event") == "demotion"]
-    assert len(demotions) == 1 and demotions[0]["details"] == "stale"
-
-
-def test_wire_from_demoted_resolves_to_validated_never_blocking(tmp_path):
-    """P2: --wire on a re-authored, now-passing record whose persisted state is
-    'demoted' resolves to 'validated' (two-step recovery), NEVER straight to
-    'blocking' — the model's invalid_transitions forbid demoted -> blocking. A
-    SECOND explicit --wire then promotes it."""
-    vdir = _write_record(tmp_path, "example_gate", _minimal_valid_record(scanner_version="v1"))
-    scripts_dir = tmp_path / "scripts"
-    _fake_gate_script(scripts_dir, "example_gate", "v1")
-    gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    _fake_gate_script(scripts_dir, "example_gate", "v2-drifted")
-    _, demoted = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir)
-    assert demoted.new_state == "demoted"
-
-    (Path(vdir) / "example_gate.json").write_text(
-        json.dumps(_minimal_valid_record(scanner_version="v2-drifted")))
-    _, first_wire = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    assert first_wire.new_state == "validated"  # NOT blocking
-    assert first_wire.event == "re_derive_and_rejournal"
-
-    _, second_wire = gv.check_and_transition("example_gate", vdir, scripts_dir=scripts_dir, wire=True)
-    assert second_wire.new_state == "blocking"
 
 
 def test_validation_dir_is_defined_once_and_imported():

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -616,6 +616,49 @@ def test_emit_demotion_writes_record(tmp_path, monkeypatch):
     assert rec["details"] == "seed_class=evasion-omission"
 
 
+# ---- emit_stale_demotion: chief-wiggum#198 / IT-fh-06 ------------------------
+#
+# The GENERIC demotion path — no seed_class, no escape, just a blocking gate's
+# validation record going stale or missing/invalid (state-machines.json's
+# Gate Blocking-Authority Lifecycle, G-008/G-014). Distinct from
+# `emit_demotion` above, which requires a `seed_class` an escape-driven
+# demotion always has and a staleness demotion never does.
+
+
+def test_emit_stale_demotion_writes_generic_record(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    assert factory_log.emit_stale_demotion(
+        "ratchet", "stale", previous_authority="blocking", repo="acme/app", ticket="198")
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["event"] == "demotion"
+    assert rec["name"] == "ratchet"
+    assert rec["details"] == "stale"
+    assert rec["previous_authority"] == "blocking"
+    assert rec["ticket"] == "198"
+    # never the escape-driven emit_demotion's seed_class= detail shape
+    assert not rec["details"].startswith("seed_class=")
+
+
+def test_emit_stale_demotion_record_missing_variant(tmp_path, monkeypatch):
+    log = tmp_path / "f.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    assert factory_log.emit_stale_demotion("ratchet", "record_missing", previous_authority="blocking")
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["details"] == "record_missing"
+
+
+def test_emit_stale_demotion_rejects_unknown_reason():
+    with pytest.raises(AssertionError):
+        factory_log.emit_stale_demotion("ratchet", "something-else")
+
+
+def test_emit_stale_demotion_is_noop_without_telemetry_enabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("CW_FACTORY_LOG", raising=False)
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    assert factory_log.emit_stale_demotion("ratchet", "stale") is False
+
+
 def test_cli_bug_with_unvalidated_seed_class_prints_no_demotion(tmp_path):
     import os
     log = tmp_path / "f.jsonl"

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -517,6 +517,89 @@ def test_record_rejects_unknown_event(tmp_path):
     assert proc.returncode != 0
 
 
+def test_it_fh_06_real_journal_corroborates_stale_while_blocking_demotion(tmp_path):
+    """IT-fh-06 (chief-wiggum#198) through the REAL `ratchet.py record` CLI —
+    not a hand-written journal fixture. Journal a gate-validation event for
+    real, author a validation record whose ratchet_record_id names it, wire the
+    gate blocking, then simulate #184's scenario (a scanner edit bumps
+    --scanner-version) and prove check_gate_validation.check_and_transition
+    auto-demotes it (blocking -> demoted), recording previous_authority."""
+    import check_gate_validation as gv  # noqa: PLC0415
+
+    cfg = make_repo(tmp_path)
+    subprocess.run(
+        [sys.executable, str(SCRIPTS / "ratchet.py"), "score", "--repo", str(tmp_path),
+         "--no-tests", "--no-quality"],
+        capture_output=True, text=True, check=True,
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "ratchet.py"), "record", "--repo", str(tmp_path),
+         "--event", "gate-validation", "--ref", "example_gate", "--merged",
+         "--notes", "IT-fh-06 fixture"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    record_id = ratchet.load_journal(cfg)[0]["record_id"]
+
+    validation_dir = cfg.journal.parent / "validation"
+    validation_dir.mkdir(parents=True, exist_ok=True)
+    scripts_dir = tmp_path / "fake_scripts"
+
+    def _write_fake_gate(version: str) -> None:
+        scripts_dir.mkdir(exist_ok=True)
+        (scripts_dir / "example_gate.py").write_text(
+            "import sys\n"
+            "if '--scanner-version' in sys.argv:\n"
+            f"    print({version!r})\n"
+            "    raise SystemExit(0)\n"
+            "raise SystemExit(2)\n"
+        )
+
+    _write_fake_gate("v1")
+    record = {
+        "gate": "example_gate",
+        "protocol_version": "1",
+        "scanner_version": "v1",
+        "telemetry_dependent": False,
+        "concurrency_applicable": False,
+        "concurrency_note": "static analysis has no concurrent dimension",
+        "authority_boundary": {"proves": "fixture", "artifact": "fixture", "assumptions": ["fixture"]},
+        "seeded_defect_trials": [
+            {"seed_id": "d1", "seed_class": "direct", "repo": "r", "expected": "fire",
+             "result": "fired", "passed": True},
+            {"seed_id": "o1", "seed_class": "evasion-omission", "repo": "r", "expected": "fire",
+             "result": "fired", "passed": True},
+            {"seed_id": "c1", "seed_class": "evasion-config-indirection", "repo": "r",
+             "expected": "fire", "result": "fired", "passed": True},
+            {"seed_id": "s1", "seed_class": "evasion-sampling-gap", "repo": "r",
+             "expected": "no-fire", "result": "not-fired", "passed": True},
+        ],
+        "clean_corpus_runs": [
+            {"repo": "r", "sha": "abc", "findings": 0, "coverage": {"n": 1}, "passed": True},
+        ],
+        "status": "passed",
+        "ratchet_record_id": record_id,
+    }
+    (validation_dir / "example_gate.json").write_text(json.dumps(record))
+
+    report, transition = gv.check_and_transition(
+        "example_gate", validation_dir, scripts_dir=scripts_dir, wire=True,
+    )
+    assert report.passing is True, (report.provenance_errors, report.schema_errors)
+    assert transition.new_state == "blocking"
+
+    _write_fake_gate("v2-after-scanner-edit")  # #184: a scanner edit bumps --scanner-version
+
+    report2, transition2 = gv.check_and_transition(
+        "example_gate", validation_dir, scripts_dir=scripts_dir,
+    )
+    assert report2.passing is False
+    assert transition2.previous_state == "blocking"
+    assert transition2.new_state == "demoted"
+    assert transition2.demotion_reason == "stale"
+    assert transition2.previous_authority == "blocking"
+
+
 # ---- --scanner-version (#184) --------------------------------------------------
 
 

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -600,6 +600,78 @@ def test_it_fh_06_real_journal_corroborates_stale_while_blocking_demotion(tmp_pa
     assert transition2.previous_authority == "blocking"
 
 
+# ---- gate-authority journal primitives: tamper-tolerance (chief-wiggum#198) ----
+
+
+def _chain(journal_path: Path, bodies: list[dict]) -> None:
+    """Write a hash-chained journal (same chaining as ratchet.append_authority_event)."""
+    from chief_wiggum.hashing import stable_hash  # noqa: PLC0415
+    prev = "genesis"
+    lines = []
+    for body in bodies:
+        body = {k: v for k, v in body.items() if k != "record_hash"}
+        body["record_hash"] = stable_hash(prev, json.dumps(body, sort_keys=True))
+        prev = body["record_hash"]
+        lines.append(json.dumps(body, sort_keys=True))
+    journal_path.write_text("\n".join(lines) + "\n")
+
+
+def test_last_authority_action_ignores_bogus_details_after_wire(tmp_path):
+    """FINDING 1: a hash-VALID gate-authority event carrying a bogus `details`
+    (e.g. 'noop') after a real wire must NOT flip the gate to un-wired — only
+    'wire'/'unwire' are authority actions; anything else is ignored, so the
+    prior genuine wire still stands."""
+    journal = tmp_path / "ratchet-journal.jsonl"
+    _chain(journal, [
+        {"record_id": "rec-00001", "event": "gate-authority", "ref": "g", "details": "wire"},
+        {"record_id": "rec-00002", "event": "gate-authority", "ref": "g", "details": "noop"},
+    ])
+    # The bogus 'noop' is ignored; the last GENUINE action is still 'wire'.
+    assert ratchet.last_authority_action(journal, "g") == "wire"
+
+
+def test_last_authority_action_respects_a_real_unwire(tmp_path):
+    """Control for finding 1: a genuine 'unwire' after a 'wire' DOES un-wire —
+    the filter ignores only non-action details, never a real unwire."""
+    journal = tmp_path / "ratchet-journal.jsonl"
+    _chain(journal, [
+        {"record_id": "rec-00001", "event": "gate-authority", "ref": "g", "details": "wire"},
+        {"record_id": "rec-00002", "event": "gate-authority", "ref": "g", "details": "unwire"},
+    ])
+    assert ratchet.last_authority_action(journal, "g") == "unwire"
+
+
+def test_verified_prefix_stops_before_a_non_json_trailing_line(tmp_path):
+    """FINDING 2: malformed JSON in the journal tail after a valid wire must not
+    crash the read — verified_prefix parses line-by-line and stops before the
+    first unparseable line, so the wire is still read (and a stale record still
+    demotes)."""
+    journal = tmp_path / "ratchet-journal.jsonl"
+    _chain(journal, [
+        {"record_id": "rec-00001", "event": "gate-authority", "ref": "g", "details": "wire"},
+    ])
+    # Corrupt the tail with a non-JSON garbage line.
+    with journal.open("a") as f:
+        f.write("this is not json at all\n")
+
+    prefix = ratchet.verified_prefix(journal)
+    assert len(prefix) == 1  # the wire survives; the garbage tail is dropped
+    assert ratchet.last_authority_action(journal, "g") == "wire"
+
+
+def test_append_authority_event_fails_closed_on_garbled_tail(tmp_path):
+    """A garbled tail is a broken chain: append_authority_event must raise
+    TamperError (never a JSONDecodeError crash) so callers can handle it."""
+    journal = tmp_path / "ratchet-journal.jsonl"
+    _chain(journal, [
+        {"record_id": "rec-00001", "event": "gate-authority", "ref": "g", "details": "wire"},
+    ])
+    with journal.open("a") as f:
+        f.write("garbage\n")
+    with pytest.raises(ratchet.TamperError):
+        ratchet.append_authority_event(journal, "g", "unwire")
+
+
 # ---- --scanner-version (#184) --------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #198. The Factory Hardening epic's committed state machine
(`docs/epics/epic-factory-hardening/models/state-machines.json`) already
modeled a "Gate Blocking-Authority Lifecycle" with `stale`/`demoted` states, a
`previous_authority` context field, and `auto_demote`/
`downgrade_nonblocking_stale`/`record_missing_or_invalid` transitions — but
none of it was implemented (`IT-fh-06` had no test anywhere, `traceability.md`
honestly listed the row `pending`). Per the ticket's decision framing, this
implements the model (the model declared it) rather than retiring it.

- `scripts/check_gate_validation.py` gains `failure_kind` (classifies a
  non-passing report as `"stale"` — scanner_version/journal-chain drift only,
  otherwise clean — vs `"invalid"` — missing record, schema errors,
  forged/failed trials, wrong status), `compute_transition` (the lifecycle's
  edges), and `check_and_transition` (wraps `check()` with the transition +
  a persisted `<gate>.authority.json` sidecar tracking
  `authority`/`previous_authority`). New `--wire`/`--unwire` CLI flags record
  the operator's wiring intent (`wire_gate`/`unwire_gate`) — the prerequisite
  for knowing a later staleness finding is a demotion (was blocking) vs a mere
  downgrade (was only validated). Report-only-safe: a gate with no record at
  all writes nothing to the (possibly shared) validation dir.
- `scripts/factory_log.py` gains `emit_stale_demotion(gate, reason,
  previous_authority=...)` — the generic `DEMOTION` event
  (`details='stale'|'record_missing'`), distinct from the pre-existing
  escape-driven `emit_demotion` (which requires a `seed_class` a staleness
  demotion never has).
- The **existing** `--gate` exit-1 guard (unchanged) already enforces
  INV-fh-003 — "no blocking without a passing record" — since a demoted gate's
  record is by definition not passing. This PR adds detection, telemetry, and
  `previous_authority` bookkeeping on top of that guard, per the ticket's
  instruction to model the guard as the enforcement point rather than
  duplicating it.
- Recovery always lands on `validated`, never straight back to `blocking`
  (the model's `invalid_transitions` explicitly forbid `demoted -> blocking`)
  — an explicit `--wire` is required to re-promote, same as first promotion.

## Model → code mapping

| Model transition | Code |
|---|---|
| `blocking -> stale -> demoted` (G-006/G-008, `auto_demote`) | `compute_transition`: `prev == "blocking"` + `failure_kind == "stale"` → `demoted`, `demotion_reason="stale"` |
| `blocking -> demoted` (G-014, `record_missing_or_invalid`) | same branch, `failure_kind == "invalid"` → `demotion_reason="record_missing"` |
| `validated -> stale -> report_only` (G-005/G-015, `downgrade_nonblocking_stale`) | `compute_transition`: `prev != "blocking"` → `report_only`, no demotion event |
| `validated -> report_only` (G-012) | same branch, `failure_kind == "invalid"` |
| `stale -> validated` (G-009) / `demoted -> validated` (G-010) | `compute_transition`: `failure_kind is None` → `validated`, event `re_derive_record`/`re_derive_and_rejournal` |
| `validated -> blocking` (G-004) / `blocking -> validated` (G-013) | `check_and_transition(wire=True)` / `check_and_transition(unwire=True)` |
| `invalid_transitions`: `demoted -> blocking` forbidden | `compute_transition` never returns `blocking` except via explicit `--wire`, which requires `passing == True` (post-re-derivation `validated`, not `demoted`) |
| generic `emit(DEMOTION, gate=gate, details='stale')` (G-008 note) | `factory_log.emit_stale_demotion(gate, "stale"/"record_missing", previous_authority=...)` — never `emit_demotion` |
| `previous_authority` context field | persisted in `<gate>.authority.json`, read back on every check |

## Deviations from the literal model

- **Transient `stale` state collapses within one CLI invocation.** A
  stateless per-process CLI can't rest in an intermediate state across calls,
  so `blocking -> stale -> demoted` and `validated -> stale -> report_only`
  each resolve in one hop. The `event` name and `previous_authority` still
  record which path was taken.
- **`details` value for the record-missing/schema-invalid demotion is
  `'record_missing'`** (the ticket's own wording), not the model's literal
  `'record-missing-or-invalid'` action string — used consistently for both
  "missing" and "schema-invalid" as the ticket specified.
- **Persisted authority sidecar (`<gate>.authority.json`) is new design, not
  in the literal model** — the model doesn't specify how a stateless CLI
  tracks authority across invocations at all. It's written only once a gate
  reaches a real authority state (or was already tracked), to avoid leaving
  stray files in a shared `docs/quality/validation/` from ad-hoc/report-only
  queries (caught by a regression test after an initial version polluted the
  real validation dir during manual testing).
- **`--wire`/`--unwire` are new, minimal CLI affordances** — not explicitly
  requested by the ticket, but required to reach `blocking` at all (the
  model's `wire_gate`/`unwire_gate` events) so the auto-demotion path is
  actually exercisable/testable end-to-end.

## Test plan

- [x] `tests/test_check_gate_validation.py` (+13 tests): stale-while-blocking
      demotion, record-missing/schema-invalid-while-blocking demotion,
      validated-only downgrade (no demotion event), recovery to `validated`
      (never straight to `blocking`), `--wire`/`--unwire` semantics, generic
      `DEMOTION` telemetry shape, CLI end-to-end, and the report-only-safe
      no-sidecar-on-unknown-gate regression.
- [x] `tests/test_ratchet.py` (+1 test): IT-fh-06 through the **real**
      `ratchet.py record` CLI (not a hand-written journal fixture).
- [x] `tests/test_factory_log.py` (+4 tests): `emit_stale_demotion` generic
      shape, both reasons, no-op without telemetry, rejects unknown reasons.
- [x] `docs/epics/epic-factory-hardening/traceability.md` row flipped
      `missing -> passing`; `integration-tests.md` IT-fh-06 gained a Status
      line; `retrospective.md` gained an addendum closing the epic's one open
      item.
- [x] Full suite: 1566 passed, 10 skipped (pre-existing `lizard`-not-installed
      skips, unchanged) — up from 1549/10 on `main`.
- [x] `ruff check` clean on all touched files (124 pre-existing errors
      elsewhere in `docs/formal-methods/examples/generated/` are unchanged
      from `main`, confirmed via `git stash`).

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF