### PR TITLE
feat(consult): business-factory hygiene — pricing.md protection enforced, portable workflow, success_metrics lint (#234)

### DIFF
--- a/scripts/business_consultant.py
+++ b/scripts/business_consultant.py
@@ -16,6 +16,11 @@ into the target repo (5 sections: cost shape / unit economics per tier /
 break-even+margin / market-comparable floor [an explicit UNRESOLVED marker —
 the step-3 live-lookup seam is NOT built here] / pricing-model fit).
 
+Writing the default in-repo artifact also registers ``docs/pricing.md`` into
+the target's ``docs/quality/ratchet.json`` ``protected_paths`` — the same
+`apply_pattern.py` code path, idempotent — so the protection the skill prose
+claims is real, not asserted (chief-wiggum#234).
+
 Target resolution mirrors the other skills:
   - ``owner/repo``  -> resolved & cloned via scripts/repo.py
   - ``--repo PATH`` -> a direct local path
@@ -38,9 +43,25 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from apply_pattern import RATCHET_REL, _merge_ratchet, _meta_path  # noqa: E402
 from consultant import derive, inputs, render  # noqa: E402
 
 PRICING_REL = "docs/pricing.md"
+
+
+def register_protected(target: Path) -> list[str]:
+    """Register docs/pricing.md in the target's ratchet protected_paths.
+
+    Reuses apply_pattern.py's merge (never a second implementation): idempotent
+    on re-runs, and a missing ratchet.json gets the same DEFAULT_PROTECTED stub
+    apply_pattern writes. Returns the globs actually added ([] when already
+    registered)."""
+    content, added = _merge_ratchet(target, [PRICING_REL])
+    if added:
+        path = _meta_path(target, RATCHET_REL)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return added
 
 
 def _current_repo_root() -> str | None:
@@ -114,7 +135,7 @@ def _summarize_text(result: dict) -> str:
     return "\n".join(lines)
 
 
-def run(args: argparse.Namespace) -> tuple[dict, str]:
+def run(args: argparse.Namespace) -> tuple[dict, str, list[str]]:
     target = resolve_target(args.owner_repo, args.repo)
     result = derive.run(
         target_dir=target,
@@ -129,11 +150,16 @@ def run(args: argparse.Namespace) -> tuple[dict, str]:
     md = render.render_pricing_md(result)
 
     out_path = Path(args.out) if args.out else Path(target) / PRICING_REL
+    protected: list[str] = []
     if not args.dry_run:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(md)
+        # Protect the in-repo artifact (#234). An --out override writes
+        # elsewhere — the target then has no docs/pricing.md to protect.
+        if out_path == Path(target) / PRICING_REL:
+            protected = register_protected(Path(target))
 
-    return result, str(out_path)
+    return result, str(out_path), protected
 
 
 def main() -> int:
@@ -154,17 +180,20 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        result, out_path = run(args)
+        result, out_path, protected = run(args)
     except inputs.ConsultantInputError as exc:
         print(f"business-consultant: {exc}", file=sys.stderr)
         return 2
 
     if args.format == "json":
-        print(json.dumps({"result": result, "out": out_path, "dry_run": args.dry_run}, indent=2))
+        print(json.dumps({"result": result, "out": out_path, "dry_run": args.dry_run,
+                          "protected_registered": protected}, indent=2))
     else:
         print(_summarize_text(result))
         verb = "would write" if args.dry_run else "wrote"
         print(f"  {verb} {out_path}")
+        if protected:
+            print(f"  registered protected path in {RATCHET_REL}: {', '.join(protected)}")
 
     return 0
 

--- a/scripts/check_patterns.py
+++ b/scripts/check_patterns.py
@@ -17,6 +17,9 @@ This linter makes the model's rules mechanical rather than trusted:
   5. Every specified index entry carries an `invariants` summary string, keeping
      the registry index uniform with the manifests (so you can list clusters
      without opening each manifest).
+  6. Every pattern declares `success_metrics.metrics` (docs/patterns-registry.md:
+     "every pattern must declare them") — missing/empty is an ERROR for a
+     specified pattern, a WARN for a candidate.
 
 Run report-only:   python3 scripts/check_patterns.py
 Errors exit 1 (wired into `make lint`); warnings are reported but do not fail.
@@ -159,6 +162,13 @@ def validate(registry_path: Path = REGISTRY) -> list[Finding]:
                 "registry index entry missing `invariants` summary string "
                 "(keep the index uniform with the manifest cluster)"))
 
+        sm = manifest.get("success_metrics")
+        if not (sm.get("metrics") if isinstance(sm, dict) else None):
+            findings.append(Finding(
+                ERROR, where,
+                "specified pattern must declare non-empty `success_metrics.metrics` "
+                "(every pattern declares its success metrics)"))
+
         entries = cluster_entries(manifest.get("invariants"))
         if not entries:
             findings.append(Finding(
@@ -182,6 +192,11 @@ def validate(registry_path: Path = REGISTRY) -> list[Finding]:
         inv = entry.get("invariants")
         if inv is not None:
             validate_cluster(cluster_entries(inv), f"candidates/{cid}.invariants", findings)
+        sm = entry.get("success_metrics")
+        if not (sm.get("metrics") if isinstance(sm, dict) else None):
+            findings.append(Finding(
+                WARN, f"candidates/{cid}",
+                "candidate has no `success_metrics.metrics` yet (required at promotion to specified)"))
 
     return findings
 

--- a/skills/chief-wiggum/SKILL.md
+++ b/skills/chief-wiggum/SKILL.md
@@ -30,7 +30,7 @@ Load the reference for the stage you need from `references/workflows/`:
 - **`implement-wave`** — parallel implementation of an epic in dependency-ordered waves.
 - **`close-epic`** — epic-level quality gate.
 
-Supporting: `seed`, `create-issue`, `ship`, `transcribe`, `tutorial-video`, `setup`, `update`, `stitch-audit` (also under `references/workflows/`).
+Supporting: `seed`, `create-issue`, `ship`, `transcribe`, `tutorial-video`, `setup`, `update`, `stitch-audit`, `business-consultant` (also under `references/workflows/`).
 
 ## Conventions
 

--- a/skills/chief-wiggum/references/workflows/business-consultant.md
+++ b/skills/chief-wiggum/references/workflows/business-consultant.md
@@ -1,0 +1,1 @@
+../../../../.claude/commands/business-consultant.md

--- a/tests/test_business_consultant.py
+++ b/tests/test_business_consultant.py
@@ -833,3 +833,100 @@ def test_cli_marketplace_flag_changes_pricing_fit(tmp_path):
     assert proc.returncode == 0, proc.stdout + proc.stderr
     out = json.loads(proc.stdout)
     assert out["result"]["pricing_fit"]["cost_shape"] == pricing_fit.MARKETPLACE
+
+
+# --- #234: docs/pricing.md becomes a ratchet protected path -------------------
+
+
+def _ratchet_cfg(tmp_path):
+    return json.loads((tmp_path / "docs" / "quality" / "ratchet.json").read_text())
+
+
+def test_cli_write_registers_pricing_md_as_protected_path(tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "registered protected path" in proc.stdout
+    cfg = _ratchet_cfg(tmp_path)
+    assert "docs/pricing.md" in cfg["protected_paths"]
+    # no-ratchet-file case: the same DEFAULT_PROTECTED stub apply_pattern writes
+    from ratchet import DEFAULT_PROTECTED
+    assert set(DEFAULT_PROTECTED) <= set(cfg["protected_paths"])
+
+
+def test_cli_registration_is_idempotent_on_rerun(tmp_path):
+    (tmp_path / ".git").mkdir()
+    for _ in range(2):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert _ratchet_cfg(tmp_path)["protected_paths"].count("docs/pricing.md") == 1
+
+
+def test_cli_registration_appends_to_an_existing_ratchet_config(tmp_path):
+    (tmp_path / ".git").mkdir()
+    q = tmp_path / "docs" / "quality"
+    q.mkdir(parents=True)
+    (q / "ratchet.json").write_text(json.dumps(
+        {"suites": [{"id": "unit", "cmd": "pytest"}], "protected_paths": ["custom/**"]}))
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    cfg = _ratchet_cfg(tmp_path)
+    assert cfg["protected_paths"] == ["custom/**", "docs/pricing.md"]
+    assert cfg["suites"] == [{"id": "unit", "cmd": "pytest"}]  # rest of the config untouched
+
+
+def test_ratchet_protected_flags_edits_to_pricing_md(tmp_path):
+    """Done-looks-like from #234: `ratchet.py protected` flags a diff touching
+    the registered docs/pricing.md."""
+    (tmp_path / ".git").mkdir()
+    subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path)],
+        capture_output=True, text=True, check=True,
+    )
+    import ratchet
+    cfg = ratchet.load_config(tmp_path)
+    assert ratchet.protected_hits(cfg, ["docs/pricing.md"]) == ["docs/pricing.md"]
+
+
+def test_cli_dry_run_does_not_register(tmp_path):
+    (tmp_path / ".git").mkdir()
+    subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path), "--dry-run"],
+        capture_output=True, text=True, check=True,
+    )
+    assert not (tmp_path / "docs" / "quality" / "ratchet.json").exists()
+
+
+def test_cli_out_override_does_not_register(tmp_path):
+    """--out writes the report elsewhere — the target then has no docs/pricing.md
+    to protect, so nothing is registered."""
+    (tmp_path / ".git").mkdir()
+    subprocess.run(
+        [sys.executable, str(SCRIPTS / "business_consultant.py"), "--repo", str(tmp_path),
+         "--out", str(tmp_path / "elsewhere.md")],
+        capture_output=True, text=True, check=True,
+    )
+    assert not (tmp_path / "docs" / "quality" / "ratchet.json").exists()
+
+
+# --- #234: portable workflow mirror -------------------------------------------
+
+
+def test_workflow_reference_mirrors_the_slash_command():
+    """skills/chief-wiggum/references/workflows/business-consultant.md follows the
+    mirroring convention of the other workflow references: a relative symlink to
+    the canonical command body (single source of truth, no drift)."""
+    command = ROOT / ".claude" / "commands" / "business-consultant.md"
+    mirror = ROOT / "skills" / "chief-wiggum" / "references" / "workflows" / "business-consultant.md"
+    assert mirror.is_symlink()
+    assert mirror.readlink() == Path("../../../../.claude/commands/business-consultant.md")
+    assert mirror.read_text() == command.read_text()

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -41,7 +41,10 @@ def _specified(pid, **extra):
 
 
 def _manifest(pid, cluster=None, **extra):
