### PR TITLE
feat(patterns): specify the final four candidates — registry reaches zero candidates (#139)

### DIFF
--- a/docs/patterns-registry.md
+++ b/docs/patterns-registry.md
@@ -416,7 +416,7 @@ surfaced a coherent set of reusable shapes. Two observations shaped how they lan
   behavioral data safe — the loop can read across tenants for analysis without
   leaking between them only atop a fail-closed, server-derived scoping layer.
 
-| Candidate | Category | One-liner |
+| Pattern (all now specified) | Category | One-liner |
 |--|--|--|
 | **multi-tenant-isolation** | saas-infra | Server-only tenant resolution → fail-closed tenant-scoped repository → standing cross-tenant isolation proof gate → quarantined cascade erasure. One multi-tenancy blueprint |
 | **provider-neutral-adapter** | multi-provider | Vendor-agnostic seam (neutral DTOs, unexported concrete types = compile-time swappability); behind it: signed-webhook-as-source-of-truth, sign-per-request access tokens, direct browser→CDN upload |
@@ -453,17 +453,18 @@ is **admin-gated**, because it's driven by end-user behavior (an injection surfa
 and touches pricing/paywall (a goalpost). Continuously improved, human always signs
 off on the ask for money.
 
-Supporting monetization candidates in `registry.json`:
+Supporting monetization/growth patterns, all now fully specified (chief-wiggum#139):
 
-| Candidate | Category | One-liner |
+| Pattern | Category | One-liner |
 |--|--|--|
-| **transactional-email-and-dunning** | process-loop | Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge, re-engagement, failed-payment dunning with bounded retries + send-once keys. Recovery outcomes are retention signal |
+| **transactional-email-and-dunning** | process-loop | Idempotent, provider-neutral lifecycle messaging: transport-shaped send seam, atomic send-once keys, outbox, declared criticality. Dunning half flagged aspirational until a product builds it. Recovery outcomes are retention signal |
 | **referral-invite-loop** | process-loop | Invite → signed single-use expiring token → attribution → two-sided reward. Reuses the signed-token discipline; a self-serve growth loop |
-| **feature-entitlements** | saas-infra | One resolver: capability flags from tier + per-account overrides + grandfathering, queried identically by backend gates and frontend UI |
-| **self-serve-billing-portal** | saas-infra | User-managed plan / payment / seats; provider-hosted portal session + a webhook-authoritative local mirror. Kills the #1 support-ticket class |
+| **feature-entitlements** | saas-infra | One resolver: capability flags from tier + per-account overrides + explicit grandfathering, queried identically by backend gates and frontend UI; reuses entitlement-overlay's mined layering |
+| **self-serve-billing-portal** | saas-infra | User-managed plan / payment / seats; caller-scoped server-minted portal session + a webhook-authoritative single-writer local mirror. Kills the #1 support-ticket class |
 
-Fully specifying the remaining candidates (a `pattern.md` + `manifest.json` each)
-is future work; the registry structure is built to hold them.
+Every candidate in `registry.json` is now promoted — the `candidates` list is
+empty, and `check_patterns.py` will flag any new candidate that lingers
+unspecified as a dangling reference the moment a specified pattern depends on it.
 
 ## Stack profiles — the concrete layer (the factory)
 

--- a/patterns/feature-entitlements/manifest.json
+++ b/patterns/feature-entitlements/manifest.json
@@ -1,0 +1,64 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/feature-entitlements/pattern.md. The whole cluster is design-derived: the per-field layering SHAPE is inherited from the in-repo entitlement-overlay pattern (INV-EO-001..003, mined) but that mined form is raise-only, while this pattern's overrides may also narrow — so no invariant here claims mined provenance. Each inverts a concrete failure mode observed while auditing shipped production SaaS (private-repo paths held out of the public registry per the provenance policy).",
+  "id": "feature-entitlements",
+  "version": 1,
+  "title": "Feature Entitlements Read-Model",
+  "category": "saas-infra",
+  "trust_class": "billing-adjacent-authorization-protected-path",
+
+  "applies_when": [
+    "more than one surface (API guards, UI, onboarding) needs 'can this account do X' and must agree",
+    "tiers exist and per-account exceptions (overrides, grandfathering) are real",
+    "subscription state (past_due, canceled) must degrade capabilities somewhere beyond a dashboard badge"
+  ],
+
+  "components": [
+    "single-resolver: exactly one implementation resolves entitlements; backend gates call it and the frontend consumes its served output — parallel derivations are the drift mechanism",
+    "per-key-layering: each capability resolves tier-base <- account-override <- grandfather stamp, per key; a partial override never zeroes absent keys (no whole-struct replacement)",
+    "fail-closed-unknown-principal: an unknown or missing account resolves to no capabilities or an explicit error — never a default account's capabilities, never permissive defaults",
+    "explicit-grandfathering: legacy accommodation is a dated per-account stamp, never an implicit 'absent config means everything enabled' default",
+    "deployment-capability-split: what the deployment can do and what the account may do are separate documents; the entitlement read is authenticated and account-scoped, client failure posture fail-closed",
+    "tier-ceiling-at-write: self-serve writes cannot exceed the tier grant; overrides may narrow, only sanctioned paths widen; every change is audited"
+  ],
+
+  "invariants": {
+    "$comment": "All six are design-derived (grounding field marks them), each inverting an observed production failure mode; 002 additionally records the in-repo entitlement-overlay mined layering shape it generalizes (related field — raise-only in the mined form, bidirectional here). They ground fully when a product first builds the resolver.",
+    "cluster": [
+      {"id": "INV-FE-001", "statement": "Single resolver: exactly one implementation answers 'what can this account do'; backend gates call it and the frontend consumes its served output. No second flag table, no parallel derivation in another language, no inline capability checks that bypass it.", "grounding": "design-derived"},
+      {"id": "INV-FE-002", "statement": "Per-key layering: every capability resolves as tier-base <- account-override <- grandfather stamp, per key; an override that sets one key never resets absent keys to zero values, and caps layer with explicit semantics. The in-repo entitlement-overlay pattern realizes the per-field layered-resolution shape in its mined form (INV-EO-001..003) with raise-only overlay semantics; this pattern's bidirectional form — an override may also narrow, under INV-FE-006's ceiling — is design-derived.", "grounding": "design-derived", "related": {"app": "chief-wiggum registry", "code": "patterns/entitlement-overlay/manifest.json (INV-EO-001..003 — the mined per-field layering shape, raise-only)"}},
+      {"id": "INV-FE-003", "statement": "Fail-closed on unknown principal: an unknown, missing, or unresolvable account yields no capabilities (or an explicit error) — never another account's capabilities, never a default tenant's configuration, never permissive defaults.", "grounding": "design-derived"},
+      {"id": "INV-FE-004", "statement": "Explicit grandfathering: legacy accommodation is a dated, per-account stamp (grandfathered_until / plan-version pin) the resolver honors and reporting can enumerate — never an implicit permissive default for accounts lacking config.", "grounding": "design-derived"},
+      {"id": "INV-FE-005", "statement": "Deployment capability is not entitlement: what the deployment can do (providers configured) and what the account may do are separate documents; the entitlement read is authenticated and account-scoped, and its client-side failure posture is fail-closed (deployment-capability display reads may fail open, entitlement reads may not).", "grounding": "design-derived"},
+      {"id": "INV-FE-006", "statement": "Tier ceiling at write time: self-serve settings writes cannot exceed what the tier grants — an account override may narrow, only sanctioned admin paths may widen — and every entitlement change is audited with actor, before, and after.", "grounding": "design-derived"}
+    ]
+  },
+
+  "parameters": {
+    "tier_matrix": {"type": "object", "required": true, "description": "Per-tier capability base: keys to grants/limits."},
+    "override_store": {"type": "string", "required": true, "description": "Where per-account overrides live; its write path is the sanctioned one (INV-FE-006)."},
+    "grandfather_stamp": {"type": "string", "required": true, "description": "The dated per-account legacy pin the resolver honors (INV-FE-004)."},
+    "served_endpoint": {"type": "string", "required": true, "description": "The authenticated, account-scoped read the frontend consumes (INV-FE-005)."},
+    "audit_sink": {"type": "string", "required": true, "description": "Where entitlement changes are recorded: actor, before, after (INV-FE-006)."},
+    "degrade_map": {"type": "object", "required": false, "description": "How subscription states (past_due, canceled) narrow the resolved set."}
+  },
+
+  "success_metrics": {
+    "$comment": "The resolver is the read-model onboarding, UI, and gates all query — disagreement between surfaces is the defect this pattern exists to make impossible.",
+    "metrics": [
+      {"id": "entitlement_check_sources", "goal": "one", "desc": "no parallel derivations (INV-FE-001)"},
+      {"id": "frontend_backend_disagreements", "goal": "zero", "desc": "both consume the same resolved output"},
+      {"id": "unknown_principal_grants", "goal": "zero", "desc": "fail-closed resolution (INV-FE-003)"},
+      {"id": "overrides_exceeding_tier", "goal": "zero", "desc": "ceiling enforced at write (INV-FE-006)"},
+      {"id": "unaudited_entitlement_changes", "goal": "zero", "desc": "every change carries actor + diff (INV-FE-006)"}
+    ]
+  },
+
+  "protected_paths": [
+    "the resolver implementation (INV-FE-001 — the single source of 'what can this account do')",
+    "the tier matrix + degrade map (billing-adjacent authorization)",
+    "the override write path (INV-FE-006 — the only sanctioned widener)"
+  ],
+
+  "depends_on": "entitlement-overlay",
+  "feeds": "tiered-subscription, frictionless-onboarding, self-serve-billing-portal"
+}

--- a/patterns/feature-entitlements/pattern.md
+++ b/patterns/feature-entitlements/pattern.md
@@ -1,0 +1,101 @@
+# Pattern: Feature Entitlements Read-Model
+
+- **Category:** saas-infra
+- **Trust class:** the resolver and the tier ceiling are billing-adjacent authorization — a protected path
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+- **Depends on:** [`entitlement-overlay`](../entitlement-overlay) — reuses its mined override-over-tier layering discipline
+- **Feeds:** [`tiered-subscription`](../tiered-subscription) gates, [`frictionless-onboarding`](../frictionless-onboarding) and UI (both query it), [`self-serve-billing-portal`](../self-serve-billing-portal) (subscription state degrades through it)
+
+## What it is
+
+**One resolver that answers "what can this account do,"** consumed identically
+by backend gates and the frontend. It derives per-key capability flags from
+tier + per-account overrides + an explicit grandfather stamp, and it is the
+read-model everything else queries — onboarding, UI affordances, API guards,
+billing degrade.
+
+Why a pattern and not "just check the plan field": the failure mode is
+**scatter**. Audits of shipped production SaaS found three disjoint flag
+systems in one app (env-derived deployment capabilities, a tenant JSON flag
+bag, a standalone opt-in boolean) with no code path consulting more than one;
+a partial override that zeroed every absent key (whole-struct replacement, so
+"turn one thing off" silently turned everything else off); and an unknown
+account silently resolving to a *default tenant's* capabilities. Each observed
+failure is an invariant below, inverted.
+
+## When to apply
+
+- More than one surface (API guards, UI, onboarding) needs "can this account
+  do X" and must agree.
+- Tiers exist and per-account exceptions (overrides, grandfathering) are real.
+- Subscription state (past_due, canceled) must degrade capabilities somewhere
+  other than a dashboard badge.
+
+## Mechanism — generic components
+
+- **Single resolver.** Exactly one implementation resolves entitlements;
+  backend gates call it and the frontend consumes its served output. Parallel
+  derivations (a second flag table in another language) are the drift
+  mechanism the pattern exists to kill. *(INV-FE-001.)*
+- **Per-key layering.** Each capability resolves as tier-base ← account
+  override ← grandfather stamp, **per key**: an override that sets one key
+  never resets absent keys to zero values. The `entitlement-overlay` pattern
+  realizes this per-field layering shape in its mined, raise-only form; the
+  bidirectional form here (an override may also narrow, under INV-FE-006's
+  ceiling) is design-derived. *(INV-FE-002.)*
+- **Fail-closed on unknown principal.** An unknown or missing account resolves
+  to *no capabilities* (or an explicit error) — never to a default account's
+  capabilities, never to permissive defaults. *(INV-FE-003.)*
+- **Explicit grandfathering.** Legacy accommodation is a dated, per-account
+  stamp (`grandfathered_until`, plan-version pin) — never an implicit
+  "absent config means everything enabled" default. *(INV-FE-004.)*
+- **Deployment capability ≠ entitlement.** What the *deployment* can do
+  (providers configured, email wired) and what the *account* may do are
+  separate documents; the entitlement read is authenticated and
+  account-scoped, and its client-side failure posture is fail-closed (a
+  deployment-capability read may fail-open for display purposes only).
+  *(INV-FE-005.)*
+- **Tier ceiling at write time.** Self-serve settings writes cannot exceed
+  what the tier grants: an account override may narrow, only sanctioned admin
+  paths may widen, and every entitlement change is audited (actor, before,
+  after). *(INV-FE-006.)*
+
+## Grounding
+
+The per-field layering *shape* in INV-FE-002 is inherited from the in-repo
+[`entitlement-overlay`](../entitlement-overlay) cluster (INV-EO-001..003),
+which is mined from a shipped production app's plan resolver — but that mined
+form is **raise-only** (`effective = max(base, overlay)`), so the bidirectional
+form this pattern requires (an override may also narrow, under INV-FE-006's
+ceiling) is design-derived, and the whole cluster (INV-FE-001..006) is marked
+**design-derived** accordingly. Each invariant inverts a concrete failure mode
+observed while auditing shipped production SaaS (scattered flag systems;
+whole-struct override replacement; silent default-tenant fallback; implicit
+permissive-default grandfathering; a public unauthenticated capability
+endpoint with fail-open client defaults; self-serve writes with no tier
+ceiling). Per the registry's provenance policy, private-repo paths are held
+out of the public registry. These invariants ground fully when a product
+first builds the resolver.
+
+## Parameters
+
+| Parameter | Required | Meaning |
+|--|--|--|
+| `tier_matrix` | yes | The per-tier capability base (keys → grants/limits). |
+| `override_store` | yes | Where per-account overrides live (sanctioned write path). |
+| `grandfather_stamp` | yes | The dated per-account legacy pin the resolver honors. |
+| `served_endpoint` | yes | The authenticated, account-scoped read the frontend consumes. |
+| `audit_sink` | yes | Where entitlement changes are recorded (actor, before, after). |
+| `degrade_map` | no | How subscription states (past_due, canceled) narrow the resolved set. |
+
+## Success metrics
+
+`entitlement_check_sources` = 1 (no parallel derivations), `frontend_backend
+disagreements` = 0, `unknown_principal_grants` = 0, `overrides_exceeding_tier`
+= 0, `unaudited_entitlement_changes` = 0.
+
+## Trust
+
+The resolver, the tier matrix, the override write path, and the degrade map
+are billing-adjacent authorization — protected paths. A worker widening a
+grant or adding a second resolution path is parked for human review.

--- a/patterns/reconciliation-sweep/manifest.json
+++ b/patterns/reconciliation-sweep/manifest.json
@@ -1,0 +1,156 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/reconciliation-sweep/pattern.md. Mined from a shipped production SaaS's payment-hold reconciler; per the registry's provenance policy, private-repo paths are held out of the public registry \u2014 realized_as describes the realized mechanism instead. INV-RSW-004 is mined-for-one-sweep and generalized by design; INV-RSW-007's surfaced-skip clause is design-derived from the mined gap.",
+  "id": "reconciliation-sweep",
+  "version": 1,
+  "title": "Bidirectional Reconciliation Sweep",
+  "category": "process-loop",
+  "trust_class": "destructive-capable-automation-protected-path",
+  "applies_when": [
+    "local records mirror an external system (payments, storage, CDN/DNS config) and divergence accumulates",
+    "some repairs are destructive (cancel, expire, abandon, release) and must be safe under retries, replicas, and races",
+    "operators need per-run evidence of what the sweep did"
+  ],
+  "components": [
+    "ordered-sweep-set: one scheduler runs the sweeps in declared order with a per-run budget, once at startup then on the interval; each returns a count",
+    "status-guarded-cas: every repairing write re-asserts the expected pre-state in the write filter; zero rows modified means a concurrent actor won \u2014 skip, no side effects",
+    "legality-before-write: each repair transition is validated against the domain state machine before the write; illegal transitions are skipped and surfaced, never forced",
+    "fail-closed-unknown-age: age-based destructive selectors exclude records with absent ordering timestamps at the query level; timestamps are never fabricated",
+    "reconfirm-before-destroy: destructive repairs fetch the external system's live state first and treat it as authoritative; unreachable external system means skip, fail-closed",
+    "deterministic-idempotency: outbound repairs carry a namespaced deterministic key (reconcile:<op>:<record-id>) so replays cannot double-apply",
+    "bidirectional-flag-sweeps: flag-set sweeps are no-ops on re-run and every set sweep has a paired clear sweep",
+    "surfaced-run-report: per-sweep counts plus provenance-tagged per-item events; an unrunnable sweep reports skipped, never a silent zero"
+  ],
+  "invariants": {
+    "$comment": "001/002/003/005/006 mined from the reconciler; 004 mined for the stale-in-flight sweep and generalized to all destructive sweeps by design; 007's surfaced-skip clause design-derived from the mined silent-zero gap.",
+    "cluster": [
+      {
+        "id": "INV-RSW-001",
+        "statement": "Status-guarded CAS repair: every repairing write re-asserts the expected pre-state in its write filter and treats zero-rows-modified as 'a concurrent actor already handled it' \u2014 the sweep skips and no follow-on side effect (capacity release, notification, external call) fires.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "payment-hold reconciler: every sweep's update filter carries the pre-state status and gates side effects on ModifiedCount > 0"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-002",
+        "statement": "Legality before write: every repair transition is validated against the domain state machine before the write; an illegal transition is skipped and surfaced as a finding, never forced by the job.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "the domain state machine's transition-validation routine is invoked before every sweep write; failures are logged per record and the record is skipped"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-003",
+        "statement": "Fail-closed on unknown age: an age/expiry-based destructive selector excludes records whose ordering timestamp is absent (query-level $ne nil), and upstream writers never fabricate the timestamp \u2014 a record with unknown age is never swept to destruction.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "expiry sweep selects capture-deadline < now AND != nil; the webhook writer deletes the field rather than defaulting it to now+7d"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-004",
+        "statement": "Re-confirm before destroy: before a destructive repair, the external system's live object is fetched and is authoritative over local belief; if the external system is unreachable or the record lacks its external binding, the sweep skips fail-closed. (Mined for the stale-in-flight sweep; the pattern requires it for every destructive sweep wherever an external truth exists.)",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "stuck-in-flight sweep re-fetches the payment intent and branches on its live status; nil client or fetch error \u2192 skip"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-005",
+        "statement": "Deterministic external idempotency: every outbound repair against the external system carries a namespaced deterministic idempotency key derived from the operation and the repaired record's id, so replays across runs and replicas cannot double-apply.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "reconcile:cancel:<request-id> set as the provider idempotency key on sweep-initiated cancels"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-006",
+        "statement": "Idempotent, bidirectional flag sweeps: alert-flag sweeps exclude already-flagged rows in their selector (no-op on re-run), and every flag-set sweep has a paired flag-clear sweep so flags track current state rather than decaying into set-once noise.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "approaching-expiry flag set with $ne-true guard and cleared by a paired sweep when the deadline moves out past the buffer"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-RSW-007",
+        "statement": "Per-run counts, surfaced skips: each sweep returns its repair count, the run emits per-sweep counts and provenance-tagged per-item events, and a sweep that cannot run (store or external client unavailable) reports skipped \u2014 never a silent zero indistinguishable from a clean pass.",
+        "grounding": "design-derived"
+      }
+    ]
+  },
+  "parameters": {
+    "sweeps": {
+      "type": "object",
+      "required": true,
+      "description": "Ordered sweep set: name, selector, repair action, direction (local-to-external, external-to-local, local-only)."
+    },
+    "interval": {
+      "type": "string",
+      "required": true,
+      "description": "Ticker period (mined loop: 60s with a 2m per-run budget)."
+    },
+    "state_machine": {
+      "type": "string",
+      "required": true,
+      "description": "The transition-legality authority every repair is checked against (INV-RSW-002)."
+    },
+    "idempotency_namespace": {
+      "type": "string",
+      "required": true,
+      "description": "Prefix for deterministic outbound repair keys (INV-RSW-005)."
+    },
+    "run_budget": {
+      "type": "string",
+      "required": false,
+      "description": "Per-run context timeout."
+    },
+    "run_ledger": {
+      "type": "string",
+      "required": false,
+      "description": "Where per-run counts persist; default emitted-only (a stated v1 boundary)."
+    }
+  },
+  "success_metrics": {
+    "$comment": "Run reports and the repair-event audit stream are operational-health signal for the improvement loop.",
+    "metrics": [
+      {
+        "id": "repairs_per_run",
+        "goal": "down",
+        "desc": "divergence is shrinking, not accumulating"
+      },
+      {
+        "id": "skipped_sweeps",
+        "goal": "zero",
+        "desc": "every sweep actually ran (INV-RSW-007)"
+      },
+      {
+        "id": "illegal_transition_skips",
+        "goal": "zero",
+        "desc": "each one is model/code drift worth a finding (INV-RSW-002)"
+      },
+      {
+        "id": "stale_inflight_age_p95",
+        "goal": "down",
+        "desc": "stuck records are recovered promptly"
+      },
+      {
+        "id": "double_repair_count",
+        "goal": "zero",
+        "desc": "CAS + idempotency-key efficacy (INV-RSW-001/005)"
+      }
+    ]
+  },
+  "protected_paths": [
+    "the sweep set, selectors, and thresholds (destructive-capable automation \u2014 trust class)",
+    "the state-machine legality authority (INV-RSW-002)",
+    "the idempotency-key derivation (INV-RSW-005)"
+  ],
+  "depends_on": "fetch-on-webhook-reconcile",
+  "feeds": "improvement-loop"
+}

