### PR TITLE
feat(patterns): /apply-pattern stamps scaffold code, not just the contract pack (#135)

### DIFF
--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -56,7 +56,7 @@ patterns/
 ├── improvement-loop/             # specified pattern
 │   ├── pattern.md                # the spec: what / when-to-apply / mechanism / parameters
 │   ├── manifest.json             # machine-readable: params, installs[], protected_paths, trust
-│   └── scaffold/                 # (future) the templated files stamped into the target app
+│   └── scaffold/                 # the templated code seams stamped into the target app (see #scaffold-layout)
 ├── engagement-instrumentation/   # specified pattern — the signal tier that feeds the loop
 │   ├── pattern.md
 │   └── manifest.json
@@ -69,6 +69,25 @@ patterns/
         ├── bindings/             # pattern × this-stack → concrete recipe (one .md per bound pattern)
         └── skills/               # runnable stand-up playbooks ("the skills to use them")
 ```
+
+<a id="scaffold-layout"></a>
+A pattern MAY also ship a **`scaffold/`** — the code half. Where the contract pack
+(`manifest.json`'s invariant cluster) declares *what must hold*, the scaffold is
+the *starting code that holds it*: the seams and guards realizing the cluster,
+stamped into the target repo by `apply_pattern.py`. Layout:
+
+- **`scaffold/scaffold.json`** — the scaffold manifest: `files[]`, each mapping a
+  `template` (a file under `scaffold/`) to a `target` (a repo-relative path in the
+  stamped app), with `realizes` (the `INV-*` ids it satisfies) and a `desc`.
+- **`scaffold/<name>.tmpl`** — a template file. Every `{{param}}` in both the
+  `target` path and the file body is replaced with the bound parameter value.
+
+Stamping rules (mechanically enforced by `apply_pattern.py`): a target that
+already exists is **skipped, never clobbered**, unless `--force` is passed (so
+hand-edits to a stamped seam survive re-application); stamping needs every
+**required** param bound, else the contract pack still installs and the scaffold
+is skipped with a note. `multi-tenant-isolation` is the first pattern to ship a
+scaffold (`internal/tenant/{resolver,scoped_repo}.go`, realizing INV-MTI-001/002).
 
 Each specified pattern is a directory. Two files are the contract:
 
@@ -97,8 +116,9 @@ A pattern is installed into a target repo by a thin workflow
 /apply-pattern owner/repo --pattern fetch-on-webhook-reconcile --param resource=subscription
 ```
 
-Mechanically — the **contract-pack** steps (1, 2, 4, 5) are **built**; scaffold
-stamping (3) is deferred until patterns ship a `scaffold/`:
+Mechanically — the **contract-pack** steps (1, 2, 4, 5) and scaffold stamping (3)
+are all **built** (`multi-tenant-isolation` is the first pattern to ship a
+`scaffold/`; see [Scaffold layout](#scaffold-layout)):
 
 1. **Resolve** the target repo (`scripts/repo.py`, as every workflow does). ✅
 2. **Bind parameters** — read `manifest.json`'s parameter schema and resolve each
@@ -106,8 +126,10 @@ stamping (3) is deferred until patterns ship a `scaffold/`:
    its model family, its protected paths). Unresolved **required** params become
    `TBD:` markers in the installed contract pack, gated exactly like every other
    CW artifact (`scripts/check_unresolved.py`). ✅
-3. **Stamp** the scaffold into the target repo with parameters bound. ⏳ *(deferred
-   — no pattern ships a `scaffold/` yet.)*
+3. **Stamp** the scaffold into the target repo with parameters bound. ✅ *(when the
+   pattern ships a `scaffold/`; idempotent — an existing target file is skipped,
+   never clobbered, unless `--force`. Needs every required param bound, else the
+   contract pack still installs and the scaffold is skipped with a note.)*
 4. **Register protected paths** — add `docs/patterns/**` (the installed contract
    pack) to the product's `docs/quality/ratchet.json`, so the adopted cluster
    becomes a goalpost the app's autonomous machinery cannot move (reuses the

--- a/patterns/multi-tenant-isolation/scaffold/scaffold.json
+++ b/patterns/multi-tenant-isolation/scaffold/scaffold.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "Scaffold manifest for multi-tenant-isolation. apply_pattern.py stamps each file into the target repo with parameters bound. This is the CODE half of the pattern (the seams that realize INV-MTI), complementing the contract-pack (invariants.md) half. Templating convention: occurrences of {{param}} in both the target path and the file body are replaced with the bound parameter value (from --param / the manifest schema). A file whose target already exists is SKIPPED (never clobbered) unless --force is passed. See docs/patterns-registry.md#scaffold-layout.",
+  "scaffold_version": 1,
+  "pattern": "multi-tenant-isolation",
+  "files": [
+    {
+      "template": "tenant_resolver.go.tmpl",
+      "target": "internal/tenant/resolver.go",
+      "realizes": ["INV-MTI-001"],
+      "desc": "Server-only tenant resolution: derive the tenant from the authenticated principal, reject client-supplied hints, 404 (not 403) on a cross-tenant probe."
+    },
+    {
+      "template": "tenant_scoped_repo.go.tmpl",
+      "target": "internal/tenant/scoped_repo.go",
+      "realizes": ["INV-MTI-002"],
+      "desc": "Fail-closed tenant-scoped repository: every query is scoped by {{tenant_key}}; there is no unscoped path and the raw {{store}} handle stays unexported."
+    }
+  ]
+}

--- a/patterns/multi-tenant-isolation/scaffold/tenant_resolver.go.tmpl
+++ b/patterns/multi-tenant-isolation/scaffold/tenant_resolver.go.tmpl
@@ -1,0 +1,55 @@
+// Package tenant — stamped from the multi-tenant-isolation registry pattern.
+//
+// Realizes INV-MTI-001 (server-only tenant resolution). The tenant is derived
+// from the authenticated principal ({{resolver}}), NEVER from a client-supplied
+// header, query param, or body field — a request that tries to name its own
+// tenant is treated as a probe and answered with 404 (indistinguishable from
+// "no such resource"), not 403 (which would confirm the resource exists).
+//
+// SCAFFOLD SEAM: wire ResolveTenant into your auth middleware and replace the
+// principalTenant lookup with your real {{resolver}} implementation. Do not add
+// a code path that reads the tenant from the request.
+package tenant
+
+import (
+	"errors"
+	"net/http"
+)
+
+// TenantKey is the scoping field for this product: {{tenant_key}}.
+const TenantKey = "{{tenant_key}}"
+
+// ErrNoTenant is returned when no tenant can be resolved from the principal.
+// Callers MUST fail closed (404) — never fall back to an unscoped view.
+var ErrNoTenant = errors.New("tenant: unresolved for principal")
+
+// Principal is the authenticated identity. It is populated by trusted auth
+// middleware, never from client-controlled request fields.
+type Principal struct {
+	Subject string
+	// resolver = {{resolver}}: the tenant is carried here (claim) or looked up
+	// from this subject (membership-lookup). Fill in per your resolver.
+	tenant string
+}
+
+// ResolveTenant derives the tenant id from the authenticated principal.
+// resolver strategy: {{resolver}}.
+//
+// It must never consult the *http.Request for the tenant. The request is passed
+// only so the seam can 404 a cross-tenant probe uniformly; do not read a tenant
+// hint out of it.
+func ResolveTenant(p *Principal) (string, error) {
+	if p == nil || p.tenant == "" {
+		// SCAFFOLD: for resolver "membership-lookup", replace this with a lookup
+		// keyed by p.Subject against your {{store}} membership records.
+		return "", ErrNoTenant
+	}
+	return p.tenant, nil
+}
+
+// ProbeResponse is the uniform answer to a request that cannot be scoped to the
+// principal's tenant (or names a foreign tenant): 404, never 403 — a 403 leaks
+// that the foreign resource exists.
+func ProbeResponse(w http.ResponseWriter) {
+	http.Error(w, "not found", http.StatusNotFound)
+}

--- a/patterns/multi-tenant-isolation/scaffold/tenant_scoped_repo.go.tmpl
+++ b/patterns/multi-tenant-isolation/scaffold/tenant_scoped_repo.go.tmpl
@@ -1,0 +1,74 @@
+// Package tenant — stamped from the multi-tenant-isolation registry pattern.
+//
+// Realizes INV-MTI-002 (fail-closed tenant-scoped repository). Every read and
+// write is scoped by {{tenant_key}}. There is NO unscoped path: the raw {{store}}
+// handle is unexported, so no caller can reach around the scoping. A filter that
+// arrives already carrying a {{tenant_key}} is rejected (not overridden) so a
+// caller can never widen its own scope.
+//
+// SCAFFOLD SEAM: replace the filter/exec bodies with your real {{store}} driver
+// calls. Keep the guards — they are the invariant. Do not export `store` and do
+// not add a method that queries without calling scope().
+package tenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrScopeConflict is returned when a caller-supplied filter already constrains
+// {{tenant_key}} — a sign the caller is trying to choose its own tenant. The repo
+// REJECTS rather than overrides, so a widening attempt fails closed.
+var ErrScopeConflict = errors.New("scoped_repo: caller filter must not set " + TenantKey)
+
+// ScopedRepo wraps the raw {{store}} handle. The handle is unexported: the only
+// way to query is through the scope-enforcing methods below.
+type ScopedRepo struct {
+	store any // {{store}} — unexported on purpose; never surface a raw handle
+}
+
+// NewScopedRepo binds a raw {{store}} handle behind the scoping guard.
+func NewScopedRepo(store any) *ScopedRepo {
+	return &ScopedRepo{store: store}
+}
+
+// scope injects {{tenant_key}} == tenant into a filter, rejecting any filter that
+// already constrains it. This is the single chokepoint every query passes.
+func scope(tenant string, filter map[string]any) (map[string]any, error) {
+	if tenant == "" {
+		return nil, ErrNoTenant
+	}
+	if filter == nil {
+		filter = map[string]any{}
+	}
+	if _, present := filter[TenantKey]; present {
+		return nil, ErrScopeConflict
+	}
+	filter[TenantKey] = tenant
+	return filter, nil
+}
+
+// Find scopes the query to the caller's tenant. There is deliberately no Find
+// that skips scope().
+func (r *ScopedRepo) Find(ctx context.Context, tenant string, filter map[string]any) ([]map[string]any, error) {
+	scoped, err := scope(tenant, filter)
+	if err != nil {
+		return nil, fmt.Errorf("scoped find: %w", err)
+	}
+	// SCAFFOLD: execute `scoped` against r.store ({{store}}) and return results.
+	_ = scoped
+	return nil, nil
+}
+
+// Update scopes the mutation to the caller's tenant, same chokepoint as Find.
+func (r *ScopedRepo) Update(ctx context.Context, tenant string, filter, set map[string]any) error {
+	scoped, err := scope(tenant, filter)
+	if err != nil {
+		return fmt.Errorf("scoped update: %w", err)
+	}
+	// SCAFFOLD: execute the scoped update against r.store ({{store}}).
+	_ = scoped
+	_ = set
+	return nil
+}

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -196,8 +196,14 @@ def load_scaffold(pattern_id: str, base: Path = ROOT) -> dict | None:
     if not isinstance(files, list) or not files:
         raise ApplyError(f"scaffold manifest {path} needs a non-empty 'files' array")
     for entry in files:
-        if not isinstance(entry, dict) or not entry.get("template") or not entry.get("target"):
-            raise ApplyError(f"scaffold file entry needs string 'template'+'target': {entry!r}")
+        if not isinstance(entry, dict):
+            raise ApplyError(f"scaffold file entry must be an object: {entry!r}")
+        tmpl, target = entry.get("template"), entry.get("target")
+        if not isinstance(tmpl, str) or not tmpl or not isinstance(target, str) or not target:
+            raise ApplyError(f"scaffold file entry needs non-empty string 'template'+'target': {entry!r}")
+        tp = PurePosixPath(tmpl)
+        if tp.is_absolute() or ".." in tp.parts or tmpl != tp.as_posix():
+            raise ApplyError(f"scaffold 'template' must be a path under scaffold/ (no '..'/absolute): {tmpl!r}")
     return scaffold
 
 
@@ -314,9 +320,13 @@ def apply_plan(plan: Plan, target: Path, write: bool = True, force: bool = False
     target_root = target.resolve()
     for rel, content in plan.scaffold_files.items():
         path = target / rel
-        # Defense in depth beyond the pure-path guard in _render_scaffold: resolve
-        # the destination (following any symlink) and confirm it stays inside the
-        # target repo, so a symlinked path component can't redirect the write out.
+        # Defense in depth beyond the pure-path guard in _render_scaffold: a
+        # scaffold target must never be a symlink (write_text follows it — a live
+        # or dangling symlink at the final path would redirect the write out of
+        # the repo, incl. under --force), and its resolved parent must stay inside
+        # the repo (so a symlinked directory component can't redirect it either).
+        if path.is_symlink():
+            raise ApplyError(f"scaffold target is a symlink (refusing to follow): {rel!r}")
         resolved_parent = path.parent.resolve()
         if resolved_parent != target_root and target_root not in resolved_parent.parents:
             raise ApplyError(f"scaffold target escapes the repo via symlink: {rel!r}")

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -37,7 +37,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS))
@@ -206,6 +206,12 @@ def _render_scaffold(pattern_id: str, scaffold: dict, bound: dict[str, str],
         rel = _render(target, bound)
         if _PLACEHOLDER.search(rel):
             raise ApplyError(f"scaffold target path has an unbound placeholder: {rel}")
+        # Fail closed on a target that would escape the target repo. Scaffold
+        # manifests (and any param bound into a path) are stamped into a real
+        # checkout — an absolute path or a `..` segment must never write outside it.
+        pp = PurePosixPath(rel)
+        if pp.is_absolute() or ".." in pp.parts or rel != pp.as_posix():
+            raise ApplyError(f"scaffold target must be a repo-relative path without '..': {rel!r}")
         out[rel] = _render(tpath.read_text(), bound)
     return out
 

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -172,47 +172,64 @@ def _invariants_doc(manifest: dict, cluster: list[dict], bound: dict, unresolved
 
 
 def _render(text: str, bound: dict[str, str]) -> str:
-    """Substitute {{param}} with its bound value. An unknown placeholder is left
-    verbatim (build_plan only renders when every required param is bound, so a
-    surviving placeholder is an optional param the author referenced)."""
+    """Substitute {{param}} with its bound value, leaving an unbound placeholder
+    verbatim. Callers (_render_scaffold) then fail closed on any survivor, so a
+    template referencing a param that isn't bound is a hard error, not silent
+    {{param}} leaking into stamped code."""
     return _PLACEHOLDER.sub(lambda m: bound.get(m.group(1), m.group(0)), text)
 
 
 def load_scaffold(pattern_id: str, base: Path = ROOT) -> dict | None:
-    """Read a pattern's scaffold/scaffold.json, or None if it ships no scaffold."""
+    """Read + structurally validate a pattern's scaffold/scaffold.json, or None if
+    it ships no scaffold. A malformed manifest is a clear ApplyError, never an
+    uncaught AttributeError (which would abort the contract-pack install too)."""
     path = base / "patterns" / pattern_id / SCAFFOLD_DIR / SCAFFOLD_MANIFEST
     if not path.is_file():
         return None
     try:
-        return json.loads(path.read_text())
+        scaffold = json.loads(path.read_text())
     except json.JSONDecodeError as exc:
         raise ApplyError(f"malformed scaffold manifest {path}: {exc}") from exc
+    if not isinstance(scaffold, dict):
+        raise ApplyError(f"scaffold manifest {path} must be a JSON object")
+    files = scaffold.get("files")
+    if not isinstance(files, list) or not files:
+        raise ApplyError(f"scaffold manifest {path} needs a non-empty 'files' array")
+    for entry in files:
+        if not isinstance(entry, dict) or not entry.get("template") or not entry.get("target"):
+            raise ApplyError(f"scaffold file entry needs string 'template'+'target': {entry!r}")
+    return scaffold
 
 
 def _render_scaffold(pattern_id: str, scaffold: dict, bound: dict[str, str],
                      base: Path = ROOT) -> dict[str, str]:
     """Render each scaffold template into {target-relpath -> content}, params bound
-    in both the target path and the body."""
+    in both the target path and the body. Fails closed if any {{param}} survives
+    the render (a template referencing a param that isn't bound)."""
     out: dict[str, str] = {}
     scaffold_dir = base / "patterns" / pattern_id / SCAFFOLD_DIR
-    for entry in scaffold.get("files", []):
-        tmpl = entry.get("template")
-        target = entry.get("target")
-        if not tmpl or not target:
-            raise ApplyError(f"scaffold file entry needs template+target: {entry}")
+    for entry in scaffold["files"]:  # structure validated in load_scaffold
+        tmpl = entry["template"]
+        target = entry["target"]
         tpath = scaffold_dir / tmpl
         if not tpath.is_file():
             raise ApplyError(f"scaffold template missing: {tpath}")
         rel = _render(target, bound)
-        if _PLACEHOLDER.search(rel):
-            raise ApplyError(f"scaffold target path has an unbound placeholder: {rel}")
         # Fail closed on a target that would escape the target repo. Scaffold
         # manifests (and any param bound into a path) are stamped into a real
         # checkout — an absolute path or a `..` segment must never write outside it.
         pp = PurePosixPath(rel)
+        if _PLACEHOLDER.search(rel):
+            raise ApplyError(f"scaffold target path has an unbound placeholder: {rel}")
         if pp.is_absolute() or ".." in pp.parts or rel != pp.as_posix():
             raise ApplyError(f"scaffold target must be a repo-relative path without '..': {rel!r}")
-        out[rel] = _render(tpath.read_text(), bound)
+        body = _render(tpath.read_text(), bound)
+        leftover = _PLACEHOLDER.search(body)
+        if leftover:
+            raise ApplyError(
+                f"scaffold template {tmpl} references unbound param "
+                f"{{{{{leftover.group(1)}}}}} — bind it or give it a manifest default")
+        out[rel] = body
     return out
 
 
@@ -294,8 +311,15 @@ def apply_plan(plan: Plan, target: Path, write: bool = True, force: bool = False
 
     # Scaffold code: idempotent. An existing target is skipped (never clobbered)
     # unless --force, so hand-edits to stamped seams survive re-application.
+    target_root = target.resolve()
     for rel, content in plan.scaffold_files.items():
         path = target / rel
+        # Defense in depth beyond the pure-path guard in _render_scaffold: resolve
+        # the destination (following any symlink) and confirm it stays inside the
+        # target repo, so a symlinked path component can't redirect the write out.
+        resolved_parent = path.parent.resolve()
+        if resolved_parent != target_root and target_root not in resolved_parent.parents:
+            raise ApplyError(f"scaffold target escapes the repo via symlink: {rel!r}")
         if path.exists() and not force:
             actions.append(f"skip scaffold {rel} (exists — use --force to re-stamp)")
             continue

--- a/scripts/apply_pattern.py
+++ b/scripts/apply_pattern.py
@@ -17,8 +17,13 @@ does the mechanical, scaffold-independent half of `/apply-pattern`:
      protected paths, so the adopted contract pack becomes a goalpost workers
      can't move.
 
-Scaffold stamping (the pattern's `scaffold/` files) is deliberately out of scope
-until scaffolds exist — this installs the contract pack, not the code.
+  6. Stamps the pattern's `scaffold/` code (the seams that realize the cluster)
+     into the target repo with parameters bound, when the pattern ships one.
+     Scaffold files are code, so stamping is idempotent: an existing target is
+     skipped (never clobbered) unless `--force` is passed. Templating replaces
+     `{{param}}` in both the target path and the file body with the bound value.
+     Scaffold stamping needs every REQUIRED param bound; if any is unresolved the
+     contract pack still installs and the scaffold is skipped with a note.
 
     python3 scripts/apply_pattern.py fetch-on-webhook-reconcile \\
         --target-dir /path/to/repo --param resource=subscription --param projected_field=plan
@@ -28,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -45,6 +51,9 @@ REGISTRY = ROOT / "patterns" / "registry.json"
 ADOPTED_REL = "docs/patterns/adopted.json"
 RATCHET_REL = "docs/quality/ratchet.json"
 PATTERN_GLOB = "docs/patterns/**"
+SCAFFOLD_DIR = "scaffold"
+SCAFFOLD_MANIFEST = "scaffold.json"
+_PLACEHOLDER = re.compile(r"\{\{(\w+)\}\}")
 
 
 class ApplyError(Exception):
@@ -55,7 +64,9 @@ class ApplyError(Exception):
 class Plan:
     pattern_id: str
     version: int
-    files: dict[str, str] = field(default_factory=dict)   # repo-rel path -> content
+    files: dict[str, str] = field(default_factory=dict)   # repo-rel path -> content (contract pack; regenerated, overwrite ok)
+    scaffold_files: dict[str, str] = field(default_factory=dict)  # repo-rel path -> rendered code (idempotent, never clobbered without --force)
+    scaffold_skipped: str = ""                            # note when scaffold stamping was skipped
     ratchet_add: list[str] = field(default_factory=list)  # globs to merge into protected_paths
     bound: dict[str, str] = field(default_factory=dict)
     unresolved: list[str] = field(default_factory=list)   # required params with no value
@@ -160,6 +171,45 @@ def _invariants_doc(manifest: dict, cluster: list[dict], bound: dict, unresolved
     return "\n".join(lines)
 
 
+def _render(text: str, bound: dict[str, str]) -> str:
+    """Substitute {{param}} with its bound value. An unknown placeholder is left
+    verbatim (build_plan only renders when every required param is bound, so a
+    surviving placeholder is an optional param the author referenced)."""
+    return _PLACEHOLDER.sub(lambda m: bound.get(m.group(1), m.group(0)), text)
+
+
+def load_scaffold(pattern_id: str, base: Path = ROOT) -> dict | None:
+    """Read a pattern's scaffold/scaffold.json, or None if it ships no scaffold."""
+    path = base / "patterns" / pattern_id / SCAFFOLD_DIR / SCAFFOLD_MANIFEST
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ApplyError(f"malformed scaffold manifest {path}: {exc}") from exc
+
+
+def _render_scaffold(pattern_id: str, scaffold: dict, bound: dict[str, str],
+                     base: Path = ROOT) -> dict[str, str]:
+    """Render each scaffold template into {target-relpath -> content}, params bound
+    in both the target path and the body."""
+    out: dict[str, str] = {}
+    scaffold_dir = base / "patterns" / pattern_id / SCAFFOLD_DIR
+    for entry in scaffold.get("files", []):
+        tmpl = entry.get("template")
+        target = entry.get("target")
+        if not tmpl or not target:
+            raise ApplyError(f"scaffold file entry needs template+target: {entry}")
+        tpath = scaffold_dir / tmpl
+        if not tpath.is_file():
+            raise ApplyError(f"scaffold template missing: {tpath}")
+        rel = _render(target, bound)
+        if _PLACEHOLDER.search(rel):
+            raise ApplyError(f"scaffold target path has an unbound placeholder: {rel}")
+        out[rel] = _render(tpath.read_text(), bound)
+    return out
+
+
 def build_plan(pattern_id: str, provided: dict[str, str],
                registry_path: Path = REGISTRY, base: Path = ROOT,
                now: str | None = None) -> Plan:
@@ -174,6 +224,19 @@ def build_plan(pattern_id: str, provided: dict[str, str],
                 ratchet_add=[PATTERN_GLOB])
     plan.files[f"docs/patterns/{pattern_id}/invariants.md"] = _invariants_doc(
         manifest, cluster, bound, unresolved)
+
+    # Scaffold (the pattern's code seams). Needs every required param bound, since
+    # the templates reference them; if any is unresolved the contract pack still
+    # installs and the scaffold is skipped with a note.
+    scaffold = load_scaffold(pattern_id, base)
+    if scaffold is not None:
+        if unresolved:
+            plan.scaffold_skipped = (
+                "scaffold not stamped — unbound required param(s): "
+                + ", ".join(sorted(unresolved))
+            )
+        else:
+            plan.scaffold_files = _render_scaffold(pattern_id, scaffold, bound, base)
     plan._adoption = {  # stashed for the adopted.json merge in apply_plan
         "version": plan.version,
         "applied_at": now or datetime.now(timezone.utc).isoformat(),
@@ -214,7 +277,7 @@ def _merge_ratchet(target: Path, add: list[str]) -> tuple[str | None, list[str]]
     return json.dumps(cfg, indent=2) + "\n", added
 
 
-def apply_plan(plan: Plan, target: Path, write: bool = True) -> list[str]:
+def apply_plan(plan: Plan, target: Path, write: bool = True, force: bool = False) -> list[str]:
     actions: list[str] = []
     for rel, content in plan.files.items():
         actions.append(f"write {rel}")
@@ -222,6 +285,21 @@ def apply_plan(plan: Plan, target: Path, write: bool = True) -> list[str]:
             path = target / rel
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(content)
+
+    # Scaffold code: idempotent. An existing target is skipped (never clobbered)
+    # unless --force, so hand-edits to stamped seams survive re-application.
+    for rel, content in plan.scaffold_files.items():
+        path = target / rel
+        if path.exists() and not force:
+            actions.append(f"skip scaffold {rel} (exists — use --force to re-stamp)")
+            continue
+        verb = "re-stamp" if path.exists() else "stamp"
+        actions.append(f"{verb} scaffold {rel}")
+        if write:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+    if plan.scaffold_skipped:
+        actions.append(plan.scaffold_skipped)
 
     adopted = _merge_adopted(target, plan.pattern_id, plan._adoption)
     actions.append(f"record adoption in {ADOPTED_REL}")
@@ -317,6 +395,8 @@ def main() -> int:
                         help="List the target's adopted patterns + clusters (for /architect) and exit")
     parser.add_argument("--now", help="ISO timestamp for the adoption record (testing)")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-stamp scaffold files that already exist (default: skip, never clobber)")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args()
 
@@ -364,7 +444,7 @@ def main() -> int:
 
     try:
         plan = build_plan(args.pattern_id, provided, now=args.now)
-        actions = apply_plan(plan, args.target_dir, write=not args.dry_run)
+        actions = apply_plan(plan, args.target_dir, write=not args.dry_run, force=args.force)
     except ApplyError as exc:
         print(f"apply_pattern: {exc}", file=sys.stderr)
         return 2

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -187,3 +187,77 @@ def test_cli_dry_run(tmp_path):
     out = json.loads(proc.stdout)
     assert out["pattern"] == REAL and out["dry_run"] is True
     assert not (tmp_path / "docs").exists()
+
+
+# --- scaffold stamping (#135) -----------------------------------------------
+
+MTI = "multi-tenant-isolation"
+MTI_PARAMS = {"tenant_key": "provider_id", "resolver": "claim",
+              "store": "firestore", "operator_routes": "/admin"}
+MTI_TARGETS = ("internal/tenant/resolver.go", "internal/tenant/scoped_repo.go")
+
+
+def test_scaffold_renders_into_plan_when_required_params_bound():
+    plan = apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    assert set(plan.scaffold_files) == set(MTI_TARGETS)
+    body = plan.scaffold_files["internal/tenant/scoped_repo.go"]
+    # placeholders are bound, none survive
+    assert "provider_id" in body and "firestore" in body
+    assert "{{" not in body
+    assert not plan.scaffold_skipped
+
+
+def test_scaffold_skipped_when_required_param_unresolved():
+    plan = apply_pattern.build_plan(MTI, {"tenant_key": "provider_id"}, now=FIXED_NOW)
+    assert plan.scaffold_files == {}
+    assert "scaffold not stamped" in plan.scaffold_skipped
+    # contract pack still installs regardless
+    assert f"docs/patterns/{MTI}/invariants.md" in plan.files
+
+
+def test_scaffold_stamps_to_target_paths(tmp_path):
+    plan = apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+    for rel in MTI_TARGETS:
+        assert (tmp_path / rel).is_file(), rel
+    assert "package tenant" in (tmp_path / "internal/tenant/resolver.go").read_text()
+
+
+def test_scaffold_is_idempotent_and_never_clobbers(tmp_path):
+    plan = apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+    edited = tmp_path / MTI_TARGETS[0]
+    edited.write_text("// hand-edited\npackage tenant\n")
+    # second apply (no force) must skip, preserving the hand edit
+    actions = apply_pattern.apply_plan(
+        apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW), tmp_path, write=True)
+    assert any("skip scaffold" in a for a in actions)
+    assert edited.read_text() == "// hand-edited\npackage tenant\n"
+
+
+def test_scaffold_force_re_stamps(tmp_path):
+    plan = apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=True)
+    edited = tmp_path / MTI_TARGETS[0]
+    edited.write_text("// hand-edited\n")
+    actions = apply_pattern.apply_plan(
+        apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW), tmp_path, write=True, force=True)
+    assert any("re-stamp scaffold" in a for a in actions)
+    assert "package tenant" in edited.read_text()
+
+
+def test_scaffold_dry_run_writes_nothing(tmp_path):
+    plan = apply_pattern.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    apply_pattern.apply_plan(plan, tmp_path, write=False)
+    assert not (tmp_path / "internal").exists()
+
+
+def test_cli_apply_stamps_scaffold(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "apply_pattern.py"), MTI,
+         "--target-dir", str(tmp_path), "--now", FIXED_NOW,
+         "--param", "tenant_key=provider_id", "--param", "resolver=claim",
+         "--param", "store=firestore", "--param", "operator_routes=/admin"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert (tmp_path / "internal/tenant/resolver.go").is_file()

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -261,3 +261,22 @@ def test_cli_apply_stamps_scaffold(tmp_path):
         capture_output=True, text=True)
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert (tmp_path / "internal/tenant/resolver.go").is_file()
+
+
+def test_scaffold_rejects_path_traversal_target(tmp_path, monkeypatch):
+    # a pattern/param that renders a target escaping the repo must fail closed
+    import apply_pattern as ap
+    orig = ap.load_scaffold
+    monkeypatch.setattr(ap, "load_scaffold", lambda pid, base=ap.ROOT: {
+        "files": [{"template": "tenant_resolver.go.tmpl", "target": "../evil.go"}]})
+    with pytest.raises(ap.ApplyError, match="repo-relative path"):
+        ap.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    monkeypatch.setattr(ap, "load_scaffold", orig)
+
+
+def test_scaffold_rejects_absolute_target(tmp_path, monkeypatch):
+    import apply_pattern as ap
+    monkeypatch.setattr(ap, "load_scaffold", lambda pid, base=ap.ROOT: {
+        "files": [{"template": "tenant_resolver.go.tmpl", "target": "/etc/evil.go"}]})
+    with pytest.raises(ap.ApplyError, match="repo-relative path"):
+        ap.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -280,3 +280,33 @@ def test_scaffold_rejects_absolute_target(tmp_path, monkeypatch):
         "files": [{"template": "tenant_resolver.go.tmpl", "target": "/etc/evil.go"}]})
     with pytest.raises(ap.ApplyError, match="repo-relative path"):
         ap.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+
