### PR TITLE
docs: re-point the two prose #259 refs to #263

### DIFF
--- a/docs/adopt.md
+++ b/docs/adopt.md
@@ -118,7 +118,7 @@ Consumers:
 - **`/status`** shows the Adoption section: brownfield flag, grandfather
   counts, nearest expiry, and prominent EXPIRED warnings.
 
-## Not measured is not measured clean (#259)
+## Not measured is not measured clean (#263)
 
 An honest report of "nothing measurable" and a real report of "everything
 measured, all clean" used to render **identically** on every surface a human

--- a/docs/ratchet.md
+++ b/docs/ratchet.md
@@ -145,7 +145,7 @@ test DLL and never the source file, so its resolution goes through the class
 name and only lands when exactly one tracked `<ClassName>.cs` exists under the
 suite cwd — ambiguous or absent matches stay unresolved, never guessed.
 
-### The `trx` parser (.NET, #259)
+### The `trx` parser (.NET, #263)
 
 `dotnet test --logger trx` is the built-in VSTest logger: it needs no NuGet
 package added to the target, unlike a JUnit logger — which matters because


### PR DESCRIPTION
## Summary

The C#/.NET ticket (shipped in #261) was re-filed as **#263** — the original #259 named a private repo and was deleted — so `#259` references now 404.

This re-points **only the two human-facing prose references**:

- `docs/adopt.md:121` — "Not measured is not measured clean"
- `docs/ratchet.md:148` — "The `trx` parser (.NET, …)"

## Why not the other 27 references

The remaining `#259` refs are code comments (15 files) and the append-only ratchet journal (8 entries). I measured the cost of renaming them and it is not worth paying:

- Gate `scanner_version` hashes cover **raw source text**, so editing a comment in `ratchet.py` / `check_single_writer.py` / `check_traceability.py` / `verification.py` / `complexity.py` / `duplication.py` / `write_emission.py` / `config/languages.json` stales **all four** gate-validation records.
- It immediately triggers the auto-demotion path:

  ```
  DEMOTION — DEMOTE ratchet to report-only (drop --gate from its workflow
  wiring) — its gate-validation record went stale WHILE BLOCKING (INV-fh-003)
  ```

- Paying that means four re-authored records and **four more permanent entries in the tamper-evident journal**, each saying "re-validated for a comment rename". That log's value is that its entries mean something.
- The journal's 8 existing refs are immutable by design (hash-chained) and are arguably the honest record anyway — they were written when the ticket *was* #259.

Code comments keep `#259`, which is historically accurate: the work was done under that number.

## Verification

- All 7 gate-validation records still `PASS` (no `scanner_version` moved — confirmed by measuring before and after).
- `render_languages_doc.py --check`: up to date.
- `pytest`: 2275 passed, 14 skipped. `ruff`: clean.
- Touches no protected path, so this does not park for goalpost review.