--- a/patterns/reconciliation-sweep/pattern.md
+++ b/patterns/reconciliation-sweep/pattern.md
@@ -1,0 +1,107 @@
+# Pattern: Bidirectional Reconciliation Sweep
+
+- **Category:** process-loop
+- **Trust class:** sweep rules are destructive-capable automation — the sweep set, its guards, and its thresholds are a protected path
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+- **Depends on:** [`fetch-on-webhook-reconcile`](../fetch-on-webhook-reconcile) — the same "the provider's live state is authoritative, never your cached belief" discipline, applied on a timer instead of a webhook
+- **Feeds:** [`improvement-loop`](../improvement-loop) — per-run counts and provenance-tagged repair events are operational-health signal
+
+## What it is
+
+A periodic in-process job that repairs divergence between local records and an
+external system (payment provider, storage, CDN config) **in both directions**,
+plus a stale-in-flight sweep for records stuck mid-transition. Mined from a
+shipped production SaaS's payment-hold reconciler (a fixed-order set of sweeps
+on a short ticker, run once at startup, each returning a count).
+
+Why a pattern and not "just write a cron job": a reconciler is **automation
+that is allowed to destroy things** (cancel holds, abandon requests, release
+capacity). The mined discipline is what keeps that safe: every repairing write
+is a status-guarded compare-and-set, every transition is legality-checked
+against the domain state machine first, age-based destruction refuses to act
+on records with missing timestamps, and destructive repairs re-confirm against
+the external system's live truth. Each of these exists because its absence is
+a real bug class — double-repair under concurrent runs, illegal transitions
+forced by a job, records fabricated into expiry, and repairs applied on stale
+local belief.
+
+## When to apply
+
+- Local records mirror an external system (payments, storage, DNS/CDN config)
+  and divergence accumulates: webhooks get missed, in-flight operations die.
+- Some repairs are destructive (cancel, expire, abandon, release) and must be
+  safe under retries, replicas, and races with live traffic.
+- Operators need per-run evidence of what the sweep did (counts, provenance).
+
+## Mechanism — generic components
+
+- **Fixed-order sweep set on a ticker.** One scheduler runs the sweeps in a
+  declared order with a per-run time budget, once at startup then on the
+  interval; each sweep returns its repair count. *(INV-RSW-007.)*
+- **Status-guarded CAS repair.** Every repairing write re-asserts the expected
+  pre-state in the write filter; a zero-row result means a concurrent actor
+  already handled it — the sweep skips, and no follow-on side effect fires.
+  *(INV-RSW-001 — mined.)*
+- **Legality before write.** Each repair transition is validated against the
+  domain state machine before the write; an illegal transition is skipped and
+  surfaced, never forced by the job. *(INV-RSW-002 — mined.)*
+- **Fail-closed on unknown age.** Age/expiry sweeps exclude records whose
+  ordering timestamp is absent at the query level (`$ne: nil`), and upstream
+  never fabricates a timestamp to fill the gap. *(INV-RSW-003 — mined.)*
+- **Re-confirm before destroy.** Before a destructive repair, fetch the
+  external system's live state and treat it as authoritative; if the external
+  system is unreachable, skip fail-closed. *(INV-RSW-004 — mined for the
+  stale-in-flight sweep; the pattern requires it for every destructive sweep
+  wherever an external truth exists.)*
+- **Deterministic external idempotency keys.** Every outbound repair against
+  the external system carries a namespaced deterministic idempotency key
+  (`reconcile:<op>:<record-id>`), so replays across runs and replicas cannot
+  double-apply. *(INV-RSW-005 — mined.)*
+- **Idempotent, bidirectional flag sweeps.** Alert-flag sweeps are no-ops on
+  re-run (the filter excludes already-flagged rows) and every flag-set sweep
+  has a paired flag-clear sweep — flags track current state, they don't decay
+  into set-once noise. *(INV-RSW-006 — mined.)*
+- **Per-run counts, surfaced skips.** The run emits per-sweep counts and
+  per-item provenance-tagged events (`source: <sweep-name>`); a sweep that
+  cannot run (store or client unavailable) reports *skipped*, never a silent
+  zero. *(INV-RSW-007 — design-derived: it strengthens the mined
+  per-run-counts mechanism, whose missing-store path returned an
+  indistinguishable 0.)*
+
+## Grounding
+
+INV-RSW-001/002/003/005/006 are **mined** from a shipped production SaaS's
+payment-hold reconciler (per this registry's provenance policy, private-repo
+paths are held out of the public registry; the manifest describes the realized
+mechanisms). INV-RSW-004 is mined for the stale-in-flight sweep and
+**generalized by design** to all destructive sweeps — the mined system applied
+it to one of three destructive sweeps, and the uncovered two are exactly where
+its review found risk. INV-RSW-007's surfaced-skip clause is design-derived
+from the mined gap (unavailable store indistinguishable from clean pass — the
+same "no-op wearing a green checkmark" failure the gate-validation protocol
+names). Known v1 boundaries, stated not hidden: no leader election (the CAS
+guards make concurrent runs safe but wasteful) and no persisted run ledger
+(counts are emitted, not stored) — both are parameters, not invariants.
+
+## Parameters
+
+| Parameter | Required | Meaning |
+|--|--|--|
+| `sweeps` | yes | The ordered sweep set: name, selector, repair, direction (local→external / external→local / local-only). |
+| `interval` | yes | Ticker period (the mined loop ran every 60s with a 2-minute per-run budget). |
+| `state_machine` | yes | The transition-legality authority repairs are checked against. |
+| `idempotency_namespace` | yes | Prefix for deterministic outbound repair keys. |
+| `run_budget` | no | Per-run context timeout. |
+| `run_ledger` | no | Where per-run counts persist (default: emitted only). |
+
+## Success metrics
+
+`repairs_per_run` trending ↓ (divergence shrinking), `skipped_sweeps` = 0,
+`illegal_transition_skips` = 0 (each one is a model/code drift finding),
+`stale_inflight_age_p95` ↓, `double_repair_count` = 0 (CAS efficacy).
+
+## Trust
+
+The sweep set, selectors, thresholds, and repair actions are destructive-capable
+automation — a protected path. A worker adding a sweep or widening a selector is
+parked for human review, exactly as with any goalpost.

