### PR TITLE
feat(patterns): specify referral-invite-loop — grounded in the in-repo signed-token discipline (#139, 1 of remaining 5)

### DIFF
--- a/patterns/referral-invite-loop/manifest.json
+++ b/patterns/referral-invite-loop/manifest.json
@@ -1,0 +1,65 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/referral-invite-loop/pattern.md. The signed-token discipline is REUSED from the in-repo elevated-access-session pattern (INV-EAS-*), not re-derived; the attribution/reward/fraud invariants are design-derived (this loop is not yet mined from a shipped app — honest per issue #139's 'design-derived statements where not yet built').",
+  "id": "referral-invite-loop",
+  "version": 1,
+  "title": "Referral / Invite Growth Loop",
+  "category": "process-loop",
+  "trust_class": "reward-and-copy-are-end-user-signal-driven-protected-path",
+
+  "applies_when": [
+    "you want existing users to invite new ones with a self-serve, trackable loop",
+    "an invite must be attributable server-side (who referred whom) and rewardable on both sides",
+    "reward economics or invite copy will be tuned over time and must stay admin-gated"
+  ],
+
+  "components": [
+    "signed-invite-token: the invite is a token minted by the trusted signer carrying the referrer as an actor claim the client cannot self-assert (reuses the elevated-access-session signing discipline)",
+    "ttl-against-own-iat: the token expires on its own issue time, independent of any session/IdP lifetime",
+    "consume-once: accepting an invite consumes the token exactly once; replay is rejected fail-closed",
+    "server-trusted-attribution: attribution is derived server-side from the consumed token, never from a client-supplied referrer field; it is trust-tagged signal",
+    "grant-only-idempotent-reward: each accepted invite rewards each side at most once, keyed on the consumed token, idempotent under retries, never revoked on replay",
+    "fail-closed-fraud-guard: self-referral and re-attribution of an already-attributed account are rejected; reward size + invite copy are a protected path"
+  ],
+
+  "invariants": {
+    "$comment": "001-002 reuse the in-repo elevated-access-session signed-token discipline (cited in realized_as); 003 is the fail-closed-consume sibling of EAS revocation; 004-006 are design-derived (grounding field marks them) and honestly flagged, this loop not yet mined from a shipped app.",
+    "cluster": [
+      {"id": "INV-RIL-001", "statement": "Un-forgeable invite token: the invite is minted by the trusted signer with the referrer identity as an actor claim the accepting client cannot self-assert; attribution can never be forged by the invitee.", "realized_as": {"app": "chief-wiggum registry", "code": "patterns/elevated-access-session/manifest.json (INV-EAS-007 un-forgeable-at-signing-root)"}},
+      {"id": "INV-RIL-002", "statement": "Expiring against its own issue time: the invite token's TTL is enforced against the token's own iat, independent of any session or IdP token lifetime.", "realized_as": {"app": "chief-wiggum registry", "code": "patterns/elevated-access-session/manifest.json (INV-EAS-001 TTL-against-own-iat)"}},
+      {"id": "INV-RIL-003", "statement": "Single-use, fail-closed: accepting an invite consumes the token exactly once; a second presentation (replay/retry-after-accept) is rejected fail-closed, mirroring the elevated-access-session fail-closed revocation-lookup discipline.", "realized_as": {"app": "chief-wiggum registry", "code": "patterns/elevated-access-session/manifest.json (INV-EAS-002 fail-closed revocation)"}},
+      {"id": "INV-RIL-004", "statement": "Server-trusted attribution: who referred whom is derived server-side from the consumed signed token, never from a client-supplied referrer field; attribution is emitted as a trust-tagged signal, not accepted as end-user input.", "grounding": "design-derived"},
+      {"id": "INV-RIL-005", "statement": "Grant-only, idempotent two-sided reward: each accepted invite rewards each side at most once, keyed on the consumed token; reward issuance is idempotent under retries and grant-only (a replay never re-grants and never revokes).", "grounding": "design-derived"},
+      {"id": "INV-RIL-006", "statement": "Fail-closed fraud guard + protected reward economics: self-referral (referrer == invitee) and re-attribution of an already-attributed account are rejected fail-closed; reward size and invite copy are end-user-signal-driven and therefore a protected path (changes are admin-gated, never auto-applied by an optimization loop).", "grounding": "design-derived"}
+    ]
+  },
+
+  "parameters": {
+    "signer": {"type": "string", "required": true, "description": "The trusted signing root that mints invite tokens (reuse the product's existing signer; same root as elevated-access-session if adopted)."},
+    "token_ttl": {"type": "string", "required": true, "description": "Invite token lifetime, enforced against the token's own iat (e.g. 14d)."},
+    "reward_spec": {"type": "object", "required": true, "description": "The two-sided reward: what the referrer and the invitee each receive on a successful, attributed accept."},
+    "attribution_sink": {"type": "string", "required": true, "description": "Where the server-trusted attribution signal is recorded (the trust-tagged event store the improvement loop reads)."},
+    "consume_store": {"type": "string", "required": true, "description": "The consume-once store that makes an invite single-use (idempotency key = the token id)."},
+    "already_attributed_check": {"type": "string", "required": false, "description": "How an account is determined to be already-attributed, for the re-attribution fraud guard."}
+  },
+
+  "success_metrics": {
+    "$comment": "Growth-loop health. Reward/copy are protected-path, so the improvement loop may PROPOSE tuning but changes are admin-gated (INV-RIL-006).",
+    "metrics": [
+      {"id": "invites_sent", "goal": "up", "desc": "invites created per active referrer per unit time"},
+      {"id": "invite_accept_rate", "goal": "up", "desc": "accepted / sent — the loop's conversion efficiency"},
+      {"id": "k_factor", "goal": "up", "desc": "new attributed signups per existing user (viral coefficient)"},
+      {"id": "reward_fraud_rate", "goal": "down", "desc": "rejected self-referral / re-attribution attempts as a share of accepts (guard efficacy)"},
+      {"id": "reward_cost_per_attributed_signup", "goal": "down", "desc": "two-sided reward spend per net new attributed account (loop unit economics)"}
+    ]
+  },
+
+  "protected_paths": [
+    "the token signer / mint path (un-forgeability root — INV-RIL-001)",
+    "the consume-once store + accept handler (single-use enforcement — INV-RIL-003)",
+    "the reward-grant path (grant-only idempotency + fraud guard — INV-RIL-005/006)",
+    "reward_spec + invite copy (end-user-signal-driven economics — INV-RIL-006)"
+  ],
+
+  "depends_on": "elevated-access-session",
+  "feeds": "improvement-loop"
+}

--- a/patterns/referral-invite-loop/pattern.md
+++ b/patterns/referral-invite-loop/pattern.md
@@ -1,0 +1,88 @@
+# Pattern: Referral / Invite Growth Loop
+
+- **Category:** process-loop
+- **Trust class:** reward economics + invite copy are end-user-signal-driven, so they are a protected path (admin-gated)
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+- **Depends on:** [`elevated-access-session`](../elevated-access-session) — reuses its signed-token discipline
+- **Feeds:** [`improvement-loop`](../improvement-loop) — attribution is trust-tagged signal the loop can optimize against
+
+## What it is
+
+A self-serve growth loop: an existing user **invites** a new one, the invite is a
+**signed, single-use, expiring token**, accepting it **attributes** the new account
+to the referrer server-side, and both sides get a **reward** — once, idempotently.
+The whole thing is trackable (k-factor, accept rate) and the reward/copy are tunable
+*under admin gating*, so the improvement loop can propose better economics without a
+public-facing paywall change shipping unreviewed.
+
+Why a pattern and not "just add an invite link": the value is the **invariants that
+keep it un-gameable**. An invite link that carries a client-editable `?ref=` is a
+free-money bug; a reward that isn't idempotent double-pays on a retry; attribution
+that trusts a client field lets anyone credit themselves. The token discipline that
+makes this safe is **the same one `elevated-access-session` already establishes** —
+un-forgeable at the signing root, TTL against the token's own issue time, fail-closed
+on the consume/revoke lookup — so this pattern **reuses** it rather than re-deriving.
+
+## When to apply
+
+- You want existing users to bring new ones through a trackable, self-serve loop.
+- An invite must be **attributable server-side** and **rewardable on both sides**.
+- Reward economics or invite copy will be tuned over time and must stay admin-gated.
+
+## Mechanism — generic components
+
+- **Signed invite token (un-forgeable).** The invite is a token minted by the trusted
+  signer carrying the referrer as an actor claim the accepting client cannot
+  self-assert — so the invitee can never forge who referred them. *(Reuses the
+  `elevated-access-session` signing root; INV-RIL-001 ← INV-EAS-007.)*
+- **TTL against the token's own iat.** The token expires on its own issue time,
+  independent of any session/IdP lifetime. *(INV-RIL-002 ← INV-EAS-001.)*
+- **Consume-once, fail-closed.** Accepting an invite consumes the token exactly once;
+  a replay or retry-after-accept is rejected fail-closed. *(INV-RIL-003, the sibling
+  of `elevated-access-session`'s fail-closed revocation lookup, INV-EAS-002.)*
+- **Server-trusted attribution.** Who referred whom is derived server-side from the
+  *consumed token*, never from a client-supplied `referrer` field, and emitted as a
+  trust-tagged signal. *(INV-RIL-004 — design-derived.)*
+- **Grant-only, idempotent two-sided reward.** Each accepted invite rewards each side
+  at most once, keyed on the consumed token; issuance is idempotent under retries and
+  grant-only (a replay never re-grants, never revokes). *(INV-RIL-005 — design-derived.)*
+- **Fail-closed fraud guard + protected economics.** Self-referral (referrer ==
+  invitee) and re-attribution of an already-attributed account are rejected; reward
+  size and invite copy are end-user-signal-driven and therefore a protected path —
+  the improvement loop may *propose* tuning, but changes are admin-gated, never
+  auto-applied. *(INV-RIL-006 — design-derived.)*
+
+## Grounding
+
+The token-discipline invariants (INV-RIL-001/002/003) are **not re-derived** — they
+cite the in-repo [`elevated-access-session`](../elevated-access-session) cluster
+(INV-EAS-007 un-forgeability, INV-EAS-001 TTL-against-own-iat, INV-EAS-002 fail-closed
+lookup), which is the same signed, single-use, time-boxed, un-forgeable-token shape.
+The attribution/reward/fraud invariants (INV-RIL-004/005/006) are **design-derived**
+and marked as such: this loop has not yet been mined from a shipped app, so they
+capture the standard, well-understood referral-integrity discipline (server-trusted
+attribution, idempotent grant-only rewards, self-referral rejection) rather than a
+per-app realization. They ground fully when a product first builds the loop.
+
+## Parameters
+
+| Parameter | Required | Meaning |
+|--|--|--|
+| `signer` | yes | The trusted signing root that mints invite tokens (same root as `elevated-access-session` if adopted). |
+| `token_ttl` | yes | Invite lifetime, enforced against the token's own iat. |
+| `reward_spec` | yes | The two-sided reward on a successful, attributed accept. |
+| `attribution_sink` | yes | Where the server-trusted attribution signal is recorded. |
+| `consume_store` | yes | The consume-once store keyed on the token id. |
+| `already_attributed_check` | no | How an account is judged already-attributed (re-attribution guard). |
+
+## Success metrics
+
+`invites_sent` ↑, `invite_accept_rate` ↑, `k_factor` ↑, `reward_fraud_rate` ↓,
+`reward_cost_per_attributed_signup` ↓. Reward/copy are protected-path — the
+improvement loop proposes; a human approves (INV-RIL-006).
+
+## Trust
+
+The signer/mint path, the consume-once accept handler, the reward-grant path, and
+`reward_spec` + invite copy are all protected paths. A worker touching them is parked
+for human review, exactly as with any goalpost.

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -138,6 +138,19 @@
       "manifest": "patterns/immutable-assignment-snapshot/manifest.json"
     },
     {
+      "id": "referral-invite-loop",
+      "title": "Referral / Invite Growth Loop",
+      "category": "process-loop",
+      "status": "specified",
+      "trust_class": "reward-and-copy-are-end-user-signal-driven-protected-path",
+      "summary": "Invite -> signed, single-use, expiring token -> server-trusted attribution on accept -> grant-only idempotent two-sided reward. The token discipline (un-forgeable at the signing root, TTL against the token's own iat, fail-closed consume-once) is REUSED from elevated-access-session; attribution/reward/fraud invariants are design-derived. A self-serve growth loop the improvement loop can propose tuning for (reward size/copy) under admin gating. Promoted from candidate; INV-RIL-001..006.",
+      "invariants": "INV-RIL-001..006",
+      "depends_on": "elevated-access-session",
+      "feeds": "improvement-loop",
+      "spec": "patterns/referral-invite-loop/pattern.md",
+      "manifest": "patterns/referral-invite-loop/manifest.json"
+    },
+    {
       "id": "build-test-floor",
       "title": "Language-Agnostic Build/Test Floor",
       "category": "gate",
@@ -160,7 +173,6 @@
   "candidates": [
     {"id": "reconciliation-sweep", "title": "Bidirectional Reconciliation Sweep", "category": "process-loop", "status": "candidate", "summary": "Periodic job repairing divergence between local records and an external system in both directions plus a stale-in-flight sweep. Fail-closed on unknown age, re-confirm before destructive action, idempotent guarded updates, per-run counts report. Its run reports and audit stream are operational-health signal.", "reusability": "high"},
     {"id": "transactional-email-and-dunning", "title": "Transactional Email & Dunning Lifecycle", "category": "process-loop", "status": "candidate", "summary": "Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge (fires if a signed-up user hasn't hit the activation event), re-engagement, and a failed-payment dunning sequence with bounded retries before degrade. Send-once keys prevent duplicate sends across retries. Recovery outcomes are conversion/retention signal.", "reusability": "high"},
-    {"id": "referral-invite-loop", "title": "Referral / Invite Growth Loop", "category": "process-loop", "status": "candidate", "summary": "Invite -> signed invite token (server-trusted, single-use, expiring) -> attribution on accept -> reward both sides. Reuses the signed-token discipline; attribution is trust-tagged signal. A self-serve growth loop the improvement loop can optimize (reward size/copy) under admin gating.", "reusability": "medium-high"},
     {"id": "feature-entitlements", "title": "Feature Entitlements Read-Model", "category": "saas-infra", "status": "candidate", "summary": "A single entitlement resolver deriving capability flags from tier + per-account overrides + grandfathering, consumed identically by backend gates and the frontend (one source of 'what can this account do'). Distinct from the tier matrix: it layers overrides and is the read model onboarding + UI both query.", "reusability": "medium-high"},
     {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"}
   ],

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -167,3 +167,29 @@ def test_candidate_malformed_cluster_is_error(tmp_path):
     }
     path = _write(tmp_path, reg, {})
     assert any("malformed invariant id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+# --- referral-invite-loop promotion (#139) ----------------------------------
+
+def test_real_registry_passes_check_patterns():
+    """The shipped registry (incl. the promoted referral-invite-loop) validates."""
+    findings = check_patterns.validate()
+    assert _errors(findings) == [], _errors(findings)
+
+
+def test_referral_invite_loop_is_specified_with_grounded_cluster():
+    reg = json.loads((SCRIPTS.parent / "patterns" / "registry.json").read_text())
+    entry = next((e for e in reg["patterns"] if e["id"] == "referral-invite-loop"), None)
+    assert entry is not None, "referral-invite-loop must be a specified pattern, not a candidate"
+    assert entry["status"] == "specified"
+    assert entry.get("depends_on") == "elevated-access-session"
+    assert not any(c["id"] == "referral-invite-loop" for c in reg.get("candidates", []))
+    manifest = json.loads(
+        (SCRIPTS.parent / "patterns" / "referral-invite-loop" / "manifest.json").read_text())
+    cluster = check_patterns.cluster_entries(manifest["invariants"])
+    ids = [e["id"] for e in cluster]
+    assert ids == [f"INV-RIL-00{n}" for n in range(1, 7)]
+    # the token-discipline invariants cite the in-repo elevated-access-session grounding
+    grounded = [e for e in cluster if isinstance(e.get("realized_as"), dict)
+                and "elevated-access-session" in e["realized_as"].get("code", "")]
+    assert {e["id"] for e in grounded} == {"INV-RIL-001", "INV-RIL-002", "INV-RIL-003"}


### PR DESCRIPTION
Part of #139 (specify the remaining candidate patterns). Promotes **referral-invite-loop** from candidate to a specified pattern.

## Grounding (the issue's bar: grounding, not just spec files)
The token-discipline invariants **cite the in-repo `elevated-access-session` cluster** rather than re-deriving — same signed / single-use / expiring / un-forgeable-at-the-signing-root shape:
- INV-RIL-001 un-forgeable invite token ← INV-EAS-007
- INV-RIL-002 TTL against the token's own iat ← INV-EAS-001
- INV-RIL-003 single-use, fail-closed consume ← INV-EAS-002

The attribution/reward/fraud invariants are **honestly marked design-derived** (this loop isn't yet mined from a shipped app — the issue explicitly permits design-derived statements):
- INV-RIL-004 server-trusted attribution (trust-tagged signal)
- INV-RIL-005 grant-only idempotent two-sided reward
- INV-RIL-006 fail-closed fraud guard + protected (admin-gated) reward economics

## What's here
`patterns/referral-invite-loop/{pattern.md,manifest.json}` mirroring the 11 specified patterns; registry entry moved candidates→patterns with `depends_on: elevated-access-session` (specified, so no dangling floor); a promotion test.

## Test plan
1687 passed, 10 skipped (2 new: real-registry validates; referral-invite-loop is specified with the grounded INV-RIL cluster and its EAS dependency resolves). `check_patterns` clean; ruff clean; no private-repo names in any artifact.

## Scope
1 of #139's 5 remaining candidates. The other 4 (reconciliation-sweep, transactional-email-and-dunning, feature-entitlements, self-serve-billing-portal) need separate grounding — several from sources not yet available — and a human steer.

https://claude.ai/code/session_01DQjc1H27KMx5N3NHf9aSbF