### PR TITLE
feat(business): bet ledger — envelopes, tranches, hashed kill criteria, portfolio invariants (#235)

### DIFF
--- a/docs/business-factory.md
+++ b/docs/business-factory.md
@@ -336,6 +336,48 @@ through A+H+C before promoting anything to `--gate`.
   `/business-consultant` skill copy; linter enforcement of `success_metrics`. (Metric
   computation moved to F, where the money data lives.)
 
+### Bet ledger usage (Track A, `scripts/bet.py`, #235)
+
+The portfolio spine, shipped. Bets live in a dedicated private portfolio repo — default
+`~/.chief-wiggum/portfolio`, overridable via `--portfolio-dir` or `CHIEF_WIGGUM_PORTFOLIO`,
+git-initialized on first use:
+
+```
+<portfolio>/
+├── journal.jsonl          # append-only hash chain (ratchet.py format — never hand-edit)
+├── means.json             # means inventory (templates/means-schema.json), optional
+└── bets/<bet-id>/
+    ├── bet.json           # templates/bet-schema.json (envelope embedded — a goalpost)
+    ├── kill-criteria.json # templates/kill-criteria-schema.json (a goalpost)
+    ├── ledger.jsonl       # append-only spend/time/rep entries
+    ├── channels.json      # optional channel-experiment records (#241)
+    └── retrospective.md   # required non-trivially before `killed`
+```
+
+```bash
+python3 scripts/bet.py create <bet-id> --title ... --envelope env.json --criteria kc.json
+python3 scripts/bet.py spend <bet-id> --amount-usd 120 --hours 6   # or --rep (distribution rep)
+python3 scripts/bet.py evaluate <bet-id> --results measured.json   # + distribution-attempted status
+python3 scripts/bet.py transition <bet-id> probing                 # kill_pending / terminals / pivot
+python3 scripts/bet.py transition <bet-id> killed --successor <id> --envelope ... --criteria ...  # pivot
+python3 scripts/bet.py rebaseline <bet-id> --envelope new.json --reason "..."  # ONLY goalpost mutation path
+python3 scripts/bet.py portfolio                                   # summary + invariants
+```
+
+The envelope and kill criteria are content-hashed into `journal.jsonl` at create; `rebaseline`
+journals old → new hashes with a required `--reason`; every read verifies the chain and fails
+closed (exit 4) on tamper. Gate checks — all report-only by default per `docs/gate-rollout.md`,
+blocking only with `--gate`, and no workflow passes `--gate` until a `validation/bet-gates.json`
+record exists: states-and-dates soundness lint; cumulative spend ≤ cumulative unlocked tranches;
+dated-criterion evaluation (triggered → journaled `kill-proposed`, spend blocked pending the
+journaled human accept/override); bets-in-flight cap (probing|validating|building, default 2);
+bet-selection lint at create (means.json sales/marketing novice + no `focused` channel + no
+ecosystem channel/owned audience in the acquisition plan); goalpost-integrity hash check.
+`killed` is hard-blocked until `retrospective.md` exists non-trivially and the harvest check ran
+(3.9 × TTM SDP vs wind-down cost; absent inputs → `skipped`, reported, never a silent block).
+Missing optional inputs (`means.json`, `channels.json`) report `skipped`/`unattempted` — never a
+crash, never silently omitted.
+
 ---
 
 ## 9. Sources (condensed)

--- a/docs/gate-rollout.md
+++ b/docs/gate-rollout.md
@@ -65,6 +65,7 @@ output), and only switch it to `--gate` once step 2 is satisfied.
 | **AI-slop signals (code survival + duplication)** | `quality_slop_gate.py` | `--gate` | **report-only** (#113); `/close-epic`; **gate-validation record: passed** (#184, fixture band-file target per CTR-fh-044 — validates the banding/verdict logic, not the external engines) |
 | Architecture model consistency | `check_architecture.py` | `--gate` | report-only in `/architect` (#174); **gate-validation record: passed** (#184, one seed per frozen `CHECKS` entry per ADR-fh-06) |
 | **Traceability: suspect-link propagation** | `check_traceability.py` (`suspect_links`) | none yet | **NEW — report-only** (#169); does not affect `coverage_ok`/the `--gate coverage` exit code; `ratchet.py check`/`regressed` surface the same sidecar cross-reference visibly. Promote once a dry-run across a real epic's link churn shows an acceptable false-positive rate (see docs/traceability.md) |
+| **Bet-ledger gates (states-and-dates soundness, tranche cap, dated-criterion evaluation, bets-in-flight cap, bet-selection lint, goalpost integrity)** | `bet.py` | `--gate` | **NEW — report-only** (#235); no workflow passes `--gate` until a `validation/bet-gates.json` record exists (dogfood one real bet end-to-end first — docs/business-factory.md §8). Journal tamper (exit 4) and `killed`-without-retrospective are hard state-machine guards, not gated findings |
 
 ## From convention to protocol: `docs/gate-validation.md` (#168)
 

--- a/scripts/bet.py
+++ b/scripts/bet.py
@@ -1,0 +1,1262 @@
+#!/usr/bin/env python3
+"""Bet ledger — the business-factory portfolio spine (chief-wiggum#235).
+
+A **bet** is a bounded venture experiment: under ~$1k to prove, ~3 months to a
+kill decision. The empirical warrant (Staw 1976; Boulding et al. 1997): founders
+escalate on failing bets and self-enforced kill rules do NOT stop them — only
+**binding predetermined rules** do. CW already owns the enforcement idioms
+(ratchet hash chain, goalpost hashing, gate scripts); this script applies them
+to the operator's own future self. See docs/business-factory.md §1–2, §8.
+
+State lives in a dedicated private portfolio repo (default
+``~/.chief-wiggum/portfolio``; override with ``--portfolio-dir`` or the
+``CHIEF_WIGGUM_PORTFOLIO`` env var), git-initialized on first use::
+
+    <portfolio>/
+    ├── journal.jsonl          # append-only hash chain (ratchet.py format — never hand-edit)
+    ├── means.json             # means inventory (templates/means-schema.json), optional
+    └── bets/<bet-id>/
+        ├── bet.json           # templates/bet-schema.json (envelope embedded — a goalpost)
+        ├── kill-criteria.json # templates/kill-criteria-schema.json (a goalpost)
+        ├── ledger.jsonl       # append-only spend/time/rep entries
+        ├── channels.json      # optional channel-experiment records (#241)
+        └── retrospective.md   # required non-trivially before `killed`
+
+The journal REUSES ``ratchet.py``'s hash-chain format via ``ratchet.load_journal``
+and ``chief_wiggum.hashing.stable_hash`` (imported, not copied): each record's
+hash covers its body plus the previous record's hash; every read verifies the
+chain from genesis and FAILS CLOSED (exit 4) on a break. The envelope and kill
+criteria are **goalpost artifacts**: content-hashed into the journal at create;
+``rebaseline`` is the only sanctioned mutation path and journals old hash → new
+hash with a required ``--reason`` (Adner & Levinthal 2004 — the abandonment
+condition must not be retroactively redefined).
+
+Bet state machine (docs/business-factory.md §2.3)::
+
+    proposed → probing → validating → building → scaling
+    kill_pending reachable from any non-terminal state
+    terminals: killed | parked | lifestyle | sold
+
+Verdicts at gates use Cooper's vocabulary — ``go | kill | hold | recycle`` —
+never binary pass/fail. **Pivot is a transition, not an edit**: it closes the
+bet (criteria evaluated against the old thesis) and opens a successor bet with
+fresh criteria + envelope. ``killed`` is blocked until ``retrospective.md``
+exists non-trivially AND a harvest check ran: if est sale value (3.9 × TTM
+seller-discretionary profit — Acquire.com micro-SaaS median) exceeds wind-down
+cost, the proposed terminal is ``sold``, not ``killed``; absent inputs → the
+check reports ``skipped``, never blocks silently, never crashes.
+
+Gate checks (ALL report-only by default per docs/gate-rollout.md — findings
+printed, exit 0; blocking only with ``--gate``; ships without any workflow
+passing ``--gate`` until a ``validation/bet-gates.json`` record exists):
+
+- **states-and-dates soundness lint** (create/rebaseline): a criterion missing
+  the measurable state (metric/comparator/threshold) OR the date is malformed.
+- **tranche gate** (spend): cumulative spend ≤ cumulative unlocked tranches.
+- **dated-criterion evaluation** (evaluate): a triggered criterion journals a
+  ``kill-proposed`` event; further spend entries are findings pending the human
+  accept (``transition <id> kill_pending``) or override
+  (``transition <id> --override-kill --reason ...``) — both journaled acts.
+- **bets-in-flight cap** (transition/portfolio): bets in probing|validating|
+  building, default 2 (``--max-in-flight``) — attention is the binding resource.
+- **bet-selection lint** (create, #235 amendment): while means.json says
+  sales AND marketing are novice and no channel across the portfolio has
+  reached ``focused``, a bet whose acquisition plan has no ecosystem channel
+  and no owned audience is flagged. means.json absent → ``skipped``.
+- **goalpost integrity** (every read): envelope/criteria content hash vs the
+  last journaled baseline — a hand edit outside ``rebaseline`` is flagged.
+
+Missing OPTIONAL inputs never crash and are never silently omitted: no
+means.json → the selection lint reports ``skipped``; no channels.json and no
+rep ledger entries → ``evaluate`` reports distribution ``unattempted`` (feeds
+the #237 verdict rule: no-demand evidence without attempted distribution is
+evidence of no marketing, not no demand).
+
+Two hard guards are state-machine integrity, not precision-risk gates, and
+block regardless of ``--gate``: an invalid state transition (exit 2), and
+``killed`` without a non-trivial retrospective (exit 1 — harvest discipline,
+``/close-epic``'s shape).
+
+Subcommands:
+    create      register a bet: envelope + kill criteria hashed into the journal
+    spend       append a ledger entry (spend/time or a distribution rep)
+    evaluate    evaluate dated criteria + report distribution-attempted status
+    transition  move the state machine (incl. pivot, kill accept/override,
+                tranche unlock — every one a journaled act)
+    rebaseline  the ONLY mutation path for envelope/kill criteria (--reason required)
+    portfolio   per-bet + portfolio summary: spend vs envelope, days to next
+                dated criterion, in-flight cap, loss distribution + kill hygiene
+                per dead bet — never per-bet win/lose ranking
+
+Exit codes: 0 = ok / report-only findings, 1 = gate violation (--gate) or hard
+guard, 2 = usage/config error, 4 = journal tamper detected (fail closed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Chain-format reuse, not a fork: ratchet.py stays the format's single home
+# (its source is frozen by its live gate-validation record — see
+# docs/quality/validation/ratchet.json), so bet.py imports its verified reader
+# and the shared stable_hash primitive instead of refactoring it.
+import ratchet  # noqa: E402
+from chief_wiggum.hashing import stable_hash  # noqa: E402
+from ratchet import TamperError  # noqa: E402  (maps to exit 4 — fail closed)
+
+JOURNAL_NAME = "journal.jsonl"
+MEANS_NAME = "means.json"
+
+ACTIVE_ORDER = ["proposed", "probing", "validating", "building", "scaling"]
+IN_FLIGHT = {"probing", "validating", "building"}
+TERMINALS = {"killed", "parked", "lifestyle", "sold"}
+ALL_STATES = set(ACTIVE_ORDER) | {"kill_pending"} | TERMINALS
+VERDICTS = ("go", "kill", "hold", "recycle")
+COMPARATORS = {"<", "<=", ">", ">=", "==", "!="}
+DEFAULT_MAX_IN_FLIGHT = 2
+
+# Acquire.com micro-SaaS median multiple on TTM seller-discretionary earnings
+# (docs/business-factory.md §2.3) — the harvest check's est-sale-value factor.
+HARVEST_MULTIPLE = 3.9
+
+# retrospective.md is "non-trivial" when, with headings stripped, at least this
+# much prose remains — an empty file or a bare title must not unlock `killed`.
+RETRO_MIN_CHARS = 40
+
+
+class BetError(Exception):
+    """Usage/config problem. Maps to exit 2."""
+
+
+# ---- portfolio repo ------------------------------------------------------------
+
+
+def portfolio_root(arg: str | None) -> Path:
+    """Resolve the portfolio repo (flag > env > default) and git-init on first use."""
+    if arg:
+        root = Path(arg).expanduser()
+    elif os.environ.get("CHIEF_WIGGUM_PORTFOLIO"):
+        root = Path(os.environ["CHIEF_WIGGUM_PORTFOLIO"]).expanduser()
+    else:
+        root = Path.home() / ".chief-wiggum" / "portfolio"
+    root = root.resolve()
+    (root / "bets").mkdir(parents=True, exist_ok=True)
+    if not (root / ".git").exists():
+        proc = subprocess.run(
+            ["git", "init", "-q"], cwd=root, capture_output=True, text=True
+        )
+        if proc.returncode != 0:
+            sys.stderr.write(f"bet: warning — git init failed: {proc.stderr.strip()}\n")
+    return root
+
+
+def bet_dir(root: Path, bet_id: str) -> Path:
+    return root / "bets" / bet_id
+
+
+def load_bet(root: Path, bet_id: str) -> dict:
+    path = bet_dir(root, bet_id) / "bet.json"
+    if not path.is_file():
+        raise BetError(f"no such bet: {bet_id} (no {path})")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise BetError(f"cannot parse {path}: {e}") from e
+
+
+def save_bet(root: Path, bet: dict) -> None:
+    path = bet_dir(root, bet["id"]) / "bet.json"
+    path.write_text(json.dumps(bet, indent=2, sort_keys=True) + "\n")
+
+
+def all_bets(root: Path) -> list[dict]:
+    out = []
+    for p in sorted((root / "bets").glob("*/bet.json")):
+        try:
+            out.append(json.loads(p.read_text()))
+        except json.JSONDecodeError:
+            sys.stderr.write(f"bet: warning — cannot parse {p}, skipping\n")
+    return out
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# ---- hash-chained journal (ratchet.py format, reused) --------------------------
+
+
+def load_journal(root: Path) -> list[dict]:
+    """Verified read of the portfolio journal — ratchet.py's chain reader reused
+    via a minimal shim (``load_journal`` only touches ``cfg.journal``). Raises
+    ``TamperError`` (exit 4) on a broken chain — fail closed."""
+    return ratchet.load_journal(SimpleNamespace(journal=root / JOURNAL_NAME))
+
+
+def append_event(root: Path, event: str, ref: str, details: dict) -> dict:
+    """Append a hash-chained record (same body+prev-hash scheme as ratchet.py).
+    The verified read first means a tampered journal is never silently extended."""
+    records = load_journal(root)
+    body = {
+        "record_id": f"rec-{len(records) + 1:05d}",
+        "event": event,
+        "ref": ref,
+        "ts": now_iso(),
+        "details": details,
+    }
+    prev = records[-1]["record_hash"] if records else "genesis"
+    body["record_hash"] = stable_hash(prev, json.dumps(body, sort_keys=True))
+    with (root / JOURNAL_NAME).open("a") as f:
+        f.write(json.dumps(body, sort_keys=True) + "\n")
+    return body
+
+
+def bet_events(records: list[dict], bet_id: str) -> list[dict]:
+    return [r for r in records if r.get("ref") == bet_id]
+
+
+# ---- goalpost hashing ----------------------------------------------------------
+
+
+def content_hash(obj) -> str:
+    """Hash the parsed JSON canonical form — reformatting is not a goalpost edit."""
+    return stable_hash(json.dumps(obj, sort_keys=True))
+
+
+def load_criteria(root: Path, bet_id: str) -> list[dict]:
+    path = bet_dir(root, bet_id) / "kill-criteria.json"
+    if not path.is_file():
+        raise BetError(f"missing {path}")
+    return parse_criteria_file(path)
+
+
+def parse_criteria_file(path: Path) -> list[dict]:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise BetError(f"cannot parse {path}: {e}") from e
+    crit = data.get("criteria") if isinstance(data, dict) else data
+    if not isinstance(crit, list):
+        raise BetError(f"{path}: expected a list or {{'criteria': [...]}}")
+    return crit
+
+
+def goalpost_baseline(records: list[dict], bet_id: str) -> tuple[str | None, str | None]:
+    """(envelope_hash, criteria_hash) last journaled for this bet (create/rebaseline)."""
+    env_h = crit_h = None
+    for rec in bet_events(records, bet_id):
+        d = rec.get("details", {}) or {}
+        if rec.get("event") == "bet-create":
+            env_h = d.get("envelope_hash", env_h)
+            crit_h = d.get("criteria_hash", crit_h)
+        elif rec.get("event") == "rebaseline":
+            env_h = d.get("new_envelope_hash", env_h)
+            crit_h = d.get("new_criteria_hash", crit_h)
+    return env_h, crit_h
+
+
+def goalpost_findings(root: Path, bet: dict, records: list[dict]) -> list[str]:
+    """Envelope/criteria drift vs the journaled baseline — an edit outside
+    `rebaseline` is a goalpost move and must be visible, never silently absorbed."""
+    out = []
+    env_h, crit_h = goalpost_baseline(records, bet["id"])
+    if env_h and content_hash(bet.get("envelope", {})) != env_h:
+        out.append(
+            f"{bet['id']}: envelope hash does not match the journaled baseline — "
+            "edited outside `bet.py rebaseline` (goalposts moved)"
+        )
+    if crit_h:
+        try:
+            cur = content_hash(load_criteria(root, bet["id"]))
+        except BetError as e:
+            out.append(f"{bet['id']}: kill criteria unreadable ({e})")
+        else:
+            if cur != crit_h:
+                out.append(
+                    f"{bet['id']}: kill-criteria hash does not match the journaled "
+                    "baseline — edited outside `bet.py rebaseline` (goalposts moved)"
+                )
+    return out
+
+
+# ---- states-and-dates soundness lint -------------------------------------------
+
+
+def _valid_date(s) -> bool:
+    try:
+        date.fromisoformat(str(s))
+        return True
+    except ValueError:
+        return False
+
+
+def criteria_soundness(criteria: list[dict]) -> list[str]:
+    """A criterion missing the measurable state OR the date is malformed (Duke:
+    every kill criterion is a state AND a date — no timeout-free criteria)."""
+    out = []
+    for i, c in enumerate(criteria):
+        if not isinstance(c, dict):
+            out.append(f"criteria[{i}]: not an object")
+            continue
+        cid = c.get("id") or f"criteria[{i}]"
+        if not c.get("metric"):
+            out.append(f"{cid}: malformed — no measurable state (missing metric)")
+        if c.get("comparator") not in COMPARATORS:
+            out.append(
+                f"{cid}: malformed — no measurable state (comparator must be one of "
+                f"{sorted(COMPARATORS)}, got {c.get('comparator')!r})"
+            )
+        if not isinstance(c.get("threshold"), (int, float)):
+            out.append(f"{cid}: malformed — no measurable state (missing numeric threshold)")
+        if "by_date" not in c or not _valid_date(c.get("by_date")):
+            out.append(f"{cid}: malformed — no date (by_date missing or not ISO)")
+        if c.get("direction", "has") not in ("has", "has_not"):
+            out.append(f"{cid}: malformed — direction must be has|has_not")
+    return out
+
+
+def envelope_soundness(envelope: dict) -> list[str]:
+    out = []
+    tranches = envelope.get("tranches") or []
+    for i, t in enumerate(tranches):
+        if not isinstance(t, dict) or not isinstance(t.get("amount_usd"), (int, float)):
+            out.append(f"tranches[{i}]: malformed — missing numeric amount_usd")
+    amounts = [t.get("amount_usd", 0) for t in tranches if isinstance(t, dict)]
+    cap = envelope.get("cash_cap_usd", 0)
+    if amounts and sum(amounts) > cap:
+        out.append(
+            f"tranches sum to ${sum(amounts):g} > cash_cap_usd ${cap:g} — "
+            "the tranche ladder exceeds the envelope"
+        )
+    return out
+
+
+# ---- ledger --------------------------------------------------------------------
+
+
+def ledger_path(root: Path, bet_id: str) -> Path:
+    return bet_dir(root, bet_id) / "ledger.jsonl"
+
+
+def load_ledger(root: Path, bet_id: str) -> list[dict]:
+    p = ledger_path(root, bet_id)
+    if not p.is_file():
+        return []
+    out = []
+    for line in p.read_text().splitlines():
+        if line.strip():
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                sys.stderr.write(f"bet: warning — unparsable ledger line in {p}, skipping\n")
+    return out
+
+
+def spend_totals(entries: list[dict]) -> tuple[float, float]:
+    cash = sum(e.get("amount_usd") or 0 for e in entries)
+    hours = sum(e.get("hours") or 0 for e in entries)
+    return cash, hours
+
+
+def unlocked_cap(bet: dict) -> float:
+    """Cumulative unlocked tranche amount. No tranches → the whole cash cap is
+    available; with tranches, null-milestone tranches plus journaled unlocks."""
+    env = bet.get("envelope", {})
+    tranches = env.get("tranches") or []
+    if not tranches:
+        return env.get("cash_cap_usd", 0)
+    unlocked = set(bet.get("unlocked_milestones") or [])
+    return sum(
+        t.get("amount_usd", 0)
+        for t in tranches
+        if isinstance(t, dict)
+        and (t.get("unlock_milestone_id") is None or t.get("unlock_milestone_id") in unlocked)
+    )
+
+
+# ---- pending kill proposals ----------------------------------------------------
+
+
+def pending_kill(records: list[dict], bet_id: str) -> dict | None:
+    """The unresolved kill-proposed event for this bet, if any. Resolved by a
+    journaled human act: a kill-override, or a transition into kill_pending or a
+    terminal state."""
+    pending = None
+    for rec in bet_events(records, bet_id):
+        ev = rec.get("event")
+        if ev == "kill-proposed":
+            pending = rec
+        elif ev == "kill-override":
+            pending = None
+        elif ev == "transition":
+            to = (rec.get("details", {}) or {}).get("to")
+            if to == "kill_pending" or to in TERMINALS:
+                pending = None
+    return pending
+
+
+# ---- distribution status (#241 seam) -------------------------------------------
+
+
+def _channel_records(root: Path, bet_id: str) -> list[dict]:
+    p = bet_dir(root, bet_id) / "channels.json"
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError:
+        sys.stderr.write(f"bet: warning — cannot parse {p}; treating as no channel records\n")
+        return []
+    if isinstance(data, dict):
+        data = data.get("channels") or data.get("experiments") or []
+    return [c for c in data if isinstance(c, dict)] if isinstance(data, list) else []
+
+
+def distribution_status(root: Path, bet_id: str) -> dict:
+    """Attempted-distribution evidence: channel-experiment records (#241) plus
+    rep-cadence ledger entries. Absent both → `unattempted` — reported, never
+    silently omitted (the #237 rule: no-demand evidence without attempted
+    distribution is evidence of no marketing, not no demand)."""
+    channels = _channel_records(root, bet_id)
+    reps = [e for e in load_ledger(root, bet_id) if e.get("type") == "rep"]
+    attempted = bool(channels or reps)
+    return {
+        "status": "attempted" if attempted else "unattempted",
+        "channel_experiments": len(channels),
+        "rep_entries": len(reps),
+    }
+
+
+def any_channel_focused(root: Path) -> bool:
+    for bet in all_bets(root):
+        for c in _channel_records(root, bet["id"]):
+            if (c.get("status") or c.get("state")) == "focused":
+                return True
+    return False
+
+
+# ---- bet-selection lint (#235 amendment) ---------------------------------------
+
+
+def load_means(root: Path) -> dict | None:
+    p = root / MEANS_NAME
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError as e:
+        raise BetError(f"cannot parse {p}: {e}") from e
+
+
+def selection_lint(root: Path, bet: dict) -> list[str]:
+    """While means.json says sales AND marketing are novice and no channel has
+    ever reached `focused`, a bet whose acquisition plan has no built-in-
+    distribution ecosystem channel and no owned audience is flagged.
+    means.json absent → skipped (reported, exit 0, never a crash)."""
+    means = load_means(root)
+    if means is None:
+        return [f"skipped: no {MEANS_NAME} in the portfolio — bet-selection lint needs it"]
+    skills = means.get("skills", {}) or {}
+    novice = (
+        skills.get("sales", "novice") == "novice"
+        and skills.get("marketing", "novice") == "novice"
+    )
+    if not novice or any_channel_focused(root):
+        return []
+    acq = bet.get("acquisition", {}) or {}
+    if not acq.get("ecosystem_channel") and not acq.get("owned_audience"):
+        return [
+            f"{bet['id']}: acquisition plan has no ecosystem channel and no owned "
+            "audience while means.json says sales/marketing novice and no channel "
+            "has reached `focused` — distribution is the binding constraint (#241)"
+        ]
+    return []
+
+
+# ---- criteria evaluation -------------------------------------------------------
+
+
+def _compare(value: float, comparator: str, threshold: float) -> bool:
+    return {
+        "<": value < threshold, "<=": value <= threshold,
+        ">": value > threshold, ">=": value >= threshold,
+        "==": value == threshold, "!=": value != threshold,
+    }[comparator]
+
+
+def evaluate_criteria(criteria: list[dict], results: dict, as_of: date) -> list[dict]:
+    """States-and-dates evaluation. direction=has: past by_date without the state
+    → TRIGGERED (no evidence of the state counts as not achieved — the honesty
+    discipline); before the date → pending/met. direction=has_not: the state
+    occurring triggers immediately; surviving past the date → held."""
+    out = []
+    for i, c in enumerate(criteria):
+        if not isinstance(c, dict):
+            out.append({"id": f"criteria[{i}]", "metric": None,
+                        "status": "malformed", "measured": None})
+            continue
+        cid = c.get("id") or f"criteria[{i}]"
+        entry = {"id": cid, "metric": c.get("metric"), "status": "pending", "measured": None}
+        try:
+            by = date.fromisoformat(str(c.get("by_date")))
+        except ValueError:
+            entry["status"] = "malformed"
+            out.append(entry)
+            continue
+        direction = c.get("direction", "has")
+        value = results.get(c.get("metric"))
+        met = None
+        if isinstance(value, (int, float)) and c.get("comparator") in COMPARATORS \
+                and isinstance(c.get("threshold"), (int, float)):
+            entry["measured"] = value
+            met = _compare(value, c["comparator"], c["threshold"])
+        due = as_of > by
+        if direction == "has":
+            if met:
+                entry["status"] = "met"
+            elif due:
+                entry["status"] = "triggered"
+                entry["reason"] = (
+                    f"by_date {by.isoformat()} passed without the state "
+                    f"({c.get('metric')} {c.get('comparator')} {c.get('threshold')})"
+                    + ("" if met is False else " — unmeasured; no evidence counts as not achieved")
+                )
+            else:
+                entry["status"] = "pending" if met is False else "unmeasured"
+        else:  # has_not
+            if met:
+                entry["status"] = "triggered"
+                entry["reason"] = (
+                    f"state occurred ({c.get('metric')} {c.get('comparator')} "
+                    f"{c.get('threshold')}) — must-not-hold criterion"
+                )
+            elif due:
+                entry["status"] = "held"
+            else:
+                entry["status"] = "pending" if met is False else "unmeasured"
+        out.append(entry)
+    return out
+
+
+# ---- harvest check -------------------------------------------------------------
+
+
+def harvest_check(bet: dict) -> dict:
+    """Est sale value (3.9 × TTM seller-discretionary profit) vs wind-down cost.
+    Absent inputs → `skipped` — reported and journaled, never a silent block,
+    never a crash (the complexity-snapshot contract)."""
+    inputs = bet.get("harvest_inputs") or {}
+    ttm = inputs.get("ttm_sdp_usd")
+    wind = inputs.get("wind_down_cost_usd")
+    if not isinstance(ttm, (int, float)) or not isinstance(wind, (int, float)):
+        return {"skipped": "harvest inputs absent (harvest_inputs.ttm_sdp_usd / "
+                           ".wind_down_cost_usd) — est sale value unknown"}
+    est = round(HARVEST_MULTIPLE * ttm, 2)
+    return {
+        "est_sale_value_usd": est,
+        "wind_down_cost_usd": wind,
+        "proposed_terminal": "sold" if est > wind else "killed",
+    }
+
+
+def retrospective_nontrivial(root: Path, bet_id: str) -> bool:
+    p = bet_dir(root, bet_id) / "retrospective.md"
+    if not p.is_file():
+        return False
+    prose = "\n".join(
+        ln for ln in p.read_text().splitlines() if not ln.lstrip().startswith("#")
+    )
+    return len("".join(prose.split())) >= RETRO_MIN_CHARS
+
+
+# ---- in-flight cap -------------------------------------------------------------
+
+
+def in_flight_bets(root: Path) -> list[str]:
+    return sorted(b["id"] for b in all_bets(root) if b.get("state") in IN_FLIGHT)
+
+
+def cap_findings(root: Path, max_in_flight: int, entering: str | None = None) -> list[str]:
+    """Bets-in-flight cap (probing|validating|building). `entering` names a bet
+    about to enter an in-flight state, counted as if it already had."""
+    flight = set(in_flight_bets(root))
+    if entering:
+        flight.add(entering)
+    if len(flight) > max_in_flight:
+        return [
+            f"bets in flight ({len(flight)}: {', '.join(sorted(flight))}) exceed the "
+            f"cap of {max_in_flight} — attention is the binding resource "
+            "(park or kill before starting another)"
+        ]
+    return []
+
+
+# ---- reporting -----------------------------------------------------------------
+
+
+def report(findings: list[str], gate: bool, label: str = "bet") -> int:
+    """docs/gate-rollout.md discipline: findings print always; exit 1 only under
+    --gate. Skipped checks are reported, never silently omitted."""
+    real = [f for f in findings if not f.startswith("skipped:")]
+    for f in findings:
+        tag = "gated" if gate and not f.startswith("skipped:") else "report-only"
+        print(f"{label}: [{tag}] {f}")
+    return 1 if gate and real else 0
+
+
+# ---- subcommands ---------------------------------------------------------------
+
+
+def cmd_create(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    if not args.bet_id.replace("-", "").replace("_", "").replace(".", "").isalnum():
+        raise BetError(f"bet id {args.bet_id!r} must be alphanumeric with ._- separators")
+    bdir = bet_dir(root, args.bet_id)
+    if (bdir / "bet.json").exists():
+        raise BetError(f"bet {args.bet_id} already exists at {bdir}")
+
+    env_path = Path(args.envelope)
+    if not env_path.is_file():
+        raise BetError(f"envelope file not found: {env_path}")
+    try:
+        envelope = json.loads(env_path.read_text())
+    except json.JSONDecodeError as e:
+        raise BetError(f"cannot parse {env_path}: {e}") from e
+    if not isinstance(envelope, dict) or not isinstance(envelope.get("cash_cap_usd"), (int, float)):
+        raise BetError(f"{env_path}: envelope needs a numeric cash_cap_usd (templates/bet-schema.json)")
+
+    criteria = parse_criteria_file(Path(args.criteria))
+
+    bet = {
+        "id": args.bet_id,
+        "title": args.title,
+        "thesis": args.thesis or "",
+        "created": now_iso(),
+        "state": "proposed",
+        "envelope": envelope,
+        "acquisition": {
+            "ecosystem_channel": args.ecosystem_channel,
+            "owned_audience": args.owned_audience,
+        },
+        "means_refs": args.means_ref or [],
+        "unlocked_milestones": [],
+        "predecessor": args.predecessor,
+        "successor": None,
+    }
+
+    findings = [f"soundness: {f}" for f in criteria_soundness(criteria)]
+    findings += [f"soundness: {f}" for f in envelope_soundness(envelope)]
+    findings += [
+        f if f.startswith("skipped:") else f"selection: {f}"
+        for f in selection_lint(root, bet)
+    ]
+
+    rc = report(findings, args.gate)
+    if rc:
+        print(f"bet: create {args.bet_id} REFUSED (--gate)")
+        return rc
+
+    bdir.mkdir(parents=True, exist_ok=True)
+    save_bet(root, bet)
+    (bdir / "kill-criteria.json").write_text(
+        json.dumps({"criteria": criteria}, indent=2, sort_keys=True) + "\n"
+    )
+    ledger_path(root, args.bet_id).touch()
+    append_event(root, "bet-create", args.bet_id, {
+        "title": args.title,
+        "envelope_hash": content_hash(envelope),
+        "criteria_hash": content_hash(criteria),
+        "predecessor": args.predecessor,
+    })
+    print(
+        f"bet: created {args.bet_id} [proposed] — envelope+criteria hashed into the "
+        f"journal (goalposts; `rebaseline` is the only mutation path)"
+    )
+    return 0
+
+
+def cmd_spend(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    bet = load_bet(root, args.bet_id)
+    if bet["state"] in TERMINALS:
+        raise BetError(f"{args.bet_id} is terminal ({bet['state']}) — no further ledger entries")
+    if args.amount_usd is None and args.hours is None and not args.rep:
+        raise BetError("nothing to record — pass --amount-usd, --hours, and/or --rep")
+
+    records = load_journal(root)
+    findings = goalpost_findings(root, bet, records)
+
+    pend = pending_kill(records, args.bet_id)
+    if pend:
+        crit = ", ".join((pend.get("details", {}) or {}).get("criteria", [])) or "?"
+        findings.append(
+            f"spend blocked pending kill decision — criterion(s) {crit} triggered "
+            f"({pend['record_id']}); accept with `transition {args.bet_id} kill_pending` "
+            f"or override with `transition {args.bet_id} --override-kill --reason ...`"
+        )
+    if bet["state"] == "kill_pending":
+        findings.append(f"{args.bet_id} is kill_pending — spend awaits the kill decision")
+
+    cash, hours = spend_totals(load_ledger(root, args.bet_id))
+    new_cash = cash + (args.amount_usd or 0)
+    new_hours = hours + (args.hours or 0)
+    cap = unlocked_cap(bet)
+    if new_cash > cap:
+        findings.append(
+            f"cumulative spend ${new_cash:g} exceeds cumulative unlocked tranches "
+            f"${cap:g} — unlock a tranche (`transition --unlock-milestone`) or "
+            "rebaseline the envelope (journaled)"
+        )
+    time_cap = bet.get("envelope", {}).get("time_cap_hours")
+    if isinstance(time_cap, (int, float)) and new_hours > time_cap:
+        findings.append(
+            f"cumulative hours {new_hours:g} exceed time_cap_hours {time_cap:g}"
+        )
+
+    rc = report(findings, args.gate)
+    if rc:
+        print(f"bet: spend on {args.bet_id} REFUSED (--gate)")
+        return rc
+
+    entry = {
+        "ts": now_iso(),
+        "type": "rep" if args.rep else "spend",
+        "amount_usd": args.amount_usd,
+        "hours": args.hours,
+        "note": args.note or "",
+    }
+    with ledger_path(root, args.bet_id).open("a") as f:
+        f.write(json.dumps(entry, sort_keys=True) + "\n")
+    print(
+        f"bet: {entry['type']} recorded for {args.bet_id} — cash ${new_cash:g}/"
+        f"${cap:g} unlocked (cap ${bet['envelope'].get('cash_cap_usd', 0):g}), "
+        f"hours {new_hours:g}"
+    )
+    return 0
+
+
+def cmd_evaluate(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    bet = load_bet(root, args.bet_id)
+    records = load_journal(root)
+    findings = goalpost_findings(root, bet, records)
+    criteria = load_criteria(root, args.bet_id)
+
+    results = {}
+    if args.results:
+        rp = Path(args.results)
+        if not rp.is_file():
+            raise BetError(f"results file not found: {rp}")
+        try:
+            results = json.loads(rp.read_text())
+        except json.JSONDecodeError as e:
+            raise BetError(f"cannot parse {rp}: {e}") from e
+    as_of = date.fromisoformat(args.as_of) if args.as_of else date.today()
+
+    rows = evaluate_criteria(criteria, results, as_of)
+    print(f"bet: evaluate {args.bet_id} [{bet['state']}] as of {as_of.isoformat()}")
+    for r in rows:
+        measured = "unmeasured" if r["measured"] is None else f"measured={r['measured']:g}"
+        line = f"  {r['id']} {r['metric']}: {r['status'].upper()} ({measured})"
+        if r.get("reason"):
+            line += f" — {r['reason']}"
+        print(line)
+
+    dist = distribution_status(root, args.bet_id)
+    print(
+        f"  distribution: {dist['status']} "
+        f"({dist['channel_experiments']} channel experiment(s), "
+        f"{dist['rep_entries']} rep entr{'y' if dist['rep_entries'] == 1 else 'ies'})"
+    )
+
+    triggered = [r["id"] for r in rows if r["status"] == "triggered"]
+    if triggered:
+        findings.append(
+            f"criterion(s) triggered: {', '.join(triggered)} — kill_pending proposed; "
+            "further spend is blocked pending the journaled human accept/override"
+        )
+        if dist["status"] == "unattempted":
+            print(
+                "  note: triggered with distribution UNATTEMPTED — evidence of no "
+                "marketing, not no demand; the #237 verdict rule downgrades kill "
+                "to recycle"
+            )
+        if pending_kill(records, args.bet_id) is None and bet["state"] not in TERMINALS:
+            rec = append_event(root, "kill-proposed", args.bet_id, {
+                "criteria": triggered,
+                "as_of": as_of.isoformat(),
+                "distribution": dist,
+            })
+            print(f"  journaled kill-proposed ({rec['record_id']})")
+        else:
+            print("  kill proposal already pending — not re-journaled")
+    return report(findings, args.gate)
+
+
+def _guard_transition(bet: dict, to: str, override: bool) -> None:
+    cur = bet["state"]
+    if cur in TERMINALS:
+        raise BetError(f"{bet['id']} is terminal ({cur}) — no further transitions")
+    if to == "kill_pending":
+        return
+    if to in TERMINALS:
+        return
+    if cur == "kill_pending":
+        if not override:
+            raise BetError(
+                f"{bet['id']} is kill_pending — resuming {to} requires "
+                "--override-kill --reason (a journaled act)"
+            )
+        return
+    if cur in ACTIVE_ORDER and to in ACTIVE_ORDER:
+        if ACTIVE_ORDER.index(to) == ACTIVE_ORDER.index(cur) + 1:
+            return
+        raise BetError(
+            f"invalid transition {cur} → {to}: forward moves are adjacent "
+            f"({' → '.join(ACTIVE_ORDER)}); kill_pending and terminals "
+            f"({'|'.join(sorted(TERMINALS))}) are reachable from anywhere"
+        )
+    raise BetError(f"invalid transition {cur} → {to}")
+
+
+def cmd_transition(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    bet = load_bet(root, args.bet_id)
+    records = load_journal(root)
+    findings = goalpost_findings(root, bet, records)
+    to = args.new_state
+
+    if args.verdict and args.verdict not in VERDICTS:
+        raise BetError(f"--verdict must be one of {VERDICTS}")
+    if args.successor and to != "killed":
+        raise BetError("--successor (pivot) closes the bet: the target state must be `killed`")
+    if args.successor and (not args.envelope or not args.criteria):
+        raise BetError("a pivot successor needs fresh --envelope and --criteria files")
+
+    # A stateless journaled act: unlock a tranche and/or override a pending kill.
+    if to is None:
+        if not args.unlock_milestone and not args.override_kill:
+            raise BetError(
+                "pass a new state, or --unlock-milestone / --override-kill for a "
+                "stateless journaled act"
+            )
+        rc = report(findings, args.gate)
+        if rc:
+            print(f"bet: stateless act on {args.bet_id} REFUSED (--gate)")
+            return rc
+        if args.unlock_milestone:
+            milestones = {
+                t.get("unlock_milestone_id")
+                for t in bet.get("envelope", {}).get("tranches") or []
+                if isinstance(t, dict)
+            }
+            if args.unlock_milestone not in milestones:
+                raise BetError(
+                    f"no tranche unlocks on milestone {args.unlock_milestone!r} "
+                    f"(tranche milestones: {sorted(m for m in milestones if m)})"
+                )
+            unlocked = bet.setdefault("unlocked_milestones", [])
+            if args.unlock_milestone not in unlocked:
+                unlocked.append(args.unlock_milestone)
+            save_bet(root, bet)
+            append_event(root, "tranche-unlock", args.bet_id, {
+                "milestone": args.unlock_milestone, "reason": args.reason or "",
+            })
+            print(
+                f"bet: unlocked milestone {args.unlock_milestone} on {args.bet_id} — "
+                f"${unlocked_cap(bet):g} now unlocked"
+            )
+        if args.override_kill:
+            if not args.reason:
+                raise BetError("--override-kill requires --reason (overrides are costly and journaled)")
+            if pending_kill(records, args.bet_id) is None:
+                raise BetError(f"no pending kill proposal on {args.bet_id} to override")
+            rec = append_event(root, "kill-override", args.bet_id, {"reason": args.reason})
+            print(
+                f"bet: kill proposal on {args.bet_id} OVERRIDDEN ({rec['record_id']}) — "
+                f"reason journaled: {args.reason}"
+            )
+        return 0
+
+    if to not in ALL_STATES:
+        raise BetError(f"unknown state {to!r} (states: {', '.join(sorted(ALL_STATES))})")
+    if args.override_kill and not args.reason:
+        raise BetError("--override-kill requires --reason (overrides are costly and journaled)")
+    _guard_transition(bet, to, args.override_kill)
+
+    harvest = None
+    if to == "killed":
+        # Hard guards — state-machine integrity, not precision-risk gates:
+        # `killed` is blocked until the retrospective exists non-trivially and
+        # the harvest check RAN (it runs right here; skipped ≠ blocked).
+        if not retrospective_nontrivial(root, args.bet_id):
+            sys.stderr.write(
+                f"bet: BLOCKED — {args.bet_id} cannot transition to killed until "
+                f"bets/{args.bet_id}/retrospective.md exists non-trivially "
+                f"(≥{RETRO_MIN_CHARS} chars of prose; harvest discipline — grade the "
+                "process, not the outcome)\n"
+            )
+            return 1
+        harvest = harvest_check(bet)
+        if "skipped" in harvest:
+            print(f"bet: harvest check skipped — {harvest['skipped']}")
+        elif harvest["proposed_terminal"] == "sold":
+            findings.append(
+                f"harvest check: est sale value ${harvest['est_sale_value_usd']:g} "
+                f"(3.9 × TTM SDP) > wind-down cost ${harvest['wind_down_cost_usd']:g} "
+                "— the proposed terminal is `sold`, not `killed`"
+            )
+        else:
+            print(
+                f"bet: harvest check — est sale value ${harvest['est_sale_value_usd']:g} "
+                f"≤ wind-down cost ${harvest['wind_down_cost_usd']:g}; kill stands"
+            )
+
+    if to in IN_FLIGHT and bet["state"] not in IN_FLIGHT:
+        findings += cap_findings(root, args.max_in_flight, entering=args.bet_id)
+
+    rc = report(findings, args.gate)
+    if rc:
+        print(f"bet: transition {args.bet_id} → {to} REFUSED (--gate)")
+        return rc
+
+    if args.override_kill and pending_kill(records, args.bet_id):
+        append_event(root, "kill-override", args.bet_id, {"reason": args.reason})
+
+    prev = bet["state"]
+    bet["state"] = to
+    details = {
+        "from": prev, "to": to,
+        "verdict": args.verdict, "reason": args.reason or "",
+    }
+    if harvest is not None:
+        details["harvest"] = harvest
+    successor_note = ""
+    if args.successor:
+        # Pivot: close this bet honestly (criteria evaluated against the OLD
+        # thesis belong in the retrospective + evaluate history) and open a
+        # successor with FRESH envelope + criteria — never an edit.
+        if not args.envelope or not args.criteria:
+            raise BetError("a pivot successor needs fresh --envelope and --criteria files")
+        details["successor"] = args.successor
+        bet["successor"] = args.successor
+        save_bet(root, bet)
+        append_event(root, "transition", args.bet_id, details)
+        sub = argparse.Namespace(
+            portfolio_dir=args.portfolio_dir, bet_id=args.successor,
+            title=args.successor_title or f"pivot of {args.bet_id}",
+            thesis=args.successor_thesis,
+            envelope=args.envelope, criteria=args.criteria,
+            ecosystem_channel=None, owned_audience=None,
+            means_ref=None, predecessor=args.bet_id, gate=args.gate,
+        )
+        rc = cmd_create(sub)
+        if rc:
+            return rc
+        successor_note = f"; successor {args.successor} opened with fresh envelope+criteria"
+    else:
+        save_bet(root, bet)
+        append_event(root, "transition", args.bet_id, details)
+    verdict = f" verdict={args.verdict}" if args.verdict else ""
+    print(f"bet: {args.bet_id} {prev} → {to}{verdict}{successor_note}")
+    return 0
+
+
+def cmd_rebaseline(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    bet = load_bet(root, args.bet_id)
+    if bet["state"] in TERMINALS:
+        raise BetError(f"{args.bet_id} is terminal ({bet['state']}) — goalposts are frozen")
+    if not args.envelope and not args.criteria:
+        raise BetError("nothing to rebaseline — pass --envelope and/or --criteria")
+
+    records = load_journal(root)
+    for f in goalpost_findings(root, bet, records):
+        # Surface a pre-existing hand edit; the rebaseline heals it FROM the
+        # journaled baseline, so the tamper stays visible in the chain.
+        print(f"bet: [report-only] {f} — rebaselining over it (journaled)")
+    old_env_h, old_crit_h = goalpost_baseline(records, args.bet_id)
+
+    details = {"reason": args.reason}
+    findings = []
+    if args.envelope:
+        env_path = Path(args.envelope)
+        if not env_path.is_file():
+            raise BetError(f"envelope file not found: {env_path}")
+        try:
+            envelope = json.loads(env_path.read_text())
+        except json.JSONDecodeError as e:
+            raise BetError(f"cannot parse {env_path}: {e}") from e
+        if not isinstance(envelope.get("cash_cap_usd"), (int, float)):
+            raise BetError(f"{env_path}: envelope needs a numeric cash_cap_usd")
+        findings += [f"soundness: {f}" for f in envelope_soundness(envelope)]
+        details["old_envelope_hash"] = old_env_h
+        details["new_envelope_hash"] = content_hash(envelope)
+    if args.criteria:
+        criteria = parse_criteria_file(Path(args.criteria))
+        findings += [f"soundness: {f}" for f in criteria_soundness(criteria)]
+        details["old_criteria_hash"] = old_crit_h
+        details["new_criteria_hash"] = content_hash(criteria)
+
+    rc = report(findings, args.gate)
+    if rc:
+        print(f"bet: rebaseline {args.bet_id} REFUSED (--gate)")
+        return rc
+
+    if args.envelope:
+        bet["envelope"] = envelope
+        save_bet(root, bet)
+    if args.criteria:
+        (bet_dir(root, args.bet_id) / "kill-criteria.json").write_text(
+            json.dumps({"criteria": criteria}, indent=2, sort_keys=True) + "\n"
+        )
+    rec = append_event(root, "rebaseline", args.bet_id, details)
+    moved = " + ".join(
+        n for n, present in (("envelope", args.envelope), ("kill criteria", args.criteria)) if present
+    )
+    print(
+        f"bet: rebaselined {moved} for {args.bet_id} ({rec['record_id']}) — old→new "
+        f"hashes journaled; reason: {args.reason}"
+    )
+    return 0
+
+
+def _next_due(criteria: list[dict], today: date) -> str:
+    dates = []
+    for c in criteria:
+        try:
+            dates.append(date.fromisoformat(str(c.get("by_date"))))
+        except ValueError:
+            continue
+    if not dates:
+        return "no dated criteria"
+    nxt = min(dates)
+    days = (nxt - today).days
+    return f"{days}d to {nxt.isoformat()}" if days >= 0 else f"OVERDUE {-days}d ({nxt.isoformat()})"
+
+
+def cmd_portfolio(args) -> int:
+    root = portfolio_root(args.portfolio_dir)
+    records = load_journal(root)
+    bets = all_bets(root)
+    today = date.today()
+
+    findings: list[str] = []
+    rows = []
+    for bet in bets:
+        bid = bet["id"]
+        findings += goalpost_findings(root, bet, records)
+        cash, hours = spend_totals(load_ledger(root, bid))
+        cap = unlocked_cap(bet)
+        env = bet.get("envelope", {})
+        if cash > cap and bet["state"] not in TERMINALS:
+            findings.append(
+                f"{bid}: cumulative spend ${cash:g} exceeds unlocked tranches ${cap:g}"
+            )
+        try:
+            criteria = load_criteria(root, bid)
+        except BetError:
+            criteria = []
+        pend = pending_kill(records, bid)
+        rows.append({
+            "id": bid,
+            "state": bet["state"],
+            "spend_usd": cash,
+            "unlocked_usd": cap,
+            "cash_cap_usd": env.get("cash_cap_usd", 0),
+            "hours": hours,
+            "next_criterion": _next_due(criteria, today),
+            "distribution": distribution_status(root, bid)["status"],
+            "kill_pending_proposal": bool(pend),
+        })
+
+    findings += cap_findings(root, args.max_in_flight)
+
+    # Loss distribution + kill hygiene per DEAD bet — process accountability
+    # (Simonson & Staw), never a per-bet win/lose ranking.
+    dead = []
+    for bet in bets:
+        if bet["state"] != "killed":
+            continue
+        bid = bet["id"]
+        cash, _ = spend_totals(load_ledger(root, bid))
+        env_cap = bet.get("envelope", {}).get("cash_cap_usd", 0)
+        proposed = next((r for r in bet_events(records, bid) if r["event"] == "kill-proposed"), None)
+        closed = next(
+            (r for r in reversed(bet_events(records, bid))
+             if r["event"] == "transition" and (r.get("details", {}) or {}).get("to") in TERMINALS),
+            None,
+        )
+        latency = "self-initiated (no trigger)"
+        if proposed and closed:
+            try:
+                d0 = datetime.fromisoformat(proposed["ts"])
+                d1 = datetime.fromisoformat(closed["ts"])
+                latency = f"{(d1 - d0).days}d from trigger to close"
+            except ValueError:
+                latency = "unknown"
+        dead.append({
+            "id": bid, "loss_usd": cash,
+            "envelope_respected": cash <= env_cap,
+            "kill_on_trigger": latency,
+        })
+
+    if args.format == "json":
+        print(json.dumps({
+            "bets": rows,
+            "in_flight": in_flight_bets(root),
+            "max_in_flight": args.max_in_flight,
+            "dead_bets": dead,
+            "findings": findings,
+        }, indent=2))
+        return 1 if args.gate and findings else 0
+
+    print(f"portfolio: {root}")
+    print(f"  bets: {len(bets)} — in flight: {len(in_flight_bets(root))}/{args.max_in_flight} "
+          f"({', '.join(in_flight_bets(root)) or 'none'})")
+    for r in rows:
+        pend = "  [KILL PROPOSAL PENDING]" if r["kill_pending_proposal"] else ""
+        print(
+            f"  {r['id']:24s} {r['state']:12s} spend ${r['spend_usd']:g}/"
+            f"${r['unlocked_usd']:g} unlocked (cap ${r['cash_cap_usd']:g}), "
+            f"{r['hours']:g}h; next criterion: {r['next_criterion']}; "
+            f"distribution: {r['distribution']}{pend}"
+        )
+    if dead:
+        losses = sorted(d["loss_usd"] for d in dead)
+        median = losses[len(losses) // 2] if len(losses) % 2 else \
+            (losses[len(losses) // 2 - 1] + losses[len(losses) // 2]) / 2
+        print(f"  dead bets: {len(dead)} — loss median ${median:g}, max ${max(losses):g} "
+              "(loss distribution + kill hygiene, never win/lose ranking)")
+        for d in dead:
+            resp = "respected" if d["envelope_respected"] else "EXCEEDED"
+            print(f"    {d['id']}: loss ${d['loss_usd']:g}, envelope {resp}, "
+                  f"kill hygiene: {d['kill_on_trigger']}")
+    return report(findings, args.gate)
+
+
+# ---- CLI -----------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def common(sp):
+        sp.add_argument(
+            "--portfolio-dir", default=None,
+            help="portfolio repo (default: $CHIEF_WIGGUM_PORTFOLIO or ~/.chief-wiggum/portfolio)",
+        )
+        sp.add_argument(
+            "--gate", action="store_true",
+            help="exit 1 on findings (report-only by default — docs/gate-rollout.md)",
+        )
+
+    sp = sub.add_parser("create", help="register a bet (envelope+criteria hashed as goalposts)")
+    common(sp)
+    sp.add_argument("bet_id")
+    sp.add_argument("--title", required=True)
+    sp.add_argument("--thesis", default="")
+    sp.add_argument("--envelope", required=True, metavar="JSON",
+                    help="affordable-loss envelope file (templates/bet-schema.json $defs.envelope)")
+    sp.add_argument("--criteria", required=True, metavar="JSON",
+                    help="states-and-dates kill criteria file (templates/kill-criteria-schema.json)")
+    sp.add_argument("--ecosystem-channel", default=None,
+                    help="built-in-distribution ecosystem channel the acquisition plan ships into")
+    sp.add_argument("--owned-audience", default=None,
+                    help="owned audience the acquisition plan draws on")
+    sp.add_argument("--means-ref", action="append", metavar="REF",
+                    help="means.json entry this bet draws on (repeatable — bird-in-hand)")
+    sp.add_argument("--predecessor", default=None, help=argparse.SUPPRESS)
+
+    sp = sub.add_parser("spend", help="append a spend/time/rep ledger entry")
+    common(sp)
+    sp.add_argument("bet_id")
+    sp.add_argument("--amount-usd", type=float, default=None)
+    sp.add_argument("--hours", type=float, default=None)
+    sp.add_argument("--rep", action="store_true",
+                    help="a distribution rep (outreach/channel work) — counts toward "
+                         "distribution-attempted, not cash spend")
+    sp.add_argument("--note", default="")
+
+    sp = sub.add_parser("evaluate", help="evaluate dated kill criteria + distribution status")
+    common(sp)
+    sp.add_argument("bet_id")
+    sp.add_argument("--results", default=None, metavar="JSON",
+                    help="measured values file: {metric: value}; absent metrics are UNMEASURED")
+    sp.add_argument("--as-of", default=None, metavar="YYYY-MM-DD",
+                    help="evaluation date (default: today)")
+
+    sp = sub.add_parser(
+        "transition",
+        help="move the state machine (pivot via --successor; kill accept/override; "
+             "tranche unlock) — every one a journaled act",
+    )
+    common(sp)
+    sp.add_argument("bet_id")
+    sp.add_argument("new_state", nargs="?", default=None,
+                    help=f"target state ({', '.join(sorted(ALL_STATES))}); omit for a "
+                         "stateless act (--unlock-milestone / --override-kill)")
+    sp.add_argument("--verdict", default=None, choices=VERDICTS,
+                    help="gate verdict recorded with the transition (Cooper vocabulary)")
+    sp.add_argument("--reason", default=None)
+    sp.add_argument("--override-kill", action="store_true",
+                    help="override a pending kill proposal (journaled; requires --reason)")
+    sp.add_argument("--unlock-milestone", default=None, metavar="ID",
+                    help="record a tranche-unlocking milestone as reached (journaled)")
+    sp.add_argument("--successor", default=None, metavar="BET_ID",
+                    help="pivot: close this bet (state must be `killed`) and open a "
+                         "successor with fresh --envelope/--criteria")
+    sp.add_argument("--envelope", default=None, metavar="JSON",
+                    help="successor's fresh envelope (pivot only)")
+    sp.add_argument("--criteria", default=None, metavar="JSON",
+                    help="successor's fresh kill criteria (pivot only)")
+    sp.add_argument("--successor-title", default=None)
+    sp.add_argument("--successor-thesis", default="")
+    sp.add_argument("--max-in-flight", type=int, default=DEFAULT_MAX_IN_FLIGHT,
+                    help=f"bets-in-flight cap over probing|validating|building "
+                         f"(default {DEFAULT_MAX_IN_FLIGHT})")
+
+    sp = sub.add_parser("rebaseline",
+                        help="the ONLY mutation path for envelope/kill criteria (journaled)")
+    common(sp)
+    sp.add_argument("bet_id")
+    sp.add_argument("--envelope", default=None, metavar="JSON")
+    sp.add_argument("--criteria", default=None, metavar="JSON")
+    sp.add_argument("--reason", required=True,
+                    help="why the goalposts move — journaled with old→new hashes")
+
+    sp = sub.add_parser("portfolio", help="portfolio summary + invariants")
+    common(sp)
+    sp.add_argument("--max-in-flight", type=int, default=DEFAULT_MAX_IN_FLIGHT)
+    sp.add_argument("--format", choices=["text", "json"], default="text")
+
+    args = p.parse_args()
+    dispatch = {
+        "create": cmd_create, "spend": cmd_spend, "evaluate": cmd_evaluate,
+        "transition": cmd_transition, "rebaseline": cmd_rebaseline,
+        "portfolio": cmd_portfolio,
+    }
+    try:
+        return dispatch[args.cmd](args)
+    except BetError as e:
+        sys.stderr.write(f"bet: {e}\n")
+        return 2
+    except TamperError as e:
+        sys.stderr.write(f"bet: {e}\n")
+        return 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/bet-schema.json
+++ b/templates/bet-schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/bet.json",
+  "title": "Bet Record",
+  "description": "A bounded venture experiment (`bets/<bet-id>/bet.json` in the portfolio repo, written by scripts/bet.py — see docs/business-factory.md, chief-wiggum#235). A bet is under ~$1k to prove and ~3 months to a kill decision. The embedded `envelope` is a GOALPOST artifact: content-hashed into the portfolio journal at create; `bet.py rebaseline` is the only sanctioned mutation path (Adner & Levinthal 2004 — abandonment conditions must not be retroactively redefined). `state` is maintained by `bet.py transition` only; stage labels are derived from evidence, never self-declared unlocks.",
+  "type": "object",
+  "required": ["id", "title", "created", "state", "envelope"],
+  "additionalProperties": false,
+  "properties": {
+    "$comment": { "type": "string" },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "description": "Stable bet id — the `bets/<id>/` directory name."
+    },
+    "title": { "type": "string", "minLength": 1 },
+    "thesis": {
+      "type": "string",
+      "description": "The falsifiable thesis this bet exists to test. A pivot closes this bet (criteria evaluated against THIS thesis) and opens a successor with a fresh one."
+    },
+    "created": { "type": "string", "description": "ISO timestamp the bet was created." },
+    "state": {
+      "type": "string",
+      "enum": ["proposed", "probing", "validating", "building", "scaling", "kill_pending", "killed", "parked", "lifestyle", "sold"],
+      "description": "proposed → probing → validating → building → scaling; kill_pending reachable from anywhere; terminals killed|parked|lifestyle|sold. `killed` is blocked until retrospective.md exists non-trivially and a harvest check ran."
+    },
+    "envelope": { "$ref": "#/$defs/envelope" },
+    "acquisition": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The acquisition plan the bet-selection lint reads (chief-wiggum#235 amendment): while means.json says sales/marketing novice and no channel has reached `focused`, a plan with neither an ecosystem channel nor an owned audience is flagged.",
+      "properties": {
+        "ecosystem_channel": {
+          "type": ["string", "null"],
+          "description": "A built-in-distribution ecosystem channel (marketplace, app store, plugin directory, ...) this bet ships into, or null."
+        },
+        "owned_audience": {
+          "type": ["string", "null"],
+          "description": "An owned audience (list, following, community) the plan draws on, or null."
+        }
+      }
+    },
+    "means_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References into portfolio means.json entries (skills/assets/network/owned_audience ids or names) this bet draws on — effectuation bird-in-hand: a proposal must reference the means it uses."
+    },
+    "harvest_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Inputs to the harvest check run before a `killed` transition: est sale value = 3.9 × TTM seller-discretionary profit (Acquire.com micro-SaaS median) vs wind-down cost. Absent inputs → the check reports `skipped`, never blocks silently, never crashes.",
+      "properties": {
+        "ttm_sdp_usd": { "type": "number", "minimum": 0, "description": "Trailing-twelve-month seller-discretionary profit, USD." },
+        "wind_down_cost_usd": { "type": "number", "minimum": 0, "description": "Cost of winding the bet down (time, refunds, contract exits), USD." }
+      }
+    },
+    "unlocked_milestones": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Milestone ids whose tranches have been unlocked (journaled human acts via `bet.py transition --unlock-milestone`). Invariant: cumulative spend ≤ cumulative unlocked tranches."
+    },
+    "predecessor": {
+      "type": ["string", "null"],
+      "description": "Bet id this bet succeeded via a pivot, or null."
+    },
+    "successor": {
+      "type": ["string", "null"],
+      "description": "Bet id opened when this bet was closed by a pivot, or null. Pivot is a transition, not an edit."
+    }
+  },
+  "$defs": {
+    "envelope": {
+      "type": "object",
+      "required": ["cash_cap_usd"],
+      "additionalProperties": false,
+      "description": "Affordable-loss envelope (Dew et al. 2009 field list), human-set, script-enforced, raisable only via `bet.py rebaseline` (a journaled act with a required --reason).",
+      "properties": {
+        "cash_cap_usd": { "type": "number", "minimum": 0 },
+        "time_cap_hours": { "type": "number", "minimum": 0 },
+        "calendar_cap_days": { "type": "number", "minimum": 0 },
+        "attention_slots": { "type": "number", "minimum": 0 },
+        "tranches": {
+          "type": "array",
+          "description": "Gompers (1995) staging: the cash cap released stepwise. A tranche with unlock_milestone_id null is unlocked from creation; others unlock via a journaled `--unlock-milestone` act. Invariant: cumulative spend ≤ cumulative unlocked tranches.",
+          "items": {
+            "type": "object",
+            "required": ["amount_usd", "unlock_milestone_id"],
+            "additionalProperties": false,
+            "properties": {
+              "amount_usd": { "type": "number", "minimum": 0 },
+              "unlock_milestone_id": { "type": ["string", "null"] }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/kill-criteria-schema.json
+++ b/templates/kill-criteria-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/kill-criteria.json",
+  "title": "Kill Criteria",
+  "description": "States-and-dates kill criteria (`bets/<bet-id>/kill-criteria.json`, Duke 2022 — see docs/business-factory.md §2.3, chief-wiggum#235). Every criterion is a measurable state PLUS a date; one missing either is MALFORMED (soundness lint at creation). Criteria must be evidence-shaped (paid conversions, commitment-class signals), never MRR-target-shaped: a 3-month box can only validate demand existence. This file is a GOALPOST artifact — content-hashed into the portfolio journal at create; `bet.py rebaseline` (journaled, --reason required) is the only sanctioned mutation path.",
+  "type": "object",
+  "required": ["criteria"],
+  "additionalProperties": false,
+  "properties": {
+    "$comment": { "type": "string" },
+    "criteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/criterion" }
+    }
+  },
+  "$defs": {
+    "criterion": {
+      "type": "object",
+      "required": ["id", "metric", "comparator", "threshold", "by_date", "direction"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "description": "Stable criterion id, e.g. 'KC-1'." },
+        "metric": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The measurable state's metric, e.g. 'paid_conversions'. Prefer commitment currencies (scheduled time, staked reputation, paid money) over opinion/click metrics."
+        },
+        "comparator": { "type": "string", "enum": ["<", "<=", ">", ">=", "==", "!="] },
+        "threshold": { "type": "number" },
+        "by_date": { "type": "string", "format": "date", "description": "ISO date the state must (direction=has) or must not (direction=has_not) hold by. A criterion without a date has no timeout semantics and is malformed." },
+        "direction": {
+          "type": "string",
+          "enum": ["has", "has_not"],
+          "description": "'has': the state must have been reached by by_date — past the date without it, the criterion TRIGGERS (proposes kill_pending). 'has_not': the state must not occur — it triggers as soon as it does."
+        }
+      }
+    }
+  }
+}

--- a/templates/means-schema.json
+++ b/templates/means-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/means.json",
+  "title": "Means Inventory",
+  "description": "Portfolio-level means inventory (`<portfolio>/means.json` — effectuation bird-in-hand, chief-wiggum#235 amendment). Honest skill levels are load-bearing inputs, not vanity fields: the bet-selection lint reads sales/marketing here — while both are novice and no channel has ever reached `focused`, a bet whose acquisition plan has no ecosystem channel and no owned audience is flagged (report-only). A bet proposal must reference the means it draws on (bet.json means_refs). Absent means.json → dependent checks report `skipped`, never crash.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$comment": { "type": "string" },
+    "skills": {
+      "type": "object",
+      "description": "Skill → honest self-assessed level. Keys are free-form ('sales', 'marketing', 'engineering', ...); the bet-selection lint reads 'sales' and 'marketing'.",
+      "additionalProperties": { "type": "string", "enum": ["novice", "competent", "strong"] }
+    },
+    "assets": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Things owned that a bet can draw on (codebases, infra, tooling, cash-adjacent assets)."
+    },
+    "network": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Who you know — reachable people/communities a bet's distribution can lean on."
+    },
+    "owned_audience": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Audiences already owned (lists, followings, communities) — the bet-selection lint accepts a plan that draws on one."
+    },
+    "hours_per_week": { "type": "number", "minimum": 0 },
+    "cash_available": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Current zero-based slack, USD — the ability side of affordable loss. Envelopes justified by projected future revenue are the business analogue of building on an UNRESOLVED: fact."
+    }
+  }
+}

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -1,0 +1,547 @@
+"""Tests for scripts/bet.py — the bet ledger (chief-wiggum#235).
+
+Seeded-defect coverage for every gate the script ships (all report-only by
+default per docs/gate-rollout.md): malformed states-and-dates criterion, spend
+past the unlocked tranches, `killed` without a retrospective, a tampered
+journal (fail closed, exit 4), the bets-in-flight cap, rebaseline without
+--reason, a dated criterion firing at evaluate, and pivot-as-transition.
+Everything runs against a tmp_path portfolio — never the real ~/.chief-wiggum.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import ratchet  # noqa: E402
+
+BET = str(SCRIPTS / "bet.py")
+
+ENVELOPE = {
+    "cash_cap_usd": 900,
+    "time_cap_hours": 120,
+    "calendar_cap_days": 90,
+    "attention_slots": 1,
+    "tranches": [
+        {"amount_usd": 300, "unlock_milestone_id": None},
+        {"amount_usd": 600, "unlock_milestone_id": "M1"},
+    ],
+}
+
+CRITERIA = {
+    "criteria": [
+        {"id": "KC-1", "metric": "paid_conversions", "comparator": ">=",
+         "threshold": 3, "by_date": "2026-11-01", "direction": "has"},
+        {"id": "KC-2", "metric": "refund_rate_pct", "comparator": ">",
+         "threshold": 30, "by_date": "2026-11-01", "direction": "has_not"},
+    ]
+}
+
+
+@pytest.fixture
+def portfolio(tmp_path):
+    return tmp_path / "portfolio"
+
+
+def _run(portfolio: Path, *argv: str, env_extra: dict | None = None):
+    import os
+    env = dict(os.environ)
+    # Belt-and-braces: even a test that forgets --portfolio-dir stays in tmp.
+    env["CHIEF_WIGGUM_PORTFOLIO"] = str(portfolio)
+    env.update(env_extra or {})
+    return subprocess.run(
+        [sys.executable, BET, *argv, "--portfolio-dir", str(portfolio)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def _files(tmp_path, envelope=None, criteria=None) -> tuple[str, str]:
+    env_p = tmp_path / "envelope.json"
+    crit_p = tmp_path / "criteria.json"
+    env_p.write_text(json.dumps(envelope or ENVELOPE))
+    crit_p.write_text(json.dumps(criteria or CRITERIA))
+    return str(env_p), str(crit_p)
+
+
+def _create(portfolio, tmp_path, bet_id="b1", *extra, envelope=None, criteria=None):
+    env_p, crit_p = _files(tmp_path, envelope, criteria)
+    return _run(portfolio, "create", bet_id, "--title", f"bet {bet_id}",
+                "--envelope", env_p, "--criteria", crit_p, *extra)
+
+
+def _journal(portfolio: Path) -> list[dict]:
+    return ratchet.load_journal(SimpleNamespace(journal=portfolio / "journal.jsonl"))
+
+
+def _state(portfolio: Path, bet_id: str) -> str:
+    return json.loads((portfolio / "bets" / bet_id / "bet.json").read_text())["state"]
+
+
+def _retro(portfolio: Path, bet_id: str) -> None:
+    (portfolio / "bets" / bet_id / "retrospective.md").write_text(
+        "# retro\n\nEnvelope respected; criteria evaluated honestly; the kill "
+        "was executed on trigger. Distribution was never attempted.\n"
+    )
+
+
+# ---- create + journal ----------------------------------------------------------
+
+
+def test_create_hashes_goalposts_into_journal(portfolio, tmp_path):
+    proc = _create(portfolio, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert (portfolio / "bets" / "b1" / "bet.json").is_file()
+    assert (portfolio / "bets" / "b1" / "kill-criteria.json").is_file()
+    assert (portfolio / "bets" / "b1" / "ledger.jsonl").is_file()
+    assert (portfolio / ".git").exists()  # git-initialized on first use
+    records = _journal(portfolio)  # verifies the hash chain from genesis
+    assert len(records) == 1
+    assert records[0]["event"] == "bet-create"
+    assert records[0]["details"]["envelope_hash"]
+    assert records[0]["details"]["criteria_hash"]
+
+
+def test_create_duplicate_bet_is_usage_error(portfolio, tmp_path):
+    assert _create(portfolio, tmp_path).returncode == 0
+    proc = _create(portfolio, tmp_path)
+    assert proc.returncode == 2
+    assert "already exists" in proc.stderr
+
+
+def test_env_var_portfolio_dir_is_respected(tmp_path):
+    import os
+    env = dict(os.environ)
+    env["CHIEF_WIGGUM_PORTFOLIO"] = str(tmp_path / "envport")
+    env_p, crit_p = _files(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, BET, "create", "b1", "--title", "t",
+         "--envelope", env_p, "--criteria", crit_p],
+        capture_output=True, text=True, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "envport" / "bets" / "b1" / "bet.json").is_file()
+
+
+# ---- seeded defect: malformed criterion (states-and-dates lint) ---------------
+
+
+def test_malformed_criterion_no_date_is_flagged_report_only(portfolio, tmp_path):
+    bad = {"criteria": [{"id": "KC-1", "metric": "paid_conversions",
+                         "comparator": ">=", "threshold": 3, "direction": "has"}]}
+    proc = _create(portfolio, tmp_path, criteria=bad)
+    assert proc.returncode == 0  # report-only default: findings print, exit 0
+    assert "malformed" in proc.stdout and "no date" in proc.stdout
+
+
+def test_malformed_criterion_no_metric_blocks_under_gate(portfolio, tmp_path):
+    bad = {"criteria": [{"id": "KC-1", "comparator": ">=", "threshold": 3,
+                         "by_date": "2026-11-01", "direction": "has"}]}
+    proc = _create(portfolio, tmp_path, "b1", "--gate", criteria=bad)
+    assert proc.returncode == 1
+    assert "REFUSED" in proc.stdout
+    assert not (portfolio / "bets" / "b1" / "bet.json").exists()
+
+
+# ---- seeded defect: spend past the unlocked tranches ---------------------------
+
+
+def test_spend_past_tranche_flagged_and_gated(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    ok = _run(portfolio, "spend", "b1", "--amount-usd", "250")
+    assert ok.returncode == 0 and "exceeds" not in ok.stdout
+    over = _run(portfolio, "spend", "b1", "--amount-usd", "100")
+    assert over.returncode == 0  # report-only: recorded, finding printed
+    assert "exceeds cumulative unlocked tranches" in over.stdout
+    gated = _run(portfolio, "spend", "b1", "--amount-usd", "100", "--gate")
+    assert gated.returncode == 1
+    assert "REFUSED" in gated.stdout
+    entries = (portfolio / "bets" / "b1" / "ledger.jsonl").read_text().splitlines()
+    assert len([ln for ln in entries if ln.strip()]) == 2  # gated entry NOT appended
+
+
+def test_unlock_milestone_raises_the_cap(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "spend", "b1", "--amount-usd", "300")
+    proc = _run(portfolio, "transition", "b1", "--unlock-milestone", "M1")
+    assert proc.returncode == 0, proc.stderr
+    assert "$900 now unlocked" in proc.stdout
+    after = _run(portfolio, "spend", "b1", "--amount-usd", "200", "--gate")
+    assert after.returncode == 0, after.stdout + after.stderr
+    events = [r["event"] for r in _journal(portfolio)]
+    assert "tranche-unlock" in events
+
+
+# ---- seeded defect: killed without retrospective -------------------------------
+
+
+def test_killed_without_retrospective_is_blocked(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    proc = _run(portfolio, "transition", "b1", "killed", "--reason", "done")
+    assert proc.returncode == 1
+    assert "retrospective.md" in proc.stderr
+    assert _state(portfolio, "b1") == "proposed"
+
+
+def test_trivial_retrospective_does_not_unlock_killed(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    (portfolio / "bets" / "b1" / "retrospective.md").write_text("# retro\n\nok\n")
+    proc = _run(portfolio, "transition", "b1", "killed")
+    assert proc.returncode == 1
+    assert _state(portfolio, "b1") == "proposed"
+
+
+def test_killed_with_retrospective_runs_harvest_check_skipped(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _retro(portfolio, "b1")
+    proc = _run(portfolio, "transition", "b1", "killed", "--verdict", "kill")
+    assert proc.returncode == 0, proc.stderr
+    assert "harvest check skipped" in proc.stdout  # absent inputs: reported, never a silent block
+    assert _state(portfolio, "b1") == "killed"
+    trans = [r for r in _journal(portfolio) if r["event"] == "transition"][-1]
+    assert trans["details"]["harvest"] == {
+        "skipped": "harvest inputs absent (harvest_inputs.ttm_sdp_usd / "
+                   ".wind_down_cost_usd) — est sale value unknown"}
+
+
+def test_harvest_check_proposes_sold_when_sale_beats_wind_down(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _retro(portfolio, "b1")
+    bet_path = portfolio / "bets" / "b1" / "bet.json"
+    bet = json.loads(bet_path.read_text())
+    bet["harvest_inputs"] = {"ttm_sdp_usd": 10000, "wind_down_cost_usd": 500}
+    bet_path.write_text(json.dumps(bet))
+    proc = _run(portfolio, "transition", "b1", "killed")
+    assert proc.returncode == 0  # report-only
+    assert "`sold`, not `killed`" in proc.stdout
+    # under --gate the killed transition is refused until sold is chosen
+    bet["state"] = "proposed"  # (previous run applied it report-only)
+    bet_path.write_text(json.dumps(bet))
+    gated = _run(portfolio, "transition", "b1", "killed", "--gate")
+    assert gated.returncode == 1
+    assert _state(portfolio, "b1") == "proposed"
+    sold = _run(portfolio, "transition", "b1", "sold", "--gate")
+    assert sold.returncode == 0, sold.stdout + sold.stderr
+
+
+# ---- seeded defect: tampered journal fails closed ------------------------------
+
+
+def test_tampered_journal_fails_closed_exit_4(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "spend", "b1", "--amount-usd", "10")
+    jpath = portfolio / "journal.jsonl"
+    lines = jpath.read_text().splitlines()
+    rec = json.loads(lines[0])
+    rec["details"]["envelope_hash"] = "forged"  # interior rewrite
+    lines[0] = json.dumps(rec, sort_keys=True)
+    jpath.write_text("\n".join(lines) + "\n")
+    for cmd in (["portfolio"], ["spend", "b1", "--amount-usd", "1"],
+                ["evaluate", "b1"], ["transition", "b1", "probing"]):
+        proc = _run(portfolio, *cmd)
+        assert proc.returncode == 4, f"{cmd}: {proc.stdout}{proc.stderr}"
+        assert "tamper" in proc.stderr
+
+
+# ---- seeded defect: bets-in-flight cap -----------------------------------------
+
+
+def test_third_in_flight_bet_over_cap(portfolio, tmp_path):
+    for bid in ("b1", "b2", "b3"):
+        _create(portfolio, tmp_path, bid)
+    _run(portfolio, "transition", "b1", "probing")
+    _run(portfolio, "transition", "b2", "probing")
+    gated = _run(portfolio, "transition", "b3", "probing", "--gate")
+    assert gated.returncode == 1
+    assert "exceed the cap of 2" in gated.stdout
+    assert _state(portfolio, "b3") == "proposed"  # refused, not applied
+    reported = _run(portfolio, "transition", "b3", "probing")
+    assert reported.returncode == 0  # report-only: finding printed, applied
+    assert "exceed the cap of 2" in reported.stdout
+    assert _state(portfolio, "b3") == "probing"
+    summary = _run(portfolio, "portfolio")
+    assert summary.returncode == 0
+    assert "exceed the cap of 2" in summary.stdout
+    assert _run(portfolio, "portfolio", "--gate").returncode == 1
+
+
+def test_max_in_flight_override(portfolio, tmp_path):
+    for bid in ("b1", "b2", "b3"):
+        _create(portfolio, tmp_path, bid)
+        _run(portfolio, "transition", bid, "probing")
+    proc = _run(portfolio, "portfolio", "--max-in-flight", "3", "--gate")
+    assert proc.returncode == 0, proc.stdout
+
+
+# ---- seeded defect: rebaseline discipline --------------------------------------
+
+
+def test_rebaseline_without_reason_rejected(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    env_p, _ = _files(tmp_path, envelope={"cash_cap_usd": 2000})
+    proc = _run(portfolio, "rebaseline", "b1", "--envelope", env_p)
+    assert proc.returncode == 2  # argparse: --reason is required
+    assert "--reason" in proc.stderr
+
+
+def test_rebaseline_journals_old_and_new_hashes(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    old_hash = _journal(portfolio)[0]["details"]["envelope_hash"]
+    env_p, _ = _files(tmp_path, envelope={"cash_cap_usd": 2000})
+    proc = _run(portfolio, "rebaseline", "b1", "--envelope", env_p,
+                "--reason", "means changed: contract income landed")
+    assert proc.returncode == 0, proc.stderr
+    rec = [r for r in _journal(portfolio) if r["event"] == "rebaseline"][-1]
+    assert rec["details"]["old_envelope_hash"] == old_hash
+    assert rec["details"]["new_envelope_hash"] != old_hash
+    assert rec["details"]["reason"].startswith("means changed")
+    bet = json.loads((portfolio / "bets" / "b1" / "bet.json").read_text())
+    assert bet["envelope"]["cash_cap_usd"] == 2000
+
+
+def test_hand_edited_criteria_detected_and_healed_by_rebaseline(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    crit_path = portfolio / "bets" / "b1" / "kill-criteria.json"
+    doc = json.loads(crit_path.read_text())
+    doc["criteria"][0]["threshold"] = 1  # goalposts quietly lowered
+    crit_path.write_text(json.dumps(doc))
+    proc = _run(portfolio, "evaluate", "b1")
+    assert proc.returncode == 0
+    assert "does not match the journaled baseline" in proc.stdout
+    assert _run(portfolio, "evaluate", "b1", "--gate").returncode == 1
+    new_p = tmp_path / "new-crit.json"
+    new_p.write_text(json.dumps(doc))
+    heal = _run(portfolio, "rebaseline", "b1", "--criteria", str(new_p),
+                "--reason", "threshold deliberately lowered after re-scoping")
+    assert heal.returncode == 0, heal.stderr
+    assert _run(portfolio, "evaluate", "b1", "--gate").returncode == 0
+
+
+# ---- seeded defect: dated criterion fires at evaluate --------------------------
+
+
+def test_evaluate_fires_dated_criterion_and_blocks_spend(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps({"paid_conversions": 1}))
+    proc = _run(portfolio, "evaluate", "b1", "--results", str(results),
+                "--as-of", "2026-12-01")
+    assert proc.returncode == 0
+    assert "TRIGGERED" in proc.stdout
+    assert "journaled kill-proposed" in proc.stdout
+    assert [r for r in _journal(portfolio) if r["event"] == "kill-proposed"]
+    # second evaluate does not duplicate the pending proposal
+    again = _run(portfolio, "evaluate", "b1", "--results", str(results),
+                 "--as-of", "2026-12-01")
+    assert "already pending" in again.stdout
+    assert len([r for r in _journal(portfolio) if r["event"] == "kill-proposed"]) == 1
+    # further spend is blocked pending the human decision
+    spend = _run(portfolio, "spend", "b1", "--amount-usd", "10", "--gate")
+    assert spend.returncode == 1
+    assert "blocked pending kill decision" in spend.stdout
+    # accept: transition into kill_pending resolves the proposal
+    accept = _run(portfolio, "transition", "b1", "kill_pending", "--verdict", "kill")
+    assert accept.returncode == 0, accept.stderr
+    assert _state(portfolio, "b1") == "kill_pending"
+    assert _run(portfolio, "spend", "b1", "--amount-usd", "10", "--gate").returncode == 1
+
+
+def test_kill_override_is_journaled_and_unblocks_spend(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "evaluate", "b1", "--as-of", "2026-12-01")
+    bad = _run(portfolio, "transition", "b1", "--override-kill")
+    assert bad.returncode == 2  # override without a reason is refused
+    proc = _run(portfolio, "transition", "b1", "--override-kill",
+                "--reason", "distribution unattempted — recycle, not kill")
+    assert proc.returncode == 0, proc.stderr
+    assert [r for r in _journal(portfolio) if r["event"] == "kill-override"]
+    spend = _run(portfolio, "spend", "b1", "--amount-usd", "10", "--gate")
+    assert spend.returncode == 0, spend.stdout
+
+
+def test_has_not_criterion_triggers_immediately(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps({"refund_rate_pct": 45, "paid_conversions": 5}))
+    proc = _run(portfolio, "evaluate", "b1", "--results", str(results),
+                "--as-of", "2026-09-01")  # before by_date
+    assert "KC-2 refund_rate_pct: TRIGGERED" in proc.stdout
+    assert "KC-1 paid_conversions: MET" in proc.stdout
+
+
+# ---- seeded defect: pivot closes + opens successor -----------------------------
+
+
+def test_pivot_closes_bet_and_opens_successor(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _retro(portfolio, "b1")
+    env_p, crit_p = _files(tmp_path)
+    proc = _run(portfolio, "transition", "b1", "killed",
+                "--successor", "b1-v2", "--envelope", env_p, "--criteria", crit_p,
+                "--successor-title", "fresh thesis", "--reason", "pivot")
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert _state(portfolio, "b1") == "killed"
+    assert _state(portfolio, "b1-v2") == "proposed"
+    old = json.loads((portfolio / "bets" / "b1" / "bet.json").read_text())
+    new = json.loads((portfolio / "bets" / "b1-v2" / "bet.json").read_text())
+    assert old["successor"] == "b1-v2"
+    assert new["predecessor"] == "b1"
+    events = [(r["event"], r["ref"]) for r in _journal(portfolio)]
+    assert ("transition", "b1") in events
+    assert ("bet-create", "b1-v2") in events  # fresh goalposts hashed for the successor
+
+
+def test_pivot_requires_fresh_envelope_and_criteria(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _retro(portfolio, "b1")
+    proc = _run(portfolio, "transition", "b1", "killed", "--successor", "b1-v2")
+    assert proc.returncode == 2
+    assert "fresh --envelope and --criteria" in proc.stderr
+    assert _state(portfolio, "b1") == "proposed"
+
+
+# ---- state machine -------------------------------------------------------------
+
+
+def test_invalid_transition_is_usage_error(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    proc = _run(portfolio, "transition", "b1", "scaling")
+    assert proc.returncode == 2
+    assert "invalid transition" in proc.stderr
+    assert _state(portfolio, "b1") == "proposed"
+
+
+def test_terminal_bets_are_frozen(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "parked")
+    assert _state(portfolio, "b1") == "parked"
+    assert _run(portfolio, "transition", "b1", "probing").returncode == 2
+    assert _run(portfolio, "spend", "b1", "--amount-usd", "1").returncode == 2
+    env_p, _ = _files(tmp_path, envelope={"cash_cap_usd": 1})
+    assert _run(portfolio, "rebaseline", "b1", "--envelope", env_p,
+                "--reason", "x").returncode == 2
+
+
+def test_kill_pending_resume_requires_override(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "kill_pending")
+    proc = _run(portfolio, "transition", "b1", "probing")
+    assert proc.returncode == 2
+    assert "--override-kill" in proc.stderr
+    ok = _run(portfolio, "transition", "b1", "probing", "--override-kill",
+              "--reason", "fresh data changed the picture")
+    assert ok.returncode == 0, ok.stderr
+    assert _state(portfolio, "b1") == "probing"
+
+
+# ---- bet-selection lint (#235 amendment) ---------------------------------------
+
+
+def _means(portfolio, sales="novice", marketing="novice"):
+    portfolio.mkdir(parents=True, exist_ok=True)
+    (portfolio / "means.json").write_text(json.dumps({
+        "skills": {"sales": sales, "marketing": marketing, "engineering": "strong"},
+        "assets": ["chief-wiggum"], "network": [], "owned_audience": [],
+        "hours_per_week": 10, "cash_available": 5000,
+    }))
+
+
+def test_selection_lint_flags_no_channel_no_audience(portfolio, tmp_path):
+    _means(portfolio)
+    proc = _create(portfolio, tmp_path)
+    assert proc.returncode == 0  # report-only
+    assert "no ecosystem channel and no owned audience" in proc.stdout
+    gated = _create(portfolio, tmp_path, "b2", "--gate")
+    assert gated.returncode == 1
+    assert not (portfolio / "bets" / "b2").exists()
+
+
+def test_selection_lint_passes_with_ecosystem_channel(portfolio, tmp_path):
+    _means(portfolio)
+    proc = _create(portfolio, tmp_path, "b1", "--ecosystem-channel", "shopify-app-store",
+                   "--gate")
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_selection_lint_passes_when_not_novice(portfolio, tmp_path):
+    _means(portfolio, marketing="competent")
+    proc = _create(portfolio, tmp_path, "b1", "--gate")
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_selection_lint_passes_once_a_channel_is_focused(portfolio, tmp_path):
+    _means(portfolio)
+    assert _create(portfolio, tmp_path, "b1", "--ecosystem-channel", "x").returncode == 0
+    (portfolio / "bets" / "b1" / "channels.json").write_text(json.dumps(
+        {"channels": [{"channel": "seo", "status": "focused"}]}))
+    proc = _create(portfolio, tmp_path, "b2", "--gate")
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_selection_lint_skips_without_means_json(portfolio, tmp_path):
+    proc = _create(portfolio, tmp_path, "b1", "--gate")
+    assert proc.returncode == 0, proc.stdout  # skipped is reported, never blocks
+    assert "skipped: no means.json" in proc.stdout
+
+
+# ---- distribution-attempted status ---------------------------------------------
+
+
+def test_distribution_unattempted_reported_never_omitted(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    proc = _run(portfolio, "evaluate", "b1", "--as-of", "2026-09-01")
+    assert "distribution: unattempted" in proc.stdout
+    trig = _run(portfolio, "evaluate", "b1", "--as-of", "2026-12-01")
+    assert "no marketing, not no demand" in trig.stdout
+
+
+def test_rep_entries_count_as_attempted_distribution(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "spend", "b1", "--rep", "--note", "20 cold emails")
+    proc = _run(portfolio, "evaluate", "b1", "--as-of", "2026-09-01")
+    assert "distribution: attempted" in proc.stdout
+    assert "1 rep entry" in proc.stdout
+
+
+# ---- portfolio summary ---------------------------------------------------------
+
+
+def test_portfolio_reports_loss_distribution_and_kill_hygiene(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "spend", "b1", "--amount-usd", "150")
+    _run(portfolio, "evaluate", "b1", "--as-of", "2026-12-01")  # trigger → proposal
+    _retro(portfolio, "b1")
+    _run(portfolio, "transition", "b1", "kill_pending")
+    _run(portfolio, "transition", "b1", "killed", "--verdict", "kill")
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0, proc.stderr
+    assert "loss median $150" in proc.stdout
+    assert "envelope respected" in proc.stdout
+    assert "from trigger to close" in proc.stdout
+    assert "never win/lose ranking" in proc.stdout
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["dead_bets"][0]["loss_usd"] == 150
+    assert data["dead_bets"][0]["envelope_respected"] is True
+
+
+def test_journal_chain_matches_ratchet_format(portfolio, tmp_path):
+    """The portfolio journal IS a ratchet-format chain: ratchet.load_journal
+    verifies it, and recomputing each record's hash from body + previous hash
+    reproduces the stored record_hash."""
+    from chief_wiggum.hashing import stable_hash
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "probing")
+    records = _journal(portfolio)
+    prev = "genesis"
+    for rec in records:
+        body = {k: v for k, v in rec.items() if k != "record_hash"}
+        assert rec["record_hash"] == stable_hash(prev, json.dumps(body, sort_keys=True))
+        prev = rec["record_hash"]


### PR DESCRIPTION
Closes #235 (Business factory Track A — the portfolio spine).

## What

`scripts/bet.py`: six subcommands (`create`, `spend`, `evaluate`, `transition`, `rebaseline`, `portfolio`) over a dedicated portfolio repo (default `~/.chief-wiggum/portfolio`, git-init on first use) with a ratchet-format append-only hash-chain journal.

- **Goalpost discipline**: envelope + states-and-dates kill criteria content-hashed at create; `rebaseline` (journaled, `--reason` required) is the only mutation path; tampered journal → exit 4, fail closed on every reading command.
- **Gates (report-only by default, `--gate` to block, per docs/gate-rollout.md)**: criteria soundness lint; cumulative spend ≤ unlocked tranches; dated-criterion evaluation → kill-proposal + spend block pending human accept/journaled override; bets-in-flight cap (default 2); bet-selection lint (no ecosystem channel + no owned audience while means say sales/marketing novice → flagged, per #241 policy); distribution-attempted status in evaluate (`unattempted` when no channel/rep evidence — never silently absent, per the #237 fairness amendment).
- State machine: proposed→probing→validating→building→scaling; kill_pending from anywhere; terminals killed|parked|lifestyle|sold; pivot = honest close + successor; `killed` blocked without retrospective; harvest check (3.9× SDE) reports `skipped` on missing inputs.
- Schemas: `templates/bet-schema.json`, `kill-criteria-schema.json`, `means-schema.json`. Docs: usage section in `docs/business-factory.md`, gate-ledger row in `docs/gate-rollout.md` (report-only; `validation/bet-gates.json` required before any workflow passes `--gate`).

## Verification (orchestrator-independent)

- Full suite run twice (agent + orchestrator): **2117 passed / 14 skipped**, including all untouched ratchet/gate-validation tests (`ratchet.py` reused by import — zero edits, format identity proved by test).
- Orchestrator CLI exercise: create→hash, report-only over-tranche spend recorded then `--gate` refused, manual journal tamper → exit 4.
- 34 new tests incl. every seeded defect class from the issue.

## Notes

Rebased over #233/#242 merges; the doc conflict was add/add on `docs/business-factory.md` (this branch = main's content + usage section, verified byte-identical base).