--- a/patterns/registry.json
+++ b/patterns/registry.json
@@ -161,21 +161,76 @@
       "feeds": "deployment-release, improvement-loop",
       "spec": "patterns/build-test-floor/pattern.md",
       "manifest": "patterns/build-test-floor/manifest.json"
+    },
+    {
+      "id": "reconciliation-sweep",
+      "title": "Bidirectional Reconciliation Sweep",
+      "category": "process-loop",
+      "status": "specified",
+      "trust_class": "destructive-capable-automation-protected-path",
+      "summary": "Periodic job repairing local<->external divergence in both directions plus a stale-in-flight sweep. Mined discipline: status-guarded CAS repair, state-machine legality before every write, fail-closed on unknown age, re-confirm against live external truth before destroying, deterministic idempotency keys, paired flag set/clear sweeps, per-run counts with surfaced skips. Promoted from candidate; INV-RSW-001..007.",
+      "invariants": "INV-RSW-001..007",
+      "depends_on": "fetch-on-webhook-reconcile",
+      "feeds": "improvement-loop",
+      "spec": "patterns/reconciliation-sweep/pattern.md",
+      "manifest": "patterns/reconciliation-sweep/manifest.json"
+    },
+    {
+      "id": "transactional-email-and-dunning",
+      "title": "Transactional Email & Dunning Lifecycle",
+      "category": "process-loop",
+      "status": "specified",
+      "trust_class": "outbound-end-user-messaging-protected-path",
+      "summary": "Provider-neutral lifecycle messaging: transport-shaped send seam, atomic send-once keys (unique index/CAS, never read-then-write), outbox with provider correlation, re-assert-state-before-send, declared blocking/best-effort criticality. Dunning half (bounded ladder -> explicit grant-preserving degrade) is design-derived and flagged ASPIRATIONAL until a product builds it. Promoted from candidate; INV-TED-001..007.",
+      "invariants": "INV-TED-001..007",
+      "depends_on": "provider-neutral-adapter, feature-entitlements",
+      "feeds": "engagement-instrumentation, improvement-loop",
+      "spec": "patterns/transactional-email-and-dunning/pattern.md",
+      "manifest": "patterns/transactional-email-and-dunning/manifest.json"
+    },
+    {
+      "id": "feature-entitlements",
+      "title": "Feature Entitlements Read-Model",
+      "category": "saas-infra",
+      "status": "specified",
+      "trust_class": "billing-adjacent-authorization-protected-path",
+      "summary": "One resolver answering 'what can this account do', consumed identically by backend gates and frontend: per-key tier<-override<-grandfather layering (reuses entitlement-overlay's mined discipline), fail-closed on unknown principal, explicit dated grandfathering, deployment-capability/entitlement split, tier ceiling enforced at write with audit. Promoted from candidate; INV-FE-001..006.",
+      "invariants": "INV-FE-001..006",
+      "depends_on": "entitlement-overlay",
+      "feeds": "tiered-subscription, frictionless-onboarding, self-serve-billing-portal",
+      "spec": "patterns/feature-entitlements/pattern.md",
+      "manifest": "patterns/feature-entitlements/manifest.json"
+    },
+    {
+      "id": "self-serve-billing-portal",
+      "title": "Self-Serve Billing Portal",
+      "category": "saas-infra",
+      "status": "specified",
+      "trust_class": "money-moving-surface-protected-path",
+      "summary": "Provider-hosted portal session minted server-side (customer binding from the server's own mirror, caller-scoped, fail-closed) + a webhook-authoritative local plan/seat mirror with a single sanctioned writer, fetch-on-webhook intake (verified, event-id-deduped, persist-after-mutate), and subscription state that actually degrades capability via feature-entitlements. Promoted from candidate; INV-SBP-001..006.",
+      "invariants": "INV-SBP-001..006",
+      "depends_on": "fetch-on-webhook-reconcile, feature-entitlements",
+      "feeds": "feature-entitlements",
+      "spec": "patterns/self-serve-billing-portal/pattern.md",
+      "manifest": "patterns/self-serve-billing-portal/manifest.json"
     }
   ],
   "stacks": {
     "$comment": "Concrete stack profiles bind these vendor-neutral patterns to a real infrastructure stack + runnable stand-up skills + a cost model. This is the layer that turns the catalog into a micro/mini-SaaS factory. Index: patterns/stacks/registry.json. See docs/patterns-registry.md#stack-profiles.",
     "index": "patterns/stacks/registry.json",
     "profiles": [
-      {"id": "gcp-serverless-saas", "summary": "Firebase Hosting + Cloud Run + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless WIF, as a T0->T1->T2 cost ladder ($0 PoC -> paid prod).", "provenance": ["plwp.net", "booking-forms", "dogeared-coach"]}
+      {
+        "id": "gcp-serverless-saas",
+        "summary": "Firebase Hosting + Cloud Run + Firestore/Atlas + Firebase Auth + Stripe + Resend + Secret Manager + keyless WIF, as a T0->T1->T2 cost ladder ($0 PoC -> paid prod).",
+        "provenance": [
+          "plwp.net",
+          "booking-forms",
+          "dogeared-coach"
+        ]
+      }
     ]
   },
