### PR TITLE
feat(patterns): /business-consultant — mechanical unit-economics + pricing-model deriver (#122, steps 1-2)

### DIFF
--- a/.claude/commands/business-consultant.md
+++ b/.claude/commands/business-consultant.md
@@ -79,15 +79,20 @@ cost-shape + pricing-model-fit section, but unit economics per tier will be
 empty until the pattern is applied (`/apply-pattern <owner/repo> --pattern
 tiered-subscription ...`).
 
-Check whether the target repo has its own `docs/cost-inputs.json`. If not, the
-deriver falls back to the stack's illustrative seed automatically — no action
-needed, but expect (and keep) the loud caveat in the rendered report.
+Check whether the target repo has its own `docs/cost-inputs.json`. With no
+`--cost-inputs` flag the deriver **auto-uses** `<target>/docs/cost-inputs.json`
+when it exists, and only falls back to the stack's illustrative seed when it
+doesn't — so you rarely need to pass the flag. Whenever illustrative rates are
+used (the seed, or any meter marked `provenance: "illustrative"`, however the
+file was supplied), the loud caveat is surfaced in the report — it rides on the
+data, not the code path.
 
 ### Step 3: Run the deriver
 
 ```bash
-python3 "$CW_HOME/scripts/business_consultant.py" --repo "$TARGET_REPO" \
-  --cost-inputs "$TARGET_REPO/docs/cost-inputs.json"   # omit if the repo has none yet
+python3 "$CW_HOME/scripts/business_consultant.py" --repo "$TARGET_REPO"
+# auto-uses $TARGET_REPO/docs/cost-inputs.json if present, else the illustrative seed;
+# pass --cost-inputs <path> only to point at a non-default location
 ```
 
 This derives, purely mechanically (no AI consultation, no network calls):
@@ -98,9 +103,15 @@ This derives, purely mechanically (no AI consultation, no network calls):
 2. **Unit economics per tier** — worst-case (matrix cap × meter rate) + typical
    (a documented fraction of worst-case) per tier, flagging any tier priced
    **underwater** (price below worst-case cost — most commonly the free tier,
-   since a free tier's worst-case cost isn't automatically near-zero).
+   since a free tier's worst-case cost isn't automatically near-zero). A tier
+   with an **unlimited (`-1`) cap on a metered line** is reported as
+   **unbounded worst-case** (uncomputable, never a safe-looking $0 / 100% margin
+   / finite break-even) — a single heavy tenant can cost arbitrarily much. A
+   declared meter with **no cap field** in a tier's matrix is surfaced as
+   `no cap declared`, never silently dropped.
 3. **Break-even** — paying tenants of each tier needed to cover the flat nut,
-   plus gross margin at typical usage.
+   plus gross margin at typical usage; **unbounded** for any tier whose
+   worst-case is uncapped.
 4. **Market-comparable floor** — an explicit `UNRESOLVED:` marker (rollout step
    3, not built).
 5. **Pricing-model fit** — a model *family* recommendation