-    m = {"id": pid, "title": pid}
+    # success_metrics is part of the bar for `specified` (#234) — default it so
+    # fixtures exercise their own concern, not the metrics lint.
+    m = {"id": pid, "title": pid,
+         "success_metrics": {"metrics": [{"id": "m1", "goal": "down", "desc": "d"}]}}
     if cluster is not None:
         m["invariants"] = {"cluster": cluster}
     m.update(extra)
@@ -168,6 +171,46 @@ def test_candidate_malformed_cluster_is_error(tmp_path):
     }
     path = _write(tmp_path, reg, {})
     assert any("malformed invariant id" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+# --- #234: success_metrics enforcement ---------------------------------------
+
+def test_specified_missing_success_metrics_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    manifest = _manifest("foo", cluster=[GOOD_INV])
+    del manifest["success_metrics"]
+    path = _write(tmp_path, reg, {"foo": manifest})
+    assert any("success_metrics.metrics" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_specified_empty_success_metrics_is_error(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg,
+                  {"foo": _manifest("foo", cluster=[GOOD_INV], success_metrics={"metrics": []})})
+    assert any("success_metrics.metrics" in e.message for e in _errors(check_patterns.validate(path)))
+
+
+def test_specified_with_success_metrics_passes(tmp_path):
+    reg = {"patterns": [_specified("foo")], "candidates": []}
+    path = _write(tmp_path, reg, {"foo": _manifest("foo", cluster=[GOOD_INV])})
+    assert _errors(check_patterns.validate(path)) == []
+
+
+def test_candidate_missing_success_metrics_is_warn_not_error(tmp_path):
+    reg = {"patterns": [], "candidates": [{"id": "cand", "status": "candidate"}]}
+    path = _write(tmp_path, reg, {})
+    findings = check_patterns.validate(path)
+    assert _errors(findings) == []
+    assert any(f.severity == check_patterns.WARN and "success_metrics" in f.message
+               for f in findings)
+
+
+def test_candidate_with_success_metrics_gets_no_warn(tmp_path):
+    reg = {"patterns": [], "candidates": [
+        {"id": "cand", "status": "candidate",
+         "success_metrics": {"metrics": [{"id": "m1", "goal": "down", "desc": "d"}]}}]}
+    path = _write(tmp_path, reg, {})
+    assert not any("success_metrics" in f.message for f in check_patterns.validate(path))
 
 
 # --- referral-invite-loop promotion (#139) ----------------------------------


### PR DESCRIPTION
Closes #234 (Business factory Track G).

Three mechanical fixes from the business-factory seam inventory (docs/business-factory.md §7, PR #233):

1. **`docs/pricing.md` protection is now real**: `business_consultant.py` registers it into the target's `docs/quality/ratchet.json` `protected_paths` on default in-repo writes, reusing `apply_pattern.py`'s `_merge_ratchet` code path (no fork). Idempotent; `--out`/`--dry-run` correctly excluded; missing ratchet gets the same DEFAULT_PROTECTED stub apply_pattern writes.
2. **Portable workflow copy**: `skills/chief-wiggum/references/workflows/business-consultant.md` as a relative symlink (the discovered house convention — enforced by `test_skill_packaging.py`); SKILL.md workflow index updated. 14 → 15 workflows.
3. **`check_patterns.py` rule 6**: specified pattern without non-empty `success_metrics.metrics` = ERROR; candidate = WARN — enforcing what docs/patterns-registry.md already asserts. All 18 current specified patterns comply; registry stays green.

**Verification (orchestrator-independent)**: full suite 2095 passed / 14 skipped; `check_patterns.py` exit 0 on the real registry. 12 new tests.