-  "candidates": [
-    {"id": "reconciliation-sweep", "title": "Bidirectional Reconciliation Sweep", "category": "process-loop", "status": "candidate", "summary": "Periodic job repairing divergence between local records and an external system in both directions plus a stale-in-flight sweep. Fail-closed on unknown age, re-confirm before destructive action, idempotent guarded updates, per-run counts report. Its run reports and audit stream are operational-health signal.", "reusability": "high"},
-    {"id": "transactional-email-and-dunning", "title": "Transactional Email & Dunning Lifecycle", "category": "process-loop", "status": "candidate", "summary": "Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge (fires if a signed-up user hasn't hit the activation event), re-engagement, and a failed-payment dunning sequence with bounded retries before degrade. Send-once keys prevent duplicate sends across retries. Recovery outcomes are conversion/retention signal.", "reusability": "high"},
-    {"id": "feature-entitlements", "title": "Feature Entitlements Read-Model", "category": "saas-infra", "status": "candidate", "summary": "A single entitlement resolver deriving capability flags from tier + per-account overrides + grandfathering, consumed identically by backend gates and the frontend (one source of 'what can this account do'). Distinct from the tier matrix: it layers overrides and is the read model onboarding + UI both query.", "reusability": "medium-high"},
-    {"id": "self-serve-billing-portal", "title": "Self-Serve Billing Portal", "category": "saas-infra", "status": "candidate", "summary": "Let users manage plan, payment method, and seats without support -- provider-hosted portal session minted server-side + a local mirror of plan/seat state kept authoritative via billing webhooks. Removes the #1 support-ticket class for tiered SaaS.", "reusability": "medium"}
-  ],
+  "candidates": [],
   "meta_disciplines": {
     "$comment": "Recurring cross-pattern engineering rules worth stating once, not registry entries themselves.",
     "rules": [

--- a/patterns/self-serve-billing-portal/manifest.json
+++ b/patterns/self-serve-billing-portal/manifest.json
@@ -1,0 +1,142 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/self-serve-billing-portal/pattern.md. INV-SBP-001/005 mined from a shipped production billing integration (private-repo paths held out of the public registry per the provenance policy); INV-SBP-004 reuses the in-repo fetch-on-webhook-reconcile pattern; INV-SBP-002/003/006 are design-derived, each inverting an observed production failure (unscoped minting, two-writer mirror field, status gating nothing).",
+  "id": "self-serve-billing-portal",
+  "version": 1,
+  "title": "Self-Serve Billing Portal",
+  "category": "saas-infra",
+  "trust_class": "money-moving-surface-protected-path",
+  "applies_when": [
+    "plan/payment-method/seat management is a real support-ticket class to remove",
+    "the payment provider offers a hosted portal session API plus subscription-lifecycle webhooks",
+    "subscription state must gate capability through the entitlement read-model, not just render a badge"
+  ],
+  "components": [
+    "server-minted-session: portal/checkout session minted server-side; customer binding read from the server's own mirror, never client-supplied; return URL server-controlled; missing provider client fails closed",
+    "caller-scoped-minting: a self-serve caller mints only for the account they administer, asserted server-side from the authenticated principal; staff minting is separately authorized and audited",
+    "webhook-authoritative-mirror: the local plan/seat mirror has one sanctioned write path driven by provider webhooks; synchronous syncs route through the same writer (declare controls_field + sanctioned_writers for check_single_writer)",
+    "fetch-on-webhook: handlers re-fetch the authoritative object from the provider rather than trusting the event payload",
+    "verified-idempotent-intake: signature verification fail-closed; event-id dedupe persisted AFTER the mutation so failed mutations retry instead of stranding; handler errors return non-2xx so the provider retries",
+    "declared-degrade: subscription states map to a declared capability degrade consumed via feature-entitlements"
+  ],
+  "invariants": {
+    "$comment": "001/005 mined (realized_as describes the mechanism, paths withheld); 004 cites the in-repo fetch-on-webhook-reconcile pattern; 002/003/006 design-derived (grounding field marks them) \u2014 they ground fully when a product first builds the self-serve surface.",
+    "cluster": [
+      {
+        "id": "INV-SBP-001",
+        "statement": "Server-minted session: the provider-hosted portal/checkout session is minted server-side \u2014 the customer binding is read from the server's own mirror and never accepted from the client, the return URL is server-controlled, and an unconfigured provider client refuses to mint (fail-closed), returning only the session URL to the caller.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "portal-session endpoint: customer id read from the tenant mirror (400 when absent), hardcoded server-side return URL, 503 when the provider client is nil"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-SBP-002",
+        "statement": "Caller-scoped minting: a self-serve caller may mint a portal session only for the account they administer, with the account binding asserted server-side from the authenticated principal \u2014 never from a request parameter; staff minting for arbitrary accounts is a separately-authorized, audited path.",
+        "grounding": "design-derived"
+      },
+      {
+        "id": "INV-SBP-003",
+        "statement": "Webhook-authoritative mirror with a single writer: the local plan/seat mirror is written through exactly one sanctioned write path driven by provider webhooks; synchronous admin syncs route through that same writer, so no last-write-wins race between a sync and a webhook can clobber newer state. Declared as controls_field + sanctioned_writers so check_single_writer enforces it mechanically.",
+        "grounding": "design-derived"
+      },
+      {
+        "id": "INV-SBP-004",
+        "statement": "Fetch on webhook: on receiving a billing webhook, the handler re-fetches the authoritative object from the provider and derives all mirror writes from the fetched object, never from the event payload.",
+        "realized_as": {
+          "app": "chief-wiggum registry",
+          "code": "patterns/fetch-on-webhook-reconcile/manifest.json (the payload-is-a-doorbell discipline)"
+        }
+      },
+      {
+        "id": "INV-SBP-005",
+        "statement": "Verified, idempotent, retryable intake: webhook signatures are verified fail-closed (a missing secret refuses intake, never bypasses verification); events dedupe on provider event id via a unique index; the dedupe record is persisted AFTER the local mutation so a failed mutation is retried by the provider rather than stranded behind an 'applied' record; and a handler error returns non-2xx so the provider's retry machinery engages.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "payments-side webhook intake: unique event-id index, persist-after-mutate ordering with the stranded-retry rationale documented inline, 5xx on the retry-critical event type"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-SBP-006",
+        "statement": "Declared degrade: every mirrored subscription state (past_due, canceled, trialing) maps to a declared capability consequence consumed through the entitlement read-model; a mirrored status that gates nothing is a defect, not a feature.",
+        "grounding": "design-derived"
+      }
+    ]
+  },
+  "parameters": {
+    "provider": {
+      "type": "string",
+      "required": true,
+      "description": "Billing provider offering the hosted portal session API and lifecycle webhooks."
+    },
+    "mirror_fields": {
+      "type": "object",
+      "required": true,
+      "description": "Mirrored plan/seat fields and their store \u2014 the controls_field set for single-writer enforcement (INV-SBP-003)."
+    },
+    "webhook_writer": {
+      "type": "string",
+      "required": true,
+      "description": "The single sanctioned writer of the mirror (INV-SBP-003)."
+    },
+    "mint_scope": {
+      "type": "string",
+      "required": true,
+      "description": "How the authenticated principal maps to the one account they may mint for (INV-SBP-002)."
+    },
+    "return_url": {
+      "type": "string",
+      "required": true,
+      "description": "Server-controlled portal return URL (INV-SBP-001)."
+    },
+    "degrade_map": {
+      "type": "object",
+      "required": true,
+      "description": "Subscription state to entitlement degrade, consumed by feature-entitlements (INV-SBP-006)."
+    },
+    "staff_mint_audit": {
+      "type": "string",
+      "required": false,
+      "description": "Audit sink for the separately-authorized staff minting path (INV-SBP-002)."
+    }
+  },
+  "success_metrics": {
+    "$comment": "The pattern exists to remove the #1 support-ticket class for tiered SaaS while keeping the mirror truthful.",
+    "metrics": [
+      {
+        "id": "billing_support_tickets",
+        "goal": "down",
+        "desc": "plan/payment/seat changes self-served"
+      },
+      {
+        "id": "mirror_provider_divergence",
+        "goal": "zero",
+        "desc": "webhook-authoritative + fetch-on-webhook discipline (INV-SBP-003/004)"
+      },
+      {
+        "id": "unsanctioned_mirror_writers",
+        "goal": "zero",
+        "desc": "check_single_writer over the declared controls_field (INV-SBP-003)"
+      },
+      {
+        "id": "webhook_replay_side_effects",
+        "goal": "zero",
+        "desc": "idempotent intake (INV-SBP-005)"
+      },
+      {
+        "id": "canceled_accounts_with_full_capability",
+        "goal": "zero",
+        "desc": "declared degrade actually gates (INV-SBP-006)"
+      }
+    ]
+  },
+  "protected_paths": [
+    "the session-minting endpoint + mint scope (INV-SBP-001/002)",
+    "the mirror's sanctioned write path (INV-SBP-003)",
+    "webhook intake: verification, dedupe, ordering (INV-SBP-005)",
+    "the degrade map (INV-SBP-006 \u2014 billing-adjacent authorization)"
+  ],
+  "depends_on": "fetch-on-webhook-reconcile, feature-entitlements",
+  "feeds": "feature-entitlements"
+}

--- a/patterns/self-serve-billing-portal/pattern.md
+++ b/patterns/self-serve-billing-portal/pattern.md
@@ -1,0 +1,106 @@
+# Pattern: Self-Serve Billing Portal
+
+- **Category:** saas-infra
+- **Trust class:** money-moving surface — minting, the mirror's write path, and webhook intake are protected paths
+- **Status:** specified (spec complete; `scaffold/` not yet built)
+- **Depends on:** [`fetch-on-webhook-reconcile`](../fetch-on-webhook-reconcile) — billing webhooks re-fetch the authoritative object, never trust the payload; [`feature-entitlements`](../feature-entitlements) — the degrade map (INV-SBP-006) is enforceable only through the entitlement read-model
+- **Feeds:** [`feature-entitlements`](../feature-entitlements) — subscription state is an input the entitlement resolver degrades from
+
+## What it is
+
+Users manage plan, payment method, and seats without a support ticket: the
+app mints a **provider-hosted portal session server-side** and keeps a **local
+mirror of plan/seat state that only billing webhooks write**. The provider's
+UI does the PCI-heavy lifting; the app's job is the two disciplines around it —
+*who may mint a session for whom*, and *how the mirror stays truthful*.
+
+Why a pattern and not "just call the portal API": audits of a shipped
+production billing integration found the exact failure classes this cluster
+prevents. The same subscription-status field had **two independent writers**
+(a synchronous admin path and the webhook, no ordering guard — last write
+wins, so a slow webhook clobbers a newer sync); the billing webhook **trusted
+the event payload** while the payments webhook beside it correctly re-fetched;
+webhook handler errors returned 200 (so the provider never retried); and the
+mirrored status **gated nothing** — a canceled tenant retained full
+functionality. Each is an invariant below.
+
+## When to apply
+
+- Plan/payment-method/seat management is a real support-ticket class you want
+  off the support queue.
+- A payment provider offers a hosted portal (e.g. a billing portal session
+  API) and webhooks for subscription lifecycle.
+- Subscription state must actually gate capability (through the entitlement
+  read-model), not just render a badge.
+
+## Mechanism — generic components
+
+- **Server-minted session.** The portal/checkout session is minted server-side:
+  the customer binding comes from the server's own mirror (never a
+  client-supplied customer id), the return URL is server-controlled, and a
+  missing provider client fails closed. *(INV-SBP-001 — mined.)*
+- **Caller-scoped minting.** A self-serve caller may mint only for the account
+  they administer — the account-scoping is asserted server-side from the
+  authenticated principal, not from a request parameter. Staff minting for
+  arbitrary accounts is a separately-authorized, audited path. *(INV-SBP-002 —
+  design-derived; the mined implementation was staff-only and unscoped.)*
+- **Webhook-authoritative mirror, single writer.** The local plan/seat mirror
+  is written through **one** write path, driven by provider webhooks; any
+  synchronous admin sync routes through that same writer. No second `$set`
+  site, no last-write-wins races between sync and webhook. *(INV-SBP-003 —
+  design-derived; declare `controls_field` + `sanctioned_writers` so
+  `check_single_writer` can enforce it mechanically.)*
+- **Fetch on webhook.** Handlers re-fetch the authoritative object from the
+  provider on receipt rather than trusting the event payload. *(INV-SBP-004 ←
+  the in-repo `fetch-on-webhook-reconcile` pattern.)*
+- **Verified, idempotent, retryable intake.** Signature verification fails
+  closed (missing secret refuses intake, never bypasses); events dedupe on
+  event id; the dedupe record persists **after** the mutation so a failed
+  mutation is retried rather than stranded behind an "applied" record; and a
+  handler error returns non-2xx so the provider retries. *(INV-SBP-005 —
+  mined from the payments-side intake of the same system.)*
+- **Declared degrade.** Subscription states (past_due, canceled) map to a
+  declared capability degrade consumed via the entitlement read-model — a
+  mirror nobody reads is decoration. *(INV-SBP-006 — design-derived.)*
+
+## Grounding
+
+INV-SBP-001 and INV-SBP-005 are **mined** from a shipped production billing
+integration (per the registry's provenance policy, private-repo paths are held
+out of the public registry; the manifest describes the realized mechanisms —
+server-read customer binding + hardcoded return URL, and the payments-side
+event-id dedupe with persist-after-mutate ordering and its documented
+stranded-retry rationale). INV-SBP-004 cites the in-repo
+[`fetch-on-webhook-reconcile`](../fetch-on-webhook-reconcile) pattern — the
+mined system practiced it on the payments side and **omitted it on the billing
+side**, which is exactly the gap the dependency closes. INV-SBP-002/003/006
+are **design-derived** and marked as such: each inverts an observed failure
+(unscoped staff-only minting; a two-writer subscription-status field; a
+status that gated nothing). They ground fully when a product first builds the
+self-serve surface.
+
+## Parameters
+
+| Parameter | Required | Meaning |
+|--|--|--|
+| `provider` | yes | The billing provider (portal-session API + webhooks). |
+| `mirror_fields` | yes | The mirrored plan/seat fields and their store (the `controls_field` set for single-writer enforcement). |
+| `webhook_writer` | yes | The single sanctioned writer of the mirror. |
+| `mint_scope` | yes | How the authenticated principal maps to the one account they may mint for. |
+| `return_url` | yes | Server-controlled portal return URL. |
+| `degrade_map` | yes | Subscription state → entitlement degrade (consumed by feature-entitlements). |
+| `staff_mint_audit` | no | Audit sink for the separately-authorized staff minting path. |
+
+## Success metrics
+
+`billing_support_tickets` ↓ (the pattern's reason to exist),
+`mirror_provider_divergence` = 0 (webhook-authoritative discipline),
+`unsanctioned_mirror_writers` = 0 (single-writer check),
+`webhook_replay_side_effects` = 0 (idempotent intake),
+`canceled_accounts_with_full_capability` = 0 (declared degrade).
+
+## Trust
+
+Session minting, the mirror's write path, webhook intake, and the degrade map
+are money-moving surface — protected paths. A worker adding a mirror writer or
+widening mint scope is parked for human review.

--- a/patterns/transactional-email-and-dunning/manifest.json
+++ b/patterns/transactional-email-and-dunning/manifest.json
@@ -1,0 +1,146 @@
+{
+  "$comment": "Machine-readable surface for /apply-pattern. Human spec: patterns/transactional-email-and-dunning/pattern.md. INV-TED-003/004/005 mined from a shipped production SaaS's email subsystem (private-repo paths held out of the public registry per the provenance policy); INV-TED-001 reuses the in-repo provider-neutral-adapter; INV-TED-002 is the atomic strengthening of a mined mechanism with a real read-then-write race; INV-TED-006/007 are design-derived and flagged ASPIRATIONAL per issue #139 \u2014 no mined app has built dunning.",
+  "id": "transactional-email-and-dunning",
+  "version": 1,
+  "title": "Transactional Email & Dunning Lifecycle",
+  "category": "process-loop",
+  "trust_class": "outbound-end-user-messaging-protected-path",
+  "applies_when": [
+    "the product sends state-triggered lifecycle messages (signup, inactivity, payment failure), not only request/response receipts",
+    "sends must be exactly-once per (entity, message-type) under retries and replicas",
+    "failed payments need a bounded recovery sequence ending in an explicit, reversible degrade"
+  ],
+  "components": [
+    "transport-shaped-seam: all sends go through one adapter port (Send(message)); domain helpers compose messages and never hold provider SDK types",
+    "atomic-send-once: a deterministic (entity, message_type) key claimed via unique index or CAS \u2014 never read-then-write \u2014 so replicas and retries produce one send",
+    "outbox: every attempt writes a row with status, error, and provider message id; manual resend only from failed",
+    "reassert-state-before-send: async notify paths re-read the entity and confirm the triggering state still holds before sending",
+    "declared-criticality: each message type is blocking (failure fails the operation; missing recipient fails before send) or best-effort (failure logged, never blocks)",
+    "bounded-dunning-ladder: failed payment starts a bounded, spaced retry-and-message ladder; exhaustion ends in an explicit grant-preserving degrade via the entitlement read-model (ASPIRATIONAL)",
+    "suppression: bounce/complaint/unsubscribe list checked before every send; provider delivery webhooks feed it (ASPIRATIONAL)"
+  ],
+  "invariants": {
+    "$comment": "003/004/005 mined (realized_as describes mechanisms, paths withheld); 001 cites the in-repo provider-neutral-adapter; 002 atomically strengthens a mined mechanism whose race is real; 006/007 design-derived + aspirational \u2014 they ground when a product first builds dunning/suppression.",
+    "cluster": [
+      {
+        "id": "INV-TED-001",
+        "statement": "Transport-shaped provider seam: every send goes through one adapter port shaped like Send(message); domain code composes messages and never holds provider SDK types, so swapping providers touches the adapter alone. A domain-shaped many-method interface that leaks provider types into every signature does not satisfy this.",
+        "realized_as": {
+          "app": "chief-wiggum registry",
+          "code": "patterns/provider-neutral-adapter/manifest.json (the port/adapter discipline this seam instantiates)"
+        }
+      },
+      {
+        "id": "INV-TED-002",
+        "statement": "Atomic send-once: every lifecycle send derives a deterministic send key (entity, message_type) and claims it atomically (unique index or CAS) before sending \u2014 never read-then-write \u2014 so N replicas running the same scheduler and user-driven retries produce exactly one send per key.",
+        "grounding": "design-derived"
+      },
+      {
+        "id": "INV-TED-003",
+        "statement": "Outbox with provider correlation: every send attempt writes an outbox row carrying status (sent/failed), the error on failure, and the provider's message id on success; recording is best-effort and never blocks delivery; manual resend is permitted only from the failed state.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "email outbox: both branches of the single send path record a row (failed + error, sent + provider msg id); resend endpoint refuses non-failed rows"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-TED-004",
+        "statement": "Re-assert state before send: an asynchronous notify path re-reads the triggering entity and confirms the triggering state still holds immediately before sending; if the entity has moved on, the send is dropped silently as correct behavior, not an error.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "post-sweep notifier: detached goroutine with its own timeout re-queries the record asserting the swept status before composing the email"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-TED-005",
+        "statement": "Criticality-declared failure: each message type declares blocking (send failure fails the surrounding operation with a client-visible error; missing recipient or provider config fails before any send) or best-effort (failure is logged and never blocks the operation); the declaration lives with the message type, not ad hoc at call sites.",
+        "realized_as": {
+          "app": "a shipped production SaaS (private; path provenance held out of the public registry)",
+          "code": "booking intake: business notification failure aborts the request (5xx), customer courtesy copy failure is logged and the request succeeds; empty business recipient fails before send"
+        },
+        "grounding": "mined-anonymized (mechanism-described; private-repo path provenance withheld per the registry provenance policy)"
+      },
+      {
+        "id": "INV-TED-006",
+        "statement": "Bounded dunning ladder with explicit grant-preserving degrade (ASPIRATIONAL): a failed payment starts a bounded, spaced sequence of retry-and-message steps; exhaustion ends in an explicit degrade that narrows future capability via the entitlement read-model and never claws back delivered value; the outcome is never silence (no stamped status that messages no one) and never infinite grace; ladder timing, copy, and degrade economics are admin-gated.",
+        "grounding": "design-derived"
+      },
+      {
+        "id": "INV-TED-007",
+        "statement": "Suppression respected (ASPIRATIONAL): a bounce/complaint/unsubscribe suppression store is consulted before every send, and provider delivery webhooks (bounce, complaint) feed it; a send to a suppressed address is a defect, not a delivery attempt.",
+        "grounding": "design-derived"
+      }
+    ]
+  },
+  "parameters": {
+    "send_adapter": {
+      "type": "string",
+      "required": true,
+      "description": "The transport-shaped port \u2014 a provider-neutral-adapter instance (INV-TED-001)."
+    },
+    "message_types": {
+      "type": "object",
+      "required": true,
+      "description": "Each message type with trigger, template, and declared criticality: blocking or best-effort (INV-TED-005)."
+    },
+    "send_once_store": {
+      "type": "string",
+      "required": true,
+      "description": "Where (entity, message_type) keys are atomically claimed (INV-TED-002)."
+    },
+    "outbox": {
+      "type": "string",
+      "required": true,
+      "description": "The attempt ledger: status, error, provider message id (INV-TED-003)."
+    },
+    "dunning_ladder": {
+      "type": "object",
+      "required": false,
+      "description": "Steps (delay, message, retry) and the exhaustion degrade action \u2014 the aspirational half (INV-TED-006)."
+    },
+    "suppression_store": {
+      "type": "string",
+      "required": false,
+      "description": "Bounce/complaint/unsubscribe list consulted before send (INV-TED-007)."
+    }
+  },
+  "success_metrics": {
+    "$comment": "Recovery outcomes are conversion/retention signal; ladder economics are protected-path so the improvement loop proposes, a human approves.",
+    "metrics": [
+      {
+        "id": "duplicate_sends",
+        "goal": "zero",
+        "desc": "atomic send-once efficacy (INV-TED-002)"
+      },
+      {
+        "id": "blocking_send_failures_surfaced",
+        "goal": "up",
+        "desc": "share of blocking failures that reached a human/operator (INV-TED-005)"
+      },
+      {
+        "id": "dunning_recovery_rate",
+        "goal": "up",
+        "desc": "failed payments recovered by the ladder (INV-TED-006)"
+      },
+      {
+        "id": "silent_churn_after_payment_failure",
+        "goal": "zero",
+        "desc": "no stamped status that messages no one (INV-TED-006)"
+      },
+      {
+        "id": "suppression_violations",
+        "goal": "zero",
+        "desc": "sends to suppressed addresses (INV-TED-007)"
+      }
+    ]
+  },
+  "protected_paths": [
+    "message templates + triggers (outbound end-user messaging \u2014 trust class)",
+    "the send-once store + key derivation (INV-TED-002)",
+    "the dunning ladder's timing, copy, and degrade economics (INV-TED-006)"
+  ],
+  "depends_on": "provider-neutral-adapter, feature-entitlements",
+  "feeds": "engagement-instrumentation, improvement-loop"
+}

--- a/patterns/transactional-email-and-dunning/pattern.md
+++ b/patterns/transactional-email-and-dunning/pattern.md
@@ -1,0 +1,110 @@
+# Pattern: Transactional Email & Dunning Lifecycle
+
+- **Category:** process-loop
+- **Trust class:** outbound messaging to end users — templates, triggers, and the dunning ladder's economics are protected paths
+- **Status:** specified (spec complete; `scaffold/` not yet built; dunning half aspirational — see Grounding)
+- **Depends on:** [`provider-neutral-adapter`](../provider-neutral-adapter) — the send seam is an adapter port, not a vendor SDK call site; [`feature-entitlements`](../feature-entitlements) — the dunning ladder's grant-preserving degrade (INV-TED-006) executes through the entitlement read-model
+- **Feeds:** [`engagement-instrumentation`](../engagement-instrumentation) / [`improvement-loop`](../improvement-loop) — send outcomes and recovery rates are conversion/retention signal
+
+## What it is
+
+Idempotent, provider-neutral lifecycle messaging: welcome, activation nudge,
+re-engagement, and a failed-payment **dunning** sequence with bounded retries
+before an explicit degrade. The value is not "send email" — it is the
+discipline that makes lifecycle messaging safe to automate: **send-once keys
+enforced atomically** (retries, replicas, and double-clicks produce one send),
+an **outbox** correlating every attempt with provider evidence, and
+**criticality-declared failure handling** (a blocking message aborts the
+operation; a courtesy message never does).
+
+Why a pattern and not "call the email API": audits of shipped production
+SaaS found the inverse of each invariant below: duplicate sends on retry
+because the only dedupe key lived in a *different* service; send-once
+implemented as read-then-write (two replicas both select, both send); a
+13-method domain-shaped email interface that locks in the vendor; a
+lifecycle-stage function that computed `at_risk`/`churned` and then drove
+nothing; and a failed-payment webhook that stamped `past_due` and emailed
+no one, ever.
+
+## When to apply
+
+- The product sends lifecycle messages triggered by state (signup, inactivity,
+  payment failure), not only direct request/response receipts.
+- Sends must be exactly-once per (entity, message-type) under retries and
+  replicas.
+- Failed payments need a bounded recovery sequence that ends in an explicit,
+  reversible degrade — not silent cancellation, not infinite grace.
+
+## Mechanism — generic components
+
+- **Transport-shaped provider seam.** All sends go through one adapter port
+  (`Send(message)`) so the provider swaps without touching domain call sites;
+  domain helpers compose messages, they don't hold SDK types. *(INV-TED-001 ←
+  `provider-neutral-adapter`; the mined system's domain-shaped 13-method
+  interface is the anti-pattern.)*
+- **Atomic send-once.** Every lifecycle send derives a deterministic send key
+  `(entity, message_type)` enforced by a unique index or CAS claim — never
+  read-then-write — so N replicas and user retries produce exactly one send.
+  *(INV-TED-002 — the mined stamped-timestamp mechanism plus its documented
+  multi-replica race is the rationale for requiring the atomic form.)*
+- **Outbox with provider correlation.** Every attempt writes an outbox row
+  (status, error, provider message id); manual resend is permitted only from
+  `failed`. *(INV-TED-003 — mined.)*
+- **Re-assert state before send.** Async notify paths re-read the entity and
+  confirm the triggering state still holds before sending — the world may have
+  moved on since the trigger fired. *(INV-TED-004 — mined.)*
+- **Criticality-declared failure.** Each message type declares `blocking`
+  (send failure fails the surrounding operation — e.g. the business copy of a
+  booking) or `best-effort` (failure is logged, never blocks — e.g. the
+  customer courtesy copy); missing recipient/config on a blocking message
+  fails **before** any send. *(INV-TED-005 — mined.)*
+- **Bounded dunning ladder → explicit degrade.** Failed payment starts a
+  bounded, spaced retry-and-message ladder; exhaustion ends in an explicit,
+  grant-preserving degrade (capability narrows via the entitlement read-model;
+  delivered value is never clawed back) — never silence, never infinite
+  grace. Ladder timing/copy are admin-gated economics. *(INV-TED-006 —
+  design-derived, aspirational.)*
+- **Suppression respected.** Bounce/complaint/unsubscribe suppression is
+  checked before every send; provider delivery webhooks feed the suppression
+  store. *(INV-TED-007 — design-derived.)*
+
+## Grounding
+
+INV-TED-003/004/005 are **mined** from a shipped production SaaS's email
+subsystem (per the registry's provenance policy, private-repo paths are held
+out of the public registry; the manifest describes the realized mechanisms —
+the best-effort outbox with provider message ids and failed-only resend, the
+re-read-and-confirm-state notify goroutine, and the asymmetric
+business-blocking/customer-best-effort booking mail). INV-TED-001 cites the
+in-repo [`provider-neutral-adapter`](../provider-neutral-adapter) pattern;
+INV-TED-002 is the **atomic strengthening** of a mined mechanism whose
+read-then-write race is real in the source. INV-TED-006 (the dunning half) and
+INV-TED-007 are **design-derived and flagged aspirational** exactly as issue
+#139 requires: no mined app has built the ladder (the observed failed-payment
+path stamps a status and messages no one), so these capture the standard
+recovery discipline and ground fully when a product first builds dunning.
+
+## Parameters
+
+| Parameter | Required | Meaning |
+|--|--|--|
+| `send_adapter` | yes | The transport-shaped port (provider-neutral-adapter instance). |
+| `message_types` | yes | Each with trigger, template, and declared criticality (`blocking` / `best-effort`). |
+| `send_once_store` | yes | Where `(entity, message_type)` keys are atomically claimed. |
+| `outbox` | yes | The attempt ledger (status, error, provider message id). |
+| `dunning_ladder` | no | Steps: delay, message, retry; exhaustion → degrade action (aspirational half). |
+| `suppression_store` | no | Bounce/complaint/unsubscribe list consulted before send. |
+
+## Success metrics
+
+`duplicate_sends` = 0 (atomic send-once), `blocking_send_failures_surfaced` =
+100%, `dunning_recovery_rate` ↑, `silent_churn_after_payment_failure` = 0,
+`suppression_violations` = 0. Recovery outcomes are retention signal for the
+improvement loop; ladder economics stay admin-gated.
+
+## Trust
+
+Templates, triggers, the send-once store, and the dunning ladder's
+timing/copy/degrade are outbound messaging to end users — protected paths. A
+worker adding a message type or touching ladder economics is parked for human
+review.

--- a/tests/test_apply_pattern.py
+++ b/tests/test_apply_pattern.py
@@ -41,9 +41,16 @@ def test_unknown_pattern_raises():
         apply_pattern.build_plan("nope", {}, now=FIXED_NOW)
 
 
-def test_candidate_pattern_raises():
+def test_candidate_pattern_raises(tmp_path):
+    # No real candidates remain (#139 promoted the last four), so pin the
+    # refusal behavior against a synthetic registry.
+    reg = tmp_path / "registry.json"
+    reg.write_text(json.dumps({
+        "patterns": [],
+        "candidates": [{"id": "someday", "title": "Someday", "category": "saas-infra",
+                        "status": "candidate", "summary": "not yet specified"}]}))
     with pytest.raises(apply_pattern.ApplyError, match="candidate"):
-        apply_pattern.build_plan("reconciliation-sweep", {}, now=FIXED_NOW)  # still a candidate
+        apply_pattern.build_plan("someday", {}, registry_path=reg, now=FIXED_NOW)
 
 
 def test_unknown_param_raises():
@@ -155,8 +162,8 @@ def test_catalog_lists_specified_with_applies_when():
     assert REAL in items
     assert items[REAL]["status"] == "specified"
     assert items[REAL]["applies_when"]  # non-empty selection criteria from the manifest
-    # candidates are listed too, flagged
-    assert any(c["status"] == "candidate" for c in apply_pattern.catalog())
+    # every entry is specified now — the last candidates were promoted (#139)
+    assert all(c["status"] == "specified" for c in apply_pattern.catalog())
 
 
 def test_cli_catalog_needs_no_target(tmp_path):

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -1,6 +1,7 @@
 """Tests for scripts/check_patterns.py."""
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -193,3 +194,66 @@ def test_referral_invite_loop_is_specified_with_grounded_cluster():
     grounded = [e for e in cluster if isinstance(e.get("realized_as"), dict)
                 and "elevated-access-session" in e["realized_as"].get("code", "")]
     assert {e["id"] for e in grounded} == {"INV-RIL-001", "INV-RIL-002", "INV-RIL-003"}
+
+
+# --- #139 final promotions: the last four candidates --------------------------
+
+FINAL_PROMOTIONS = {
+    "reconciliation-sweep": ("INV-RSW", 7, "fetch-on-webhook-reconcile"),
+    "feature-entitlements": ("INV-FE", 6, "entitlement-overlay"),
+    "self-serve-billing-portal": (
+        "INV-SBP", 6, "fetch-on-webhook-reconcile, feature-entitlements"),
+    "transactional-email-and-dunning": (
+        "INV-TED", 7, "provider-neutral-adapter, feature-entitlements"),
+}
+
+
+def test_final_four_are_specified_and_candidates_is_empty():
+    reg = json.loads((SCRIPTS.parent / "patterns" / "registry.json").read_text())
+    assert reg.get("candidates") == [], "#139 done looks like: zero remaining candidates"
+    for pid, (prefix, n, dep) in FINAL_PROMOTIONS.items():
+        entry = next((e for e in reg["patterns"] if e["id"] == pid), None)
+        assert entry is not None, f"{pid} must be a specified pattern"
+        assert entry["status"] == "specified"
+        assert entry.get("depends_on") == dep
+        # the index's invariants summary stays in sync with the manifest cluster
+        assert entry["invariants"] == f"{prefix}-001..00{n}", entry["invariants"]
+
+
+def test_final_four_clusters_are_complete_and_grounding_is_honest():
+    """Every invariant carries exactly one honest grounding class: in-repo
+    provenance, mined-anonymized provenance (mechanism-described, never a
+    path), or an explicit design-derived marker. The anonymization policy is
+    enforced with real checks: no file:line refs, no path separators, no
+    source-file extensions in private provenance."""
+    path_like = re.compile(r":\d+|\.(go|ts|tsx|js|py|rb|java)\b|/")
+    for pid, (prefix, n, _) in FINAL_PROMOTIONS.items():
+        manifest = json.loads(
+            (SCRIPTS.parent / "patterns" / pid / "manifest.json").read_text())
+        cluster = check_patterns.cluster_entries(manifest["invariants"])
+        ids = [e["id"] for e in cluster]
+        assert ids == [f"{prefix}-00{i}" for i in range(1, n + 1)], ids
+        for e in cluster:
+            grounding = e.get("grounding", "")
+            in_repo = (isinstance(e.get("realized_as"), dict)
+                       and "chief-wiggum" in e["realized_as"]["app"])
+            mined = grounding.startswith("mined-anonymized")
+            is_design = grounding == "design-derived"
+            assert in_repo or mined or is_design, (
+                f"{e['id']} has no honest grounding class")
+            if mined:
+                ra = e.get("realized_as")
+                assert isinstance(ra, dict), f"{e['id']} mined without realized_as mechanism"
+                code = ra.get("code", "")
+                assert not path_like.search(code), (
+                    f"{e['id']} leaks path-like provenance: {code}")
+
+
+def test_dunning_half_is_flagged_aspirational():
+    manifest = json.loads((SCRIPTS.parent / "patterns" /
+                           "transactional-email-and-dunning" / "manifest.json").read_text())
+    cluster = check_patterns.cluster_entries(manifest["invariants"])
+    dunning = next(e for e in cluster if e["id"] == "INV-TED-006")
+    assert dunning.get("grounding") == "design-derived"
+    assert "ASPIRATIONAL" in dunning["statement"], (
+        "issue #139 flags the dunning half aspirational — the invariant must say so")


### PR DESCRIPTION
## Summary

Promotes the last four candidate patterns to fully specified: reconciliation-sweep (INV-RSW-001..007, mined from a shipped production reconciler — status-guarded CAS repair, state-machine legality before every write, fail-closed on unknown age, re-confirm against live external truth before destroying, deterministic idempotency keys, paired flag sweeps, surfaced skips), feature-entitlements (INV-FE-001..006, design-derived — single resolver, per-key layering generalizing entitlement-overlay's mined raise-only shape to a ceiling-governed bidirectional form, fail-closed unknown principal, explicit grandfathering, deployment/entitlement split, tier ceiling at write), self-serve-billing-portal (INV-SBP-001..006 — mined server-minting + persist-after-mutate idempotent intake; caller scoping, single-writer mirror, declared degrade design-derived), and transactional-email-and-dunning (INV-TED-001..007 — mined outbox/state-reassert/criticality, atomic send-once strengthening, dunning half flagged ASPIRATIONAL per the issue). Provenance follows the anonymization policy: mined invariants carry an explicit mined-anonymized grounding class with mechanism-described (never path-cited) realized_as, enforced by a real regex in the tests. Registry candidates list is now EMPTY (17 specified patterns); check_patterns passes; docs updated. Review hardening applied: FE-002's entitlement-overlay citation corrected (the mined form is raise-only — the bidirectional form is honestly design-derived), depends_on now names feature-entitlements for the two patterns whose degrade invariants require it, registry invariant-range sync is test-pinned, and the anonymization test's dead disjunct was replaced with a working pattern.

Closes #139

## Architecture

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
graph TD
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff

    ISS["Issue #139: last four candidates"]:::entry
    RSW["reconciliation-sweep<br/>INV-RSW-001..007 (mined-anonymized)"]:::new
    FE["feature-entitlements<br/>INV-FE-001..006 (design-derived)"]:::new
    SBP["self-serve-billing-portal<br/>INV-SBP-001..006 (mixed)"]:::new
    TED["transactional-email-and-dunning<br/>INV-TED-001..007 (dunning ASPIRATIONAL)"]:::new
    FOWR["fetch-on-webhook-reconcile"]:::existing
    EO["entitlement-overlay (raise-only mined layering)"]:::existing
    PNA["provider-neutral-adapter"]:::existing
    REG["registry.json: 17 specified, 0 candidates"]:::modified
    TESTS["tests: promotion pins + anonymization regex<br/>+ registry-range sync + aspirational flag"]:::modified

    ISS --> RSW & FE & SBP & TED
    RSW --> FOWR
    FE -.shape.-> EO
    SBP --> FOWR
    SBP --> FE
    TED --> PNA
    TED --> FE
    RSW & FE & SBP & TED --> REG --> TESTS
```

## Changes

- 4 new pattern dirs: pattern.md + manifest.json each, with honest three-class grounding (in-repo / mined-anonymized / design-derived)
- registry.json: four candidates promoted; candidates list empty; depends_on graphs include the entitlement read-model where degrade invariants need it
- docs/patterns-registry.md: candidate tables retitled; monetization section reflects full specification
- tests: promotion pins, aspirational-flag pin, registry-range sync, real anonymization regex; candidate-refusal test now uses a synthetic registry (no real candidates remain)

## Test Evidence

**Verification: all green**
- ✓ `make test` — exit 0
- ✓ `make lint` — exit 0

## Review Checklist

- [ ] Tests pass locally
- [ ] No new warnings or lint errors
- [ ] Multi-AI review feedback addressed
- [ ] No secrets or credentials committed

## Code review

- **codex** (`REQUEST_CHANGES`, 2 findings, both addressed): (P1) mined invariants carried neither file:line nor a design-derived marker — now an explicit third grounding class, `mined-anonymized`, machine-readable on every mined invariant, with the anonymization policy (which postdates the issue's AC wording and governs it) enforced by a real test regex. (P2) `depends_on` omitted `feature-entitlements` for the two patterns whose degrade invariants require it — added to manifests, registry, specs, and the test pins.
- **Adversarial refute-soundness + grounding-honesty pass** (opus subagent, 7 findings, all addressed): FE-002's entitlement-overlay citation mis-claimed mined grounding for narrowing semantics the mined form (raise-only `max(base, overlay)`) cannot realize — reclassified design-derived with the relationship stated honestly; doc table still labeled promoted patterns "Candidate" — retitled; RSW-007 prose/manifest grounding mismatch — aligned; anonymization test had a dead disjunct — replaced with `:\d+ | source-file extensions | /`; registry invariant-range summaries were unvalidated — now test-pinned; an FE prose over-claim was trimmed; a verbatim private-repo Go identifier in RSW-002's provenance was genericized.
- claude-interactive delegate: timed out (known-degraded in this environment; required quorum satisfied per role semantics).

Note for a follow-up ticket: the four *pre-existing* mined manifests on main (entitlement-overlay, multi-tenant-isolation, etc.) still carry named private-repo file:line provenance from before the anonymization policy — this PR's new patterns are clean, but the retro-scrub is a separate decision.