--- a/.claude/commands/business-consultant.md
+++ b/.claude/commands/business-consultant.md
@@ -103,12 +103,15 @@ This derives, purely mechanically (no AI consultation, no network calls):
 2. **Unit economics per tier** — worst-case (matrix cap × meter rate) + typical
    (a documented fraction of worst-case) per tier, flagging any tier priced
    **underwater** (price below worst-case cost — most commonly the free tier,
-   since a free tier's worst-case cost isn't automatically near-zero). A tier
-   with an **unlimited (`-1`) cap on a metered line** is reported as
-   **unbounded worst-case** (uncomputable, never a safe-looking $0 / 100% margin
-   / finite break-even) — a single heavy tenant can cost arbitrarily much. A
-   declared meter with **no cap field** in a tier's matrix is surfaced as
-   `no cap declared`, never silently dropped.
+   since a free tier's worst-case cost isn't automatically near-zero). If a tier
+   has **any meter whose cost can't be bounded**, its worst-case /
+   underwater / margin / break-even are all **suppressed** (never a safe-looking
+   $0 / 100% margin / finite break-even that omits a cost we couldn't bound) —
+   in one of two forms the report distinguishes:
+   **UNBOUNDED (uncapped by design)** for an unlimited (`-1` / `"-1"`) or
+   `capped_by: null` meter (a heavy tenant can cost arbitrarily much), and
+   **INDETERMINATE (cap not declared / unparseable — fix your cost inputs)** for
+   a missing or unparseable matrix cap (a data gap, not a $0 cost).
 3. **Break-even** — paying tenants of each tier needed to cover the flat nut,
    plus gross margin at typical usage; **unbounded** for any tier whose
    worst-case is uncapped.

--- a/.claude/commands/business-consultant.md
+++ b/.claude/commands/business-consultant.md
@@ -1,0 +1,126 @@
+# Business Consultant — Unit Economics & Pricing-Model Fit
+
+Produces a product's **unit economics + pricing-model recommendation** from what
+Chief Wiggum already knows about it: its adopted registry patterns
+(`docs/patterns/adopted.json` — in particular `tiered-subscription`'s bound
+`matrix` caps), its stack profile's cost tiers, and a cost-inputs document
+(operator-authoritative, or a documented illustrative fallback). See
+`docs/patterns-registry.md#the-cost-axis-is-first-class` and
+chief-wiggum#122.
+
+**Scope (rollout steps 1+2 only):** the mechanical deriver + the `docs/pricing.md`
+output contract. Two things are explicitly **not** built here, and are marked as
+such in the rendered output rather than faked:
+
+- **Market-comparable pricing** (rollout step 3 — a live lookup of what
+  comparable products charge) is an `UNRESOLVED:` marker in the rendered
+  report, gated by `scripts/check_unresolved.py`. Never fabricate a competitor
+  price to fill this in.
+- **Wiring the output into monetization patterns' `success_metrics`** (rollout
+  step 4, e.g. `mrr`/`revenue_leak` on `tiered-subscription`) is a follow-up.
+
+`docs/pricing.md` is a **protected path** once a product ships it — pricing is a
+protected, admin-gated surface the same way `tiered-subscription`'s entitlement
+logic is (see the pattern's `trust_class`). Treat a re-run that changes the
+recommendation as something a human reviews, not an autonomous auto-apply.
+
+## When to use
+
+- Once a product has adopted `tiered-subscription` (its `matrix` is what bounds
+  worst-case per-tenant cost) and a stack profile, to sanity-check the pricing
+  before/alongside launch.
+- Re-run whenever the cost-inputs change (a vendor repriced, a new cost tier
+  went active) or the tier matrix changes (a plan's caps moved).
+
+## Usage
+
+```
+/business-consultant <owner/repo> [--cost-inputs <path>] [--stack <id>] [--out <path>] [--marketplace] [--dry-run]
+```
+
+## Parameters
+
+- `owner/repo`: Target GitHub repository (resolved + cloned via `repo.py`), or use `--repo <path>` for a local checkout.
+- `--cost-inputs <path>`: An operator-authoritative cost-inputs.json (`templates/cost-inputs-schema.json`). Omit to fall back to the stack's illustrative seed (`patterns/stacks/<id>/cost-inputs.illustrative.json`) — the fallback is always loudly caveated in the output, never presented as a quote.
+- `--stack <id>`: Stack profile id (default `gcp-serverless-saas`).
+- `--out <path>`: Override the output path (default `<target>/docs/pricing.md`).
+- `--marketplace`: Declare a take-rate/marketplace revenue model. Not inferred automatically — no registry pattern currently signals it.
+- `--dry-run`: Derive and print without writing `docs/pricing.md`.
+
+## Autonomy
+
+Run to completion; this is an analysis skill. The one judgement call is whether
+the target has adopted `tiered-subscription` at all — if not, the report still
+renders (cost shape + pricing-model fit still hold) but says plainly that
+per-tier unit economics need the pattern adopted first. Never invent matrix caps
+or a market price to fill a gap; an honest "can't compute this yet" beats a
+fabricated number.
+
+---
+
+## Workflow
+
+### Step 1: Resolve paths
+
+```bash
+CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
+CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+```
+
+### Step 2: Check the inputs are there
+
+```bash
+python3 "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted
+```
+
+If `tiered-subscription` isn't adopted, note it — the run will still produce a
+cost-shape + pricing-model-fit section, but unit economics per tier will be
+empty until the pattern is applied (`/apply-pattern <owner/repo> --pattern
+tiered-subscription ...`).
+
+Check whether the target repo has its own `docs/cost-inputs.json`. If not, the
+deriver falls back to the stack's illustrative seed automatically — no action
+needed, but expect (and keep) the loud caveat in the rendered report.
+
+### Step 3: Run the deriver
+
+```bash
+python3 "$CW_HOME/scripts/business_consultant.py" --repo "$TARGET_REPO" \
+  --cost-inputs "$TARGET_REPO/docs/cost-inputs.json"   # omit if the repo has none yet
+```
+
+This derives, purely mechanically (no AI consultation, no network calls):
+
+1. **Cost shape** — flat nut (flat_monthly + the active stack cost-tier's fixed
+   add-on) + per-tenant variable cost; names the single largest **uncapped**
+   meter and the first fixed **step-jump**.
+2. **Unit economics per tier** — worst-case (matrix cap × meter rate) + typical
+   (a documented fraction of worst-case) per tier, flagging any tier priced
+   **underwater** (price below worst-case cost — most commonly the free tier,
+   since a free tier's worst-case cost isn't automatically near-zero).
+3. **Break-even** — paying tenants of each tier needed to cover the flat nut,
+   plus gross margin at typical usage.
+4. **Market-comparable floor** — an explicit `UNRESOLVED:` marker (rollout step
+   3, not built).
+5. **Pricing-model fit** — a model *family* recommendation
+   (`patterns/pricing-models/`), not a specific price.
+
+### Step 4: Verify the unresolved seam is gated
+
+```bash
+python3 "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/pricing.md"
+```
+
+Confirm it reports the market-comparable-floor marker — that's expected and
+correct until rollout step 3 ships; it means dependent work can't silently treat
+that section as resolved.
+
+### Step 5: Report
+
+Summarize for the user: the flat nut, the named uncapped meter + step-jump, any
+underwater tier, break-even counts, and the recommended pricing-model family +
+its `never` list (e.g. "usage-based-or-subscription; never lifetime-deal"). Point
+at `docs/pricing.md` in the target repo and flag plainly if the illustrative seed
+was used (numbers are unverified — recommend the operator supply a real
+`docs/cost-inputs.json`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A collection of portable workflow contracts, scripts, and Claude Code slash-comm
 - **Epic level**: `/plan-epic` → `/architect` → (implement tickets) → `/close-epic` — defines contracts, invariants, and integration tests before implementation, validates cross-cutting quality after.
 - **Ticket level**: `/implement` — TDD, multi-AI consultation, structured review, static analysis, and independent verification per ticket.
 - **Wave level**: `/implement-wave` — parallel implementation of an entire epic in dependency-ordered waves. Each wave runs multiple `/implement` loops concurrently in isolated worktrees, merges to main, then starts the next wave.
-- **Supporting**: `/setup`, `/transcribe`, `/seed`, `/create-issue`, `/ship`, `/update`, `/stitch-audit`, `/code-metrics`, `/tutorial-video`.
+- **Supporting**: `/setup`, `/transcribe`, `/seed`, `/create-issue`, `/ship`, `/update`, `/stitch-audit`, `/code-metrics`, `/tutorial-video`, `/business-consultant`.
 
 ## Key Principles
 
@@ -227,6 +227,7 @@ Skills are invoked from any target repo that has chief-wiggum configured as a sk
 /reflect owner/repo                         # Factory self-assessment: mine a built repo → CW-improvement issues
 /tutorial-video owner/repo --feature "..."  # Narrated click-through tutorial video
 /saas-gate owner/repo --base-url <url>     # SaaS non-functional-requirements gate (security/isolation/perf/observability)
+/business-consultant owner/repo             # Unit economics + pricing-model fit from adopted patterns + stack cost tiers
 /update                         # Refresh model IDs and library versions
 ```
 

--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -507,6 +507,16 @@ trigger** (the concrete signal that says "now add this"). The single most import
 number a profile surfaces is the **first real fixed-cost jump** and the **only
 uncapped variable cost** — so a builder knows exactly what they're signing up for.
 
+The `cost_tiers`/`graduation_triggers` prose above is deliberately illustrative,
+not a set of structured per-unit rates (real rates are region/billing-mode
+dependent). `/business-consultant` (chief-wiggum#122) is the advisory layer that
+turns them into a decision: it derives unit economics + a pricing-model-family
+recommendation from a product's adopted `tiered-subscription` matrix plus a
+structured `cost-inputs.json` (`templates/cost-inputs-schema.json`) — either
+operator-authoritative, or a stack's own loudly-caveated illustrative seed
+(`patterns/stacks/<id>/cost-inputs.illustrative.json`) as a documented fallback,
+never presented as a quote. See `.claude/commands/business-consultant.md`.
+
 ### First profile: `gcp-serverless-saas`
 
 The house stack behind every CW-built app so far — **Firebase Hosting + Cloud Run

--- a/patterns/pricing-models/models.json
+++ b/patterns/pricing-models/models.json
@@ -1,0 +1,49 @@
+{
+  "$comment": "Machine-readable cost-shape -> pricing-model decision table + reusable pricing tactics. Consumed by scripts/business_consultant.py (patterns/pricing-models/reference.md is the human-facing spec). This is a KNOWLEDGE BASE, not an installable registry pattern -- it carries no invariants/parameters/manifest and is deliberately absent from patterns/registry.json, so scripts/check_patterns.py does not (and should not) validate it against the invariant-cluster model.",
+  "version": 1,
+
+  "cost_shape_to_model": [
+    {
+      "cost_shape": "flat-cost",
+      "model_family": "subscription-or-seat",
+      "rationale": "Marginal cost per additional tenant/seat is ~0 (no metered variable cost scales with usage); price on value delivered per seat/account, not consumption.",
+      "never": [],
+      "notes": "Founding-member grandfathering and annual-prepay work cleanly here since the provider's own cost floor doesn't move with usage."
+    },
+    {
+      "cost_shape": "per-unit-recurring",
+      "model_family": "usage-based-or-subscription",
+      "rationale": "A recurring per-tenant variable cost (a metered vendor bill that keeps charging every month the tenant stays active) means the provider's cost never stops -- price must recur too, tracking or capping usage. A one-time price guarantees the provider eventually pays more to serve a long-lived customer than that customer ever paid.",
+      "never": ["lifetime-deal", "one-time-purchase"],
+      "notes": "This is the load-bearing rule the skill exists to enforce: recurring infra cost implies recurring price. Cap usage per tier (the tiered-subscription `matrix`) so an underwater tenant is bounded, not just probable."
+    },
+    {
+      "cost_shape": "marketplace",
+      "model_family": "take-rate",
+      "rationale": "The provider's cost and revenue both scale with transaction volume flowing through the platform, not with a fixed subscriber count -- price as a percentage of the transaction, matching cost to volume automatically.",
+      "never": ["flat-per-seat-only"],
+      "notes": "A flat subscription fee alongside the take-rate is fine for a supply-side seat (e.g. a vendor dashboard seat) as long as the transaction-volume-linked cost itself is still take-rate priced."
+    }
+  ],
+
+  "tactics": [
+    {
+      "id": "founding-member-grandfathering",
+      "one_liner": "Early customers keep their original price/terms even as list price rises later.",
+      "applies_when": "any cost shape; strongest signal when the product isn't yet proven and early adopters are taking real risk.",
+      "guardrail": "Grandfathering must never extend to raising the effective cost floor underneath them (e.g. adding a metered feature they didn't sign up for) without also grandfathering its cost -- see tiered-subscription's non-destructive-degradation invariant (INV-TSB-005) for the general principle: changes must not silently worsen a customer's existing deal."
+    },
+    {
+      "id": "annual-two-months-free",
+      "one_liner": "Annual plan priced at ~10x monthly (roughly 2 months free) rather than a deeper discount.",
+      "applies_when": "subscription-or-seat or usage-based-or-subscription model families with a stable, predictable per-tenant cost (so a year of prepaid revenue doesn't undercut a year of accruing variable cost).",
+      "guardrail": "Do not offer annual prepay on a cost shape with an uncapped meter (capped_by=null) unless that meter's actual usage is separately metered and billed on top -- prepaying flat for unbounded variable cost reproduces the lifetime-deal risk one billing cycle at a time."
+    },
+    {
+      "id": "free-tier-bounded-loss-leader",
+      "one_liner": "A free tier is a deliberate, capped loss leader for acquisition/activation -- never an unbounded cost sink.",
+      "applies_when": "any cost shape; most load-bearing on per-unit-recurring, where a free tier's variable-cost exposure must be tightly capped by the tiered-subscription matrix (the free tier's `matrix` entry should have the tightest caps, never -1/unlimited on a metered field).",
+      "guardrail": "The unit-economics check (worst-case matrix caps x meter rates) applies to the free tier too -- if a free tier's worst-case cost isn't near-zero, the loss leader isn't bounded, it's just a loss."
+    }
+  ]
+}

--- a/patterns/pricing-models/reference.md
+++ b/patterns/pricing-models/reference.md
@@ -1,0 +1,86 @@
+# Reference: Pricing Models That Worked
+
+- **Category:** knowledge base (not an installable registry pattern)
+- **Status:** reference — consumed by `/business-consultant`, not by `/apply-pattern`
+
+## What this is (and isn't)
+
+This is a captured, reusable **cost-shape → pricing-model decision table**, plus
+the handful of pricing tactics that keep re-earning their keep across CW-built
+products — so `/business-consultant` doesn't re-derive "what pricing model fits a
+product like this" from scratch every time, the same reason the patterns registry
+exists at all (see `docs/patterns-registry.md`).
+
+It deliberately does **not** live in `patterns/registry.json` and ships no
+`manifest.json` invariant cluster: it isn't a contract pack `/apply-pattern`
+installs into a target repo, and `scripts/check_patterns.py` correctly does not
+scan it. It's read by `scripts/business_consultant.py` (via
+[`models.json`](models.json)) as a **lookup table**, the same role a stack
+profile's `bindings/` plays for pattern↔vendor recipes.
+
+## The load-bearing rule
+
+**Recurring infra cost implies recurring price.** If serving a tenant costs the
+provider a metered vendor bill that keeps charging every month the tenant stays
+active (video storage/delivery, database rows, email sends, compute), a one-time
+price guarantees the provider eventually pays more to serve a long-lived customer
+than that customer ever paid. A lifetime deal on a product with per-tenant
+recurring costs is a bet the customer *churns quickly enough* — the opposite of
+what "lifetime" is supposed to promise. This is the rule
+[`business_consultant.py`](../../scripts/business_consultant.py) enforces
+mechanically: any cost shape with a nonzero per-tenant meter recommends a
+recurring model family and explicitly rules out `lifetime-deal` /
+`one-time-purchase`.
+
+## The decision table
+
+| Cost shape | Signal | Model family | Never |
+|--|--|--|--|
+| **flat-cost** | no metered per-tenant variable cost (or every meter is $0) | subscription-or-seat | — |
+| **per-unit-recurring** | at least one nonzero per-tenant meter that recurs monthly | usage-based-or-subscription | lifetime-deal, one-time-purchase |
+| **marketplace** | cost *and* revenue scale with transaction volume, not subscriber count | take-rate | flat-per-seat-only |
+
+The machine-readable form (`model_family`, `rationale`, `never`, `notes` per row)
+is [`models.json`](models.json)'s `cost_shape_to_model` array — the exact
+structure `/business-consultant`'s pricing-fit step looks up. Classifying a
+product's own cost shape (flat vs per-unit-recurring vs marketplace) is the
+deriver's job, from its `cost-inputs.json` + adopted patterns; this table only
+answers "given that shape, which model family fits."
+
+## Pricing tactics (apply regardless of cost shape)
+
+Captured in `models.json`'s `tactics` array; each also carries a `guardrail` — the
+non-obvious way the tactic goes wrong if applied carelessly:
+
+- **Founding-member grandfathering** — early customers keep their original
+  price/terms as list price rises later. Guardrail: grandfathering must never let
+  the *cost* underneath them silently rise uncompensated (see
+  `tiered-subscription`'s non-destructive-degradation invariant, `INV-TSB-005`,
+  for the general shape of this principle).
+- **Annual ≈ 2 months free** — annual plans priced at roughly 10x monthly rather
+  than a steeper discount. Guardrail: don't offer this on a cost shape with an
+  *uncapped* meter (`capped_by: null`) unless that usage is metered and billed
+  separately — prepaying flat against unbounded variable cost is the lifetime-deal
+  risk one billing cycle at a time.
+- **Free tier as a bounded loss leader** — a free tier is a deliberate, capped
+  acquisition/activation cost, never an unbounded sink. Guardrail: the free
+  tier's `tiered-subscription` `matrix` entry must keep every metered field
+  tightly capped (never `-1`/unlimited) — the same worst-case-cost check the
+  deriver runs on paid tiers applies to the free tier too.
+
+## How `/business-consultant` consults this table
+
+1. Classifies the product's cost shape from its cost-inputs + adopted
+   `tiered-subscription` matrix (mechanical — see the skill's Step 3).
+2. Looks up that shape's row in `models.json`'s `cost_shape_to_model`.
+3. Emits the **model family** (a family, not a specific price point — an actual
+   number needs market-comparable data, the step-3 live-lookup seam tracked in
+   chief-wiggum#122) plus its `rationale` and `never` list, and surfaces any
+   `tactics` whose `applies_when` matches.
+
+## Provenance
+
+Distilled from the same worked example the registry's cost axis cites
+(`docs/patterns-registry.md#the-cost-axis-is-first-class`): a shipped production
+SaaS's hand-written `docs/pricing.md`, genericized — no app name, no real vendor
+quote, no customer data.

--- a/patterns/stacks/gcp-serverless-saas/cost-inputs.illustrative.json
+++ b/patterns/stacks/gcp-serverless-saas/cost-inputs.illustrative.json
@@ -1,0 +1,41 @@
+{
+  "$comment": "Illustrative cost-inputs seed for the gcp-serverless-saas stack (templates/cost-inputs-schema.json). Ballparks mined loosely from the stack's own cost_tiers/graduation_triggers prose (manifest.json) -- NOT a live vendor quote. business_consultant.py falls back to this file only when a target repo has no operator-authored docs/cost-inputs.json, and always surfaces $caveat + each meter's provenance/verified_date in the rendered report. Region, billing mode, and committed-use discounts all move these numbers -- re-verify against live vendor pricing before treating any rate here as real.",
+  "$caveat": "ILLUSTRATIVE -- every rate in this file is a placeholder, not a verified vendor price. Region, billing mode, committed-use discounts, and vendor pricing changes all move these numbers. Verify against live vendor pricing pages before quoting a customer or setting a real price floor. This file exists so the deriver has *something* mechanical to run against before step 3 (live market-comparables lookup, chief-wiggum#122) ships -- it is a documented fallback, never an authority.",
+  "as_of": "2026-07-19",
+  "currency": "USD",
+  "flat_monthly": 5.0,
+  "tier_fixed": {
+    "T0": 0.0,
+    "T1": 0.0,
+    "T2": 55.0
+  },
+  "meters": [
+    {
+      "id": "media_delivery_hour",
+      "unit": "hour",
+      "rate": 0.06,
+      "unit_desc": "provider-neutral media delivery (Cloudflare Stream exemplar), per hour watched",
+      "capped_by": null,
+      "provenance": "illustrative",
+      "verified_date": "2026-07-19"
+    },
+    {
+      "id": "email_send",
+      "unit": "send",
+      "rate": 0.001,
+      "unit_desc": "Resend transactional email, per send",
+      "capped_by": "emails_per_month",
+      "provenance": "illustrative",
+      "verified_date": "2026-07-19"
+    },
+    {
+      "id": "object_storage_gb_month",
+      "unit": "gb-month",
+      "rate": 0.02,
+      "unit_desc": "Firestore/Atlas + Cloud Storage, per GB stored per month",
+      "capped_by": "storage_gb",
+      "provenance": "illustrative",
+      "verified_date": "2026-07-19"
+    }
+  ]
+}

--- a/scripts/business_consultant.py
+++ b/scripts/business_consultant.py
@@ -87,14 +87,20 @@ def _summarize_text(result: dict) -> str:
         j = result["cost_shape"]["first_step_jump"]
         lines.append(f"  first fixed step-jump: {j['from']} -> {j['to']} (+${j['monthly_usd']:.2f}/mo)")
     for e in result["economics"]:
-        flag = ""
-        if e["underwater"] is True:
-            flag = "  ** UNDERWATER **"
+        if e["worst_case_unbounded"]:
+            worst = "UNBOUNDED (uncapped meter)"
+            flag = "  ** UNBOUNDED WORST-CASE **"
+        else:
+            worst = f"${e['worst_case_cost']:.2f}"
+            flag = "  ** UNDERWATER **" if e["underwater"] is True else ""
         lines.append(
-            f"  tier {e['tier']}: price={e['price']} worst_case=${e['worst_case_cost']:.2f} "
+            f"  tier {e['tier']}: price={e['price']} worst_case={worst} "
             f"typical=${e['typical_cost']:.2f}{flag}"
         )
     for b in result["breakeven"]:
+        if b["unbounded"]:
+            lines.append(f"  break-even {b['tier']}: unbounded (uncapped meter — no finite break-even)")
+            continue
         be = b["breakeven_tenants"] if b["breakeven_tenants"] is not None else "never"
         lines.append(f"  break-even {b['tier']}: {be} tenant(s), margin {b['gross_margin_pct']}%")
     lines.append(f"  pricing-model fit: {result['pricing_fit']['model_family']} (shape={result['pricing_fit']['cost_shape']})")

--- a/scripts/business_consultant.py
+++ b/scripts/business_consultant.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""business_consultant.py — orchestrator for the /business-consultant skill.
+
+The COST-MODEL DERIVER (chief-wiggum#122, rollout steps 1+2 only): mechanically
+derives a product's cost shape, per-tier unit economics, break-even + gross
+margin, and a pricing-MODEL-family recommendation from:
+
+  - the target repo's ``docs/patterns/adopted.json`` (which patterns are
+    adopted + the bound ``tiered-subscription`` tier/matrix caps),
+  - a cost-inputs.json (templates/cost-inputs-schema.json) — either an
+    operator-authoritative document, or (documented, loudly-caveated fallback)
+    the stack's illustrative seed.
+
+Pure arithmetic, deterministic given its inputs. Renders ``docs/pricing.md``
+into the target repo (5 sections: cost shape / unit economics per tier /
+break-even+margin / market-comparable floor [an explicit UNRESOLVED marker —
+the step-3 live-lookup seam is NOT built here] / pricing-model fit).
+
+Target resolution mirrors the other skills:
+  - ``owner/repo``  -> resolved & cloned via scripts/repo.py
+  - ``--repo PATH`` -> a direct local path
+  - neither         -> the current git repo (git rev-parse --show-toplevel)
+
+Usage:
+    python3 scripts/business_consultant.py [owner/repo] [--repo PATH] \\
+        [--cost-inputs PATH] [--stack ID] [--out PATH] \\
+        [--price-field FIELD] [--typical-fraction F] [--marketplace] \\
+        [--dry-run] [--format text|json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from consultant import derive, inputs, render  # noqa: E402
+
+PRICING_REL = "docs/pricing.md"
+
+
+def _current_repo_root() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def resolve_target(owner_repo: str | None, repo_path: str | None) -> str:
+    """Resolve the target repo to a local absolute path."""
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        if not (p / ".git").exists():
+            print(f"Error: {p} is not a git repository", file=sys.stderr)
+            sys.exit(1)
+        return str(p)
+    if owner_repo:
+        from repo import resolve_repo  # local import: only needed for owner/repo
+        return str(resolve_repo(owner_repo))
+    root = _current_repo_root()
+    if not root:
+        print("Error: not inside a git repo; pass owner/repo or --repo PATH", file=sys.stderr)
+        sys.exit(1)
+    return root
+
+
+def _summarize_text(result: dict) -> str:
+    lines = [
+        f"business-consultant: analysis {result['analysis_date']} (stack={result['stack_id']}, "
+        f"active_tier={result['cost_shape']['active_tier']})",
+        f"  cost inputs: {result['cost_inputs_source']}"
+        + (" [ILLUSTRATIVE SEED -- unverified]" if result["used_illustrative_seed"] else ""),
+        f"  flat nut: ${result['cost_shape']['flat_nut']:.2f}/mo",
+    ]
+    if result["cost_shape"]["largest_uncapped_meter"]:
+        m = result["cost_shape"]["largest_uncapped_meter"]
+        lines.append(f"  largest uncapped meter: {m['id']} (${m['rate']}/{m['unit']})")
+    if result["cost_shape"]["first_step_jump"]:
+        j = result["cost_shape"]["first_step_jump"]
+        lines.append(f"  first fixed step-jump: {j['from']} -> {j['to']} (+${j['monthly_usd']:.2f}/mo)")
+    for e in result["economics"]:
+        flag = ""
+        if e["underwater"] is True:
+            flag = "  ** UNDERWATER **"
+        lines.append(
+            f"  tier {e['tier']}: price={e['price']} worst_case=${e['worst_case_cost']:.2f} "
+            f"typical=${e['typical_cost']:.2f}{flag}"
+        )
+    for b in result["breakeven"]:
+        be = b["breakeven_tenants"] if b["breakeven_tenants"] is not None else "never"
+        lines.append(f"  break-even {b['tier']}: {be} tenant(s), margin {b['gross_margin_pct']}%")
+    lines.append(f"  pricing-model fit: {result['pricing_fit']['model_family']} (shape={result['pricing_fit']['cost_shape']})")
+    lines.append(f"  {render.AUTHORITY_LINE}")
+    return "\n".join(lines)
+
+
+def run(args: argparse.Namespace) -> tuple[dict, str]:
+    target = resolve_target(args.owner_repo, args.repo)
+    result = derive.run(
+        target_dir=target,
+        cost_inputs_path=args.cost_inputs,
+        stack_id=args.stack,
+        price_field=args.price_field,
+        typical_fraction=args.typical_fraction,
+        marketplace=args.marketplace,
+        now=args.now,
+        base=inputs.ROOT,
+    )
+    md = render.render_pricing_md(result)
+
+    out_path = Path(args.out) if args.out else Path(target) / PRICING_REL
+    if not args.dry_run:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(md)
+
+    return result, str(out_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="/business-consultant cost-model deriver: unit economics + pricing-model fit"
+    )
+    parser.add_argument("owner_repo", nargs="?", default=None, help="owner/repo to resolve+clone (optional)")
+    parser.add_argument("--repo", default=None, help="direct local repo path")
+    parser.add_argument("--cost-inputs", default=None, help="path to an operator cost-inputs.json (templates/cost-inputs-schema.json); falls back to the stack's illustrative seed")
+    parser.add_argument("--stack", default=inputs.DEFAULT_STACK, help="stack profile id (patterns/stacks/<id>)")
+    parser.add_argument("--out", default=None, help="output path for the rendered report (default: <target>/docs/pricing.md)")
+    parser.add_argument("--price-field", default="price_monthly_usd", help="tiered-subscription matrix key holding each tier's price")
+    parser.add_argument("--typical-fraction", type=float, default=0.3, help="assumed fraction of worst-case cap used for 'typical' cost (documented assumption)")
+    parser.add_argument("--marketplace", action="store_true", help="declare a take-rate/marketplace revenue model (never inferred from meter shape)")
+    parser.add_argument("--now", default=None, help="ISO analysis date override (testing)")
+    parser.add_argument("--dry-run", action="store_true", help="derive + print without writing docs/pricing.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    try:
+        result, out_path = run(args)
+    except inputs.ConsultantInputError as exc:
+        print(f"business-consultant: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"result": result, "out": out_path, "dry_run": args.dry_run}, indent=2))
+    else:
+        print(_summarize_text(result))
+        verb = "would write" if args.dry_run else "wrote"
+        print(f"  {verb} {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/business_consultant.py
+++ b/scripts/business_consultant.py
@@ -90,6 +90,9 @@ def _summarize_text(result: dict) -> str:
         if e["worst_case_unbounded"]:
             worst = "UNBOUNDED (uncapped meter)"
             flag = "  ** UNBOUNDED WORST-CASE **"
+        elif e["worst_case_indeterminate"]:
+            worst = "INDETERMINATE (cap not declared / unparseable)"
+            flag = "  ** INDETERMINATE WORST-CASE -- fix your cost inputs **"
         else:
             worst = f"${e['worst_case_cost']:.2f}"
             flag = "  ** UNDERWATER **" if e["underwater"] is True else ""
@@ -100,6 +103,9 @@ def _summarize_text(result: dict) -> str:
     for b in result["breakeven"]:
         if b["unbounded"]:
             lines.append(f"  break-even {b['tier']}: unbounded (uncapped meter — no finite break-even)")
+            continue
+        if b["indeterminate"]:
+            lines.append(f"  break-even {b['tier']}: indeterminate (cap not declared — no finite break-even)")
             continue
         be = b["breakeven_tenants"] if b["breakeven_tenants"] is not None else "never"
         lines.append(f"  break-even {b['tier']}: {be} tenant(s), margin {b['gross_margin_pct']}%")

--- a/scripts/consultant/__init__.py
+++ b/scripts/consultant/__init__.py
@@ -1,0 +1,6 @@
+"""consultant — the /business-consultant deriver: mechanical unit-economics +
+pricing-model-fit arithmetic over a target repo's adopted patterns + cost inputs.
+
+See scripts/business_consultant.py for the CLI entrypoint and
+docs/patterns-registry.md#the-cost-axis-is-first-class for the surrounding model.
+"""

--- a/scripts/consultant/derive.py
+++ b/scripts/consultant/derive.py
@@ -25,7 +25,24 @@ def run(
     base: Path = inputs.ROOT,
 ) -> dict:
     adopted = inputs.load_adopted(target_dir)
-    cost_inputs, used_illustrative, source = inputs.load_cost_inputs(cost_inputs_path, stack_id, base)
+
+    # With no explicit --cost-inputs, prefer the target's OWN operator-authored
+    # docs/cost-inputs.json over the stack's illustrative seed (the seed is a
+    # last-resort fallback, per its own $comment + the skill workflow).
+    if not cost_inputs_path:
+        own = Path(target_dir) / inputs.TARGET_COST_INPUTS_REL
+        if own.is_file():
+            cost_inputs_path = str(own)
+
+    cost_inputs, seed_fallback, source = inputs.load_cost_inputs(cost_inputs_path, stack_id, base)
+
+    # The illustrative caveat is a property of the DATA, not the code path: it
+    # surfaces whenever the loaded cost-inputs is illustrative (its own $caveat,
+    # or any meter marked provenance:"illustrative") — including when an operator
+    # explicitly passes the seed via --cost-inputs. Never let an illustrative
+    # rate render as if it were a verified quote just because of how it arrived.
+    is_illustrative = seed_fallback or inputs.is_illustrative(cost_inputs)
+    caveat = cost_inputs.get("$caveat") or (inputs.DEFAULT_ILLUSTRATIVE_CAVEAT if is_illustrative else "")
 
     try:
         stack_manifest = inputs.load_stack_manifest(stack_id, base)
@@ -50,8 +67,8 @@ def run(
         "analysis_date": analysis_date,
         "stack_id": stack_id,
         "cost_inputs_source": source,
-        "used_illustrative_seed": used_illustrative,
-        "caveat": cost_inputs.get("$caveat", "") if used_illustrative else "",
+        "used_illustrative_seed": is_illustrative,
+        "caveat": caveat,
         "adopted_patterns": sorted(adopted.keys()),
         "cost_shape": asdict(cost_shape),
         "economics": [asdict(e) for e in economics],

--- a/scripts/consultant/derive.py
+++ b/scripts/consultant/derive.py
@@ -1,0 +1,62 @@
+"""derive.py — orchestrates inputs -> model -> pricing_fit into one JSON-
+serializable result dict, consumed by both `--format json` and the
+docs/pricing.md renderer. The only non-pure step is reading files; every
+number after that is deterministic arithmetic (model.py) or a table lookup
+(pricing_fit.py) — no network calls, no AI consultation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import date
+from pathlib import Path
+
+from . import inputs, model, pricing_fit
+
+
+def run(
+    target_dir: str | Path,
+    cost_inputs_path: str | Path | None = None,
+    stack_id: str = inputs.DEFAULT_STACK,
+    price_field: str = model.DEFAULT_PRICE_FIELD,
+    typical_fraction: float = model.DEFAULT_TYPICAL_FRACTION,
+    marketplace: bool = False,
+    now: str | None = None,
+    base: Path = inputs.ROOT,
+) -> dict:
+    adopted = inputs.load_adopted(target_dir)
+    cost_inputs, used_illustrative, source = inputs.load_cost_inputs(cost_inputs_path, stack_id, base)
+
+    try:
+        stack_manifest = inputs.load_stack_manifest(stack_id, base)
+    except inputs.ConsultantInputError:
+        stack_manifest = {}
+
+    active_tier = inputs.active_cost_tier(adopted, stack_manifest) if stack_manifest else "T0"
+    cost_shape = model.derive_cost_shape(cost_inputs, active_tier, stack_manifest or None)
+
+    tiers, matrix = inputs.tiered_subscription_binding(adopted)
+    economics = model.derive_unit_economics(tiers, matrix, cost_inputs.get("meters", []), price_field, typical_fraction)
+    breakeven = model.derive_breakeven(cost_shape.flat_nut, economics)
+
+    table = pricing_fit.load_decision_table()
+    shape_label = pricing_fit.classify_cost_shape(cost_inputs.get("meters", []), marketplace=marketplace)
+    fit_row = pricing_fit.fit(shape_label, table)
+    tactics = pricing_fit.applicable_tactics(table)
+
+    analysis_date = now or cost_inputs.get("as_of") or date.today().isoformat()
+
+    return {
+        "analysis_date": analysis_date,
+        "stack_id": stack_id,
+        "cost_inputs_source": source,
+        "used_illustrative_seed": used_illustrative,
+        "caveat": cost_inputs.get("$caveat", "") if used_illustrative else "",
+        "adopted_patterns": sorted(adopted.keys()),
+        "cost_shape": asdict(cost_shape),
+        "economics": [asdict(e) for e in economics],
+        "breakeven": [asdict(b) for b in breakeven],
+        "typical_fraction": typical_fraction,
+        "pricing_fit": fit_row,
+        "tactics": tactics,
+    }

--- a/scripts/consultant/inputs.py
+++ b/scripts/consultant/inputs.py
@@ -1,0 +1,154 @@
+"""inputs.py — read a target repo's adopted patterns + resolve cost-inputs.
+
+Two input sources feed the deriver (scripts/business_consultant.py):
+
+  1. The target repo's ``docs/patterns/adopted.json`` (written by
+     ``scripts/apply_pattern.py``): which patterns are adopted, and each
+     pattern's *bound parameters* — in particular ``tiered-subscription``'s
+     ``tiers``/``matrix``, the per-tenant limit caps that bound worst-case cost.
+
+     ``apply_pattern.list_adopted()`` intentionally does not expose bound
+     parameters (it's the ``/architect`` invariant-folding view); this module
+     reads the adoption record's raw ``parameters`` block directly instead of
+     going through that function, since the deriver's whole job is arithmetic
+     over those bound values.
+
+  2. A cost-inputs.json (templates/cost-inputs-schema.json): either the
+     operator-authoritative document a human supplied, or — absent that — the
+     stack's illustrative seed, loaded with its ``$caveat`` surfaced so the
+     deriver never lets those numbers pass as a verified quote.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from apply_pattern import ADOPTED_REL  # noqa: E402
+
+ROOT = SCRIPTS.parent
+DEFAULT_STACK = "gcp-serverless-saas"
+
+
+class ConsultantInputError(Exception):
+    """A required input (adopted.json, cost-inputs, stack manifest) is missing or malformed."""
+
+
+def load_adopted(target_dir: str | Path) -> dict:
+    """Return the target repo's adopted patterns: {pattern_id: adoption_record}.
+
+    Empty dict if the repo has no adoption record yet — the deriver degrades
+    honestly (no tiered-subscription -> no per-tier unit economics) rather
+    than crashing.
+    """
+    path = Path(target_dir) / ADOPTED_REL
+    if not path.is_file():
+        return {}
+    try:
+        doc = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ConsultantInputError(f"malformed {path}: {exc}") from exc
+    return doc.get("patterns", {}) or {}
+
+
+def _maybe_json(value):
+    """A parameter bound via `apply_pattern.py --param k=v` is always a raw CLI
+    string; a hand-authored fixture may already carry the native JSON value.
+    Accept both: try to parse a JSON-looking string, else pass the value through.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped[:1] in "{[":
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError:
+                return value
+    return value
+
+
+def tiered_subscription_binding(adopted: dict) -> tuple[list[str], dict]:
+    """Return (tiers, matrix) bound to the adopted `tiered-subscription` pattern,
+    or ([], {}) if the pattern isn't adopted. `matrix` per tiered-subscription's
+    manifest: {tier: {cap_key: limit (-1 = unlimited), ...}, ...}.
+    """
+    record = adopted.get("tiered-subscription")
+    if not isinstance(record, dict):
+        return [], {}
+    params = record.get("parameters", {}) or {}
+    tiers = _maybe_json(params.get("tiers", []))
+    matrix = _maybe_json(params.get("matrix", {}))
+    if not isinstance(tiers, list):
+        tiers = [t.strip() for t in str(tiers).split(",") if t.strip()]
+    if not isinstance(matrix, dict):
+        matrix = {}
+    return tiers, matrix
+
+
+def load_stack_manifest(stack_id: str, base: Path = ROOT) -> dict:
+    path = base / "patterns" / "stacks" / stack_id / "manifest.json"
+    if not path.is_file():
+        raise ConsultantInputError(f"unknown stack {stack_id!r}: manifest not found at {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ConsultantInputError(f"malformed stack manifest {path}: {exc}") from exc
+
+
+def active_cost_tier(adopted: dict, stack_manifest: dict) -> str:
+    """The highest-numbered stack cost tier (patterns/stacks/<id>/manifest.json's
+    `cost_tiers` ladder) among the target's adopted patterns' `bindings` entries.
+
+    A stack manifest's `bindings` map ties an adopted pattern id to the cost tier
+    it goes live at (e.g. gcp-serverless-saas binds `tiered-subscription` at T2).
+    Falls back to the ladder's lowest/first tier if none of the adopted patterns
+    have a binding (a T0 product with no monetization pattern adopted yet).
+    """
+    ladder = [t.get("id") for t in stack_manifest.get("cost_tiers", []) if t.get("id")]
+    bindings = stack_manifest.get("bindings", {}) or {}
+    candidates = [
+        bindings[pid]["tier"]
+        for pid in adopted
+        if isinstance(bindings.get(pid), dict) and bindings[pid].get("tier")
+    ]
+    if not candidates:
+        return ladder[0] if ladder else "T0"
+    in_ladder = [t for t in candidates if t in ladder]
+    if not in_ladder:
+        return candidates[0]
+    return max(in_ladder, key=ladder.index)
+
+
+def load_cost_inputs(
+    cost_inputs_path: str | Path | None, stack_id: str, base: Path = ROOT
+) -> tuple[dict, bool, str]:
+    """Return (cost_inputs, used_illustrative_seed, source_path).
+
+    Operator-supplied path wins when given. Otherwise falls back to the stack's
+    illustrative seed (patterns/stacks/<id>/cost-inputs.illustrative.json) —
+    the DESIGN DECISION per chief-wiggum#122: the seed is a documented fallback,
+    never presented as authoritative (its `$caveat` is surfaced by the caller).
+    """
+    if cost_inputs_path:
+        p = Path(cost_inputs_path)
+        if not p.is_file():
+            raise ConsultantInputError(f"cost-inputs file not found: {p}")
+        try:
+            return json.loads(p.read_text()), False, str(p)
+        except json.JSONDecodeError as exc:
+            raise ConsultantInputError(f"malformed cost-inputs {p}: {exc}") from exc
+
+    seed = base / "patterns" / "stacks" / stack_id / "cost-inputs.illustrative.json"
+    if not seed.is_file():
+        raise ConsultantInputError(
+            f"no --cost-inputs supplied and no illustrative seed for stack {stack_id!r} "
+            f"(looked at {seed})"
+        )
+    try:
+        return json.loads(seed.read_text()), True, str(seed)
+    except json.JSONDecodeError as exc:
+        raise ConsultantInputError(f"malformed illustrative seed {seed}: {exc}") from exc

--- a/scripts/consultant/inputs.py
+++ b/scripts/consultant/inputs.py
@@ -34,6 +34,28 @@ from apply_pattern import ADOPTED_REL  # noqa: E402
 ROOT = SCRIPTS.parent
 DEFAULT_STACK = "gcp-serverless-saas"
 
+# Where a target repo keeps its OWN operator-authored cost inputs (preferred over
+# a stack's illustrative seed when no explicit --cost-inputs is passed).
+TARGET_COST_INPUTS_REL = "docs/cost-inputs.json"
+
+DEFAULT_ILLUSTRATIVE_CAVEAT = (
+    "ILLUSTRATIVE -- these cost inputs carry illustrative (unverified) rates, "
+    "not verified vendor prices. Verify against live vendor pricing before "
+    "quoting a customer or setting a real price floor."
+)
+
+
+def is_illustrative(cost_inputs: dict) -> bool:
+    """A cost-inputs document is illustrative — and its caveat must surface,
+    however it was supplied — if it declares a top-level ``$caveat`` or ANY
+    meter is marked ``provenance: "illustrative"``. This is a property of the
+    DATA, so passing an illustrative seed explicitly via ``--cost-inputs`` still
+    surfaces the caveat (a rate doesn't become verified by how the file arrived).
+    """
+    if cost_inputs.get("$caveat"):
+        return True
+    return any(m.get("provenance") == "illustrative" for m in cost_inputs.get("meters", []) or [])
+
 
 class ConsultantInputError(Exception):
     """A required input (adopted.json, cost-inputs, stack manifest) is missing or malformed."""

--- a/scripts/consultant/model.py
+++ b/scripts/consultant/model.py
@@ -13,6 +13,23 @@ DEFAULT_PRICE_FIELD = "price_monthly_usd"
 DEFAULT_TYPICAL_FRACTION = 0.3  # documented assumption: "typical" = 30% of a tier's worst-case cap
 
 
+def _cap_number(cap: object) -> float | None:
+    """Normalize a matrix cap to a number so the unlimited sentinel is caught
+    regardless of representation. Accepts int/float and numeric strings (so a
+    hand-authored ``"-1"`` reads as unlimited, not ``float("-1")*rate`` negative
+    cost); returns None for a non-numeric value the caller must not coerce."""
+    if isinstance(cap, bool):  # bool is an int subclass — never a cap
+        return None
+    if isinstance(cap, (int, float)):
+        return float(cap)
+    if isinstance(cap, str):
+        try:
+            return float(cap.strip())
+        except ValueError:
+            return None
+    return None
+
+
 @dataclass
 class CostShape:
     """The flat nut + per-tenant variable shape (issue #122, deriver bullet a)."""
@@ -182,7 +199,11 @@ def derive_unit_economics(
             rate = float(m.get("rate", 0))
             mid = m.get("id", "?")
             if cap_key is None:
-                # Globally uncapped meter: excluded + named in section 1.
+                # Globally uncapped meter (capped_by: null): the worst case for
+                # this meter is literally unbounded — no matrix key limits it — so
+                # it forces the same unbounded state as a -1 sentinel, not a silent
+                # exclusion that leaves a finite-looking worst-case subtotal.
+                unbounded_meters.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
@@ -192,15 +213,23 @@ def derive_unit_economics(
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
-            cap = caps[cap_key]
-            if cap == -1:
-                # Unlimited sentinel on a metered line -> unbounded worst case.
+            cap = _cap_number(caps[cap_key])
+            if cap is None:
+                # Unparseable cap (e.g. a non-numeric string): cannot bound the
+                # meter, so surface it as undeclared rather than coercing it into
+                # a definitive (possibly negative) cost.
+                no_cap_declared.append(mid)
+                worst_excluded.append(mid)
+                typical_excluded.append(mid)
+                continue
+            if cap < 0:
+                # -1 (or any negative sentinel), incl. the string "-1" -> unlimited.
                 unbounded_meters.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
-            worst += float(cap) * rate
-            typical += float(cap) * rate * typical_fraction
+            worst += cap * rate
+            typical += cap * rate * typical_fraction
         unbounded = bool(unbounded_meters)
         if unbounded:
             worst_case_cost: float | None = None

--- a/scripts/consultant/model.py
+++ b/scripts/consultant/model.py
@@ -52,16 +52,28 @@ class TierEconomics:
     the underwater check is then also None (cannot flag underwater without a
     price to compare against).
 
-    A tier whose matrix leaves a metered line UNCAPPED — either an unlimited
-    (`-1`) sentinel on that field, or a globally-uncapped meter (`capped_by:
-    null`) — has an UNBOUNDED worst case: a single heavy tenant can cost an
-    arbitrary amount. In that case `worst_case_unbounded` is True and
-    `worst_case_cost` is None (NOT $0). Presenting an uncapped tier as $0
-    worst-case / 100%-margin is exactly the founder-misleads-himself failure
-    this deriver exists to prevent, so the unbounded state is explicit and
-    never collapses to a definitive-looking number. `typical_cost` is still
-    estimated from the BOUNDED meters (labeled typical-not-worst by the
-    renderer) but excludes the unbounded meters (no cap to estimate against).
+    A tier's worst case is NOT definitively computable — so `worst_case_cost`,
+    `underwater`, and (in derive_breakeven) margin/break-even are ALL suppressed
+    to None — whenever ANY meter's cost on that tier cannot be bounded. There are
+    two reasons, rendered differently but with the SAME economic effect (never a
+    finite worst-case that silently omits a cost we couldn't bound):
+
+    - **unbounded (uncapped by design):** an unlimited (`-1` / `"-1"`) sentinel,
+      or a globally-uncapped meter (`capped_by: null`). A single heavy tenant can
+      cost an arbitrary amount. Flagged `worst_case_unbounded`, meters in
+      `unbounded_meters`.
+    - **indeterminate (data gap):** a meter's cap field is absent from this
+      tier's matrix, or its cap value is unparseable (e.g. `"lots"`). The cost
+      *might* be bounded, but the cost inputs don't say — so we can't compute a
+      worst case and must not pretend the meter is free. Flagged
+      `worst_case_indeterminate`, meters in `no_cap_declared_meters`.
+
+    Presenting either as a finite $0-inclusive worst-case / 100%-margin is the
+    founder-misleads-himself failure this deriver exists to prevent. `typical_cost`
+    is still estimated from the BOUNDED meters (labeled typical-not-worst by the
+    renderer) but excludes the unbounded/indeterminate meters (no cap to estimate
+    against). `price` is None if the matrix carries no recognizable price field —
+    the underwater check is then also None regardless of the cost side.
     """
 
     tier: str
@@ -73,7 +85,14 @@ class TierEconomics:
     underwater: bool | None
     worst_case_unbounded: bool = False
     unbounded_meters: list[str] = field(default_factory=list)   # -1 sentinel OR globally-uncapped, on this tier
-    no_cap_declared_meters: list[str] = field(default_factory=list)  # declared meter, cap key absent from this tier's matrix
+    worst_case_indeterminate: bool = False
+    no_cap_declared_meters: list[str] = field(default_factory=list)  # cap field absent OR unparseable for this tier
+
+    @property
+    def worst_case_computable(self) -> bool:
+        """True only when the tier's worst case is a definitive number — neither
+        unbounded (uncapped by design) nor indeterminate (data gap)."""
+        return not (self.worst_case_unbounded or self.worst_case_indeterminate)
 
 
 @dataclass
@@ -83,11 +102,12 @@ class Breakeven:
     recovers its typical cost (margin <= 0 — priced underwater at typical
     usage, not just worst case).
 
-    When the tier's worst case is unbounded (an uncapped metered line), margin
-    and break-even are UNCOMPUTABLE, not a definitive number: `unbounded` is
-    True and `gross_margin_per_tenant` / `gross_margin_pct` / `breakeven_tenants`
-    are all None. A tenant on an uncapped tier can cost arbitrarily much, so no
-    finite break-even or margin can be guaranteed."""
+    When the tier's worst case is not definitively computable — unbounded (an
+    uncapped metered line) OR indeterminate (a missing/unparseable cap) — margin
+    and break-even are UNCOMPUTABLE, not a definitive number:
+    `gross_margin_per_tenant` / `gross_margin_pct` / `breakeven_tenants` are all
+    None. `unbounded` and `indeterminate` mirror the tier's economics so the
+    renderer can distinguish the two while both suppress definitive numbers."""
 
     tier: str
     price: float
@@ -96,6 +116,7 @@ class Breakeven:
     gross_margin_pct: float | None
     breakeven_tenants: int | None
     unbounded: bool = False
+    indeterminate: bool = False
 
 
 def first_fixed_step_jump(stack_manifest: dict, cost_inputs: dict) -> dict | None:
@@ -155,29 +176,25 @@ def derive_unit_economics(
     """Worst-case (matrix cap x rate, summed over every capped meter) + typical
     (a documented `typical_fraction` of that same worst case) cost per tier.
 
-    A metered line leaves a tier's worst case UNBOUNDED (not $0) when its plan
-    matrix cap is the `-1` unlimited sentinel. This is the dangerous, INVISIBLE
-    case: the field IS in the matrix (so the tier looks capped) but the cap is
-    unlimited, so the old behavior collapsed it to a $0 line and the tier read as
-    underwater=False / 100% margin / a finite break-even — the precise
-    founder-misleads-himself failure this deriver exists to prevent. Such meters
-    go in `unbounded_meters` and force `worst_case_unbounded=True` with
-    `worst_case_cost=None`, surfaced explicitly, never as a safe-looking number.
+    If a tier has ANY meter whose cost cannot be bounded, its worst case is NOT
+    definitively computable and `worst_case_cost` / `underwater` are suppressed to
+    None (and derive_breakeven suppresses margin/break-even) — never a finite
+    subtotal from the OTHER meters that silently omits a cost we couldn't bound.
+    Two reasons, rendered differently but with the SAME economic suppression:
 
-    A globally-uncapped meter (`capped_by: null`) is excluded from the per-tier
-    worst case as before — it is uncapped for EVERY tier equally and is already
-    headlined in the cost-shape section as "the largest uncapped meter", so it's
-    a named, visible risk rather than an invisible one; it's still listed in each
-    tier's excluded-meters note.
+    - **unbounded (uncapped by design):** the matrix cap is a `-1`/`"-1"` unlimited
+      sentinel, or the meter is globally uncapped (`capped_by: null`). A single
+      heavy tenant can cost an arbitrary amount. -> `unbounded_meters`,
+      `worst_case_unbounded=True`.
+    - **indeterminate (data gap):** the meter's cap field is absent from this
+      tier's matrix, or its cap value is unparseable (e.g. `"lots"`). The cost
+      might be bounded, but the inputs don't say — so we can't compute a worst
+      case and must not pretend the meter is free. -> `no_cap_declared_meters`,
+      `worst_case_indeterminate=True`.
 
-    A declared meter whose cap FIELD is simply absent from a tier's matrix goes
-    in `no_cap_declared_meters` — it may genuinely not apply to this tier, but a
-    missing cap must be shown (via the renderer), never silently omitted in a way
-    that improves the economics.
-
-    `typical_cost` is still estimated from the BOUNDED meters (the renderer
-    labels it typical-not-worst); unbounded / uncapped / no-cap-declared meters
-    are excluded from it too, since there's no cap to base an estimate on.
+    `typical_cost` is still estimated from the BOUNDED meters (the renderer labels
+    it typical-not-worst); unbounded / indeterminate meters are excluded from it
+    too, since there's no cap to base an estimate on.
     """
     out: list[TierEconomics] = []
     for tier in tiers:
@@ -201,14 +218,16 @@ def derive_unit_economics(
             if cap_key is None:
                 # Globally uncapped meter (capped_by: null): the worst case for
                 # this meter is literally unbounded — no matrix key limits it — so
-                # it forces the same unbounded state as a -1 sentinel, not a silent
-                # exclusion that leaves a finite-looking worst-case subtotal.
+                # it forces the unbounded state, not a silent exclusion that leaves
+                # a finite-looking worst-case subtotal.
                 unbounded_meters.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
             if cap_key not in caps:
-                # Cap field not declared for this tier: surface it, never omit silently.
+                # Cap field not declared for this tier: a data gap. Surface it AND
+                # suppress definitive economics (indeterminate) — never omit it in
+                # a way that leaves a finite worst-case from the other meters.
                 no_cap_declared.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
@@ -216,8 +235,8 @@ def derive_unit_economics(
             cap = _cap_number(caps[cap_key])
             if cap is None:
                 # Unparseable cap (e.g. a non-numeric string): cannot bound the
-                # meter, so surface it as undeclared rather than coercing it into
-                # a definitive (possibly negative) cost.
+                # meter, so it's a data gap (indeterminate), not a coerced cost and
+                # not an unlimited sentinel.
                 no_cap_declared.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
@@ -231,9 +250,12 @@ def derive_unit_economics(
             worst += cap * rate
             typical += cap * rate * typical_fraction
         unbounded = bool(unbounded_meters)
-        if unbounded:
+        indeterminate = bool(no_cap_declared)
+        if unbounded or indeterminate:
+            # Either reason makes the worst case non-computable -> suppress the
+            # definitive worst-case cost and underwater flag alike.
             worst_case_cost: float | None = None
-            underwater: bool | None = None  # cannot flag underwater against an unbounded cost
+            underwater: bool | None = None
         else:
             worst_case_cost = round(worst, 4)
             underwater = (price < worst) if price is not None else None
@@ -248,6 +270,7 @@ def derive_unit_economics(
                 underwater=underwater,
                 worst_case_unbounded=unbounded,
                 unbounded_meters=unbounded_meters,
+                worst_case_indeterminate=indeterminate,
                 no_cap_declared_meters=no_cap_declared,
             )
         )
@@ -260,16 +283,16 @@ def derive_breakeven(flat_nut: float, economics: list[TierEconomics]) -> list[Br
     tiers contribute no break-even coverage and are skipped — they can't recover
     a flat cost on zero revenue.
 
-    A tier with an unbounded worst case (an uncapped metered line) has no
-    guaranteeable margin or break-even: a single heavy tenant can cost an
-    arbitrary amount. Such a tier is emitted with `unbounded=True` and
-    None margin/break-even, never a definitive number computed from the
-    (bounded) typical cost alone."""
+    A tier whose worst case is not definitively computable — unbounded (an
+    uncapped metered line) OR indeterminate (a missing/unparseable cap) — has no
+    guaranteeable margin or break-even, since a cost we couldn't bound might
+    swamp the (bounded) typical estimate. Such a tier is emitted with the matching
+    flag set and None margin/break-even, never a definitive number."""
     out: list[Breakeven] = []
     for e in economics:
         if e.price is None or e.price <= 0:
             continue
-        if e.worst_case_unbounded:
+        if not e.worst_case_computable:
             out.append(
                 Breakeven(
                     tier=e.tier,
@@ -278,7 +301,8 @@ def derive_breakeven(flat_nut: float, economics: list[TierEconomics]) -> list[Br
                     gross_margin_per_tenant=None,
                     gross_margin_pct=None,
                     breakeven_tenants=None,
-                    unbounded=True,
+                    unbounded=e.worst_case_unbounded,
+                    indeterminate=e.worst_case_indeterminate,
                 )
             )
             continue

--- a/scripts/consultant/model.py
+++ b/scripts/consultant/model.py
@@ -29,17 +29,34 @@ class CostShape:
 @dataclass
 class TierEconomics:
     """Worst-case + typical per-tenant variable cost for one pricing tier
-    (deriver bullet b). `price` is None if the matrix entry carries no
-    recognizable price field — the underwater check is then also None
-    (cannot flag underwater without a price to compare against)."""
+    (deriver bullet b).
+
+    `price` is None if the matrix entry carries no recognizable price field —
+    the underwater check is then also None (cannot flag underwater without a
+    price to compare against).
+
+    A tier whose matrix leaves a metered line UNCAPPED — either an unlimited
+    (`-1`) sentinel on that field, or a globally-uncapped meter (`capped_by:
+    null`) — has an UNBOUNDED worst case: a single heavy tenant can cost an
+    arbitrary amount. In that case `worst_case_unbounded` is True and
+    `worst_case_cost` is None (NOT $0). Presenting an uncapped tier as $0
+    worst-case / 100%-margin is exactly the founder-misleads-himself failure
+    this deriver exists to prevent, so the unbounded state is explicit and
+    never collapses to a definitive-looking number. `typical_cost` is still
+    estimated from the BOUNDED meters (labeled typical-not-worst by the
+    renderer) but excludes the unbounded meters (no cap to estimate against).
+    """
 
     tier: str
     price: float | None
-    worst_case_cost: float
+    worst_case_cost: float | None
     worst_case_excluded_meters: list[str]
     typical_cost: float
     typical_excluded_meters: list[str]
     underwater: bool | None
+    worst_case_unbounded: bool = False
+    unbounded_meters: list[str] = field(default_factory=list)   # -1 sentinel OR globally-uncapped, on this tier
+    no_cap_declared_meters: list[str] = field(default_factory=list)  # declared meter, cap key absent from this tier's matrix
 
 
 @dataclass
@@ -47,14 +64,21 @@ class Breakeven:
     """Break-even paying-tenant count + gross margin for one paying tier
     (deriver bullet c). `breakeven_tenants` is None when the tier never
     recovers its typical cost (margin <= 0 — priced underwater at typical
-    usage, not just worst case)."""
+    usage, not just worst case).
+
+    When the tier's worst case is unbounded (an uncapped metered line), margin
+    and break-even are UNCOMPUTABLE, not a definitive number: `unbounded` is
+    True and `gross_margin_per_tenant` / `gross_margin_pct` / `breakeven_tenants`
+    are all None. A tenant on an uncapped tier can cost arbitrarily much, so no
+    finite break-even or margin can be guaranteed."""
 
     tier: str
     price: float
     typical_cost: float
-    gross_margin_per_tenant: float
-    gross_margin_pct: float
+    gross_margin_per_tenant: float | None
+    gross_margin_pct: float | None
     breakeven_tenants: int | None
+    unbounded: bool = False
 
 
 def first_fixed_step_jump(stack_manifest: dict, cost_inputs: dict) -> dict | None:
@@ -114,15 +138,29 @@ def derive_unit_economics(
     """Worst-case (matrix cap x rate, summed over every capped meter) + typical
     (a documented `typical_fraction` of that same worst case) cost per tier.
 
-    A meter is excluded from BOTH worst-case and typical for a tier when:
-      - it's globally uncapped (`capped_by: null` — no plan field bounds it at
-        all), or
-      - the tier's matrix entry has no such cap field (the meter doesn't apply
-        to this product), or
-      - the tier's cap for that field is the `-1` unlimited sentinel.
-    Excluding rather than guessing keeps every number here honest: an excluded
-    meter needs a real usage number (production telemetry) to bound, not a
-    fabricated one.
+    A metered line leaves a tier's worst case UNBOUNDED (not $0) when its plan
+    matrix cap is the `-1` unlimited sentinel. This is the dangerous, INVISIBLE
+    case: the field IS in the matrix (so the tier looks capped) but the cap is
+    unlimited, so the old behavior collapsed it to a $0 line and the tier read as
+    underwater=False / 100% margin / a finite break-even — the precise
+    founder-misleads-himself failure this deriver exists to prevent. Such meters
+    go in `unbounded_meters` and force `worst_case_unbounded=True` with
+    `worst_case_cost=None`, surfaced explicitly, never as a safe-looking number.
+
+    A globally-uncapped meter (`capped_by: null`) is excluded from the per-tier
+    worst case as before — it is uncapped for EVERY tier equally and is already
+    headlined in the cost-shape section as "the largest uncapped meter", so it's
+    a named, visible risk rather than an invisible one; it's still listed in each
+    tier's excluded-meters note.
+
+    A declared meter whose cap FIELD is simply absent from a tier's matrix goes
+    in `no_cap_declared_meters` — it may genuinely not apply to this tier, but a
+    missing cap must be shown (via the renderer), never silently omitted in a way
+    that improves the economics.
+
+    `typical_cost` is still estimated from the BOUNDED meters (the renderer
+    labels it typical-not-worst); unbounded / uncapped / no-cap-declared meters
+    are excluded from it too, since there's no cap to base an estimate on.
     """
     out: list[TierEconomics] = []
     for tier in tiers:
@@ -137,33 +175,51 @@ def derive_unit_economics(
         typical = 0.0
         worst_excluded: list[str] = []
         typical_excluded: list[str] = []
+        unbounded_meters: list[str] = []
+        no_cap_declared: list[str] = []
         for m in meters:
             cap_key = m.get("capped_by")
             rate = float(m.get("rate", 0))
             mid = m.get("id", "?")
             if cap_key is None:
+                # Globally uncapped meter: excluded + named in section 1.
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
             if cap_key not in caps:
-                continue  # this meter doesn't apply to this product's matrix
+                # Cap field not declared for this tier: surface it, never omit silently.
+                no_cap_declared.append(mid)
+                worst_excluded.append(mid)
+                typical_excluded.append(mid)
+                continue
             cap = caps[cap_key]
             if cap == -1:
+                # Unlimited sentinel on a metered line -> unbounded worst case.
+                unbounded_meters.append(mid)
                 worst_excluded.append(mid)
                 typical_excluded.append(mid)
                 continue
             worst += float(cap) * rate
             typical += float(cap) * rate * typical_fraction
-        underwater = (price < worst) if price is not None else None
+        unbounded = bool(unbounded_meters)
+        if unbounded:
+            worst_case_cost: float | None = None
+            underwater: bool | None = None  # cannot flag underwater against an unbounded cost
+        else:
+            worst_case_cost = round(worst, 4)
+            underwater = (price < worst) if price is not None else None
         out.append(
             TierEconomics(
                 tier=tier,
                 price=price,
-                worst_case_cost=round(worst, 4),
+                worst_case_cost=worst_case_cost,
                 worst_case_excluded_meters=worst_excluded,
                 typical_cost=round(typical, 4),
                 typical_excluded_meters=typical_excluded,
                 underwater=underwater,
+                worst_case_unbounded=unbounded,
+                unbounded_meters=unbounded_meters,
+                no_cap_declared_meters=no_cap_declared,
             )
         )
     return out
@@ -173,10 +229,29 @@ def derive_breakeven(flat_nut: float, economics: list[TierEconomics]) -> list[Br
     """Break-even paying-tenant count (# of that tier alone needed to cover the
     flat nut) + gross margin, per paying (price > 0) tier. Free ($0 or unpriced)
     tiers contribute no break-even coverage and are skipped — they can't recover
-    a flat cost on zero revenue."""
+    a flat cost on zero revenue.
+
+    A tier with an unbounded worst case (an uncapped metered line) has no
+    guaranteeable margin or break-even: a single heavy tenant can cost an
+    arbitrary amount. Such a tier is emitted with `unbounded=True` and
+    None margin/break-even, never a definitive number computed from the
+    (bounded) typical cost alone."""
     out: list[Breakeven] = []
     for e in economics:
         if e.price is None or e.price <= 0:
+            continue
+        if e.worst_case_unbounded:
+            out.append(
+                Breakeven(
+                    tier=e.tier,
+                    price=e.price,
+                    typical_cost=e.typical_cost,
+                    gross_margin_per_tenant=None,
+                    gross_margin_pct=None,
+                    breakeven_tenants=None,
+                    unbounded=True,
+                )
+            )
             continue
         margin = round(e.price - e.typical_cost, 4)
         margin_pct = round((margin / e.price) * 100, 2)

--- a/scripts/consultant/model.py
+++ b/scripts/consultant/model.py
@@ -1,0 +1,194 @@
+"""model.py — the mechanical cost-model deriver: pure arithmetic over
+cost-inputs.json + a tiered-subscription matrix. No network calls, no AI
+consultation, no live pricing lookup (that's the documented step-3 seam,
+chief-wiggum#122) — every number here is deterministic given its inputs.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+DEFAULT_PRICE_FIELD = "price_monthly_usd"
+DEFAULT_TYPICAL_FRACTION = 0.3  # documented assumption: "typical" = 30% of a tier's worst-case cap
+
+
+@dataclass
+class CostShape:
+    """The flat nut + per-tenant variable shape (issue #122, deriver bullet a)."""
+
+    flat_monthly: float
+    active_tier: str
+    tier_fixed_amount: float
+    flat_nut: float
+    meters: list[dict] = field(default_factory=list)
+    largest_uncapped_meter: dict | None = None
+    first_step_jump: dict | None = None
+
+
+@dataclass
+class TierEconomics:
+    """Worst-case + typical per-tenant variable cost for one pricing tier
+    (deriver bullet b). `price` is None if the matrix entry carries no
+    recognizable price field — the underwater check is then also None
+    (cannot flag underwater without a price to compare against)."""
+
+    tier: str
+    price: float | None
+    worst_case_cost: float
+    worst_case_excluded_meters: list[str]
+    typical_cost: float
+    typical_excluded_meters: list[str]
+    underwater: bool | None
+
+
+@dataclass
+class Breakeven:
+    """Break-even paying-tenant count + gross margin for one paying tier
+    (deriver bullet c). `breakeven_tenants` is None when the tier never
+    recovers its typical cost (margin <= 0 — priced underwater at typical
+    usage, not just worst case)."""
+
+    tier: str
+    price: float
+    typical_cost: float
+    gross_margin_per_tenant: float
+    gross_margin_pct: float
+    breakeven_tenants: int | None
+
+
+def first_fixed_step_jump(stack_manifest: dict, cost_inputs: dict) -> dict | None:
+    """The first (in the stack's own graduation_triggers order) tier transition
+    that carries a nonzero tier_fixed dollar amount in the supplied cost-inputs —
+    i.e. the first real fixed-cost jump, not just a prose trigger description."""
+    tier_fixed = cost_inputs.get("tier_fixed", {}) or {}
+    for trig in stack_manifest.get("graduation_triggers", []) or []:
+        to_tier = trig.get("to")
+        amount = tier_fixed.get(to_tier, 0)
+        if amount and amount > 0:
+            return {
+                "from": trig.get("from"),
+                "to": to_tier,
+                "trigger": trig.get("trigger"),
+                "add": trig.get("add"),
+                "monthly_usd": amount,
+            }
+    return None
+
+
+def largest_uncapped_meter(meters: list[dict]) -> dict | None:
+    """Name the single largest-rate meter with no plan cap (`capped_by: null`) —
+    the dangerous line item a plan-limit matrix cannot bound (issue #122's
+    "the single uncapped variable cost" callout)."""
+    uncapped = [m for m in meters if m.get("capped_by") is None]
+    if not uncapped:
+        return None
+    return max(uncapped, key=lambda m: m.get("rate", 0))
+
+
+def derive_cost_shape(
+    cost_inputs: dict, active_tier: str, stack_manifest: dict | None = None
+) -> CostShape:
+    flat_monthly = float(cost_inputs.get("flat_monthly", 0))
+    tier_fixed = cost_inputs.get("tier_fixed", {}) or {}
+    tier_fixed_amount = float(tier_fixed.get(active_tier, 0) or 0)
+    meters = cost_inputs.get("meters", []) or []
+    return CostShape(
+        flat_monthly=flat_monthly,
+        active_tier=active_tier,
+        tier_fixed_amount=tier_fixed_amount,
+        flat_nut=round(flat_monthly + tier_fixed_amount, 4),
+        meters=meters,
+        largest_uncapped_meter=largest_uncapped_meter(meters),
+        first_step_jump=first_fixed_step_jump(stack_manifest, cost_inputs) if stack_manifest else None,
+    )
+
+
+def derive_unit_economics(
+    tiers: list[str],
+    matrix: dict,
+    meters: list[dict],
+    price_field: str = DEFAULT_PRICE_FIELD,
+    typical_fraction: float = DEFAULT_TYPICAL_FRACTION,
+) -> list[TierEconomics]:
+    """Worst-case (matrix cap x rate, summed over every capped meter) + typical
+    (a documented `typical_fraction` of that same worst case) cost per tier.
+
+    A meter is excluded from BOTH worst-case and typical for a tier when:
+      - it's globally uncapped (`capped_by: null` — no plan field bounds it at
+        all), or
+      - the tier's matrix entry has no such cap field (the meter doesn't apply
+        to this product), or
+      - the tier's cap for that field is the `-1` unlimited sentinel.
+    Excluding rather than guessing keeps every number here honest: an excluded
+    meter needs a real usage number (production telemetry) to bound, not a
+    fabricated one.
+    """
+    out: list[TierEconomics] = []
+    for tier in tiers:
+        caps = matrix.get(tier, {}) or {}
+        price = caps.get(price_field)
+        if price is not None:
+            try:
+                price = float(price)
+            except (TypeError, ValueError):
+                price = None
+        worst = 0.0
+        typical = 0.0
+        worst_excluded: list[str] = []
+        typical_excluded: list[str] = []
+        for m in meters:
+            cap_key = m.get("capped_by")
+            rate = float(m.get("rate", 0))
+            mid = m.get("id", "?")
+            if cap_key is None:
+                worst_excluded.append(mid)
+                typical_excluded.append(mid)
+                continue
+            if cap_key not in caps:
+                continue  # this meter doesn't apply to this product's matrix
+            cap = caps[cap_key]
+            if cap == -1:
+                worst_excluded.append(mid)
+                typical_excluded.append(mid)
+                continue
+            worst += float(cap) * rate
+            typical += float(cap) * rate * typical_fraction
+        underwater = (price < worst) if price is not None else None
+        out.append(
+            TierEconomics(
+                tier=tier,
+                price=price,
+                worst_case_cost=round(worst, 4),
+                worst_case_excluded_meters=worst_excluded,
+                typical_cost=round(typical, 4),
+                typical_excluded_meters=typical_excluded,
+                underwater=underwater,
+            )
+        )
+    return out
+
+
+def derive_breakeven(flat_nut: float, economics: list[TierEconomics]) -> list[Breakeven]:
+    """Break-even paying-tenant count (# of that tier alone needed to cover the
+    flat nut) + gross margin, per paying (price > 0) tier. Free ($0 or unpriced)
+    tiers contribute no break-even coverage and are skipped — they can't recover
+    a flat cost on zero revenue."""
+    out: list[Breakeven] = []
+    for e in economics:
+        if e.price is None or e.price <= 0:
+            continue
+        margin = round(e.price - e.typical_cost, 4)
+        margin_pct = round((margin / e.price) * 100, 2)
+        breakeven = math.ceil(flat_nut / margin) if margin > 0 else None
+        out.append(
+            Breakeven(
+                tier=e.tier,
+                price=e.price,
+                typical_cost=e.typical_cost,
+                gross_margin_per_tenant=margin,
+                gross_margin_pct=margin_pct,
+                breakeven_tenants=breakeven,
+            )
+        )
+    return out

--- a/scripts/consultant/pricing_fit.py
+++ b/scripts/consultant/pricing_fit.py
@@ -1,0 +1,61 @@
+"""pricing_fit.py — cost-shape -> pricing-MODEL-family lookup.
+
+Reads patterns/pricing-models/models.json (see reference.md for the human
+spec) and answers "which pricing model family fits this cost shape" — a
+family (subscription-or-seat / usage-based-or-subscription / take-rate), never
+a specific price point. A specific number needs market-comparable data (the
+step-3 live-lookup seam, chief-wiggum#122).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+MODELS_JSON = ROOT / "patterns" / "pricing-models" / "models.json"
+
+FLAT_COST = "flat-cost"
+PER_UNIT_RECURRING = "per-unit-recurring"
+MARKETPLACE = "marketplace"
+
+
+class PricingFitError(Exception):
+    pass
+
+
+def load_decision_table(path: Path = MODELS_JSON) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise PricingFitError(f"pricing-models decision table not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PricingFitError(f"malformed decision table {path}: {exc}") from exc
+
+
+def classify_cost_shape(meters: list[dict], marketplace: bool = False) -> str:
+    """Deterministic cost-shape classification (issue #122 bullet e input).
+
+    `marketplace` is an explicit operator declaration (no adopted pattern in
+    the registry yet signals take-rate revenue, so this is never inferred from
+    meter shape alone — see patterns/pricing-models/reference.md). Otherwise:
+    no nonzero per-tenant meter -> flat-cost; any nonzero meter -> per-unit-recurring.
+    """
+    if marketplace:
+        return MARKETPLACE
+    if not meters or all(float(m.get("rate", 0)) == 0 for m in meters):
+        return FLAT_COST
+    return PER_UNIT_RECURRING
+
+
+def fit(cost_shape: str, table: dict | None = None) -> dict:
+    table = table or load_decision_table()
+    for row in table.get("cost_shape_to_model", []):
+        if row.get("cost_shape") == cost_shape:
+            return row
+    raise PricingFitError(f"no decision-table row for cost shape {cost_shape!r}")
+
+
+def applicable_tactics(table: dict | None = None) -> list[dict]:
+    table = table or load_decision_table()
+    return table.get("tactics", []) or []

--- a/scripts/consultant/render.py
+++ b/scripts/consultant/render.py
@@ -105,21 +105,45 @@ def render_pricing_md(result: dict) -> str:
             "a documented assumption, not measured usage; replace with real telemetry once live."
         )
         lines.append("")
-        lines.append("| Tier | Price/mo | Worst-case cost | Typical cost | Underwater? |")
+        lines.append("| Tier | Price/mo | Worst-case cost | Typical (not worst) cost | Underwater? |")
         lines.append("|--|--|--|--|--|")
         for e in economics:
-            underwater = "n/a (no price bound)" if e["underwater"] is None else ("**YES**" if e["underwater"] else "no")
+            if e["worst_case_unbounded"]:
+                worst_cell = "**UNBOUNDED**"
+                underwater = "**UNBOUNDED** (uncapped meter)"
+            else:
+                worst_cell = _fmt_usd(e["worst_case_cost"])
+                underwater = "n/a (no price bound)" if e["underwater"] is None else ("**YES**" if e["underwater"] else "no")
             lines.append(
-                f"| `{e['tier']}` | {_fmt_usd(e['price'])} | {_fmt_usd(e['worst_case_cost'])} | "
+                f"| `{e['tier']}` | {_fmt_usd(e['price'])} | {worst_cell} | "
                 f"{_fmt_usd(e['typical_cost'])} | {underwater} |"
             )
         lines.append("")
         for e in economics:
-            excluded = sorted(set(e["worst_case_excluded_meters"]))
-            if excluded:
+            if e["unbounded_meters"]:
+                meters = ", ".join(f"`{x}`" for x in sorted(set(e["unbounded_meters"])))
                 lines.append(
-                    f"- `{e['tier']}`: excluded from worst-case/typical (uncapped, not applicable, "
-                    f"or `-1` unlimited in this tier): {', '.join(f'`{x}`' for x in excluded)}"
+                    f"- `{e['tier']}`: **unbounded worst-case** — {meters} "
+                    "has a `-1` unlimited cap on this tier; a single heavy tenant "
+                    "can cost an arbitrary amount, so worst-case cost / margin / "
+                    "break-even are uncomputable, not $0."
+                )
+            if e["no_cap_declared_meters"]:
+                meters = ", ".join(f"`{x}`" for x in sorted(set(e["no_cap_declared_meters"])))
+                lines.append(
+                    f"- `{e['tier']}`: **no cap declared** for {meters} — the meter's "
+                    "`capped_by` field is absent from this tier's matrix. It may not apply "
+                    "to this tier, but confirm: a missing cap is not the same as a $0 cost."
+                )
+            other_excluded = sorted(
+                set(e["worst_case_excluded_meters"])
+                - set(e["unbounded_meters"])
+                - set(e["no_cap_declared_meters"])
+            )
+            if other_excluded:
+                lines.append(
+                    f"- `{e['tier']}`: excluded from worst-case/typical: "
+                    f"{', '.join(f'`{x}`' for x in other_excluded)}"
                 )
         lines.append("")
 
@@ -135,10 +159,17 @@ def render_pricing_md(result: dict) -> str:
         lines.append("| Tier | Price/mo | Typical cost | Margin/tenant | Margin % | Break-even tenants |")
         lines.append("|--|--|--|--|--|--|")
         for b in breakeven:
-            be = "never (margin <= 0 at typical usage)" if b["breakeven_tenants"] is None else str(b["breakeven_tenants"])
+            if b["unbounded"]:
+                margin_cell = "**UNBOUNDED**"
+                margin_pct_cell = "**UNBOUNDED**"
+                be = "unbounded (uncapped meter — no finite break-even)"
+            else:
+                margin_cell = _fmt_usd(b["gross_margin_per_tenant"])
+                margin_pct_cell = _fmt_pct(b["gross_margin_pct"])
+                be = "never (margin <= 0 at typical usage)" if b["breakeven_tenants"] is None else str(b["breakeven_tenants"])
             lines.append(
                 f"| `{b['tier']}` | {_fmt_usd(b['price'])} | {_fmt_usd(b['typical_cost'])} | "
-                f"{_fmt_usd(b['gross_margin_per_tenant'])} | {_fmt_pct(b['gross_margin_pct'])} | {be} |"
+                f"{margin_cell} | {margin_pct_cell} | {be} |"
             )
         lines.append("")
 

--- a/scripts/consultant/render.py
+++ b/scripts/consultant/render.py
@@ -111,6 +111,9 @@ def render_pricing_md(result: dict) -> str:
             if e["worst_case_unbounded"]:
                 worst_cell = "**UNBOUNDED**"
                 underwater = "**UNBOUNDED** (uncapped meter)"
+            elif e["worst_case_indeterminate"]:
+                worst_cell = "**INDETERMINATE**"
+                underwater = "**INDETERMINATE** (cap not declared)"
             else:
                 worst_cell = _fmt_usd(e["worst_case_cost"])
                 underwater = "n/a (no price bound)" if e["underwater"] is None else ("**YES**" if e["underwater"] else "no")
@@ -123,17 +126,19 @@ def render_pricing_md(result: dict) -> str:
             if e["unbounded_meters"]:
                 meters = ", ".join(f"`{x}`" for x in sorted(set(e["unbounded_meters"])))
                 lines.append(
-                    f"- `{e['tier']}`: **unbounded worst-case** — {meters} "
-                    "has a `-1` unlimited cap on this tier; a single heavy tenant "
-                    "can cost an arbitrary amount, so worst-case cost / margin / "
+                    f"- `{e['tier']}`: **unbounded worst-case (uncapped by design)** — {meters} "
+                    "has an unlimited (`-1`) or `capped_by: null` cap on this tier; a single "
+                    "heavy tenant can cost an arbitrary amount, so worst-case cost / margin / "
                     "break-even are uncomputable, not $0."
                 )
             if e["no_cap_declared_meters"]:
                 meters = ", ".join(f"`{x}`" for x in sorted(set(e["no_cap_declared_meters"])))
                 lines.append(
-                    f"- `{e['tier']}`: **no cap declared** for {meters} — the meter's "
-                    "`capped_by` field is absent from this tier's matrix. It may not apply "
-                    "to this tier, but confirm: a missing cap is not the same as a $0 cost."
+                    f"- `{e['tier']}`: **indeterminate worst-case (cap not declared / unparseable — "
+                    f"fix your cost inputs)** — {meters} has no usable cap for this tier (the "
+                    "`capped_by` field is absent from the matrix, or its value can't be parsed). "
+                    "The cost may be bounded, but the inputs don't say, so worst-case cost / "
+                    "margin / break-even are suppressed — a missing cap is not a $0 cost."
                 )
             other_excluded = sorted(
                 set(e["worst_case_excluded_meters"])
@@ -163,6 +168,10 @@ def render_pricing_md(result: dict) -> str:
                 margin_cell = "**UNBOUNDED**"
                 margin_pct_cell = "**UNBOUNDED**"
                 be = "unbounded (uncapped meter — no finite break-even)"
+            elif b["indeterminate"]:
+                margin_cell = "**INDETERMINATE**"
+                margin_pct_cell = "**INDETERMINATE**"
+                be = "indeterminate (cap not declared — no finite break-even)"
             else:
                 margin_cell = _fmt_usd(b["gross_margin_per_tenant"])
                 margin_pct_cell = _fmt_pct(b["gross_margin_pct"])

--- a/scripts/consultant/render.py
+++ b/scripts/consultant/render.py
@@ -1,0 +1,173 @@
+"""render.py — renders the deriver's output into docs/pricing.md's 5-section
+contract (issue #122 bullet 5): cost shape / unit economics per tier /
+break-even+margin / market-comparable floor (the documented UNRESOLVED seam) /
+pricing-model fit.
+"""
+
+from __future__ import annotations
+
+AUTHORITY_LINE = (
+    "Unit economics are derived mechanically from the supplied cost inputs; "
+    "illustrative seed numbers are unverified and dated, not a quote."
+)
+
+MARKET_SEAM_NOTE = (
+    "UNRESOLVED: market-comparable pricing floor needs a live lookup of what "
+    "comparable products charge (chief-wiggum#122, rollout step 3 — not built "
+    "yet). Do not fabricate competitor prices; this section stays an open "
+    "question, gated by scripts/check_unresolved.py, until the live-lookup "
+    "step ships."
+)
+
+
+def _fmt_usd(value) -> str:
+    if value is None:
+        return "n/a"
+    return f"${value:,.2f}"
+
+
+def _fmt_pct(value) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}%"
+
+
+def render_pricing_md(result: dict) -> str:
+    lines: list[str] = []
+    lines.append("# Pricing — unit economics & pricing-model fit")
+    lines.append("")
+    lines.append(f"> Analysis date: **{result['analysis_date']}**  ")
+    lines.append(f"> Stack: `{result['stack_id']}`, active cost tier: `{result['cost_shape']['active_tier']}`  ")
+    lines.append(f"> Cost inputs source: `{result['cost_inputs_source']}`")
+    lines.append("")
+    if result["used_illustrative_seed"]:
+        lines.append(f"> **{result['caveat']}**")
+        lines.append("")
+    lines.append(f"_{AUTHORITY_LINE}_")
+    lines.append("")
+
+    # --- 1. Cost shape --------------------------------------------------
+    lines.append("## 1. Cost shape")
+    lines.append("")
+    cs = result["cost_shape"]
+    lines.append(
+        f"**Flat nut**: {_fmt_usd(cs['flat_nut'])}/mo "
+        f"({_fmt_usd(cs['flat_monthly'])} baseline + {_fmt_usd(cs['tier_fixed_amount'])} "
+        f"active-tier fixed cost at `{cs['active_tier']}`) + a per-tenant variable cost "
+        "summed over the meters below."
+    )
+    lines.append("")
+    if cs["largest_uncapped_meter"]:
+        m = cs["largest_uncapped_meter"]
+        lines.append(
+            f"**Largest uncapped meter**: `{m['id']}` at {_fmt_usd(m['rate'])}/{m['unit']} "
+            f"({m['unit_desc']}) — no plan-limit `matrix` field bounds this meter's usage. "
+            "Not the only metered line; put a budget alert on every meter, not just this one."
+        )
+    else:
+        lines.append("**Largest uncapped meter**: none — every declared meter is bounded by a plan-limit `matrix` field.")
+    lines.append("")
+    if cs["first_step_jump"]:
+        j = cs["first_step_jump"]
+        lines.append(
+            f"**First fixed step-jump**: `{j['from']}` -> `{j['to']}` "
+            f"(+{_fmt_usd(j['monthly_usd'])}/mo) — triggered by: {j['trigger']}"
+            + (f"; adds {j['add']}" if j.get("add") else "")
+            + "."
+        )
+    else:
+        lines.append("**First fixed step-jump**: none identified (no graduation trigger in the stack manifest carries a nonzero fixed cost at the active tier, or no stack manifest was available).")
+    lines.append("")
+    lines.append("| Meter | Unit | Rate | Capped by | Provenance | Verified |")
+    lines.append("|--|--|--|--|--|--|")
+    for m in cs["meters"]:
+        capped = m.get("capped_by") or "_(uncapped)_"
+        lines.append(
+            f"| `{m['id']}` | {m['unit']} | {_fmt_usd(m['rate'])} | {capped} | "
+            f"{m['provenance']} | {m.get('verified_date', 'n/a')} |"
+        )
+    lines.append("")
+
+    # --- 2. Unit economics per tier --------------------------------------
+    lines.append("## 2. Unit economics per tier")
+    lines.append("")
+    economics = result["economics"]
+    if not economics:
+        lines.append(
+            "No `tiered-subscription` pattern adopted (or no tiers bound) — "
+            "per-tier unit economics need the pattern's `matrix` to bound worst-case "
+            "usage. Adopt `tiered-subscription` (`scripts/apply_pattern.py`) first."
+        )
+    else:
+        lines.append(
+            f"Worst-case = matrix cap x meter rate, summed over every capped meter. "
+            f"Typical assumes {result['typical_fraction'] * 100:.0f}% of that worst case — "
+            "a documented assumption, not measured usage; replace with real telemetry once live."
+        )
+        lines.append("")
+        lines.append("| Tier | Price/mo | Worst-case cost | Typical cost | Underwater? |")
+        lines.append("|--|--|--|--|--|")
+        for e in economics:
+            underwater = "n/a (no price bound)" if e["underwater"] is None else ("**YES**" if e["underwater"] else "no")
+            lines.append(
+                f"| `{e['tier']}` | {_fmt_usd(e['price'])} | {_fmt_usd(e['worst_case_cost'])} | "
+                f"{_fmt_usd(e['typical_cost'])} | {underwater} |"
+            )
+        lines.append("")
+        for e in economics:
+            excluded = sorted(set(e["worst_case_excluded_meters"]))
+            if excluded:
+                lines.append(
+                    f"- `{e['tier']}`: excluded from worst-case/typical (uncapped, not applicable, "
+                    f"or `-1` unlimited in this tier): {', '.join(f'`{x}`' for x in excluded)}"
+                )
+        lines.append("")
+
+    # --- 3. Break-even & gross margin ------------------------------------
+    lines.append("## 3. Break-even & gross margin")
+    lines.append("")
+    breakeven = result["breakeven"]
+    if not breakeven:
+        lines.append("No paying (price > 0) tier available to compute break-even against.")
+    else:
+        lines.append(f"Tenants of that tier alone needed to cover the flat nut ({_fmt_usd(cs['flat_nut'])}/mo), at typical cost.")
+        lines.append("")
+        lines.append("| Tier | Price/mo | Typical cost | Margin/tenant | Margin % | Break-even tenants |")
+        lines.append("|--|--|--|--|--|--|")
+        for b in breakeven:
+            be = "never (margin <= 0 at typical usage)" if b["breakeven_tenants"] is None else str(b["breakeven_tenants"])
+            lines.append(
+                f"| `{b['tier']}` | {_fmt_usd(b['price'])} | {_fmt_usd(b['typical_cost'])} | "
+                f"{_fmt_usd(b['gross_margin_per_tenant'])} | {_fmt_pct(b['gross_margin_pct'])} | {be} |"
+            )
+        lines.append("")
+
+    # --- 4. Market-comparable floor ---------------------------------------
+    lines.append("## 4. Market-comparable floor")
+    lines.append("")
+    lines.append(MARKET_SEAM_NOTE)
+    lines.append("")
+
+    # --- 5. Pricing-model fit ---------------------------------------------
+    lines.append("## 5. Pricing-model fit")
+    lines.append("")
+    fit = result["pricing_fit"]
+    lines.append(f"**Cost shape**: `{fit['cost_shape']}` -> **model family**: `{fit['model_family']}`")
+    lines.append("")
+    lines.append(f"Rationale: {fit['rationale']}")
+    lines.append("")
+    if fit.get("never"):
+        lines.append(f"Never: {', '.join(fit['never'])}.")
+        lines.append("")
+    if fit.get("notes"):
+        lines.append(f"Notes: {fit['notes']}")
+        lines.append("")
+    tactics = result.get("tactics") or []
+    if tactics:
+        lines.append("**Applicable pricing tactics** (patterns/pricing-models/reference.md):")
+        lines.append("")
+        for t in tactics:
+            lines.append(f"- **{t['id']}** — {t['one_liner']} _Guardrail: {t['guardrail']}_")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/templates/cost-inputs-schema.json
+++ b/templates/cost-inputs-schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/cost-inputs.json",
+  "title": "Cost Inputs",
+  "description": "Operator-authoritative structured cost-model inputs consumed by scripts/business_consultant.py to derive unit economics + a pricing-model fit (see docs/patterns-registry.md#the-cost-axis-is-first-class). Distinct from a stack profile's cost_tiers/graduation_triggers (patterns/stacks/*/manifest.json), which are deliberately prose/illustrative -- region- and billing-mode-dependent, not structured invariants. A product's own docs/cost-inputs.json (this schema) is the operator-authoritative source of per-unit rates; a stack may ship a cost-inputs.illustrative.json seed (same schema, every meter provenance:\"illustrative\") as a documented, loudly-caveated fallback when the operator hasn't supplied one yet.",
+  "type": "object",
+  "required": ["flat_monthly", "meters", "tier_fixed"],
+  "additionalProperties": false,
+  "properties": {
+    "$comment": {
+      "type": "string",
+      "description": "Free-text note about this cost-inputs document's origin/scope."
+    },
+    "$caveat": {
+      "type": "string",
+      "description": "Present + non-empty on an illustrative seed: a loud, human-readable warning that every number here is a placeholder, unverified against live vendor pricing, and must never be presented as an authoritative quote."
+    },
+    "as_of": {
+      "type": "string",
+      "description": "ISO date this cost-inputs snapshot was assembled/last verified. Stamped into the rendered pricing.md analysis date."
+    },
+    "currency": {
+      "type": "string",
+      "default": "USD",
+      "description": "ISO currency code every rate/flat cost is denominated in."
+    },
+    "flat_monthly": {
+      "type": "number",
+      "minimum": 0,
+      "description": "The baseline flat platform nut before any cost-tier step-jump or per-tenant meter -- e.g. always-on base hosting."
+    },
+    "tier_fixed": {
+      "type": "object",
+      "description": "Additional fixed monthly cost that switches on when a stack cost tier (e.g. T0/T1/T2 from a stack profile's cost_tiers) becomes active for this product -- e.g. the Cloud Run min-instances=1 jump at T2. Keyed by cost-tier id. The deriver adds the bound-in active tier's amount (if any) to flat_monthly.",
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0
+      }
+    },
+    "meters": {
+      "type": "array",
+      "description": "Per-tenant variable-cost meters -- one line per billed unit of usage-based spend.",
+      "items": { "$ref": "#/$defs/meter" }
+    }
+  },
+  "$defs": {
+    "meter": {
+      "type": "object",
+      "required": ["id", "unit", "rate", "unit_desc", "capped_by", "provenance", "verified_date"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable meter id, e.g. 'media_delivery_hour'."
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The billed unit, e.g. 'hour', 'send', 'write', 'gb-month'."
+        },
+        "rate": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cost per unit, in `currency`."
+        },
+        "unit_desc": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable description of what one unit is (for the rendered report)."
+        },
+        "capped_by": {
+          "type": ["string", "null"],
+          "description": "The tiered-subscription `matrix` key (patterns/tiered-subscription/manifest.json) that bounds this meter's per-tenant usage, or null if no plan cap bounds it. A null capped_by is the dangerous case the deriver names explicitly -- an uncapped meter has no plan-enforced ceiling on worst-case cost."
+        },
+        "provenance": {
+          "type": "string",
+          "enum": ["operator-verified", "illustrative"],
+          "description": "'operator-verified': a human confirmed this rate against live vendor pricing. 'illustrative': a shipped seed's placeholder number -- never presented as a quote."
+        },
+        "verified_date": {
+          "type": "string",
+          "description": "ISO date this rate was last checked against live vendor pricing."
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/business_consultant/adopted-capped.json
+++ b/tests/fixtures/business_consultant/adopted-capped.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Synthetic FULLY-MATRIX-CAPPED fixture for tests/test_business_consultant.py -- every meter in cost-inputs-capped.json is capped_by a key present in this matrix (emails_per_month + media_hours_per_month), so each tier's worst-case is finite and legitimately computable. NOT a real product's adoption record.",
+  "patterns": {
+    "tiered-subscription": {
+      "version": 1,
+      "applied_at": "2026-07-01T00:00:00Z",
+      "provenance": {"registry": "chief-wiggum", "manifest": "patterns/tiered-subscription/manifest.json"},
+      "parameters": {
+        "tiers": ["free", "pro"],
+        "matrix": {
+          "free": {"emails_per_month": 100, "media_hours_per_month": 2, "price_monthly_usd": 0},
+          "pro": {"emails_per_month": 5000, "media_hours_per_month": 50, "price_monthly_usd": 25}
+        },
+        "billing_provider": "stripe"
+      },
+      "unresolved": [],
+      "invariants": ["INV-TSB-001", "INV-TSB-002"],
+      "protected_path_intents": []
+    }
+  }
+}

--- a/tests/fixtures/business_consultant/adopted.json
+++ b/tests/fixtures/business_consultant/adopted.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Synthetic fixture for tests/test_business_consultant.py -- NOT a real product's adoption record.",
+  "patterns": {
+    "tiered-subscription": {
+      "version": 1,
+      "applied_at": "2026-07-01T00:00:00Z",
+      "provenance": {"registry": "chief-wiggum", "manifest": "patterns/tiered-subscription/manifest.json"},
+      "parameters": {
+        "tiers": ["free", "pro"],
+        "matrix": {
+          "free": {"emails_per_month": 100, "price_monthly_usd": 0},
+          "pro": {"emails_per_month": 5000, "price_monthly_usd": 25}
+        },
+        "billing_provider": "stripe"
+      },
+      "unresolved": [],
+      "invariants": ["INV-TSB-001", "INV-TSB-002"],
+      "protected_path_intents": []
+    },
+    "multi-tenant-isolation": {
+      "version": 1,
+      "applied_at": "2026-07-01T00:00:00Z",
+      "provenance": {"registry": "chief-wiggum", "manifest": "patterns/multi-tenant-isolation/manifest.json"},
+      "parameters": {},
+      "unresolved": [],
+      "invariants": ["INV-MTI-001"],
+      "protected_path_intents": []
+    }
+  }
+}

--- a/tests/fixtures/business_consultant/cost-inputs-capped.json
+++ b/tests/fixtures/business_consultant/cost-inputs-capped.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Synthetic FULLY-MATRIX-CAPPED cost-inputs fixture for tests/test_business_consultant.py -- every meter's capped_by names a key present in adopted-capped.json's matrix, so per-tier worst-case is finite (no capped_by:null, no -1 sentinel). Controlled numbers for exact arithmetic assertions, not a real vendor quote.",
+  "as_of": "2026-07-01",
+  "currency": "USD",
+  "flat_monthly": 5.0,
+  "tier_fixed": {
+    "T1": 0.0,
+    "T2": 40.0
+  },
+  "meters": [
+    {
+      "id": "email_send",
+      "unit": "send",
+      "rate": 0.002,
+      "unit_desc": "fixture transactional email, per send",
+      "capped_by": "emails_per_month",
+      "provenance": "operator-verified",
+      "verified_date": "2026-07-01"
+    },
+    {
+      "id": "media_delivery_hour",
+      "unit": "hour",
+      "rate": 0.06,
+      "unit_desc": "fixture media delivery, per hour",
+      "capped_by": "media_hours_per_month",
+      "provenance": "operator-verified",
+      "verified_date": "2026-07-01"
+    }
+  ]
+}

--- a/tests/fixtures/business_consultant/cost-inputs.json
+++ b/tests/fixtures/business_consultant/cost-inputs.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Synthetic cost-inputs fixture for tests/test_business_consultant.py -- controlled numbers, not a real vendor quote.",
+  "as_of": "2026-07-01",
+  "currency": "USD",
+  "flat_monthly": 5.0,
+  "tier_fixed": {
+    "T1": 0.0,
+    "T2": 40.0
+  },
+  "meters": [
+    {
+      "id": "media_delivery_hour",
+      "unit": "hour",
+      "rate": 0.05,
+      "unit_desc": "fixture media delivery, per hour",
+      "capped_by": null,
+      "provenance": "operator-verified",
+      "verified_date": "2026-07-01"
+    },
+    {
+      "id": "email_send",
+      "unit": "send",
+      "rate": 0.002,
+      "unit_desc": "fixture transactional email, per send",
+      "capped_by": "emails_per_month",
+      "provenance": "operator-verified",
+      "verified_date": "2026-07-01"
+    }
+  ]
+}

--- a/tests/fixtures/business_consultant/fixture_base/patterns/stacks/fixture-stack/cost-inputs.illustrative.json
+++ b/tests/fixtures/business_consultant/fixture_base/patterns/stacks/fixture-stack/cost-inputs.illustrative.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Synthetic illustrative-seed fixture for tests/test_business_consultant.py.",
+  "$caveat": "FIXTURE ILLUSTRATIVE -- placeholder numbers for test assertions only, not a real vendor price.",
+  "as_of": "2026-06-01",
+  "flat_monthly": 2.0,
+  "tier_fixed": {"T2": 10.0},
+  "meters": [
+    {
+      "id": "fixture_meter",
+      "unit": "unit",
+      "rate": 0.01,
+      "unit_desc": "fixture uncapped meter",
+      "capped_by": null,
+      "provenance": "illustrative",
+      "verified_date": "2026-06-01"
+    }
+  ]
+}

--- a/tests/fixtures/business_consultant/fixture_base/patterns/stacks/fixture-stack/manifest.json
+++ b/tests/fixtures/business_consultant/fixture_base/patterns/stacks/fixture-stack/manifest.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Synthetic stack manifest fixture for tests/test_business_consultant.py -- deterministic cost_tiers/graduation_triggers/bindings, not a real stack.",
+  "id": "fixture-stack",
+  "cost_tiers": [
+    {"id": "T0", "name": "Static"},
+    {"id": "T1", "name": "Thin serverless"},
+    {"id": "T2", "name": "Full production"}
+  ],
+  "graduation_triggers": [
+    {"from": "T0", "to": "T1", "trigger": "need server logic", "add": "Compute"},
+    {"from": "T1", "to": "T2", "trigger": "cold starts hurt UX", "add": "min-instances=1"}
+  ],
+  "bindings": {
+    "tiered-subscription": {"tier": "T2", "vendor": "fixture-billing"}
+  }
+}

--- a/tests/test_business_consultant.py
+++ b/tests/test_business_consultant.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import jsonschema
@@ -218,12 +219,70 @@ def test_unit_economics_no_price_field_is_not_flagged_underwater():
     assert econ[0].underwater is None
 
 
-def test_unit_economics_unlimited_sentinel_excluded_from_worst_case():
+def test_unit_economics_unlimited_sentinel_is_unbounded_not_zero():
+    """P1 regression: a -1 (unlimited) cap on a metered line must make the tier's
+    worst-case UNBOUNDED, never a safe-looking $0 / 100%-margin / finite
+    break-even. This is the invisible danger the deriver exists to catch."""
     matrix = {"enterprise": {"emails_per_month": -1, "price_monthly_usd": 500}}
     econ = model.derive_unit_economics(["enterprise"], matrix, _fixture_cost_inputs()["meters"])
     e = econ[0]
+    assert e.worst_case_unbounded is True
+    assert "email_send" in e.unbounded_meters
+    assert e.worst_case_cost is None  # NOT 0.0
+    assert e.underwater is None  # cannot flag underwater against an unbounded cost
+
+
+def test_breakeven_unbounded_tier_has_no_finite_margin_or_breakeven():
+    """P1 regression: an unbounded (uncapped-metered) paying tier yields no
+    definitive margin/break-even — a heavy tenant can cost arbitrarily much."""
+    matrix = {"enterprise": {"emails_per_month": -1, "price_monthly_usd": 500}}
+    econ = model.derive_unit_economics(["enterprise"], matrix, _fixture_cost_inputs()["meters"])
+    breakeven = model.derive_breakeven(45.0, econ)
+    b = breakeven[0]
+    assert b.unbounded is True
+    assert b.gross_margin_per_tenant is None
+    assert b.gross_margin_pct is None
+    assert b.breakeven_tenants is None
+
+
+def test_render_surfaces_unbounded_tier_never_as_dollar_zero():
+    """P1 regression at the render layer: the unbounded state reaches the report
+    as UNBOUNDED, not $0.00 / 100%."""
+    matrix = {"free": {"emails_per_month": -1, "price_monthly_usd": 0},
+              "paid": {"emails_per_month": -1, "price_monthly_usd": 100}}
+    result = derive.run(
+        target_dir=".", cost_inputs_path=str(FIXTURES / "cost-inputs.json"),
+        stack_id="fixture-stack", now=FIXED_NOW, base=FIXTURE_BASE,
+    )
+    econ = model.derive_unit_economics(["paid"], matrix, _fixture_cost_inputs()["meters"])
+    result["economics"] = [asdict(e) for e in econ]
+    result["breakeven"] = [asdict(b) for b in model.derive_breakeven(45.0, econ)]
+    md = render.render_pricing_md(result)
+    assert "UNBOUNDED" in md
+    section = md.split("## 2.")[1].split("## 4.")[0]
+    assert "$0.00 | 100" not in section  # never a safe-looking 100% margin row
+
+
+def test_unit_economics_missing_cap_field_is_surfaced_not_silently_omitted():
+    """P2 regression: a declared meter whose cap key is absent from a tier's
+    matrix must be surfaced (no_cap_declared_meters), never silently contribute
+    $0 and vanish from the report."""
+    # a matrix that caps NOTHING the email_send meter needs
+    matrix = {"pro": {"seats": 5, "price_monthly_usd": 40}}
+    meters = [{"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
+               "capped_by": "emails_per_month", "provenance": "operator-verified",
+               "verified_date": "2026-07-01"}]
+    econ = model.derive_unit_economics(["pro"], matrix, meters)
+    e = econ[0]
+    assert "email_send" in e.no_cap_declared_meters
     assert "email_send" in e.worst_case_excluded_meters
-    assert e.worst_case_cost == 0.0  # only email_send was capped, and it's -1 here
+    md = render.render_pricing_md({
+        **_sample_result(),
+        "economics": [asdict(e)],
+        "breakeven": [],
+    })
+    assert "no cap declared" in md
+    assert "email_send" in md
 
 
 # --- model.py: break-even + gross margin -------------------------------------
@@ -333,15 +392,22 @@ def _sample_result() -> dict:
             "largest_uncapped_meter": _fixture_cost_inputs()["meters"][0],
             "first_step_jump": {"from": "T1", "to": "T2", "trigger": "cold starts", "add": "min-instances=1", "monthly_usd": 40.0},
         },
+        # Built from the real dataclasses via asdict so the sample never drifts
+        # from the model's field schema.
         "economics": [
-            {"tier": "free", "price": 0.0, "worst_case_cost": 0.2, "worst_case_excluded_meters": ["media_delivery_hour"],
-             "typical_cost": 0.06, "typical_excluded_meters": ["media_delivery_hour"], "underwater": True},
-            {"tier": "pro", "price": 25.0, "worst_case_cost": 10.0, "worst_case_excluded_meters": ["media_delivery_hour"],
-             "typical_cost": 3.0, "typical_excluded_meters": ["media_delivery_hour"], "underwater": False},
+            asdict(model.TierEconomics(
+                tier="free", price=0.0, worst_case_cost=0.2,
+                worst_case_excluded_meters=["media_delivery_hour"], typical_cost=0.06,
+                typical_excluded_meters=["media_delivery_hour"], underwater=True)),
+            asdict(model.TierEconomics(
+                tier="pro", price=25.0, worst_case_cost=10.0,
+                worst_case_excluded_meters=["media_delivery_hour"], typical_cost=3.0,
+                typical_excluded_meters=["media_delivery_hour"], underwater=False)),
         ],
         "breakeven": [
-            {"tier": "pro", "price": 25.0, "typical_cost": 3.0, "gross_margin_per_tenant": 22.0,
-             "gross_margin_pct": 88.0, "breakeven_tenants": 3},
+            asdict(model.Breakeven(
+                tier="pro", price=25.0, typical_cost=3.0, gross_margin_per_tenant=22.0,
+                gross_margin_pct=88.0, breakeven_tenants=3)),
         ],
         "typical_fraction": 0.3,
         "pricing_fit": pricing_fit.fit(pricing_fit.PER_UNIT_RECURRING),
@@ -435,6 +501,57 @@ def test_derive_run_against_the_real_gcp_stack_illustrative_seed(tmp_path):
     assert result["used_illustrative_seed"] is True
     assert result["caveat"]
     assert result["cost_shape"]["largest_uncapped_meter"]["id"] == "media_delivery_hour"
+
+
+def test_derive_run_explicit_seed_still_surfaces_caveat(tmp_path):
+    """P2 regression: passing the illustrative seed EXPLICITLY via --cost-inputs
+    must still surface the caveat — the caveat is a property of the data, not the
+    auto-fallback code path."""
+    seed = FIXTURE_BASE / "patterns" / "stacks" / "fixture-stack" / "cost-inputs.illustrative.json"
+    result = derive.run(
+        target_dir=tmp_path, cost_inputs_path=str(seed),
+        stack_id="fixture-stack", now=FIXED_NOW, base=FIXTURE_BASE,
+    )
+    assert result["used_illustrative_seed"] is True
+    assert "FIXTURE ILLUSTRATIVE" in result["caveat"]
+
+
+def test_derive_run_illustrative_meter_provenance_surfaces_caveat(tmp_path):
+    """P2 regression: even an operator file with no top-level $caveat surfaces a
+    caveat if ANY meter is marked provenance:'illustrative'."""
+    ci = tmp_path / "ci.json"
+    ci.write_text(json.dumps({
+        "flat_monthly": 1.0, "tier_fixed": {},
+        "meters": [{"id": "m", "unit": "u", "rate": 0.01, "unit_desc": "d",
+                    "capped_by": None, "provenance": "illustrative", "verified_date": "2026-01-01"}],
+    }))
+    result = derive.run(
+        target_dir=tmp_path, cost_inputs_path=str(ci),
+        stack_id="fixture-stack", now=FIXED_NOW, base=FIXTURE_BASE,
+    )
+    assert result["used_illustrative_seed"] is True
+    assert result["caveat"]  # the default illustrative caveat
+
+
+def test_derive_run_auto_uses_target_docs_cost_inputs_over_seed(tmp_path):
+    """P2 regression: with no --cost-inputs, the target's own
+    docs/cost-inputs.json is preferred over the stack's illustrative seed."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "cost-inputs.json").write_text((FIXTURES / "cost-inputs.json").read_text())
+    result = derive.run(
+        target_dir=tmp_path, cost_inputs_path=None,
+        stack_id="fixture-stack", now=FIXED_NOW, base=FIXTURE_BASE,
+    )
+    assert result["used_illustrative_seed"] is False  # operator-verified, not the seed
+    assert result["cost_inputs_source"].endswith("docs/cost-inputs.json")
+
+
+def test_is_illustrative_helper_detects_caveat_and_provenance():
+    assert inputs.is_illustrative({"$caveat": "x", "meters": []}) is True
+    assert inputs.is_illustrative({"meters": [{"provenance": "illustrative"}]}) is True
+    assert inputs.is_illustrative({"meters": [{"provenance": "operator-verified"}]}) is False
+    assert inputs.is_illustrative({"meters": []}) is False
 
 
 # --- schema validation of the illustrative seed ------------------------------

--- a/tests/test_business_consultant.py
+++ b/tests/test_business_consultant.py
@@ -1,0 +1,577 @@
+"""Tests for scripts/business_consultant.py and scripts/consultant/*
+(the /business-consultant cost-model deriver, chief-wiggum#122 steps 1+2).
+
+Fixtures under tests/fixtures/business_consultant/ are synthetic -- controlled
+numbers chosen to make the arithmetic assertions exact, never a real product's
+adoption record or a real vendor quote.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+FIXTURES = ROOT / "tests" / "fixtures" / "business_consultant"
+FIXTURE_BASE = FIXTURES / "fixture_base"
+
+sys.path.insert(0, str(SCRIPTS))
+
+from consultant import derive, inputs, model, pricing_fit, render  # noqa: E402
+
+FIXED_NOW = "2026-07-15"
+
+
+def _fixture_adopted() -> dict:
+    return json.loads((FIXTURES / "adopted.json").read_text())["patterns"]
+
+
+def _fixture_cost_inputs() -> dict:
+    return json.loads((FIXTURES / "cost-inputs.json").read_text())
+
+
+def _fixture_stack_manifest() -> dict:
+    return json.loads(
+        (FIXTURE_BASE / "patterns" / "stacks" / "fixture-stack" / "manifest.json").read_text()
+    )
+
+
+# --- inputs.py ---------------------------------------------------------------
+
+
+def test_load_adopted_reads_patterns_block(tmp_path):
+    d = tmp_path / "docs" / "patterns"
+    d.mkdir(parents=True)
+    (d / "adopted.json").write_text((FIXTURES / "adopted.json").read_text())
+    adopted = inputs.load_adopted(tmp_path)
+    assert set(adopted) == {"tiered-subscription", "multi-tenant-isolation"}
+
+
+def test_load_adopted_empty_when_missing(tmp_path):
+    assert inputs.load_adopted(tmp_path) == {}
+
+
+def test_tiered_subscription_binding_native_json():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    assert tiers == ["free", "pro"]
+    assert matrix["pro"]["emails_per_month"] == 5000
+
+
+def test_tiered_subscription_binding_cli_string_params():
+    """A pattern bound via `apply_pattern.py --param matrix=<json>` stores the
+    raw CLI string in adopted.json -- the deriver must parse that too."""
+    adopted = {
+        "tiered-subscription": {
+            "parameters": {
+                "tiers": '["free", "pro"]',
+                "matrix": '{"free": {"price_monthly_usd": 0}, "pro": {"price_monthly_usd": 10}}',
+            }
+        }
+    }
+    tiers, matrix = inputs.tiered_subscription_binding(adopted)
+    assert tiers == ["free", "pro"]
+    assert matrix["pro"]["price_monthly_usd"] == 10
+
+
+def test_tiered_subscription_binding_absent_pattern():
+    assert inputs.tiered_subscription_binding({}) == ([], {})
+
+
+def test_active_cost_tier_picks_highest_bound_tier():
+    manifest = _fixture_stack_manifest()
+    tier = inputs.active_cost_tier(_fixture_adopted(), manifest)
+    assert tier == "T2"  # tiered-subscription binds at T2 in the fixture stack
+
+
+def test_active_cost_tier_defaults_to_ladder_floor_when_nothing_bound():
+    manifest = _fixture_stack_manifest()
+    assert inputs.active_cost_tier({}, manifest) == "T0"
+
+
+def test_load_cost_inputs_operator_path(tmp_path):
+    p = tmp_path / "cost-inputs.json"
+    p.write_text((FIXTURES / "cost-inputs.json").read_text())
+    data, used_illustrative, source = inputs.load_cost_inputs(str(p), "fixture-stack", FIXTURE_BASE)
+    assert used_illustrative is False
+    assert source == str(p)
+    assert data["flat_monthly"] == 5.0
+
+
+def test_load_cost_inputs_falls_back_to_illustrative_seed():
+    data, used_illustrative, source = inputs.load_cost_inputs(None, "fixture-stack", FIXTURE_BASE)
+    assert used_illustrative is True
+    assert "cost-inputs.illustrative.json" in source
+    assert data["$caveat"]  # the loud caveat is present
+
+
+def test_load_cost_inputs_missing_operator_file_raises(tmp_path):
+    with pytest.raises(inputs.ConsultantInputError):
+        inputs.load_cost_inputs(str(tmp_path / "nope.json"), "fixture-stack", FIXTURE_BASE)
+
+
+def test_load_cost_inputs_unknown_stack_no_seed_raises(tmp_path):
+    with pytest.raises(inputs.ConsultantInputError):
+        inputs.load_cost_inputs(None, "no-such-stack", FIXTURE_BASE)
+
+
+# --- model.py: cost shape -----------------------------------------------------
+
+
+def test_derive_cost_shape_flat_nut_is_flat_monthly_plus_active_tier_fixed():
+    ci = _fixture_cost_inputs()
+    shape = model.derive_cost_shape(ci, "T2", _fixture_stack_manifest())
+    assert shape.flat_monthly == 5.0
+    assert shape.tier_fixed_amount == 40.0
+    assert shape.flat_nut == 45.0
+
+
+def test_derive_cost_shape_at_lower_tier_excludes_the_fixed_addon():
+    ci = _fixture_cost_inputs()
+    shape = model.derive_cost_shape(ci, "T1", _fixture_stack_manifest())
+    assert shape.tier_fixed_amount == 0.0
+    assert shape.flat_nut == 5.0
+
+
+def test_largest_uncapped_meter_is_named():
+    ci = _fixture_cost_inputs()
+    shape = model.derive_cost_shape(ci, "T2", _fixture_stack_manifest())
+    assert shape.largest_uncapped_meter is not None
+    assert shape.largest_uncapped_meter["id"] == "media_delivery_hour"
+
+
+def test_no_uncapped_meter_is_none():
+    ci = _fixture_cost_inputs()
+    ci = dict(ci, meters=[m for m in ci["meters"] if m["capped_by"] is not None])
+    shape = model.derive_cost_shape(ci, "T2", _fixture_stack_manifest())
+    assert shape.largest_uncapped_meter is None
+
+
+def test_first_fixed_step_jump_names_the_first_nonzero_transition():
+    ci = _fixture_cost_inputs()
+    jump = model.first_fixed_step_jump(_fixture_stack_manifest(), ci)
+    assert jump == {
+        "from": "T1",
+        "to": "T2",
+        "trigger": "cold starts hurt UX",
+        "add": "min-instances=1",
+        "monthly_usd": 40.0,
+    }
+
+
+def test_first_fixed_step_jump_none_when_every_transition_is_zero_cost():
+    ci = dict(_fixture_cost_inputs(), tier_fixed={"T1": 0.0, "T2": 0.0})
+    assert model.first_fixed_step_jump(_fixture_stack_manifest(), ci) is None
+
+
+# --- model.py: unit economics + underwater detection -------------------------
+
+
+def test_unit_economics_worst_case_is_matrix_cap_times_rate():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    free = next(e for e in econ if e.tier == "free")
+    # only email_send applies (media is globally uncapped -> excluded);
+    # free cap 100 emails * $0.002/send = $0.20
+    assert free.worst_case_cost == pytest.approx(0.20)
+    assert "media_delivery_hour" in free.worst_case_excluded_meters
+
+
+def test_unit_economics_underwater_tier_is_flagged():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    free = next(e for e in econ if e.tier == "free")
+    # free tier is priced at $0 but its worst-case cost is $0.20 -> underwater
+    assert free.price == 0.0
+    assert free.underwater is True
+
+
+def test_unit_economics_non_underwater_tier():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    pro = next(e for e in econ if e.tier == "pro")
+    # pro cap 5000 emails * $0.002 = $10 worst case, priced at $25 -> not underwater
+    assert pro.worst_case_cost == pytest.approx(10.0)
+    assert pro.underwater is False
+
+
+def test_unit_economics_typical_is_documented_fraction_of_worst_case():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"], typical_fraction=0.3)
+    pro = next(e for e in econ if e.tier == "pro")
+    assert pro.typical_cost == pytest.approx(pro.worst_case_cost * 0.3)
+
+
+def test_unit_economics_no_price_field_is_not_flagged_underwater():
+    matrix = {"mystery": {"emails_per_month": 100}}  # no price_monthly_usd
+    econ = model.derive_unit_economics(["mystery"], matrix, _fixture_cost_inputs()["meters"])
+    assert econ[0].price is None
+    assert econ[0].underwater is None
+
+
+def test_unit_economics_unlimited_sentinel_excluded_from_worst_case():
+    matrix = {"enterprise": {"emails_per_month": -1, "price_monthly_usd": 500}}
+    econ = model.derive_unit_economics(["enterprise"], matrix, _fixture_cost_inputs()["meters"])
+    e = econ[0]
+    assert "email_send" in e.worst_case_excluded_meters
+    assert e.worst_case_cost == 0.0  # only email_send was capped, and it's -1 here
+
+
+# --- model.py: break-even + gross margin -------------------------------------
+
+
+def test_breakeven_count_covers_the_flat_nut():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    shape = model.derive_cost_shape(ci, "T2", _fixture_stack_manifest())
+    breakeven = model.derive_breakeven(shape.flat_nut, econ)
+    pro = next(b for b in breakeven if b.tier == "pro")
+    # margin = 25 - (10 * 0.3) = 22; ceil(45 / 22) = 3
+    assert pro.gross_margin_per_tenant == pytest.approx(22.0)
+    assert pro.breakeven_tenants == 3
+
+
+def test_breakeven_skips_free_zero_price_tiers():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    breakeven = model.derive_breakeven(45.0, econ)
+    assert {b.tier for b in breakeven} == {"pro"}
+
+
+def test_breakeven_never_when_margin_non_positive():
+    matrix = {"paid": {"emails_per_month": 100, "price_monthly_usd": 0.05}}
+    econ = model.derive_unit_economics(["paid"], matrix, _fixture_cost_inputs()["meters"])
+    breakeven = model.derive_breakeven(45.0, econ)
+    assert breakeven[0].breakeven_tenants is None
+
+
+def test_gross_margin_pct_is_margin_over_price():
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
+    ci = _fixture_cost_inputs()
+    econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
+    breakeven = model.derive_breakeven(45.0, econ)
+    pro = next(b for b in breakeven if b.tier == "pro")
+    assert pro.gross_margin_pct == pytest.approx(22.0 / 25.0 * 100, rel=1e-6)
+
+
+# --- pricing_fit.py: decision-table lookup ------------------------------------
+
+
+def test_classify_cost_shape_flat_when_no_meters():
+    assert pricing_fit.classify_cost_shape([]) == pricing_fit.FLAT_COST
+
+
+def test_classify_cost_shape_flat_when_every_meter_is_zero_rate():
+    assert pricing_fit.classify_cost_shape([{"rate": 0}, {"rate": 0}]) == pricing_fit.FLAT_COST
+
+
+def test_classify_cost_shape_per_unit_recurring_when_a_meter_has_rate():
+    assert pricing_fit.classify_cost_shape([{"rate": 0.05}]) == pricing_fit.PER_UNIT_RECURRING
+
+
+def test_classify_cost_shape_marketplace_is_explicit_declaration():
+    assert pricing_fit.classify_cost_shape([{"rate": 0.05}], marketplace=True) == pricing_fit.MARKETPLACE
+
+
+@pytest.mark.parametrize(
+    "shape,expected_family",
+    [
+        (pricing_fit.FLAT_COST, "subscription-or-seat"),
+        (pricing_fit.PER_UNIT_RECURRING, "usage-based-or-subscription"),
+        (pricing_fit.MARKETPLACE, "take-rate"),
+    ],
+)
+def test_fit_looks_up_every_cost_shape(shape, expected_family):
+    row = pricing_fit.fit(shape)
+    assert row["model_family"] == expected_family
+
+
+def test_fit_per_unit_recurring_rules_out_lifetime_deal():
+    row = pricing_fit.fit(pricing_fit.PER_UNIT_RECURRING)
+    assert "lifetime-deal" in row["never"]
+
+
+def test_fit_unknown_shape_raises():
+    with pytest.raises(pricing_fit.PricingFitError):
+        pricing_fit.fit("not-a-real-shape")
+
+
+def test_tactics_carry_a_guardrail():
+    tactics = pricing_fit.applicable_tactics()
+    assert tactics  # the registry ships at least one tactic
+    assert all(t.get("guardrail") for t in tactics)
+
+
+# --- render.py: docs/pricing.md's 5-section contract -------------------------
+
+
+def _sample_result() -> dict:
+    return {
+        "analysis_date": FIXED_NOW,
+        "stack_id": "fixture-stack",
+        "cost_inputs_source": "/fixtures/cost-inputs.json",
+        "used_illustrative_seed": False,
+        "caveat": "",
+        "adopted_patterns": ["tiered-subscription"],
+        "cost_shape": {
+            "flat_monthly": 5.0,
+            "active_tier": "T2",
+            "tier_fixed_amount": 40.0,
+            "flat_nut": 45.0,
+            "meters": _fixture_cost_inputs()["meters"],
+            "largest_uncapped_meter": _fixture_cost_inputs()["meters"][0],
+            "first_step_jump": {"from": "T1", "to": "T2", "trigger": "cold starts", "add": "min-instances=1", "monthly_usd": 40.0},
+        },
+        "economics": [
+            {"tier": "free", "price": 0.0, "worst_case_cost": 0.2, "worst_case_excluded_meters": ["media_delivery_hour"],
+             "typical_cost": 0.06, "typical_excluded_meters": ["media_delivery_hour"], "underwater": True},
+            {"tier": "pro", "price": 25.0, "worst_case_cost": 10.0, "worst_case_excluded_meters": ["media_delivery_hour"],
+             "typical_cost": 3.0, "typical_excluded_meters": ["media_delivery_hour"], "underwater": False},
+        ],
+        "breakeven": [
+            {"tier": "pro", "price": 25.0, "typical_cost": 3.0, "gross_margin_per_tenant": 22.0,
+             "gross_margin_pct": 88.0, "breakeven_tenants": 3},
+        ],
+        "typical_fraction": 0.3,
+        "pricing_fit": pricing_fit.fit(pricing_fit.PER_UNIT_RECURRING),
+        "tactics": pricing_fit.applicable_tactics(),
+    }
+
+
+def test_render_has_all_five_sections():
+    md = render.render_pricing_md(_sample_result())
+    for heading in [
+        "## 1. Cost shape",
+        "## 2. Unit economics per tier",
+        "## 3. Break-even & gross margin",
+        "## 4. Market-comparable floor",
+        "## 5. Pricing-model fit",
+    ]:
+        assert heading in md
+
+
+def test_render_market_seam_is_an_unresolved_marker():
+    md = render.render_pricing_md(_sample_result())
+    assert "UNRESOLVED:" in md
+    section = md.split("## 4. Market-comparable floor")[1].split("## 5.")[0]
+    assert "UNRESOLVED:" in section
+
+
+def test_render_surfaces_underwater_tier():
+    md = render.render_pricing_md(_sample_result())
+    assert "**YES**" in md  # the free tier's underwater flag
+
+
+def test_render_surfaces_illustrative_caveat_when_seed_used():
+    result = _sample_result()
+    result["used_illustrative_seed"] = True
+    result["caveat"] = "TEST CAVEAT TEXT"
+    md = render.render_pricing_md(result)
+    assert "TEST CAVEAT TEXT" in md
+
+
+def test_render_authority_line_present():
+    md = render.render_pricing_md(_sample_result())
+    assert "not a quote" in md
+
+
+def test_render_names_uncapped_meter_and_step_jump():
+    md = render.render_pricing_md(_sample_result())
+    assert "media_delivery_hour" in md
+    assert "T1` -> `T2`" in md
+
+
+# --- derive.py: end-to-end orchestration -------------------------------------
+
+
+def test_derive_run_end_to_end_with_operator_cost_inputs(tmp_path):
+    docs = tmp_path / "docs" / "patterns"
+    docs.mkdir(parents=True)
+    (docs / "adopted.json").write_text(json.dumps({"patterns": _fixture_adopted()}))
+
+    result = derive.run(
+        target_dir=tmp_path,
+        cost_inputs_path=str(FIXTURES / "cost-inputs.json"),
+        stack_id="fixture-stack",
+        now=FIXED_NOW,
+        base=FIXTURE_BASE,
+    )
+    assert result["used_illustrative_seed"] is False
+    assert result["cost_shape"]["active_tier"] == "T2"
+    assert result["cost_shape"]["flat_nut"] == 45.0
+    assert result["pricing_fit"]["cost_shape"] == pricing_fit.PER_UNIT_RECURRING
+    free = next(e for e in result["economics"] if e["tier"] == "free")
+    assert free["underwater"] is True
+
+
+def test_derive_run_falls_back_to_illustrative_seed_and_surfaces_caveat(tmp_path):
+    result = derive.run(
+        target_dir=tmp_path,  # no adopted.json at all
+        cost_inputs_path=None,
+        stack_id="fixture-stack",
+        now=FIXED_NOW,
+        base=FIXTURE_BASE,
+    )
+    assert result["used_illustrative_seed"] is True
+    assert "FIXTURE ILLUSTRATIVE" in result["caveat"]
+    assert result["economics"] == []  # no tiered-subscription adopted
+
+
+def test_derive_run_against_the_real_gcp_stack_illustrative_seed(tmp_path):
+    """Integration check that the real shipped seed + real stack manifest work
+    together end to end, not just the test fixtures."""
+    result = derive.run(target_dir=tmp_path, cost_inputs_path=None, stack_id="gcp-serverless-saas", now=FIXED_NOW)
+    assert result["used_illustrative_seed"] is True
+    assert result["caveat"]
+    assert result["cost_shape"]["largest_uncapped_meter"]["id"] == "media_delivery_hour"
+
+
+# --- schema validation of the illustrative seed ------------------------------
+
+
+def test_illustrative_seed_conforms_to_schema():
+    schema = json.loads((ROOT / "templates" / "cost-inputs-schema.json").read_text())
+    data = json.loads(
+        (ROOT / "patterns" / "stacks" / "gcp-serverless-saas" / "cost-inputs.illustrative.json").read_text()
+    )
+    jsonschema.Draft202012Validator(schema).validate(data)
+
+
+def test_illustrative_seed_every_meter_is_marked_illustrative():
+    data = json.loads(
+        (ROOT / "patterns" / "stacks" / "gcp-serverless-saas" / "cost-inputs.illustrative.json").read_text()
+    )
+    assert data.get("$caveat")
+    assert all(m["provenance"] == "illustrative" for m in data["meters"])
+
+
+def test_schema_rejects_missing_required_field():
+    schema = json.loads((ROOT / "templates" / "cost-inputs-schema.json").read_text())
+    bad = {"flat_monthly": 1.0, "meters": []}  # missing tier_fixed
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(schema).validate(bad)
+
+
+def test_schema_rejects_unknown_top_level_property():
+    schema = json.loads((ROOT / "templates" / "cost-inputs-schema.json").read_text())
+    bad = {"flat_monthly": 1.0, "meters": [], "tier_fixed": {}, "unexpected": True}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(schema).validate(bad)
+
+
+def test_schema_rejects_meter_missing_capped_by():
+    schema = json.loads((ROOT / "templates" / "cost-inputs-schema.json").read_text())
+    bad = {
+        "flat_monthly": 1.0,
+        "tier_fixed": {},
+        "meters": [{
+            "id": "x", "unit": "u", "rate": 1, "unit_desc": "d",
+            "provenance": "illustrative", "verified_date": "2026-01-01",
+        }],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(schema).validate(bad)
+
+
+def test_pricing_models_decision_table_covers_every_shape():
+    table = pricing_fit.load_decision_table()
+    shapes = {row["cost_shape"] for row in table["cost_shape_to_model"]}
+    assert shapes == {pricing_fit.FLAT_COST, pricing_fit.PER_UNIT_RECURRING, pricing_fit.MARKETPLACE}
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def test_cli_dry_run_writes_nothing_and_prints_text(tmp_path):
+    docs = tmp_path / "docs" / "patterns"
+    docs.mkdir(parents=True)
+    (docs / "adopted.json").write_text(json.dumps({"patterns": _fixture_adopted()}))
+    (tmp_path / ".git").mkdir()
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path), "--dry-run"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "pricing-model fit" in proc.stdout
+    assert not (tmp_path / "docs" / "pricing.md").exists()
+
+
+def test_cli_json_format(tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path),
+         "--dry-run", "--format", "json"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["dry_run"] is True
+    assert out["result"]["used_illustrative_seed"] is True  # no cost-inputs supplied
+
+
+def test_cli_writes_docs_pricing_md_by_default(tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out_file = tmp_path / "docs" / "pricing.md"
+    assert out_file.is_file()
+    assert "## 5. Pricing-model fit" in out_file.read_text()
+
+
+def test_cli_out_override(tmp_path):
+    (tmp_path / ".git").mkdir()
+    out = tmp_path / "elsewhere.md"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert out.is_file()
+    assert not (tmp_path / "docs" / "pricing.md").exists()
+
+
+def test_cli_missing_cost_inputs_path_is_a_clean_error(tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path),
+         "--cost-inputs", str(tmp_path / "nope.json")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 2
+    assert "not found" in proc.stderr
+
+
+def test_cli_requires_a_git_repo_for_repo_flag(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 1
+    assert "not a git repository" in proc.stderr
+
+
+def test_cli_marketplace_flag_changes_pricing_fit(tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path),
+         "--dry-run", "--format", "json", "--marketplace"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["result"]["pricing_fit"]["cost_shape"] == pricing_fit.MARKETPLACE

--- a/tests/test_business_consultant.py
+++ b/tests/test_business_consultant.py
@@ -282,10 +282,11 @@ def test_render_surfaces_unbounded_tier_never_as_dollar_zero():
     assert "$0.00 | 100" not in section  # never a safe-looking 100% margin row
 
 
-def test_unit_economics_missing_cap_field_is_surfaced_not_silently_omitted():
-    """P2 regression: a declared meter whose cap key is absent from a tier's
-    matrix must be surfaced (no_cap_declared_meters), never silently contribute
-    $0 and vanish from the report."""
+def test_unit_economics_missing_cap_field_is_indeterminate_not_finite():
+    """A declared meter whose cap key is absent from a tier's matrix is a DATA
+    GAP: it must be surfaced (no_cap_declared_meters) AND suppress the tier's
+    definitive economics (worst_case_indeterminate), never silently contribute
+    $0 and leave a finite worst-case from the other meters."""
     # a matrix that caps NOTHING the email_send meter needs
     matrix = {"pro": {"seats": 5, "price_monthly_usd": 40}}
     meters = [{"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
@@ -295,12 +296,23 @@ def test_unit_economics_missing_cap_field_is_surfaced_not_silently_omitted():
     e = econ[0]
     assert "email_send" in e.no_cap_declared_meters
     assert "email_send" in e.worst_case_excluded_meters
+    # a missing cap suppresses definitive economics — never a finite number
+    assert e.worst_case_indeterminate is True
+    assert e.worst_case_unbounded is False
+    assert e.worst_case_cost is None
+    assert e.underwater is None
+    b = model.derive_breakeven(45.0, econ)[0]
+    assert b.indeterminate is True
+    assert b.unbounded is False
+    assert b.gross_margin_per_tenant is None
+    assert b.breakeven_tenants is None
     md = render.render_pricing_md({
         **_sample_result(),
         "economics": [asdict(e)],
-        "breakeven": [],
+        "breakeven": [asdict(b)],
     })
-    assert "no cap declared" in md
+    assert "INDETERMINATE" in md
+    assert "cap not declared" in md
     assert "email_send" in md
 
 
@@ -342,10 +354,11 @@ def test_string_minus_one_cap_is_unbounded_not_negative_cost():
     assert e.worst_case_cost is None
 
 
-def test_unparseable_cap_is_surfaced_as_no_cap_declared_not_coerced():
-    """A non-numeric cap value ("lots") can't bound the meter, so it is surfaced
-    as no-cap-declared rather than coerced into a definitive (possibly bogus)
-    number — and is NOT mistaken for an unlimited sentinel."""
+def test_unparseable_cap_is_indeterminate_not_coerced_and_not_finite_zero():
+    """A non-numeric cap value ("lots") can't bound the meter: it is surfaced as a
+    data gap (no_cap_declared_meters + worst_case_indeterminate) — NOT coerced
+    into a number, NOT mistaken for an unlimited sentinel, and NOT collapsed to a
+    finite $0 worst-case that would let underwater/margin/break-even compute."""
     matrix = {"pro": {"emails_per_month": "lots", "price_monthly_usd": 25}}
     meters = [{"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
                "capped_by": "emails_per_month", "provenance": "operator-verified", "verified_date": "2026-07-01"}]
@@ -353,10 +366,54 @@ def test_unparseable_cap_is_surfaced_as_no_cap_declared_not_coerced():
     e = econ[0]
     assert "email_send" in e.no_cap_declared_meters
     assert "email_send" not in e.unbounded_meters
+    assert e.worst_case_indeterminate is True
     assert e.worst_case_unbounded is False
-    assert e.worst_case_cost == pytest.approx(0.0)  # no bounded meter contributed
-    md = render.render_pricing_md({**_sample_result(), "economics": [asdict(e)], "breakeven": []})
-    assert "no cap declared" in md
+    assert e.worst_case_cost is None  # NOT 0.0 — the cost couldn't be bounded
+    assert e.underwater is None
+    b = model.derive_breakeven(45.0, econ)[0]
+    assert b.indeterminate is True
+    assert b.gross_margin_per_tenant is None
+    assert b.breakeven_tenants is None
+    md = render.render_pricing_md({**_sample_result(), "economics": [asdict(e)], "breakeven": [asdict(b)]})
+    assert "INDETERMINATE" in md
+    assert "unparseable" in md or "cap not declared" in md
+
+
+def test_unbounded_and_indeterminate_render_differently_but_both_suppress_economics():
+    """Both non-computable states suppress definitive worst-case/underwater/margin/
+    break-even, but the renderer distinguishes them: UNBOUNDED (uncapped by
+    design) vs INDETERMINATE (a data gap to fix). Each reason is isolated in its
+    own single-meter derivation so a tier carries exactly one."""
+    meter_uncapped = [{"id": "media", "unit": "hour", "rate": 0.06, "unit_desc": "d",
+                       "capped_by": None, "provenance": "operator-verified", "verified_date": "2026-07-01"}]
+    meter_missing = [{"id": "email", "unit": "send", "rate": 0.002, "unit_desc": "d",
+                      "capped_by": "emails_per_month", "provenance": "operator-verified", "verified_date": "2026-07-01"}]
+    unbnd = model.derive_unit_economics(
+        ["unbnd"], {"unbnd": {"price_monthly_usd": 30}}, meter_uncapped)[0]
+    indet = model.derive_unit_economics(
+        ["indet"], {"indet": {"seats": 3, "price_monthly_usd": 30}}, meter_missing)[0]
+    # distinct flags...
+    assert unbnd.worst_case_unbounded is True and unbnd.worst_case_indeterminate is False
+    assert indet.worst_case_indeterminate is True and indet.worst_case_unbounded is False
+    # ...but the SAME suppression of definitive economics
+    for e in (unbnd, indet):
+        assert e.worst_case_cost is None
+        assert e.underwater is None
+        assert e.worst_case_computable is False
+    breakeven = model.derive_breakeven(45.0, [unbnd, indet])
+    for b in breakeven:
+        assert b.gross_margin_per_tenant is None
+        assert b.breakeven_tenants is None
+    md = render.render_pricing_md({
+        **_sample_result(),
+        "economics": [asdict(unbnd), asdict(indet)],
+        "breakeven": [asdict(b) for b in breakeven],
+    })
+    # rendered differently
+    assert "UNBOUNDED" in md
+    assert "INDETERMINATE" in md
+    assert "uncapped by design" in md
+    assert "fix your cost inputs" in md
 
 
 # --- model.py: break-even + gross margin -------------------------------------

--- a/tests/test_business_consultant.py
+++ b/tests/test_business_consultant.py
@@ -34,7 +34,20 @@ def _fixture_adopted() -> dict:
 
 
 def _fixture_cost_inputs() -> dict:
+    """The media-UNCAPPED fixture (media_delivery_hour has capped_by: null) — used
+    by the section-1 'largest uncapped meter' tests and the unbounded-state tests."""
     return json.loads((FIXTURES / "cost-inputs.json").read_text())
+
+
+def _fixture_capped_adopted() -> dict:
+    """A fully-matrix-capped adoption record: the matrix caps BOTH meters in
+    cost-inputs-capped.json, so every tier's worst-case is finite/computable."""
+    return json.loads((FIXTURES / "adopted-capped.json").read_text())["patterns"]
+
+
+def _fixture_capped_cost_inputs() -> dict:
+    """The fully-matrix-capped cost-inputs (every meter capped_by a matrix key)."""
+    return json.loads((FIXTURES / "cost-inputs-capped.json").read_text())
 
 
 def _fixture_stack_manifest() -> dict:
@@ -174,48 +187,54 @@ def test_first_fixed_step_jump_none_when_every_transition_is_zero_cost():
 
 
 def test_unit_economics_worst_case_is_matrix_cap_times_rate():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    # Fully-capped fixture: BOTH meters are bounded by the matrix, so worst-case
+    # is finite and computable. free = 100 emails * $0.002 + 2 media-hrs * $0.06
+    #                               = $0.20 + $0.12 = $0.32
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     free = next(e for e in econ if e.tier == "free")
-    # only email_send applies (media is globally uncapped -> excluded);
-    # free cap 100 emails * $0.002/send = $0.20
-    assert free.worst_case_cost == pytest.approx(0.20)
-    assert "media_delivery_hour" in free.worst_case_excluded_meters
+    assert free.worst_case_unbounded is False
+    assert free.worst_case_cost == pytest.approx(0.32)
+    assert free.worst_case_excluded_meters == []  # nothing excluded — all capped
 
 
 def test_unit_economics_underwater_tier_is_flagged():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     free = next(e for e in econ if e.tier == "free")
-    # free tier is priced at $0 but its worst-case cost is $0.20 -> underwater
+    # free is priced at $0 but its worst-case cost is $0.32 -> underwater
     assert free.price == 0.0
     assert free.underwater is True
 
 
 def test_unit_economics_non_underwater_tier():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     pro = next(e for e in econ if e.tier == "pro")
-    # pro cap 5000 emails * $0.002 = $10 worst case, priced at $25 -> not underwater
-    assert pro.worst_case_cost == pytest.approx(10.0)
+    # pro = 5000 emails * $0.002 + 50 media-hrs * $0.06 = $10 + $3 = $13 worst
+    # case, priced at $25 -> not underwater
+    assert pro.worst_case_cost == pytest.approx(13.0)
     assert pro.underwater is False
 
 
 def test_unit_economics_typical_is_documented_fraction_of_worst_case():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"], typical_fraction=0.3)
     pro = next(e for e in econ if e.tier == "pro")
     assert pro.typical_cost == pytest.approx(pro.worst_case_cost * 0.3)
 
 
 def test_unit_economics_no_price_field_is_not_flagged_underwater():
-    matrix = {"mystery": {"emails_per_month": 100}}  # no price_monthly_usd
-    econ = model.derive_unit_economics(["mystery"], matrix, _fixture_cost_inputs()["meters"])
+    # No price field AND a finite (fully-capped) worst case, so underwater is None
+    # only because there's no price to compare against — not because of unbounded.
+    matrix = {"mystery": {"emails_per_month": 100, "media_hours_per_month": 2}}
+    econ = model.derive_unit_economics(["mystery"], matrix, _fixture_capped_cost_inputs()["meters"])
     assert econ[0].price is None
+    assert econ[0].worst_case_unbounded is False
     assert econ[0].underwater is None
 
 
@@ -285,43 +304,104 @@ def test_unit_economics_missing_cap_field_is_surfaced_not_silently_omitted():
     assert "email_send" in md
 
 
+def test_capped_by_null_meter_forces_unbounded_not_finite_zero():
+    """A genuinely-uncapped meter (capped_by: null, e.g. media delivery) makes
+    the TIER's worst-case UNBOUNDED — it must not be silently excluded to leave a
+    finite email-only subtotal that reads as safe."""
+    matrix = {"pro": {"emails_per_month": 5000, "price_monthly_usd": 25}}
+    meters = [
+        {"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
+         "capped_by": "emails_per_month", "provenance": "operator-verified", "verified_date": "2026-07-01"},
+        {"id": "media_delivery_hour", "unit": "hour", "rate": 0.06, "unit_desc": "d",
+         "capped_by": None, "provenance": "operator-verified", "verified_date": "2026-07-01"},
+    ]
+    econ = model.derive_unit_economics(["pro"], matrix, meters)
+    e = econ[0]
+    assert e.worst_case_unbounded is True
+    assert "media_delivery_hour" in e.unbounded_meters
+    assert e.worst_case_cost is None  # NOT $10 (email-only) and NOT $0
+    assert e.underwater is None
+    b = model.derive_breakeven(45.0, econ)[0]
+    assert b.unbounded is True
+    assert b.gross_margin_per_tenant is None
+    assert b.breakeven_tenants is None
+    md = render.render_pricing_md({**_sample_result(), "economics": [asdict(e)], "breakeven": [asdict(b)]})
+    assert "UNBOUNDED" in md
+
+
+def test_string_minus_one_cap_is_unbounded_not_negative_cost():
+    """A matrix cap authored as the STRING "-1" must read as unlimited
+    (unbounded), never coerced to float('-1') * rate = a negative 'cost'."""
+    matrix = {"pro": {"emails_per_month": "-1", "price_monthly_usd": 25}}
+    meters = [{"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
+               "capped_by": "emails_per_month", "provenance": "operator-verified", "verified_date": "2026-07-01"}]
+    econ = model.derive_unit_economics(["pro"], matrix, meters)
+    e = econ[0]
+    assert e.worst_case_unbounded is True
+    assert "email_send" in e.unbounded_meters
+    assert e.worst_case_cost is None
+
+
+def test_unparseable_cap_is_surfaced_as_no_cap_declared_not_coerced():
+    """A non-numeric cap value ("lots") can't bound the meter, so it is surfaced
+    as no-cap-declared rather than coerced into a definitive (possibly bogus)
+    number — and is NOT mistaken for an unlimited sentinel."""
+    matrix = {"pro": {"emails_per_month": "lots", "price_monthly_usd": 25}}
+    meters = [{"id": "email_send", "unit": "send", "rate": 0.002, "unit_desc": "d",
+               "capped_by": "emails_per_month", "provenance": "operator-verified", "verified_date": "2026-07-01"}]
+    econ = model.derive_unit_economics(["pro"], matrix, meters)
+    e = econ[0]
+    assert "email_send" in e.no_cap_declared_meters
+    assert "email_send" not in e.unbounded_meters
+    assert e.worst_case_unbounded is False
+    assert e.worst_case_cost == pytest.approx(0.0)  # no bounded meter contributed
+    md = render.render_pricing_md({**_sample_result(), "economics": [asdict(e)], "breakeven": []})
+    assert "no cap declared" in md
+
+
 # --- model.py: break-even + gross margin -------------------------------------
 
 
 def test_breakeven_count_covers_the_flat_nut():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     shape = model.derive_cost_shape(ci, "T2", _fixture_stack_manifest())
     breakeven = model.derive_breakeven(shape.flat_nut, econ)
     pro = next(b for b in breakeven if b.tier == "pro")
-    # margin = 25 - (10 * 0.3) = 22; ceil(45 / 22) = 3
-    assert pro.gross_margin_per_tenant == pytest.approx(22.0)
+    # pro typical = $13 * 0.3 = $3.90; margin = 25 - 3.90 = $21.10;
+    # ceil(45 / 21.10) = 3
+    assert pro.gross_margin_per_tenant == pytest.approx(21.10)
     assert pro.breakeven_tenants == 3
 
 
 def test_breakeven_skips_free_zero_price_tiers():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     breakeven = model.derive_breakeven(45.0, econ)
     assert {b.tier for b in breakeven} == {"pro"}
 
 
 def test_breakeven_never_when_margin_non_positive():
-    matrix = {"paid": {"emails_per_month": 100, "price_monthly_usd": 0.05}}
-    econ = model.derive_unit_economics(["paid"], matrix, _fixture_cost_inputs()["meters"])
+    # Fully-capped so the tier's worst case is FINITE — this exercises the
+    # genuine margin<=0 path (break-even None because unrecoverable at typical
+    # usage), NOT the unbounded path.
+    matrix = {"paid": {"emails_per_month": 100, "media_hours_per_month": 2, "price_monthly_usd": 0.05}}
+    econ = model.derive_unit_economics(["paid"], matrix, _fixture_capped_cost_inputs()["meters"])
+    assert econ[0].worst_case_unbounded is False
     breakeven = model.derive_breakeven(45.0, econ)
-    assert breakeven[0].breakeven_tenants is None
+    assert breakeven[0].unbounded is False
+    assert breakeven[0].breakeven_tenants is None  # margin <= 0 at typical usage
 
 
 def test_gross_margin_pct_is_margin_over_price():
-    tiers, matrix = inputs.tiered_subscription_binding(_fixture_adopted())
-    ci = _fixture_cost_inputs()
+    tiers, matrix = inputs.tiered_subscription_binding(_fixture_capped_adopted())
+    ci = _fixture_capped_cost_inputs()
     econ = model.derive_unit_economics(tiers, matrix, ci["meters"])
     breakeven = model.derive_breakeven(45.0, econ)
     pro = next(b for b in breakeven if b.tier == "pro")
-    assert pro.gross_margin_pct == pytest.approx(22.0 / 25.0 * 100, rel=1e-6)
+    assert pro.gross_margin_pct == pytest.approx(21.10 / 25.0 * 100, rel=1e-6)
 
 
 # --- pricing_fit.py: decision-table lookup ------------------------------------
@@ -462,13 +542,15 @@ def test_render_names_uncapped_meter_and_step_jump():
 
 
 def test_derive_run_end_to_end_with_operator_cost_inputs(tmp_path):
+    # Fully-capped adopted + cost-inputs, so the per-tier economics are finite
+    # and the free tier's underwater flag is legitimately computable.
     docs = tmp_path / "docs" / "patterns"
     docs.mkdir(parents=True)
-    (docs / "adopted.json").write_text(json.dumps({"patterns": _fixture_adopted()}))
+    (docs / "adopted.json").write_text(json.dumps({"patterns": _fixture_capped_adopted()}))
 
     result = derive.run(
         target_dir=tmp_path,
-        cost_inputs_path=str(FIXTURES / "cost-inputs.json"),
+        cost_inputs_path=str(FIXTURES / "cost-inputs-capped.json"),
         stack_id="fixture-stack",
         now=FIXED_NOW,
         base=FIXTURE_BASE,
@@ -478,6 +560,8 @@ def test_derive_run_end_to_end_with_operator_cost_inputs(tmp_path):
     assert result["cost_shape"]["flat_nut"] == 45.0
     assert result["pricing_fit"]["cost_shape"] == pricing_fit.PER_UNIT_RECURRING
     free = next(e for e in result["economics"] if e["tier"] == "free")
+    assert free["worst_case_unbounded"] is False
+    assert free["worst_case_cost"] == pytest.approx(0.32)
     assert free["underwater"] is True
 
 


### PR DESCRIPTION
## Summary

Implements chief-wiggum#122's rollout **steps 1+2 only**: the mechanical cost-model deriver + the `docs/pricing.md` output contract. Steps 3 (live market-comparables lookup) and 4 (wiring into monetization `success_metrics`) are explicit follow-ups, not built here.

- **`templates/cost-inputs-schema.json`** — the operator-authoritative structured cost-inputs schema (Draft 2020-12, `additionalProperties: false`, matching `templates/formal-models/*`): `flat_monthly` + `meters[]` (`id`, `unit`, `rate`, `unit_desc`, `capped_by`, `provenance`, `verified_date`) + `tier_fixed{}`.
- **`patterns/stacks/gcp-serverless-saas/cost-inputs.illustrative.json`** — an illustrative seed conforming to that schema. Every meter is `provenance: "illustrative"`, and a top-level `$caveat` states plainly these are placeholders, not verified vendor prices.
- **`scripts/business_consultant.py` + `scripts/consultant/`** — the deriver, CLI-shaped like `quality_metrics.py` (`owner/repo|--repo`, `--cost-inputs PATH`, `--out`, `--format text|json`, plus `--stack`, `--marketplace`, `--dry-run`). Reads a target repo's `docs/patterns/adopted.json` (which patterns + the bound `tiered-subscription` tier `matrix` caps) and a cost-inputs.json (operator's, else the illustrative seed with the caveat surfaced) and mechanically derives:
  - **cost shape**: flat nut (flat_monthly + the active stack cost-tier's fixed add-on, resolved from the stack manifest's pattern→tier `bindings`) + per-tenant variable cost; names the single largest **uncapped** meter and the **first fixed step-jump** (from `graduation_triggers`).
  - **unit economics per tier**: worst-case (matrix cap × rate, summed over capped meters) + typical (a documented fraction of worst-case — no fabricated usage numbers), flagging any **underwater** tier (price below worst-case cost — the deriver catches a free tier with worst-case cost above $0 out of the box).
  - **break-even** paying-tenant count + **gross margin** per paying tier.
- **`patterns/pricing-models/`** — a cost-shape → pricing-model decision table (`models.json`) + human spec (`reference.md`): flat-cost→subscription-or-seat, per-unit-recurring→usage-based-or-subscription (**never** lifetime-deal/one-time-purchase), marketplace→take-rate, plus founding-member grandfathering / annual≈2-months-free / free-tier-as-bounded-loss-leader tactics, each with a guardrail. This is a knowledge-base lookup table, not an installable registry pattern — deliberately absent from `patterns/registry.json` so `check_patterns.py` doesn't (and shouldn't) validate it against the invariant-cluster model.
- **`docs/pricing.md` output**: 5 sections (cost shape / unit economics per tier / break-even+margin / market-comparable floor / pricing-model fit), analysis date stamped, illustrative-seed caveat surfaced when the seed was used. The market-comparable-floor section is an explicit `UNRESOLVED:` marker — gated by `scripts/check_unresolved.py` — rather than a fabricated number.
- **`.claude/commands/business-consultant.md`** — the skill adapter orchestrating the deriver, noting `docs/pricing.md` is a protected, admin-gated path.

## Mechanical vs. the documented seam

Everything above is deterministic arithmetic + table lookups — no AI consultation, no network calls. The one open seam is **market-comparable pricing** (rollout step 3): a live lookup of what comparable products charge. That's marked `UNRESOLVED:` in the rendered report and left for the follow-up, never fabricated.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 1674 passed, 10 skipped (59 new tests in `tests/test_business_consultant.py`)
- [x] `python3 -m ruff check scripts tests` — clean
- [x] Manual smoke test: CLI end-to-end against a synthetic tiered-subscription adoption record + the real illustrative seed, confirming the free-tier underwater catch and `check_unresolved.py` gating the market-comparable-floor marker
- [x] Schema validation of the illustrative seed (positive + negative cases: missing required field, unknown top-level property, meter missing `capped_by`)

## Deviations from the brief

- No deviations from the scoped brief (steps 1+2). Added a small cross-reference in `docs/patterns-registry.md`'s cost-axis section and a `CLAUDE.md` skill-list entry for consistency with how other skills are documented — not explicitly requested but matches existing convention.

Claude-Session: https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF