### PR TITLE
feat(system): durable deferred-rigor index + mechanical trigger check wired into /reflect (#171, #161)

### DIFF
--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -51,6 +51,14 @@ python3 "$CW_HOME/scripts/reflect.py" "$TARGET_REPO" --prs "$CW_TMP/prs.json" --
 
 The report has: `commit_kinds`, `gate_mentions`, `force_bypasses`, `slippage_commits`, `assumptions` (TBD markers), `ratchet` health, `pattern_coverage`, `retrospectives`, and mechanical `findings` seeding your analysis.
 
+Also run the deferred-rigor trigger check (report-only — see `docs/deferred-rigor.json`, the durable index that replaced chief-wiggum#171/#161's open-issue parking):
+
+```bash
+python3 "$CW_HOME/scripts/check_deferred_triggers.py" --repo "$TARGET_REPO" --format text
+```
+
+Each deferred system-layer decision carries a quorum-settled design and a concrete build trigger. A `FIRED` item means its mechanical trigger is now true: file the full issue **from the item's `settled_notes`** (the design is settled — do not relitigate it) in Step 4 alongside the other drafted issues. A `CANDIDATE` item has soft evidence (heuristic counts, matching bug events) — confirm with the human before filing. `UNEVALUATED` items need human judgment and are listed so nothing is silently dropped.
+
 ### Step 3: Reason across the dimensions
 
 The mechanical findings are a starting point, not the analysis. Reason over the evidence:

--- a/docs/deferred-rigor.json
+++ b/docs/deferred-rigor.json
@@ -1,0 +1,110 @@
+{
+  "$comment": "Deferred system-layer rigor index (chief-wiggum#171, #161). Each item is a DEFERRED decision litigated by the 2026-07-19 3-lens quorum (soundness-refuter / adoption-cost / completeness) — the designs are SETTLED; when an item's trigger fires, file a full issue from its settled_notes rather than relitigating. scripts/check_deferred_triggers.py evaluates the mechanical checks (report-only scrutiny cue, never a gate) and /reflect runs it each pass. Ticket-every-deferral doctrine: this file replaces the open index issue #171 as the durable home.",
+  "source_issues": [171, 161],
+  "items": [
+    {
+      "id": "reflexion-conformance-c4",
+      "title": "Reflexion conformance gate + C4 architecture.json",
+      "source_issue": 171,
+      "trigger": "repo >15 modules OR second human contributor",
+      "checks": [
+        {"kind": "module_count_gt", "value": 15},
+        {"kind": "human_contributors_gte", "value": 2}
+      ],
+      "settled_notes": "declared vs extracted graph diff; ArchUnit-style freeze store WITH owner/expiry/risk per frozen divergence (refuter #9); edges classified by evidence source, absence-claims only where extractor has channel authority (refuter #7); import-edge extraction ships EARLIER as a code_query emission (#159 follow-on)"
+    },
+    {
+      "id": "edge-contracts",
+      "title": "edges.json full edge contracts (retry/idempotency/dup-injection)",
+      "source_issue": 171,
+      "trigger": "first duplicate-delivery or retry-storm bug in prod",
+      "checks": [
+        {"kind": "telemetry_bug_keyword", "keywords": ["duplicate", "retry storm", "retry-storm", "double-send", "double send"]}
+      ],
+      "settled_notes": "idempotency contracts must name dedupe boundary + protected side effects; tests assert downstream effect cardinality under retry/concurrency/crash (refuter #11); external EDG- edges carry assumed-vs-probe-verified provider claims + required reconcile path (completeness #2); schema_ref + --against breaking-diff gate (completeness #5)"
+    },
+    {
+      "id": "trace-replayer",
+      "title": "Trace-conformance replayer",
+      "source_issue": 171,
+      "trigger": "first prod bug caused by a shipped state machine",
+      "checks": [
+        {"kind": "telemetry_bug_keyword", "keywords": ["state machine", "transition", "invalid state"]}
+      ],
+      "settled_notes": "events must come from an audited wrapper/storage layer, never sampled, else evidence-only (refuter #4-6); zero-observation guard via @cw-emits gate; per-entity replay != cross-entity invariants — history checkers are a separate rung (refuter #5). Already shipped now (free): new state machines emit {machine, entity_id, from, to, ts} under an OTel-conventioned name via /architect templates"
+    },
+    {
+      "id": "promql-bounded-liveness",
+      "title": "PromQL bounded-liveness thresholds",
+      "source_issue": 171,
+      "trigger": "first running system emitting the series",
+      "checks": [],
+      "settled_notes": "liveness -> bounded safety ('completes or dead-letters within T' = queue-age threshold); dlq named per async edge"
+    },
+    {
+      "id": "gate-attestations",
+      "title": "Gate attestations (ITE-6/DSSE, signed)",
+      "source_issue": 171,
+      "trigger": "external party contractually requires signed provenance",
+      "checks": [],
+      "settled_notes": "ratchet hash-chain journal is sufficient provenance until then; without key/code/journal separation signatures are theater (refuter #14)"
+    },
+    {
+      "id": "federation-registry",
+      "title": "Federation registry (trace-manifest.json, aggregator, can-i-deploy matrix)",
+      "source_issue": 171,
+      "trigger": ">=2 services in one product deploy independently AND a cross-service contract has broken in prod",
+      "checks": [
+        {"kind": "telemetry_bug_keyword", "keywords": ["cross-service", "contract break", "schema drift"]}
+      ],
+      "settled_notes": "never checkout-aggregate; per-repo CI manifests + central merge; manifests need negative-space checks vs self-reporting (refuter #15); verification results carry environment; ID lifecycle: status/superseded_by/owner, retired IDs leave orphan math (completeness #9)"
+    },
+    {
+      "id": "gate-validation-designer",
+      "title": "Automated gate-validation designer + mutation testing",
+      "source_issue": 171,
+      "trigger": ">5 gates make the manual protocol a real burden",
+      "checks": [
+        {"kind": "validated_gates_gt", "value": 5}
+      ],
+      "settled_notes": "seeds versioned separately from gate code; evasion seed classes mandatory; independent escape intake for the live matrix (refuter #18-20)"
+    },
+    {
+      "id": "security-tenancy-notation",
+      "title": "Security/tenancy/residency notation (trust_zone, region, security block per edge, data_class + carries reachability)",
+      "source_issue": 171,
+      "trigger": "first regulated/multi-tenant build post-Dogeared (SafeTrail-class) OR /saas-gate needs stable IDs for its probes",
+      "checks": [],
+      "settled_notes": "declared-graph label propagation only — NO taint analysis; rebind existing /saas-gate probes as verifies targets"
+    },
+    {
+      "id": "process-json",
+      "title": "process.json (PRC- approval chains, deploy windows, promotion order)",
+      "source_issue": 171,
+      "trigger": "second human joins deploys OR a compliance requirement demands recorded approvals",
+      "checks": [
+        {"kind": "human_contributors_gte", "value": 2}
+      ],
+      "settled_notes": "in-toto layout fields (functionaries, N-of-M, windows); break-glass record schema (scope, expiry, approver, incident ref) ships EARLIER inside the infra-writer issue"
+    },
+    {
+      "id": "migration-safety",
+      "title": "Migration safety (schema DDL single-writer, expand/contract sequencing)",
+      "source_issue": 171,
+      "trigger": "first multi-service schema migration",
+      "checks": [],
+      "settled_notes": "controls_field: schema.<store>; destructive step blocked while old-version writers registered"
+    },
+    {
+      "id": "gnosis-emission-cache",
+      "title": "Gnosis phase 2 — content-addressed emission cache",
+      "source_issue": 161,
+      "trigger": "query telemetry shows repeated whole-repo query shapes (writers/governs/map) are a real per-ticket cost, OR target repos grow beyond ~10^4 files",
+      "checks": [
+        {"kind": "telemetry_whole_repo_queries_gte", "value": 50},
+        {"kind": "file_count_gt", "value": 10000}
+      ],
+      "settled_notes": "Full settled design in issue #161 (do not weaken): per-file emission shards keyed (content_hash, scanner_source_hash), write-once CAS under ~/.chief-wiggum/index/<repo>/, path-free values, manifest-driven validity, claims never cached per-file, --no-cache dual-run zero-diff as the validation gate on a dirty worktree, /close-epic --gate coverage stays full-scan forever"
+    }
+  ]
+}

--- a/scripts/check_deferred_triggers.py
+++ b/scripts/check_deferred_triggers.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Evaluate the deferred-rigor index's build triggers (chief-wiggum#171/#161).
+
+``docs/deferred-rigor.json`` records every DEFERRED system-layer decision with
+its settled design notes and a concrete build trigger. This script evaluates
+the MECHANICAL half of those triggers and reports, per item:
+
+- ``FIRED``       — a mechanical check is true; file the full issue from the
+                    item's ``settled_notes`` (do not relitigate the design).
+- ``CANDIDATE``   — soft evidence found (e.g. a telemetry bug event matching
+                    the trigger's keywords); a human confirms before filing.
+- ``QUIET``       — mechanical checks evaluated and none fired.
+- ``UNEVALUATED`` — the trigger needs human judgment (no mechanical checks,
+                    or a required input like ``--repo`` wasn't provided);
+                    surfaced, never silently skipped.
+
+This is a **permanently report-only scrutiny cue, never a gate** (exit 0
+always, same doctrine as the high-water test-file cue): the trigger table is
+about not silently dropping deferred work, not about blocking anything.
+``/reflect`` runs it each pass and converts FIRED rows into issues.
+
+Check kinds:
+- ``file_count_gt``: git-tracked file count in ``--repo`` exceeds ``value``.
+- ``module_count_gt``: heuristic — directories (depth <= 2, excluding
+  tests/vendor/node_modules/hidden) containing source files in ``--repo``.
+- ``human_contributors_gte``: distinct non-bot author emails on ``--repo``'s
+  history (heuristic: excludes emails containing bot/noreply markers).
+- ``validated_gates_gt``: gate-validation records in
+  ``<cw>/docs/quality/validation/*.json``.
+- ``telemetry_whole_repo_queries_gte``: factory-log ``query`` events named
+  writers/governs/map (the whole-repo shapes #161's trigger names).
+- ``telemetry_bug_keyword``: factory-log ``bug`` events whose summary matches
+  a keyword — always CANDIDATE, never FIRED (a human reads the bug).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CW_ROOT = HERE.parent
+INDEX = CW_ROOT / "docs" / "deferred-rigor.json"
+
+SOURCE_SUFFIXES = {".py", ".go", ".ts", ".tsx", ".js", ".rs", ".java", ".rb"}
+EXCLUDED_DIRS = {"tests", "test", "vendor", "node_modules", "dist", "build"}
+BOT_EMAIL_MARKERS = ("bot", "noreply", "no-reply", "actions@github.com")
+
+
+def _git_files(repo: Path) -> list[str]:
+    out = subprocess.run(["git", "-C", str(repo), "ls-files"],
+                         capture_output=True, text=True, check=True)
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def check_file_count_gt(repo: Path | None, value: int) -> tuple[str, str]:
+    if repo is None:
+        return "UNEVALUATED", "needs --repo"
+    n = len(_git_files(repo))
+    return ("FIRED" if n > value else "QUIET"), f"{n} tracked files (threshold {value})"
+
+
+def check_module_count_gt(repo: Path | None, value: int) -> tuple[str, str]:
+    """Heuristic (what counts as a 'module' is judgment) — CANDIDATE at most,
+    never FIRED: a fuzzy definition must not mechanically demand an issue."""
+    if repo is None:
+        return "UNEVALUATED", "needs --repo"
+    dirs: set[str] = set()
+    for f in _git_files(repo):
+        p = Path(f)
+        if p.suffix not in SOURCE_SUFFIXES:
+            continue
+        parts = [seg for seg in p.parent.parts if seg]
+        if any(seg in EXCLUDED_DIRS or seg.startswith(".") for seg in parts):
+            continue
+        dirs.add("/".join(parts[:2]) or ".")
+    n = len(dirs)
+    return ("CANDIDATE" if n > value else "QUIET"), \
+        f"{n} source modules, heuristic (threshold {value}) — human confirms module definition"
+
+
+def check_human_contributors_gte(repo: Path | None, value: int) -> tuple[str, str]:
+    """Heuristic (one human commonly commits under several emails) — CANDIDATE
+    at most, never FIRED: email identity must be confirmed by a human."""
+    if repo is None:
+        return "UNEVALUATED", "needs --repo"
+    out = subprocess.run(["git", "-C", str(repo), "log", "--format=%ae"],
+                         capture_output=True, text=True, check=True)
+    humans = sorted({e.strip().lower() for e in out.stdout.splitlines() if e.strip()
+                     and not any(m in e.lower() for m in BOT_EMAIL_MARKERS)})
+    n = len(humans)
+    return ("CANDIDATE" if n >= value else "QUIET"), \
+        f"{n} distinct non-bot author email(s) {humans} (threshold {value}) — may be one human under several emails"
+
+
+def check_validated_gates_gt(value: int) -> tuple[str, str]:
+    records = sorted((CW_ROOT / "docs" / "quality" / "validation").glob("*.json"))
+    n = len(records)
+    return ("FIRED" if n > value else "QUIET"), f"{n} gate-validation records (threshold {value})"
+
+
+def _factory_events(log_path: Path) -> list[dict]:
+    if not log_path.is_file():
+        return []
+    events = []
+    for line in log_path.read_text().splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def check_telemetry_whole_repo_queries_gte(log_path: Path, value: int) -> tuple[str, str]:
+    if not log_path.is_file():
+        return "UNEVALUATED", f"no factory log at {log_path}"
+    n = sum(1 for e in _factory_events(log_path)
+            if e.get("event") == "query" and e.get("name") in ("writers", "governs", "map"))
+    return ("FIRED" if n >= value else "QUIET"), f"{n} whole-repo query events (threshold {value})"
+
+
+def check_telemetry_bug_keyword(log_path: Path, keywords: list[str]) -> tuple[str, str]:
+    if not log_path.is_file():
+        return "UNEVALUATED", f"no factory log at {log_path}"
+    hits = []
+    for e in _factory_events(log_path):
+        if e.get("event") != "bug":
+            continue
+        summary = str(e.get("summary", "")).lower()
+        if any(k.lower() in summary for k in keywords):
+            hits.append(e.get("summary"))
+    if hits:
+        return "CANDIDATE", f"{len(hits)} bug event(s) match {keywords}: {hits[:3]} — human confirms before filing"
+    return "QUIET", f"no bug events matching {keywords}"
+
+
+def evaluate_item(item: dict, repo: Path | None, log_path: Path) -> dict:
+    checks = item.get("checks", [])
+    results = []
+    for chk in checks:
+        kind = chk.get("kind")
+        if kind == "file_count_gt":
+            status, detail = check_file_count_gt(repo, chk["value"])
+        elif kind == "module_count_gt":
+            status, detail = check_module_count_gt(repo, chk["value"])
+        elif kind == "human_contributors_gte":
+            status, detail = check_human_contributors_gte(repo, chk["value"])
+        elif kind == "validated_gates_gt":
+            status, detail = check_validated_gates_gt(chk["value"])
+        elif kind == "telemetry_whole_repo_queries_gte":
+            status, detail = check_telemetry_whole_repo_queries_gte(log_path, chk["value"])
+        elif kind == "telemetry_bug_keyword":
+            status, detail = check_telemetry_bug_keyword(log_path, chk["keywords"])
+        else:
+            status, detail = "UNEVALUATED", f"unknown check kind {kind!r}"
+        results.append({"kind": kind, "status": status, "detail": detail})
+
+    if not results:
+        overall = "UNEVALUATED"
+    elif any(r["status"] == "FIRED" for r in results):
+        overall = "FIRED"
+    elif any(r["status"] == "CANDIDATE" for r in results):
+        overall = "CANDIDATE"
+    elif all(r["status"] == "UNEVALUATED" for r in results):
+        overall = "UNEVALUATED"
+    else:
+        overall = "QUIET"
+    return {"id": item["id"], "title": item["title"], "source_issue": item.get("source_issue"),
+            "trigger": item.get("trigger"), "status": overall, "checks": results}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    ap.add_argument("--index", type=Path, default=INDEX,
+                    help=f"deferred-rigor index (default: {INDEX})")
+    ap.add_argument("--repo", type=Path, default=None,
+                    help="target repo for repo-shaped checks (module/file/contributor counts)")
+    ap.add_argument("--factory-log", type=Path,
+                    default=Path.home() / ".chief-wiggum" / "factory-log.jsonl",
+                    help="factory telemetry log for telemetry-shaped checks")
+    ap.add_argument("--format", choices=("text", "json"), default="text")
+    args = ap.parse_args()
+
+    index = json.loads(args.index.read_text())
+    results = [evaluate_item(item, args.repo, args.factory_log)
+               for item in index.get("items", [])]
+
+    if args.format == "json":
+        print(json.dumps({"items": results}, indent=2))
+    else:
+        for r in results:
+            print(f"[{r['status']:>11}] {r['id']} — {r['title']}")
+            print(f"              trigger: {r['trigger']}")
+            for c in r["checks"]:
+                print(f"              - {c['kind']}: {c['status']} ({c['detail']})")
+            if not r["checks"]:
+                print("              - no mechanical checks: human judgment (surfaced, not silent)")
+        fired = [r["id"] for r in results if r["status"] == "FIRED"]
+        cand = [r["id"] for r in results if r["status"] == "CANDIDATE"]
+        if fired:
+            print(f"\nFIRED: {', '.join(fired)} — file the full issue(s) from settled_notes "
+                  "(designs are quorum-settled; do not relitigate)")
+        if cand:
+            print(f"CANDIDATE: {', '.join(cand)} — human confirms the evidence before filing")
+    return 0  # permanently report-only: a scrutiny cue, never a gate
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_deferred_triggers.py
+++ b/tests/test_check_deferred_triggers.py
@@ -1,0 +1,106 @@
+"""check_deferred_triggers.py (#171/#161 close-out) — the deferral index's
+mechanical trigger checker: report-only always, exact checks may FIRE,
+heuristic checks cap at CANDIDATE, unevaluable triggers surface as
+UNEVALUATED (never silently skipped)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import check_deferred_triggers as cdt
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX = REPO_ROOT / "docs" / "deferred-rigor.json"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "check_deferred_triggers.py"), *args],
+        capture_output=True, text=True)
+
+
+def _write_log(tmp_path: Path, events: list[dict]) -> Path:
+    log = tmp_path / "factory-log.jsonl"
+    log.write_text("".join(json.dumps(e) + "\n" for e in events))
+    return log
+
+
+# --- shipped index integrity --------------------------------------------------
+
+def test_shipped_index_is_valid_and_covers_both_source_issues():
+    index = json.loads(INDEX.read_text())
+    assert sorted(index["source_issues"]) == [161, 171]
+    items = index["items"]
+    assert len(items) == 11  # 10 rows from #171's table + the #161 CAS row
+    assert all(it["settled_notes"] for it in items), "every deferral keeps its settled design"
+    assert all(it["trigger"] for it in items)
+    by_issue = {161: 0, 171: 0}
+    for it in items:
+        by_issue[it["source_issue"]] += 1
+    assert by_issue[161] == 1 and by_issue[171] == 10
+
+
+def test_report_only_exit_zero_even_when_triggers_fire():
+    res = _run("--repo", str(REPO_ROOT))
+    assert res.returncode == 0, res.stderr
+    # CW's own state: 7 validation records > 5 — the exact check fires.
+    assert "[      FIRED] gate-validation-designer" in res.stdout
+
+
+def test_json_format_round_trips():
+    res = _run("--format", "json")
+    assert res.returncode == 0, res.stderr
+    payload = json.loads(res.stdout)
+    assert {it["id"] for it in payload["items"]} == {
+        it["id"] for it in json.loads(INDEX.read_text())["items"]}
+
+
+# --- status semantics ---------------------------------------------------------
+
+def test_heuristic_checks_cap_at_candidate_never_fired(tmp_path):
+    """One human under several emails must not mechanically demand an issue."""
+    repo = tmp_path / "r"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    for i, email in enumerate(["a@x.com", "b@y.com"]):
+        (repo / f"f{i}.py").write_text("x = 1\n")
+        subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+        subprocess.run(["git", "-C", str(repo), "-c", f"user.email={email}",
+                        "-c", "user.name=t", "commit", "-qm", "c"], check=True)
+    status, detail = cdt.check_human_contributors_gte(repo, 2)
+    assert status == "CANDIDATE" and "2 distinct" in detail
+
+
+def test_bug_keyword_is_candidate_never_fired(tmp_path):
+    log = _write_log(tmp_path, [
+        {"event": "bug", "summary": "duplicate delivery of webhook X"},
+        {"event": "bug", "summary": "unrelated"}])
+    status, detail = cdt.check_telemetry_bug_keyword(log, ["duplicate"])
+    assert status == "CANDIDATE" and "human confirms" in detail
+
+
+def test_exact_telemetry_check_fires_at_threshold(tmp_path):
+    log = _write_log(tmp_path, [{"event": "query", "name": "writers"}] * 3)
+    assert cdt.check_telemetry_whole_repo_queries_gte(log, 3)[0] == "FIRED"
+    assert cdt.check_telemetry_whole_repo_queries_gte(log, 4)[0] == "QUIET"
+
+
+def test_missing_inputs_surface_as_unevaluated(tmp_path):
+    assert cdt.check_file_count_gt(None, 10)[0] == "UNEVALUATED"
+    assert cdt.check_telemetry_bug_keyword(tmp_path / "absent.jsonl", ["x"])[0] == "UNEVALUATED"
+    # An item with no checks at all is UNEVALUATED, not silently dropped.
+    result = cdt.evaluate_item(
+        {"id": "i", "title": "t", "trigger": "human judgment"}, None, tmp_path / "absent.jsonl")
+    assert result["status"] == "UNEVALUATED"
+
+
+def test_overall_status_prefers_fired_over_candidate(tmp_path):
+    log = _write_log(tmp_path, [
+        {"event": "query", "name": "map"},
+        {"event": "bug", "summary": "retry storm in worker"}])
+    item = {"id": "i", "title": "t", "trigger": "x",
+            "checks": [{"kind": "telemetry_whole_repo_queries_gte", "value": 1},
+                       {"kind": "telemetry_bug_keyword", "keywords": ["retry storm"]}]}
+    assert cdt.evaluate_item(item, None, log)["status"] == "FIRED"


### PR DESCRIPTION
## Summary

Closes out #171 and #161 without dropping a single deferral. #171 parked ten quorum-settled system-layer designs in an open-issue table with the AC '/reflect checks triggers against factory telemetry'; #161 parked the gnosis CAS behind a telemetry trigger. Both move to a durable in-repo home: docs/deferred-rigor.json carries every row (settled notes verbatim, so nothing is relitigated) with structured trigger checks, and scripts/check_deferred_triggers.py evaluates them — exact counts may FIRE, heuristic counts cap at CANDIDATE (a human confirms identity/definition questions), judgment-only triggers list as UNEVALUATED rather than disappearing. /reflect runs the check every pass and files issues for FIRED rows from the settled notes. Permanently report-only per gate-rollout doctrine: this is a scrutiny cue, not a gate. First live run: gate-validation-designer FIRED (7 validation records > 5) and #218 is filed; #161's own trigger is QUIET (zero whole-repo query shapes in telemetry, 474 files), so the CAS correctly stays deferred.

Closes #171

## Architecture

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
graph TD
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff

    I171["Issue #171 (index-by-open-issue)"]:::entry
    I161["Issue #161 (build-on-trigger CAS)"]:::entry
    IDX["docs/deferred-rigor.json<br/>11 deferrals: settled notes + trigger checks"]:::new
    CHK["scripts/check_deferred_triggers.py<br/>FIRED / CANDIDATE / QUIET / UNEVALUATED<br/>report-only, never a gate"]:::new
    REFL["/reflect Step 2<br/>runs the check each pass"]:::modified
    TEL["factory-log.jsonl + repo facts"]:::existing
    ISS["FIRED -> issue from settled notes<br/>first live run filed #218"]:::new

    I171 --> IDX
    I161 --> IDX
    IDX --> CHK
    TEL --> CHK
    REFL --> CHK --> ISS
```

## Changes

- docs/deferred-rigor.json — 11 deferrals (10 from #171 + #161's CAS row), settled notes + structured checks
- scripts/check_deferred_triggers.py — report-only trigger evaluator with honest precision tiers
- /reflect Step 2 wiring — FIRED rows become issues from settled notes; CANDIDATE needs human confirmation
- 8 tests: index integrity, exit-0-always, heuristics-cap-at-CANDIDATE, UNEVALUATED surfacing

## Test Evidence

**Verification: all green**
- ✓ `make test` — exit 0
- ✓ `make lint` — exit 0

## Review Checklist

- [ ] Tests pass locally
- [ ] No new warnings or lint errors
- [ ] Multi-AI review feedback addressed
- [ ] No secrets or credentials committed