+
+def test_scaffold_fails_closed_on_unbound_body_placeholder(tmp_path, monkeypatch):
+    import apply_pattern as ap
+    # a template body referencing an unbound param must fail, not leak {{param}}
+    (tmp_path / "s").mkdir()
+    monkeypatch.setattr(ap, "ROOT", tmp_path)
+    pdir = tmp_path / "patterns" / MTI / "scaffold"
+    pdir.mkdir(parents=True)
+    (pdir / "t.tmpl").write_text("package x // {{unbound_param}}\n")
+    (pdir / "scaffold.json").write_text(json.dumps(
+        {"files": [{"template": "t.tmpl", "target": "x.go"}]}))
+    with pytest.raises(ap.ApplyError, match="unbound param"):
+        ap._render_scaffold(MTI, ap.load_scaffold(MTI, base=tmp_path), {}, base=tmp_path)
+
+
+@pytest.mark.parametrize("bad,msg", [
+    ("[]", "must be a JSON object"),
+    ('{"files": {}}', "non-empty 'files'"),
+    ('{"files": []}', "non-empty 'files'"),
+    ('{"files": ["x"]}', "'template'\\+'target'"),
+    ('{"files": [{"template": "t.tmpl"}]}', "'template'\\+'target'"),
+])
+def test_malformed_scaffold_manifest_is_clean_apply_error(tmp_path, bad, msg):
+    import apply_pattern as ap
+    pdir = tmp_path / "patterns" / MTI / "scaffold"
+    pdir.mkdir(parents=True)
+    (pdir / "scaffold.json").write_text(bad)
+    with pytest.raises(ap.ApplyError, match=msg):
+        ap.load_scaffold(MTI, base=tmp_path)

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -300,10 +300,38 @@ def test_scaffold_fails_closed_on_unbound_body_placeholder(tmp_path, monkeypatch
     ("[]", "must be a JSON object"),
     ('{"files": {}}', "non-empty 'files'"),
     ('{"files": []}', "non-empty 'files'"),
-    ('{"files": ["x"]}', "'template'\\+'target'"),
-    ('{"files": [{"template": "t.tmpl"}]}', "'template'\\+'target'"),
+    ('{"files": ["x"]}', "must be an object"),
+    ('{"files": [{"template": "t.tmpl"}]}', "string 'template'"),
 ])
 def test_malformed_scaffold_manifest_is_clean_apply_error(tmp_path, bad, msg):
+    import apply_pattern as ap
+    pdir = tmp_path / "patterns" / MTI / "scaffold"
+    pdir.mkdir(parents=True)
+    (pdir / "scaffold.json").write_text(bad)
+    with pytest.raises(ap.ApplyError, match=msg):
+        ap.load_scaffold(MTI, base=tmp_path)
+
+
+def test_scaffold_refuses_symlink_target(tmp_path):
+    import apply_pattern as ap
+    plan = ap.build_plan(MTI, MTI_PARAMS, now=FIXED_NOW)
+    # a symlink at the final target path must be refused (write_text would follow it)
+    (tmp_path / "internal" / "tenant").mkdir(parents=True)
+    outside = tmp_path / "outside.go"
+    outside.write_text("// outside\n")
+    (tmp_path / "internal" / "tenant" / "resolver.go").symlink_to(outside)
+    with pytest.raises(ap.ApplyError, match="symlink"):
+        ap.apply_plan(plan, tmp_path, write=True, force=True)
+    assert outside.read_text() == "// outside\n"  # untouched
+
+
+@pytest.mark.parametrize("bad,msg", [
+    ('{"files": [{"template": ["x"], "target": "x.go"}]}', "string 'template'"),
+    ('{"files": [{"template": "t.tmpl", "target": 123}]}', "string 'template'"),
+    ('{"files": [{"template": "../t.tmpl", "target": "x.go"}]}', "under scaffold/"),
+    ('{"files": [{"template": "/abs.tmpl", "target": "x.go"}]}', "under scaffold/"),
+])
+def test_scaffold_manifest_rejects_bad_template_types_and_paths(tmp_path, bad, msg):
     import apply_pattern as ap
     pdir = tmp_path / "patterns" / MTI / "scaffold"
     pdir.mkdir(parents=True)


### PR DESCRIPTION
Closes #135.

## What
`/apply-pattern` installed a pattern's contract pack (invariant cluster doc + adopted.json + ratchet registration) but deferred step 3 of the apply flow — stamping the pattern's `scaffold/` (the code that realizes the cluster) — because no pattern shipped one. This closes it.

- **multi-tenant-isolation ships the first `scaffold/`**: `internal/tenant/resolver.go` (INV-MTI-001 — server-only tenant resolution, reject client hints, 404-on-probe) and `internal/tenant/scoped_repo.go` (INV-MTI-002 — fail-closed tenant-scoped repository, unexported `store` handle, reject-not-override on a caller-supplied `{{tenant_key}}` filter), as `{{param}}`-templated files.
- **apply_pattern.py stamps scaffold/**: loads `scaffold/scaffold.json`, renders `{{param}}` in both the target path and the body from bound params, and stamps idempotently — an existing target is **skipped, never clobbered**, unless `--force`; stamping needs every required param bound, else the contract pack still installs and the scaffold is skipped with a note. Composes with the contract-pack install (one run does both); honors `--dry-run`.
- **docs**: apply-flow step 3 ⏳→✅ + a new *Scaffold layout* section documenting the convention.

## Scaffold layout convention (defined here)
`scaffold/scaffold.json` `files[]` maps `template`→`target` (+ `realizes`/`desc`); `{{param}}` in path and body is bound from resolved params. Idempotent skip / `--force` re-stamp / required-param-gated.

## Test plan
1602 passed, 10 skipped (7 new): renders-when-bound, skipped-when-unresolved (contract pack still installs), stamps-to-target-paths, idempotent-never-clobbers, `--force` re-stamps, dry-run-writes-nothing, CLI end-to-end. `ruff` clean; `check_patterns` still OK.

Note: implemented in the main thread (background subagents were failing on a streaming-layer outage during this session).

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF