### PR TITLE
fix(telemetry): make the gate cost/benefit verdict mean something

### DIFF
--- a/config/model_pricing.json
+++ b/config/model_pricing.json
@@ -11,6 +11,7 @@
   "models": {
     "claude-fable-5":    {"input_per_mtok": 10.0, "output_per_mtok": 50.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-mythos-5":   {"input_per_mtok": 10.0, "output_per_mtok": 50.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
+    "claude-opus-5":     {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-08-03", "note": "same rate as Opus 4.8; Claude Opus 5 is a drop-in upgrade at Opus 4.8 pricing. Fast mode (speed=fast) bills 10.0/50.0 instead -- not modelled here, since factory telemetry has no fast-mode signal to key on"},
     "claude-opus-4-8":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-opus-4-7":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
     "claude-opus-4-6":   {"input_per_mtok": 5.0,  "output_per_mtok": 25.0, "provider": "anthropic", "verified": true, "as_of": "2026-06-04"},
@@ -47,6 +48,14 @@
     "z-ai/glm-5.2":             {"input_per_mtok": 1.19, "output_per_mtok": 3.74,  "provider": "openrouter", "verified": true, "as_of": "2026-08-03", "note": "OpenRouter's routed rate; the direct-from-Zhipu `glm-5.2` row above is a different price for the same weights"},
     "qwen/qwen3.7-max":         {"input_per_mtok": 1.48, "output_per_mtok": 4.42,  "provider": "openrouter", "verified": true, "as_of": "2026-08-03"},
     "minimax/minimax-m3":       {"input_per_mtok": 0.3,  "output_per_mtok": 1.2,   "provider": "openrouter", "verified": true, "as_of": "2026-08-03"}
+  },
+  "cache_multipliers": {
+    "$comment": "Multipliers applied to a model's INPUT rate for prompt-cached tokens (Anthropic prompt-caching pricing, claude-api skill reference, cached 2026-08-03). A cache READ costs ~0.1x the base input rate; a cache WRITE costs 1.25x at the default 5-minute TTL and 2x at the 1-hour TTL. factory_log.cost_for_usage applies these when a usage record carries cache token counts (Claude Code transcripts do; consult providers mostly do not). Vendor-published multipliers, not estimates -- but they are Anthropic's; a non-Anthropic model with cache counts would need its own row before these are applied to it.",
+    "cache_read": 0.1,
+    "cache_write_5m": 1.25,
+    "cache_write_1h": 2.0,
+    "as_of": "2026-08-03",
+    "applies_to_provider": "anthropic"
   },
   "_codex_note": "chief-wiggum#134 investigated the codex->billed-model mapping: there is no fixed 'codex' alias row to price, because `codex exec` bills whichever real gpt-* model is configured (verified live: codex-cli 0.142.5's `--json` event stream carries no model field at all; only the plain-text banner prints `model: <id>`, and $CODEX_HOME/config.toml's top-level `model` key is the CLI's own source of truth for its default, e.g. 'gpt-5.5' on this install -- already a priced row above). scripts/consult_ai.py's codex adapter resolves the real id at call time (--model override, else config.toml) and records THAT as the billed model; a resolved-but-unlisted id still records tokens with cost_usd null (the honest degradation, ADR-fh-05) rather than reviving a bare 'codex' placeholder row, which the ConsultUsageRecord contract now forbids as a resolved model id (CTR-fh-013)."
 }

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -295,6 +295,41 @@ including how `bet.py portfolio`/`kill-brief` surface it.
 python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app   # per-gate value + consult cost
 ```
 
+### What the cost is made of — `cost-report`
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" cost-report [--repo acme/app] [--top 10]
+```
+
+**Report-only, and deliberately never a gate.** Everything it finds is something
+the operator can act on and CW cannot — session shape, cache TTL, how wide a read
+was. A checker that can never block has no business holding `--gate`
+(`docs/gate-rollout.md`), so it always exits 0 and `session_cost_report()` returns
+`gate: False`.
+
+It answers *why* a factory run cost what it did:
+
+- **cost split by component** — cache reads / cache writes / output / fresh input.
+  On a real 65-session corpus this came out **~88% context handling, ~12%
+  generation**, which is the whole point: trimming tool output barely moves the
+  bill, and cache reads outweighed fresh input 3,032 : 1.
+- **per-session amplification** — `cache_read ÷ peak_context`, i.e. how many times
+  a session re-read its own context (observed: median 60×, worst ~520×).
+- **`usd_per_turn_per_100k`** — the normalised unit cost, and the only figure
+  comparable across sessions of different lengths.
+
+**Width beats length.** On that corpus, cost-per-turn correlated **+0.75 with mean
+context** but only **+0.40 with turn count**. So splitting a long session in two
+saves little if both halves stay wide; the intervention that works is pushing
+wide, noisy work (broad searches, log trawls, multi-file reads) into **sub-agents**,
+which carry their own context and return only findings. The report says this
+explicitly rather than leaving "session too long" as the takeaway.
+
+`/reflect` surfaces each finding as a `factory-logs` finding. When no Claude Code
+cost has been ingested at all, `/reflect` says so instead of reporting `$0.00` —
+a factory that ran on Claude Code and shows no Claude Code cost has an
+un-ingested log, not a free run.
+
 ### Two denominators the verdict will not fake
 
 **Value is DISTINCT findings, not the re-counted sum.** `caught` is a per-run

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -8,11 +8,19 @@ source for the value-vs-noise and token-cost questions.
 
 ## Opt-in by default
 
-Emitting is a **no-op** unless telemetry is enabled — so tests and CI have no side
-effects:
+Emitting is a **no-op** unless telemetry is enabled:
 
 - `CW_TELEMETRY=1` — enable, writing to the default log `~/.chief-wiggum/factory-log.jsonl`.
 - `CW_FACTORY_LOG=/path/to/log.jsonl` — enable *and* redirect the log.
+
+> **Tests must isolate the log.** "Off by default" protects a *clean* shell, not
+> the shell of an operator who set `CW_TELEMETRY=1` to measure a run — pytest in
+> that shell writes its fixture events to the real log. This is not hypothetical:
+> ~95% of the gate records in a real 32k-record log were pytest fixtures (`repo`
+> values like `epic`, `clean`, `dirty`, `test_cli_gate_exits_1_on_terra0`), and
+> every value/noise verdict was being computed over them. `tests/conftest.py`
+> carries an autouse fixture that points `CW_FACTORY_LOG` at each test's
+> `tmp_path`; keep it, and don't rely on the ambient default being unset.
 
 Enable it when you want to measure a factory run (an `/implement-wave`, an
 `/architect`, a batch of gates). `/reflect` then folds the aggregates into its
@@ -184,8 +192,46 @@ Then `aggregate`'s verdict joins `cost_by_loop[name]` (what it spent) with
 (`consult_ai` emits a `consult` event per provider call: provider · model · repo,
 with token/cost where a provider surfaces usage). But the biggest cost is the
 **Claude Code session itself** — the orchestrator plus every sub-agent it spawns.
-Claude Code emits that natively via OpenTelemetry, and CW folds it into the same
-log so `/reflect` reports one end-to-end number.
+CW folds that into the same log so `/reflect` reports one end-to-end number.
+
+There are two ways in. **Prefer the transcript ingest** — it needs no
+configuration and works retroactively.
+
+### Transcript ingest (default; retroactive, zero-config)
+
+Claude Code already writes per-turn token usage to
+`~/.claude/projects/<project>/<session>.jsonl` for every session it has ever run.
+Nothing needs to be enabled beforehand:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 30
+```
+
+Each assistant turn carries `message.model` + `message.usage` (input/output plus
+cache-read and cache-creation counts per TTL), `isSidechain` (orchestrator vs
+sub-agent), `requestId`, and `cwd`. The ingest:
+
+- **prices cache tokens at their own rates** via `cost_for_usage` — cache reads
+  at 0.1x the input rate, writes at 1.25x (5m TTL) / 2x (1h). On agent sessions
+  cache reads dwarf fresh input (billions vs millions of tokens in practice), so
+  charging them as fresh input would overstate cost by orders of magnitude. The
+  multipliers live in `config/model_pricing.json`, not in code.
+- **is idempotent** — dedup is by `requestId`, so re-running as sessions
+  accumulate adds only new turns. This is load-bearing, not just convenient: a
+  request's usage is repeated on *every* content-block line it produced
+  (thinking, text, tool_use), so summing lines would roughly double the cost.
+  All-zero usage lines are skipped, which makes dedup order-independent.
+- **attributes worktrees to their parent repo**, so a `<repo>/.claude/worktrees/<branch>`
+  cwd doesn't register as a separate project.
+
+Re-run it whenever you want the log current; `0 new` means up to date.
+
+### OTEL ingest (for an existing OTEL pipeline)
+
+`ingest-claude-code` remains for OTEL setups. It only captures a run you wrapped
+beforehand, and the console-exporter recipe below writes to stderr — which fights
+an interactive TUI session, so it suits headless `claude -p` runs.
 
 **Capture it with the console exporter (no collector needed):**
 
@@ -249,7 +295,36 @@ including how `bet.py portfolio`/`kill-brief` surface it.
 python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app   # per-gate value + consult cost
 ```
 
-`aggregate` marks each gate `earning` (caught > 0), `noise-candidate` (≥3 runs, 0
+### Two denominators the verdict will not fake
+
+**Value is DISTINCT findings, not the re-counted sum.** `caught` is a per-run
+finding *count*, so summing it counts the same unfixed finding once per run — a
+gate re-run 140 times over one repo's unchanged orphan list scored 75,517
+"catches". `aggregate` keeps `caught` (readers depend on it) but the verdict uses
+`caught_distinct`: the union of `finding_ids` when a gate emits them
+(`caught_basis: finding-ids`), otherwise the largest single run — a lower bound
+that re-runs cannot inflate. Gates should emit `finding_ids` to get an exact
+count.
+
+**Unattributed cost is `null`, never `0.0`.** Cost reaches a gate only via
+`cost_by_loop`; a gate with no such record has *unknown* cost, not zero cost.
+Defaulting it to `0.0` made every catching gate read `earning` at a confident
+`$0.000/catch` and made `demote-candidate` — the one verdict that says *switch
+this gate off* — unreachable, since it requires cost > 0. A fabricated
+denominator is worse than an absent one because it reads as a measurement. So
+the verdict distinguishes:
+
+| verdict | meaning |
+|---|---|
+| `earning` | caught > 0 |
+| `demote-candidate` | ≥3 runs, 0 caught, **measured** cost > 0 — you are paying for noise |
+| `noise-candidate` | ≥3 runs, 0 caught, **measured** cost 0 — noisy but cheap |
+| `unpriced` | ≥3 runs, 0 caught, **no cost attributed** — can't say cheap or expensive |
+| `unproven` | too few runs to judge |
+
+The text report prints `—` (not `$0.00`) for an unattributed cost.
+
+Also mark each gate `earning` (caught > 0), `noise-candidate` (≥3 runs, 0
 caught), or `unproven` (too few runs to judge) — the input to the gate-rollout
 question in `docs/gate-rollout.md`: a gate that never catches anything on real code
 is a candidate to demote or delete before it trains operators to `--force` past it.

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -284,6 +284,55 @@ def cost_for(model: str, tokens_in: int, tokens_out: int, pricing: dict | None =
     return round((tokens_in / 1_000_000) * pin + (tokens_out / 1_000_000) * pout, 6)
 
 
+def load_cache_multipliers() -> dict:
+    """Prompt-cache price multipliers from the grounded pricing table.
+
+    Empty dict when absent — callers then price cache tokens at the plain input
+    rate rather than inventing a discount.
+    """
+    try:
+        block = json.loads(PRICING_PATH.read_text()).get("cache_multipliers", {})
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return block if isinstance(block, dict) else {}
+
+
+def cost_for_usage(model: str, tokens_in: int, tokens_out: int, *,
+                   cache_read: int = 0, cache_write_5m: int = 0, cache_write_1h: int = 0,
+                   pricing: dict | None = None, multipliers: dict | None = None) -> float | None:
+    """USD cost of a call whose usage separates cached from uncached input.
+
+    ``cost_for`` prices two buckets (in/out) because that is all a consult
+    provider reports. A Claude Code turn reports four: fresh input, cache reads
+    (~0.1x input), and cache writes at two TTLs (1.25x at 5m, 2x at 1h). Pricing
+    cached tokens at the full input rate would badly overstate an agent session,
+    where cache reads routinely dwarf fresh input — so they get their own
+    multipliers, read from config/model_pricing.json rather than hardcoded.
+
+    Returns None (not 0) for an unpriced model, exactly like ``cost_for``: an
+    unpriced call records its tokens without a fabricated dollar figure
+    (INV-fh-002 — cost is derived here or not at all).
+    """
+    table = pricing if pricing is not None else load_pricing()
+    row = table.get(model)
+    if not row:
+        return None
+    pin, pout = row.get("input_per_mtok"), row.get("output_per_mtok")
+    if pin is None or pout is None:
+        return None
+    m = multipliers if multipliers is not None else load_cache_multipliers()
+    # An absent multiplier means "price it like fresh input" (1.0) — never a
+    # silent discount we can't point at a vendor page for.
+    m_read = m.get("cache_read", 1.0)
+    m_w5 = m.get("cache_write_5m", 1.0)
+    m_w1 = m.get("cache_write_1h", 1.0)
+    billed_in = (tokens_in
+                 + cache_read * m_read
+                 + cache_write_5m * m_w5
+                 + cache_write_1h * m_w1)
+    return round((billed_in / 1_000_000) * pin + (tokens_out / 1_000_000) * pout, 6)
+
+
 def _coerce_token(value) -> int | None:
     """Coerce an untrusted token count to ``int``; anything unusable (bool, junk
     string, list, non-integral float, ...) is ``None`` — a malformed count must
@@ -413,6 +462,196 @@ def _cc_field(event: dict, *names):
     return None
 
 
+DEFAULT_TRANSCRIPT_ROOT = Path.home() / ".claude" / "projects"
+
+
+def _repo_from_cwd(cwd: str | None) -> str | None:
+    """Best-effort repo name for a transcript record's working directory.
+
+    A worktree cwd (``<repo>/.claude/worktrees/<branch>``) belongs to its parent
+    repo, not to a repo named after the branch — otherwise every worktree looks
+    like a separate project and per-repo aggregation fragments.
+    """
+    if not cwd:
+        return None
+    marker = "/.claude/worktrees/"
+    if marker in cwd:
+        cwd = cwd.split(marker, 1)[0]
+    name = Path(cwd).name
+    return name or None
+
+
+def _iter_transcript_files(root: Path):
+    """Every Claude Code transcript under ``root`` (``<project>/<session>.jsonl``)."""
+    if not root.is_dir():
+        return
+    yield from sorted(root.glob("*/*.jsonl"))
+
+
+def ingested_request_ids() -> set[str]:
+    """Request IDs already present as claude_code records in the log.
+
+    The ingest is re-run as sessions accumulate, and transcripts are append-only
+    files that keep their old turns — without this, every re-run would re-add
+    every previously-ingested turn and inflate cost without bound. Keyed on the
+    API request ID, which is unique per turn and stable across re-reads.
+    """
+    seen: set[str] = set()
+    path = log_path()
+    if not path.is_file():
+        return seen
+    try:
+        with path.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if r.get("event") == CLAUDE_CODE and r.get("request_id"):
+                    seen.add(r["request_id"])
+    except OSError:
+        return seen
+    return seen
+
+
+def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
+                              since: float | None = None) -> int:
+    """Fold Claude Code's own per-turn token usage into the factory log.
+
+    This is the end-to-end cost half of the ledger. `factory_log` already records
+    what CW *runs* (gates) and what it *consults* (codex/gemini/...), but the
+    orchestrator plus every sub-agent it spawns is usually the largest line item,
+    and nothing was recording it: `aggregate`'s `claude_code_cost_usd` read
+    $0.00 not because the sessions were free but because no ingest had ever run.
+
+    Claude Code already writes everything needed, per assistant turn, to
+    ``~/.claude/projects/<project>/<session>.jsonl``:
+
+      * ``message.model`` + ``message.usage`` — input/output and, separately,
+        cache read and cache-creation tokens at each TTL (priced via
+        ``cost_for_usage``, so a cache-heavy agent session isn't billed as if
+        every cached token were fresh input)
+      * ``isSidechain`` — the orchestrator (``repl_main_thread``) vs sub-agent
+        (``subagent``) split, which is what makes "what did delegation cost"
+        answerable
+      * ``requestId`` — a stable per-turn key, so the ingest is idempotent and
+        can be re-run as sessions accumulate
+      * ``cwd`` — repo attribution, worktrees folded back to their parent repo
+
+    Reading these needs no configuration and works **retroactively** over
+    sessions that have already happened — unlike the OTEL console-exporter route
+    (``ingest_claude_code``), which only captures a run you remembered to wrap
+    beforehand and doesn't fit an interactive TUI session. That one stays for
+    OTEL pipelines; this is the path that works by default.
+
+    Explicit ingest — always writes (does not require CW_TELEMETRY). Returns the
+    number of NEW records written. See docs/factory-telemetry.md.
+    """
+    root = Path(root) if root is not None else DEFAULT_TRANSCRIPT_ROOT
+    pricing, multipliers = load_pricing(), load_cache_multipliers()
+    seen = ingested_request_ids()
+    n = 0
+    for f in _iter_transcript_files(root):
+        try:
+            lines = f.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if e.get("type") != "assistant":
+                continue
+            msg = e.get("message")
+            if not isinstance(msg, dict):
+                continue
+            usage = msg.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            req = e.get("requestId") or e.get("uuid")
+            if not req or req in seen:
+                continue
+
+            ts = _parse_iso_ts(e.get("timestamp"))
+            if since is not None and ts is not None and ts < since:
+                continue
+
+            tin = _coerce_token(usage.get("input_tokens")) or 0
+            tout = _coerce_token(usage.get("output_tokens")) or 0
+            cache_read = _coerce_token(usage.get("cache_read_input_tokens")) or 0
+            creation = usage.get("cache_creation")
+            creation = creation if isinstance(creation, dict) else {}
+            w5 = _coerce_token(creation.get("ephemeral_5m_input_tokens"))
+            w1 = _coerce_token(creation.get("ephemeral_1h_input_tokens"))
+            if w5 is None and w1 is None:
+                # Older/flatter shape: one undifferentiated cache-creation count.
+                # Price it at the 5m rate — the default TTL, and the cheaper of
+                # the two, so an unknown TTL can't silently overstate cost.
+                w5 = _coerce_token(usage.get("cache_creation_input_tokens")) or 0
+                w1 = 0
+            w5, w1 = w5 or 0, w1 or 0
+
+            model = msg.get("model")
+            # `<synthetic>` turns are harness-generated (e.g. cancellations) and
+            # were never billed — they carry no real model to price.
+            if not model or model == "<synthetic>":
+                continue
+
+            # An all-zero usage line is not a billable turn. It matters because a
+            # request's usage is repeated on EVERY content-block line it produced
+            # (thinking, text, tool_use), and dedup keeps the first line seen — so
+            # a stray zero line arriving first would shadow the real usage and
+            # undercount the request. Skipping zeros makes the dedup
+            # order-independent instead of relying on file ordering.
+            if (tin + tout + cache_read + w5 + w1) == 0:
+                continue
+
+            rec = {
+                "ts": ts or 0,
+                "event": CLAUDE_CODE,
+                "request_id": req,
+                "model": model,
+                "query_source": "subagent" if e.get("isSidechain") else "repl_main_thread",
+                "tokens_in": tin,
+                "tokens_out": tout,
+                "cache_read": cache_read,
+                "cache_creation": w5 + w1,
+                "source": "transcript",
+            }
+            if e.get("sessionId"):
+                rec["session_id"] = e["sessionId"]
+            attributed = repo or _repo_from_cwd(e.get("cwd"))
+            if attributed:
+                rec["repo"] = attributed
+            cost = cost_for_usage(model, tin, tout, cache_read=cache_read,
+                                  cache_write_5m=w5, cache_write_1h=w1,
+                                  pricing=pricing, multipliers=multipliers)
+            if cost is not None:
+                rec["cost_usd"] = cost
+            if _append(rec):
+                seen.add(req)
+                n += 1
+    return n
+
+
+def _parse_iso_ts(value) -> float | None:
+    """ISO-8601 timestamp -> epoch seconds; None if unparseable."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
 def ingest_claude_code(path: Path, repo: str | None = None) -> int:
     """Fold a Claude Code OTEL export (console-exporter stderr capture, or OTLP file)
     into the factory log so /reflect sees end-to-end orchestrator+subagent token cost
@@ -493,12 +732,23 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
     for r in records:
         if r.get("event") == GATE and r.get("name"):
             g = gates.setdefault(r["name"], {"runs": 0, "passed": 0, "failed": 0,
-                                             "caught": 0, "total_ms": 0.0})
+                                             "caught": 0, "caught_max": 0,
+                                             "runs_with_findings": 0, "total_ms": 0.0})
             g["runs"] += 1
             g["passed"] += 1 if r.get("result") == "pass" else 0
             g["failed"] += 1 if r.get("result") in ("fail", "error") else 0
-            g["caught"] += r.get("caught") or 0
+            caught = r.get("caught") or 0
+            # `caught` is a per-run finding COUNT, so summing it counts the same
+            # unfixed finding once per run: a gate re-run 140 times over one
+            # repo's unchanged orphan list scored 75,517. Keep the sum (readers
+            # depend on it) but carry the two honest denominators alongside it.
+            g["caught"] += caught
+            g["caught_max"] = max(g["caught_max"], caught)
+            g["runs_with_findings"] += 1 if caught else 0
             g["total_ms"] += r.get("duration_ms") or 0.0
+            ids = r.get("finding_ids")
+            if isinstance(ids, list):
+                g.setdefault("_ids", set()).update(str(i) for i in ids)
         elif r.get("event") in (CONSULT, WORKER):
             key = r.get("provider") or r.get("name") or r.get("event")
             c = consults.setdefault(key, {"calls": 0, "tokens_in": 0,
@@ -511,10 +761,16 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
         elif r.get("event") == CLAUDE_CODE:
             src = r.get("query_source") or "unknown"
             cc = claude_code.setdefault(src, {"calls": 0, "tokens_in": 0,
-                                              "tokens_out": 0, "cost_usd": 0.0})
+                                              "tokens_out": 0, "cache_read": 0,
+                                              "cache_creation": 0, "cost_usd": 0.0})
             cc["calls"] += 1
             cc["tokens_in"] += r.get("tokens_in") or 0
             cc["tokens_out"] += r.get("tokens_out") or 0
+            # Cache tokens are reported separately from fresh input because they
+            # are priced separately (see cost_for_usage) — folding them into
+            # tokens_in would make the token column disagree with the cost column.
+            cc["cache_read"] += r.get("cache_read") or 0
+            cc["cache_creation"] += r.get("cache_creation") or 0
             cc["cost_usd"] += r.get("cost_usd") or 0.0
             cc_cost += r.get("cost_usd") or 0.0
             if r.get("skill"):
@@ -538,9 +794,22 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
                 q["hits"] += 1
             else:
                 q["misses"] += 1
-    # value/noise hint: a gate with runs but zero caught is a noise candidate
+    # value/noise hint: a gate with runs but zero caught is a noise candidate.
+    # The value SIGNAL is distinct findings, not the re-counted sum — see the
+    # `caught` accumulation above.
     for g in gates.values():
-        g["value"] = "earning" if g["caught"] > 0 else ("noise-candidate" if g["runs"] >= 3 else "unproven")
+        ids = g.pop("_ids", None)
+        if ids is not None:
+            g["caught_distinct"] = len(ids)
+            g["caught_basis"] = "finding-ids"
+        else:
+            # No finding IDs emitted: the largest single run is the best
+            # available LOWER BOUND on distinct findings, and unlike the sum it
+            # cannot be inflated by re-running the gate on unchanged state.
+            g["caught_distinct"] = g["caught_max"]
+            g["caught_basis"] = "max-run (lower bound; gate emits no finding_ids)"
+        g["value"] = ("earning" if g["caught_distinct"] > 0
+                      else ("noise-candidate" if g["runs"] >= 3 else "unproven"))
     for cc in claude_code.values():
         cc["cost_usd"] = round(cc["cost_usd"], 6)
     for bl in by_loop.values():
@@ -567,13 +836,25 @@ def cost_value_verdict(gates: dict, by_loop: dict) -> dict:
     """Join cost (per loop/validation) with value (findings caught) into a keep/demote
     verdict per validation — the "every loop is costed and its value quantified" view.
 
-    A gate's value is its `caught` count; its cost is what its loop spent (LLM
-    validations via cost_by_loop; deterministic gates are ~$0). cost_per_catch is the
-    dollars spent per finding surfaced. The verdict:
-      - earning         — caught > 0 (deterministic gates: free value; LLM loops: paid but productive)
+    A gate's value is its DISTINCT findings (`caught_distinct`, not the re-counted
+    `caught` sum); its cost is what its loop spent. cost_per_catch is the dollars
+    spent per finding surfaced. The verdict:
+      - earning          — caught > 0 (deterministic gates: free value; LLM loops: paid but productive)
       - demote-candidate — spent real $ over >=3 runs and caught nothing (noise you're paying for)
-      - noise-candidate  — ran >=3 times, caught nothing, ~free (noisy but cheap)
+      - noise-candidate  — ran >=3 times, caught nothing, MEASURED ~free (noisy but cheap)
       - unproven         — too few runs to judge
+      - unpriced         — ran >=3 times, caught nothing, and no cost was attributed
+                           to it, so we cannot say whether it is cheap noise or
+                           expensive noise
+
+    **`cost_usd` is None, not 0.0, when nothing was attributed.** That distinction is
+    the whole point of this function. Cost reaches a gate only via `cost_by_loop`,
+    which is populated from Claude Code records carrying a loop/skill name; a gate
+    with no such record has UNKNOWN cost, not zero cost. Defaulting it to 0.0 (the
+    prior behaviour) made every gate that caught anything read `earning` at a
+    confident `$0.000/catch`, and made `demote-candidate` — the one verdict that
+    tells you to switch a gate off — unreachable, since it requires cost > 0. A
+    fabricated denominator is worse than an absent one: it reads as a measurement.
     """
     # Only validations get a verdict — a name must have emitted gate events. A loop
     # with cost but no gate events (e.g. `implement`, the build loop / orchestrator)
@@ -581,24 +862,31 @@ def cost_value_verdict(gates: dict, by_loop: dict) -> dict:
     out: dict[str, dict] = {}
     for name in gates:
         g, loop = gates.get(name, {}), by_loop.get(name, {})
-        cost = round(loop.get("cost_usd", 0.0), 6)
-        caught = g.get("caught", 0)
+        raw_cost = loop.get("cost_usd")
+        cost = round(raw_cost, 6) if raw_cost is not None else None
+        caught = g.get("caught_distinct", g.get("caught", 0))
         runs = g.get("runs", 0) or loop.get("calls", 0)
         if caught > 0:
             v = "earning"
-        elif runs >= 3 and cost > 0:
-            v = "demote-candidate"
-        elif runs >= 3:
-            v = "noise-candidate"
-        else:
+        elif runs < 3:
             v = "unproven"
+        elif cost is None:
+            v = "unpriced"
+        elif cost > 0:
+            v = "demote-candidate"
+        else:
+            v = "noise-candidate"
         out[name] = {"cost_usd": cost, "caught": caught, "runs": runs,
-                     "cost_per_catch": round(cost / caught, 6) if caught else None,
+                     "caught_total": g.get("caught", 0),
+                     "caught_basis": g.get("caught_basis"),
+                     "cost_per_catch": (round(cost / caught, 6)
+                                        if caught and cost is not None else None),
                      "verdict": v}
     return out
 
 
-_VERDICT_ORDER = {"demote-candidate": 0, "noise-candidate": 1, "unproven": 2, "earning": 3}
+_VERDICT_ORDER = {"demote-candidate": 0, "unpriced": 1, "noise-candidate": 2,
+                  "unproven": 3, "earning": 4}
 
 
 def render_report(agg: dict, repo: str | None = None) -> str:
@@ -625,11 +913,17 @@ def render_report(agg: dict, repo: str | None = None) -> str:
         L.append(f"    {'VALIDATION':<22}{'RUNS':>5}{'CAUGHT':>7}{'COST':>10}{'$/CATCH':>10}   VERDICT")
         L.append("    " + "─" * 70)
         rows = sorted(verdict.items(),
-                      key=lambda kv: (_VERDICT_ORDER.get(kv[1]["verdict"], 9), -kv[1]["cost_usd"]))
+                      key=lambda kv: (_VERDICT_ORDER.get(kv[1]["verdict"], 9),
+                                      -(kv[1]["cost_usd"] or 0.0)))
         for name, v in rows:
-            cost = f"${v['cost_usd']:.2f}"
+            # "—" for an unattributed cost, never "$0.00": no cost reached this
+            # gate, which is not the same as measuring that it was free.
+            cost = f"${v['cost_usd']:.2f}" if v["cost_usd"] is not None else "—"
             cpc = f"${v['cost_per_catch']:.3f}" if v["cost_per_catch"] is not None else "—"
             L.append(f"    {name:<22}{v['runs']:>5}{v['caught']:>7}{cost:>10}{cpc:>10}   {v['verdict']}")
+        L.append("    CAUGHT is distinct findings (max single run unless the gate emits "
+                 "finding_ids), not\n    the re-counted per-run sum. '—' cost = nothing "
+                 "attributed, not measured-free.")
 
     escapes = agg.get("escapes") or {}
     if escapes:
@@ -690,6 +984,14 @@ def main() -> int:
     ic.add_argument("otel_file", help="JSONL from `... 2>capture.jsonl` with the console OTEL exporter")
     ic.add_argument("--repo", help="Tag ingested records with this repo")
 
+    it = sub.add_parser("ingest-claude-transcripts",
+                        help="Fold Claude Code's own session transcripts (token cost) into the log")
+    it.add_argument("--root", default=str(DEFAULT_TRANSCRIPT_ROOT),
+                    help=f"Transcript root (default: {DEFAULT_TRANSCRIPT_ROOT})")
+    it.add_argument("--repo", help="Force this repo tag instead of deriving it from each record's cwd")
+    it.add_argument("--since-days", type=float,
+                    help="Only ingest turns newer than N days ago")
+
     sub.add_parser("path", help="Print the log path")
     args = parser.parse_args()
 
@@ -699,6 +1001,14 @@ def main() -> int:
     if args.cmd == "ingest-claude-code":
         n = ingest_claude_code(Path(args.otel_file), repo=args.repo)
         print(f"factory_log: ingested {n} api_request event(s) from {args.otel_file}")
+        return 0
+    if args.cmd == "ingest-claude-transcripts":
+        since = (time.time() - args.since_days * 86400) if args.since_days else None
+        n = ingest_claude_transcripts(Path(args.root), repo=args.repo, since=since)
+        # Re-running is expected and safe (dedup is by request id), so say
+        # explicitly that "0 new" means up-to-date rather than broken.
+        print(f"factory_log: ingested {n} new Claude Code turn(s) from {args.root}"
+              f"{' (already up to date)' if n == 0 else ''}")
         return 0
     if args.cmd == "emit":
         fields = {k: getattr(args, k) for k in

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -623,6 +623,11 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
                 "tokens_out": tout,
                 "cache_read": cache_read,
                 "cache_creation": w5 + w1,
+                # Split by TTL as well as totalled: a 5m write bills 1.25x and a
+                # 1h write 2x, so the mix is the difference between two very
+                # different bills for identical work (session_cost_report).
+                "cache_write_5m": w5,
+                "cache_write_1h": w1,
                 "source": "transcript",
             }
             if e.get("sessionId"):
@@ -889,6 +894,248 @@ _VERDICT_ORDER = {"demote-candidate": 0, "unpriced": 1, "noise-candidate": 2,
                   "unproven": 3, "earning": 4}
 
 
+# ---- session cost shape (report-only) ---------------------------------------
+# Thresholds for session_cost_report. Calibrated against a real 65-session /
+# 13k-turn corpus where sessions >=100 turns were 49% of sessions but 97% of
+# cache-read cost, so the bar sits above the point where amplification starts
+# dominating rather than at the median.
+LONG_SESSION_TURNS = 200
+HIGH_PEAK_CONTEXT = 500_000       # half the 1M window
+TTL_1H_DOMINANT_SHARE = 0.9
+
+
+def session_cost_report(records: list[dict], *, top: int = 10) -> dict:
+    """What a factory run's Claude Code cost is actually made of, and why.
+
+    **Report-only, and deliberately not a gate.** Everything it can find is
+    something CW cannot act on: it can't end a long session, set a cache TTL, or
+    turn a whole-file read into a grep — those are operator and harness
+    behaviours. A checker that can never block has no business holding
+    `--gate` (docs/gate-rollout.md), so this only ever prints.
+
+    The thing worth measuring is **amplification, not verbosity**. Tool output is
+    small in absolute terms; what makes it expensive is that a token placed in
+    context is re-read on every later turn of the session. So cost tracks
+    session length x context size, not how chatty any single tool was — and the
+    report is built to show that: cost split by component, per-session
+    amplification (cache reads / peak context), and concentration across
+    sessions.
+
+    Denominators are always printed alongside counts: a finding that says "3
+    long sessions" without "out of 65, carrying 64% of spend" is unactionable.
+    """
+    pricing, mult = load_pricing(), load_cache_multipliers()
+    m_read = mult.get("cache_read", 1.0)
+    m_w5 = mult.get("cache_write_5m", 1.0)
+    m_w1 = mult.get("cache_write_1h", 1.0)
+
+    comp = {"cache_read": 0.0, "cache_write": 0.0, "output": 0.0, "input": 0.0}
+    sessions: dict[str, dict] = {}
+    turns = 0
+    w5_tokens = w1_tokens = 0
+    unpriced_turns = 0
+    legacy_ttl_turns = 0
+
+    for r in records:
+        if r.get("event") != CLAUDE_CODE:
+            continue
+        turns += 1
+        tin = r.get("tokens_in") or 0
+        tout = r.get("tokens_out") or 0
+        cr = r.get("cache_read") or 0
+        # Fall back to the combined figure for records written before the
+        # per-TTL split existed; assume the cheaper 5m rather than overstate.
+        w5 = r.get("cache_write_5m")
+        w1 = r.get("cache_write_1h")
+        if w5 is None and w1 is None:
+            # Legacy record (pre-TTL-split ingest): the TTL mix is unknown, so
+            # price at the cheaper 5m rate and COUNT it, so the report can say
+            # the write figure is a lower bound rather than quietly understating.
+            w5, w1 = r.get("cache_creation") or 0, 0
+            legacy_ttl_turns += 1 if w5 else 0
+        w5, w1 = w5 or 0, w1 or 0
+        w5_tokens += w5
+        w1_tokens += w1
+
+        row = pricing.get(r.get("model")) or {}
+        pin, pout = row.get("input_per_mtok"), row.get("output_per_mtok")
+        if pin is None or pout is None:
+            unpriced_turns += 1
+            pin = pout = 0.0
+        comp["cache_read"] += cr / 1e6 * pin * m_read
+        comp["cache_write"] += (w5 * m_w5 + w1 * m_w1) / 1e6 * pin
+        comp["output"] += tout / 1e6 * pout
+        comp["input"] += tin / 1e6 * pin
+
+        sid = r.get("session_id") or "unknown"
+        s = sessions.setdefault(sid, {"session_id": sid, "turns": 0, "cache_read": 0,
+                                      "peak_context": 0, "context_sum": 0,
+                                      "cost_usd": 0.0, "repo": r.get("repo")})
+        s["turns"] += 1
+        s["cache_read"] += cr
+        s["cost_usd"] += r.get("cost_usd") or 0.0
+        ctx = cr + w5 + w1 + tin
+        s["peak_context"] = max(s["peak_context"], ctx)
+        s["context_sum"] += ctx
+
+    total = sum(comp.values())
+    for s in sessions.values():
+        s["cost_usd"] = round(s["cost_usd"], 4)
+        # How many times over the session re-read its own context. The honest
+        # denominator for "was this session too long".
+        s["amplification"] = (round(s["cache_read"] / s["peak_context"], 1)
+                              if s["peak_context"] else None)
+        s["mean_context"] = s["context_sum"] // s["turns"] if s["turns"] else 0
+        # The normalised unit cost, and the one number that is comparable across
+        # sessions of different lengths: dollars per turn per 100k of context
+        # carried. On a real corpus, cost-per-turn correlates +0.75 with mean
+        # context but only +0.40 with turn count — width is the driver, not
+        # length — so this is what to drive down.
+        s["usd_per_turn_per_100k"] = (
+            round((s["cost_usd"] / s["turns"]) / (s["mean_context"] / 100_000), 4)
+            if s["turns"] and s["mean_context"] else None)
+        s.pop("context_sum", None)
+
+    ranked = sorted(sessions.values(), key=lambda s: -s["cost_usd"])
+    cost_total = sum(s["cost_usd"] for s in ranked)
+    findings: list[dict] = []
+
+    def share(x: float) -> float:
+        return round(100 * x / cost_total, 1) if cost_total else 0.0
+
+    if total:
+        ctx_share = 100 * (comp["cache_read"] + comp["cache_write"]) / total
+        if ctx_share >= 50:
+            findings.append({
+                "code": "context-dominates-cost", "severity": "info",
+                "detail": (f"{ctx_share:.0f}% of Claude Code spend is context handling "
+                           f"(cache reads ${comp['cache_read']:,.2f} + writes "
+                           f"${comp['cache_write']:,.2f}), not generation "
+                           f"(output ${comp['output']:,.2f}). Shortening sessions moves "
+                           f"this number; trimming tool output barely does."),
+            })
+
+    long_sessions = [s for s in ranked if s["turns"] >= LONG_SESSION_TURNS]
+    if long_sessions:
+        cost = sum(s["cost_usd"] for s in long_sessions)
+        findings.append({
+            "code": "long-sessions", "severity": "warn",
+            "detail": (f"{len(long_sessions)} of {len(ranked)} session(s) ran >= "
+                       f"{LONG_SESSION_TURNS} turns and carry {share(cost)}% of Claude Code "
+                       f"cost (${cost:,.2f} of ${cost_total:,.2f}). Length is where the spend "
+                       f"sits, but see 'narrow-the-context-not-the-session' before acting: "
+                       f"turn count is the weaker of the two drivers."),
+            "evidence": [f"{s['turns']} turns, {s['peak_context']//1000}k peak context, "
+                         f"{s['amplification']}x re-read, ${s['cost_usd']:,.2f}"
+                         for s in long_sessions[:5]],
+        })
+
+    wide = [s for s in ranked if s["peak_context"] >= HIGH_PEAK_CONTEXT]
+    if wide:
+        findings.append({
+            "code": "high-peak-context", "severity": "warn",
+            "detail": (f"{len(wide)} of {len(ranked)} session(s) peaked above "
+                       f"{HIGH_PEAK_CONTEXT // 1000}k tokens of context. Every subsequent "
+                       f"turn re-reads that whole window, so anything loaded early is "
+                       f"paid for repeatedly."),
+            "evidence": [f"{s['peak_context']//1000}k peak, {s['turns']} turns, "
+                         f"${s['cost_usd']:,.2f}" for s in wide[:5]],
+        })
+
+    # Width, not length, is the lever — so say so, and name the one intervention
+    # that narrows context without dropping work: push wide exploration into
+    # sub-agents, which run their own context and return only findings.
+    wide_cost = sum(s["cost_usd"] for s in ranked if s["mean_context"] >= HIGH_PEAK_CONTEXT // 2)
+    if wide_cost and share(wide_cost) >= 25:
+        findings.append({
+            "code": "narrow-the-context-not-the-session", "severity": "info",
+            "detail": (f"${wide_cost:,.2f} ({share(wide_cost)}%) is spent in sessions averaging "
+                       f">= {HIGH_PEAK_CONTEXT // 2000}k context per turn. Cost per turn tracks "
+                       f"context WIDTH far more than session LENGTH, so splitting a session in "
+                       f"two saves little if both halves stay wide. Delegating wide, noisy work "
+                       f"(broad searches, log trawls, multi-file reads) to sub-agents does: they "
+                       f"carry their own context and return only findings."),
+        })
+
+    if ranked and len(ranked) > top:
+        head = sum(s["cost_usd"] for s in ranked[:top])
+        if share(head) >= 50:
+            findings.append({
+                "code": "cost-concentrated", "severity": "info",
+                "detail": (f"the {top} most expensive of {len(ranked)} sessions carry "
+                           f"{share(head)}% of Claude Code cost (${head:,.2f} of "
+                           f"${cost_total:,.2f}) — optimising the long tail is not worth it."),
+            })
+
+    writes = w5_tokens + w1_tokens
+    if writes and (w1_tokens / writes) >= TTL_1H_DOMINANT_SHARE:
+        # Advisory, NOT a recommendation to switch: the 1h TTL exists to survive
+        # idle gaps, and on bursty work 5m can cause more re-writes than it saves.
+        saving = (w1_tokens * (m_w1 - m_w5)) / 1e6 * 5.0
+        findings.append({
+            "code": "cache-ttl-1h-dominant", "severity": "info",
+            "detail": (f"{100 * w1_tokens / writes:.0f}% of cache-creation tokens "
+                       f"({w1_tokens:,} of {writes:,}) use the 1h TTL, which bills {m_w1}x "
+                       f"vs {m_w5}x for 5m — order ${saving:,.0f} at Opus input rates. "
+                       f"Worth checking against your turn cadence, NOT worth switching "
+                       f"blind: 1h exists to survive idle gaps, and on bursty work 5m can "
+                       f"trigger more re-writes than it saves."),
+        })
+
+    return {
+        "turns": turns,
+        "sessions": len(ranked),
+        "cost_usd": round(cost_total, 4),
+        "unpriced_turns": unpriced_turns,
+        "legacy_ttl_turns": legacy_ttl_turns,
+        "composition_usd": {k: round(v, 4) for k, v in comp.items()},
+        "composition_share": ({k: round(100 * v / total, 1) for k, v in comp.items()}
+                              if total else {}),
+        "top_sessions": ranked[:top],
+        "findings": findings,
+        "thresholds": {"long_session_turns": LONG_SESSION_TURNS,
+                       "high_peak_context": HIGH_PEAK_CONTEXT,
+                       "ttl_1h_dominant_share": TTL_1H_DOMINANT_SHARE},
+        "gate": False,  # report-only by construction — see the docstring
+    }
+
+
+def render_cost_report(rep: dict) -> str:
+    L = [f"Claude Code session cost — {rep['sessions']} session(s), {rep['turns']} turn(s), "
+         f"${rep['cost_usd']:,.2f}", ""]
+    if not rep["turns"]:
+        L.append("  No claude_code records. Run:")
+        L.append("    factory_log.py ingest-claude-transcripts")
+        return "\n".join(L)
+    if rep["unpriced_turns"]:
+        L.append(f"  NOTE: {rep['unpriced_turns']} of {rep['turns']} turn(s) ran on a model with "
+                 f"no price row — their tokens count, their cost does not.")
+        L.append("")
+    if rep.get("legacy_ttl_turns"):
+        L.append(f"  NOTE: {rep['legacy_ttl_turns']} turn(s) predate the cache-TTL split and are "
+                 f"priced at the cheaper 5m rate,\n        so cache_write below is a LOWER BOUND. "
+                 f"Re-run ingest-claude-transcripts on a fresh log to resolve.")
+        L.append("")
+    L.append("  Where the money goes:")
+    for k, v in sorted(rep["composition_usd"].items(), key=lambda kv: -kv[1]):
+        L.append(f"    {k:<14}${v:>10,.2f}   {rep['composition_share'].get(k, 0):>5.1f}%")
+    if rep["top_sessions"]:
+        L.append("\n  Most expensive sessions:")
+        L.append(f"    {'COST':>10}{'TURNS':>7}{'PEAK CTX':>10}{'RE-READ':>9}  SESSION")
+        L.append("    " + "-" * 56)
+        for s in rep["top_sessions"]:
+            L.append(f"    ${s['cost_usd']:>9,.2f}{s['turns']:>7}"
+                     f"{s['peak_context'] // 1000:>9}k{str(s['amplification']) + 'x':>9}  "
+                     f"{str(s['session_id'])[:8]}")
+    if rep["findings"]:
+        L.append("\n  Findings (report-only — CW cannot act on these, you can):")
+        for f in rep["findings"]:
+            L.append(f"    [{f['severity']}] {f['code']}: {f['detail']}")
+            for ev in f.get("evidence", [])[:5]:
+                L.append(f"        - {ev}")
+    return "\n".join(L)
+
+
 def render_report(agg: dict, repo: str | None = None) -> str:
     """Human-readable cost/value report from an aggregate() result."""
     L: list[str] = []
@@ -992,6 +1239,12 @@ def main() -> int:
     it.add_argument("--since-days", type=float,
                     help="Only ingest turns newer than N days ago")
 
+    cr_ = sub.add_parser("cost-report",
+                         help="What Claude Code session cost is made of (report-only, never a gate)")
+    cr_.add_argument("--repo")
+    cr_.add_argument("--top", type=int, default=10)
+    cr_.add_argument("--format", choices=["text", "json"], default="text")
+
     sub.add_parser("path", help="Print the log path")
     args = parser.parse_args()
 
@@ -1001,6 +1254,14 @@ def main() -> int:
     if args.cmd == "ingest-claude-code":
         n = ingest_claude_code(Path(args.otel_file), repo=args.repo)
         print(f"factory_log: ingested {n} api_request event(s) from {args.otel_file}")
+        return 0
+    if args.cmd == "cost-report":
+        records = read_log()
+        if args.repo:
+            records = [r for r in records if r.get("repo") == args.repo]
+        rep = session_cost_report(records, top=args.top)
+        # Always exit 0 — report-only by construction (see session_cost_report).
+        print(json.dumps(rep, indent=2) if args.format == "json" else render_cost_report(rep))
         return 0
     if args.cmd == "ingest-claude-transcripts":
         since = (time.time() - args.since_days * 86400) if args.since_days else None

--- a/scripts/reflect.py
+++ b/scripts/reflect.py
@@ -275,6 +275,21 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
         findings.append(Finding("factory-logs", "info",
             f"telemetry: ${telemetry['cost_usd_total']} end-to-end logged AI cost "
             f"(Claude Code ${cc} + consults ${cons}) across {telemetry['records']} events"))
+    else:
+        findings.append(Finding("factory-logs", "info",
+            "telemetry: no AI cost logged — if this factory ran on Claude Code, its own token "
+            "cost (usually the largest line item) has not been ingested. Run: "
+            "factory_log.py ingest-claude-transcripts"))
+
+    # What that cost is MADE of. Report-only: every finding here is something the
+    # operator can act on and CW cannot (session shape, cache TTL, read width),
+    # so it never gates — see factory_log.session_cost_report.
+    cost_shape = factory_log.session_cost_report(factory_log.read_log())
+    for f in cost_shape["findings"]:
+        findings.append(Finding("factory-logs",
+                                "warn" if f["severity"] == "warn" else "info",
+                                f"session cost: {f['detail']}",
+                                f.get("evidence", [])[:5]))
 
     return {
         "repo": str(repo),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures for the chief-wiggum test suite.
+
+The one thing every test in this suite needs: **telemetry isolation**.
+
+`factory_log.emit*` is a no-op unless telemetry is enabled, and it is enabled by
+an AMBIENT env var (`CW_TELEMETRY=1`) that an operator measuring a factory run
+sets in their shell. That is the correct production behaviour — but it means a
+test run in that same shell writes its fixture gate/consult events into the
+operator's REAL `~/.chief-wiggum/factory-log.jsonl`.
+
+That is not hypothetical. Before this fixture existed, ~95% of the gate records
+in a real 32k-record log were pytest fixtures: `repo` values like `epic`,
+`clean`, `dirty`, and `test_cli_gate_exits_1_on_terra0` (pytest `tmp_path`
+directory names) drowned the few hundred real runs, and every value/noise
+verdict `aggregate()` produced was computed over them.
+
+Pointing `CW_FACTORY_LOG` at a per-test `tmp_path` keeps emission ON — so tests
+that assert telemetry is written still work — while sending it somewhere that
+disappears with the test. Tests that specifically exercise the disabled path
+(`test_factory_log.py`) `delenv` both vars themselves; monkeypatch composes, so
+this fixture does not fight them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_factory_log(tmp_path, monkeypatch):
+    """Redirect factory telemetry to a per-test path (see module docstring)."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "factory-log.jsonl"))

--- a/tests/test_factory_log.py
+++ b/tests/test_factory_log.py
@@ -313,17 +313,29 @@ def test_render_report_shows_verdict_and_cost():
 
 
 def test_cost_value_verdict():
-    """Every validation costed + its value quantified into a keep/demote verdict."""
+    """Every validation costed + its value quantified into a keep/demote verdict.
+
+    Cost is UNKNOWN (None) unless something was actually attributed to the gate —
+    it does not default to 0.0. A gate with no cost record is `unpriced`, not
+    `noise-candidate`: we can't say whether it is cheap noise or expensive noise.
+    Only a *measured* 0.0 earns `noise-candidate`.
+    """
     gates = {
-        "check_patterns": {"runs": 5, "caught": 2, "total_ms": 40},   # free, catches -> earning
+        "check_patterns": {"runs": 5, "caught": 2, "total_ms": 40},   # catches -> earning
         "expensive_noise": {"runs": 4, "caught": 0, "total_ms": 0},   # runs but nothing; paid via loop
-        "cheap_noise": {"runs": 4, "caught": 0, "total_ms": 5},       # runs, nothing, ~free
+        "cheap_noise": {"runs": 4, "caught": 0, "total_ms": 5},       # runs, nothing, MEASURED free
+        "unattributed_noise": {"runs": 4, "caught": 0, "total_ms": 5},  # runs, nothing, cost unknown
     }
-    by_loop = {"expensive_noise": {"calls": 4, "cost_usd": 1.20}}
+    by_loop = {"expensive_noise": {"calls": 4, "cost_usd": 1.20},
+               "cheap_noise": {"calls": 4, "cost_usd": 0.0}}
     v = factory_log.cost_value_verdict(gates, by_loop)
-    assert v["check_patterns"]["verdict"] == "earning" and v["check_patterns"]["cost_per_catch"] == 0.0
+    assert v["check_patterns"]["verdict"] == "earning"
+    # No cost was attributed to check_patterns, so $/catch is unknown, not $0.000.
+    assert v["check_patterns"]["cost_usd"] is None
+    assert v["check_patterns"]["cost_per_catch"] is None
     assert v["expensive_noise"]["verdict"] == "demote-candidate"  # $1.20 over 4 runs, 0 catches
-    assert v["cheap_noise"]["verdict"] == "noise-candidate"       # noisy but free
+    assert v["cheap_noise"]["verdict"] == "noise-candidate"       # noisy but measured-free
+    assert v["unattributed_noise"]["verdict"] == "unpriced"       # noisy, cost never measured
     # an LLM validation that caught something -> cost_per_catch
     v2 = factory_log.cost_value_verdict(
         {"code-review": {"runs": 2, "caught": 4}}, {"code-review": {"calls": 2, "cost_usd": 0.80}})

--- a/tests/test_factory_log_cost.py
+++ b/tests/test_factory_log_cost.py
@@ -18,7 +18,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import factory_log  # noqa: E402
 
-
 PRICING = {"claude-opus-5": {"input_per_mtok": 5.0, "output_per_mtok": 25.0}}
 MULTS = {"cache_read": 0.1, "cache_write_5m": 1.25, "cache_write_1h": 2.0}
 

--- a/tests/test_factory_log_cost.py
+++ b/tests/test_factory_log_cost.py
@@ -267,3 +267,72 @@ def test_measured_free_still_reads_noise_candidate():
 def test_text_render_shows_dash_not_dollar_zero_for_unattributed():
     out = factory_log.render_report(factory_log.aggregate([_gate("g", 3)]))
     assert "$0.00" not in out
+
+
+# ---- session cost report (report-only) --------------------------------------
+
+def _cc(session, *, turns=1, model="claude-opus-5", cr=0, w5=0, w1=0, tout=0, cost=0.0):
+    return [{"event": "claude_code", "session_id": session, "model": model,
+             "request_id": f"{session}-{i}", "tokens_in": 0, "tokens_out": tout,
+             "cache_read": cr, "cache_creation": w5 + w1,
+             "cache_write_5m": w5, "cache_write_1h": w1, "cost_usd": cost}
+            for i in range(turns)]
+
+
+def test_cost_report_is_never_a_gate():
+    """Every finding is something CW cannot act on, so it must not gate."""
+    rep = factory_log.session_cost_report(_cc("s", turns=3))
+    assert rep["gate"] is False
+
+
+def test_cost_report_splits_composition():
+    rep = factory_log.session_cost_report(
+        _cc("s", turns=1, cr=1_000_000, tout=1_000_000, cost=1.0))
+    # 1M cache reads at 0.1x $5 = $0.50; 1M output at $25 = $25.00
+    assert rep["composition_usd"]["cache_read"] == pytest.approx(0.50)
+    assert rep["composition_usd"]["output"] == pytest.approx(25.0)
+
+
+def test_cost_report_flags_long_sessions_with_denominators():
+    records = _cc("long", turns=250, cost=1.0) + _cc("short", turns=5, cost=1.0)
+    rep = factory_log.session_cost_report(records)
+    f = next(x for x in rep["findings"] if x["code"] == "long-sessions")
+    assert "1 of 2 session(s)" in f["detail"]      # denominator, not a bare count
+    assert "$250.00" in f["detail"]
+
+
+def test_cost_report_computes_amplification_and_unit_cost():
+    rep = factory_log.session_cost_report(_cc("s", turns=10, cr=100_000, cost=1.0))
+    s = rep["top_sessions"][0]
+    assert s["amplification"] == 10.0          # 1M cache-read over a 100k window
+    assert s["mean_context"] == 100_000
+    # $1.00/turn carried over exactly 100k of context normalises to 1.0.
+    assert s["usd_per_turn_per_100k"] == pytest.approx(1.0)
+
+
+def test_cost_report_flags_1h_ttl_dominance_without_recommending_a_switch():
+    rep = factory_log.session_cost_report(_cc("s", turns=5, w1=1_000_000))
+    f = next(x for x in rep["findings"] if x["code"] == "cache-ttl-1h-dominant")
+    assert "NOT worth switching" in f["detail"]  # advisory, not a directive
+
+
+def test_cost_report_marks_legacy_ttl_records_as_a_lower_bound():
+    """Records predating the TTL split price at the cheaper 5m rate, so the
+    write figure understates — that must be disclosed, not hidden."""
+    legacy = [{"event": "claude_code", "session_id": "s", "model": "claude-opus-5",
+               "cache_creation": 1_000_000, "cache_read": 0,
+               "tokens_in": 0, "tokens_out": 0}]
+    rep = factory_log.session_cost_report(legacy)
+    assert rep["legacy_ttl_turns"] == 1
+    assert "LOWER BOUND" in factory_log.render_cost_report(rep)
+
+
+def test_cost_report_counts_unpriced_turns_rather_than_pricing_them_at_zero():
+    rep = factory_log.session_cost_report(_cc("s", turns=3, model="who-knows-9", cr=999))
+    assert rep["unpriced_turns"] == 3
+
+
+def test_cost_report_handles_an_empty_log():
+    rep = factory_log.session_cost_report([])
+    assert rep["turns"] == 0 and rep["findings"] == []
+    assert "ingest-claude-transcripts" in factory_log.render_cost_report(rep)

--- a/tests/test_factory_log_cost.py
+++ b/tests/test_factory_log_cost.py
@@ -1,0 +1,269 @@
+"""Tests for the gate cost/benefit signal: transcript ingest, cache-aware
+pricing, distinct-finding counting, and honest unattributed cost.
+
+These cover the three things that made `aggregate`'s verdicts unusable:
+Claude Code's own cost was never ingested, `caught` re-counted the same finding
+once per run, and an unattributed cost was reported as a measured $0.00.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import factory_log  # noqa: E402
+
+
+PRICING = {"claude-opus-5": {"input_per_mtok": 5.0, "output_per_mtok": 25.0}}
+MULTS = {"cache_read": 0.1, "cache_write_5m": 1.25, "cache_write_1h": 2.0}
+
+
+def _turn(request_id, *, model="claude-opus-5", tin=100, tout=200, cache_read=0,
+          w5=0, w1=0, sidechain=False, cwd="/repos/acme", ts="2026-08-03T06:15:00.000Z"):
+    """One assistant turn as Claude Code writes it to a session transcript."""
+    return json.dumps({
+        "type": "assistant", "requestId": request_id, "sessionId": "sess-1",
+        "timestamp": ts, "isSidechain": sidechain, "cwd": cwd,
+        "message": {"model": model, "usage": {
+            "input_tokens": tin, "output_tokens": tout,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation": {"ephemeral_5m_input_tokens": w5,
+                               "ephemeral_1h_input_tokens": w1},
+        }},
+    })
+
+
+@pytest.fixture
+def transcripts(tmp_path):
+    root = tmp_path / "projects"
+    (root / "proj-a").mkdir(parents=True)
+    return root
+
+
+# ---- cache-aware pricing ----------------------------------------------------
+
+def test_cost_for_usage_prices_cache_buckets_at_their_own_rates():
+    # 1M cache reads at 0.1x a $5/MTok input rate = $0.50, not $5.00.
+    cost = factory_log.cost_for_usage("claude-opus-5", 0, 0, cache_read=1_000_000,
+                                      pricing=PRICING, multipliers=MULTS)
+    assert cost == pytest.approx(0.50)
+
+
+def test_cost_for_usage_charges_1h_writes_more_than_5m_writes():
+    five_m = factory_log.cost_for_usage("claude-opus-5", 0, 0, cache_write_5m=1_000_000,
+                                        pricing=PRICING, multipliers=MULTS)
+    one_h = factory_log.cost_for_usage("claude-opus-5", 0, 0, cache_write_1h=1_000_000,
+                                       pricing=PRICING, multipliers=MULTS)
+    assert five_m == pytest.approx(6.25)   # 1.25x
+    assert one_h == pytest.approx(10.00)   # 2.0x
+    assert one_h > five_m
+
+
+def test_cost_for_usage_returns_none_for_unpriced_model():
+    """An unpriced model records tokens with NO cost, never a fabricated 0.0."""
+    assert factory_log.cost_for_usage("who-knows-5", 1000, 1000, pricing=PRICING) is None
+
+
+def test_missing_multipliers_price_cache_at_full_input_rate_not_free():
+    """A missing multiplier must not silently zero-rate cached tokens."""
+    cost = factory_log.cost_for_usage("claude-opus-5", 0, 0, cache_read=1_000_000,
+                                      pricing=PRICING, multipliers={})
+    assert cost == pytest.approx(5.00)
+
+
+def test_shipped_pricing_table_has_grounded_cache_multipliers():
+    m = factory_log.load_cache_multipliers()
+    assert m["cache_read"] == 0.1
+    assert m["cache_write_5m"] == 1.25
+    assert m["cache_write_1h"] == 2.0
+
+
+def test_shipped_pricing_table_prices_the_current_opus():
+    """claude-opus-5 was absent, so every turn on it recorded cost_usd: null."""
+    assert factory_log.cost_for("claude-opus-5", 1_000_000, 0) == pytest.approx(5.0)
+
+
+# ---- transcript ingest ------------------------------------------------------
+
+def test_ingest_reads_usage_and_prices_it(transcripts, monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", tin=1_000_000, tout=0) + "\n")
+
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+    rec = json.loads(Path(tmp_path / "log.jsonl").read_text().strip())
+    assert rec["event"] == "claude_code"
+    assert rec["tokens_in"] == 1_000_000
+    assert rec["cost_usd"] == pytest.approx(5.0)
+    assert rec["source"] == "transcript"
+
+
+def test_ingest_is_idempotent_across_reruns(transcripts, monkeypatch, tmp_path):
+    """Transcripts are append-only and keep old turns; a re-run must not
+    re-count them, or repeated ingests inflate cost without bound."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    f = transcripts / "proj-a" / "s.jsonl"
+    f.write_text(_turn("req-1") + "\n")
+
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+    assert factory_log.ingest_claude_transcripts(transcripts) == 0
+
+    f.write_text(_turn("req-1") + "\n" + _turn("req-2") + "\n")
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+
+    records = [json.loads(x) for x in
+               Path(tmp_path / "log.jsonl").read_text().splitlines() if x.strip()]
+    assert sorted(r["request_id"] for r in records) == ["req-1", "req-2"]
+
+
+def test_ingest_splits_orchestrator_from_subagent(transcripts, monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", sidechain=False) + "\n" + _turn("req-2", sidechain=True) + "\n")
+    factory_log.ingest_claude_transcripts(transcripts)
+
+    records = [json.loads(x) for x in
+               Path(tmp_path / "log.jsonl").read_text().splitlines() if x.strip()]
+    assert {r["query_source"] for r in records} == {"repl_main_thread", "subagent"}
+
+
+def test_ingest_folds_worktree_cwd_back_to_parent_repo(transcripts, monkeypatch, tmp_path):
+    """Otherwise every worktree branch looks like its own repo."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", cwd="/repos/acme/.claude/worktrees/feat-x") + "\n")
+    factory_log.ingest_claude_transcripts(transcripts)
+
+    rec = json.loads(Path(tmp_path / "log.jsonl").read_text().strip())
+    assert rec["repo"] == "acme"
+
+
+def test_ingest_skips_synthetic_turns(transcripts, monkeypatch, tmp_path):
+    """`<synthetic>` turns are harness-generated and were never billed."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", model="<synthetic>") + "\n")
+    assert factory_log.ingest_claude_transcripts(transcripts) == 0
+
+
+def test_ingest_dedup_is_order_independent_when_a_zero_line_comes_first(
+        transcripts, monkeypatch, tmp_path):
+    """A request's usage is repeated on every content-block line it produced, and
+    a few requests also carry an all-zero line. Dedup keeps the first line seen,
+    so a leading zero line must not shadow the real usage."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", tin=0, tout=0) + "\n"
+        + _turn("req-1", tin=1_000_000, tout=0) + "\n")
+
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+    rec = json.loads(Path(tmp_path / "log.jsonl").read_text().strip())
+    assert rec["tokens_in"] == 1_000_000
+    assert rec["cost_usd"] == pytest.approx(5.0)
+
+
+def test_repeated_usage_across_content_blocks_is_counted_once(
+        transcripts, monkeypatch, tmp_path):
+    """Summing every line instead of deduping by request id would roughly double
+    the reported cost — most requests emit 2+ lines carrying the same usage."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        (_turn("req-1", tin=1_000_000, tout=0) + "\n") * 3)
+
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+    records = [json.loads(x) for x in
+               Path(tmp_path / "log.jsonl").read_text().splitlines() if x.strip()]
+    assert factory_log.aggregate(records)["claude_code_cost_usd"] == pytest.approx(5.0)
+
+
+def test_ingest_survives_corrupt_lines(transcripts, monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        "not json\n" + _turn("req-1") + "\n{}\n")
+    assert factory_log.ingest_claude_transcripts(transcripts) == 1
+
+
+def test_ingest_feeds_end_to_end_cost(transcripts, monkeypatch, tmp_path):
+    """The headline number: claude_code_cost_usd stops reading $0.00."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    (transcripts / "proj-a" / "s.jsonl").write_text(
+        _turn("req-1", tin=1_000_000, tout=0) + "\n")
+    factory_log.ingest_claude_transcripts(transcripts)
+
+    records = [json.loads(x) for x in
+               Path(tmp_path / "log.jsonl").read_text().splitlines() if x.strip()]
+    agg = factory_log.aggregate(records)
+    assert agg["claude_code_cost_usd"] == pytest.approx(5.0)
+    assert agg["cost_usd_total"] == pytest.approx(5.0)
+    assert agg["claude_code"]["repl_main_thread"]["calls"] == 1
+
+
+# ---- distinct findings ------------------------------------------------------
+
+def _gate(name, caught, **extra):
+    return {"event": "gate", "name": name, "result": "fail", "caught": caught, **extra}
+
+
+def test_caught_is_not_inflated_by_reruns_on_unchanged_state():
+    """5 runs re-reporting the same 20 orphans is 20 findings, not 100."""
+    agg = factory_log.aggregate([_gate("check_traceability", 20) for _ in range(5)])
+    g = agg["gates"]["check_traceability"]
+    assert g["caught"] == 100          # raw sum retained for back-compat
+    assert g["caught_distinct"] == 20  # the honest signal
+    assert agg["verdict"]["check_traceability"]["caught"] == 20
+
+
+def test_finding_ids_give_exact_distinct_count():
+    records = [_gate("g", 2, finding_ids=["a", "b"]),
+               _gate("g", 2, finding_ids=["b", "c"])]
+    g = factory_log.aggregate(records)["gates"]["g"]
+    assert g["caught_distinct"] == 3           # a, b, c — b deduped
+    assert g["caught_basis"] == "finding-ids"
+
+
+def test_zero_yield_gate_is_still_noise_or_unpriced():
+    agg = factory_log.aggregate([_gate("check_patterns", 0) for _ in range(5)])
+    assert agg["gates"]["check_patterns"]["caught_distinct"] == 0
+    assert agg["verdict"]["check_patterns"]["verdict"] in ("noise-candidate", "unpriced")
+
+
+# ---- honest unattributed cost ----------------------------------------------
+
+def test_unattributed_cost_is_none_not_zero():
+    """A gate nothing was charged to has UNKNOWN cost, not free cost. Reporting
+    $0.000/catch made every catching gate read `earning` on a fabricated
+    denominator."""
+    v = factory_log.aggregate([_gate("g", 3)])["verdict"]["g"]
+    assert v["cost_usd"] is None
+    assert v["cost_per_catch"] is None
+
+
+def test_zero_yield_unattributed_gate_reads_unpriced_not_cheap():
+    v = factory_log.cost_value_verdict({"g": {"runs": 5, "caught_distinct": 0}}, {})
+    assert v["g"]["verdict"] == "unpriced"
+
+
+def test_demote_candidate_is_reachable_once_cost_is_attributed():
+    """The verdict that tells you to switch a gate off — unreachable before,
+    because cost defaulted to 0.0 and it requires cost > 0."""
+    v = factory_log.cost_value_verdict({"g": {"runs": 5, "caught_distinct": 0}},
+                                       {"g": {"calls": 5, "cost_usd": 12.5}})
+    assert v["g"]["verdict"] == "demote-candidate"
+
+
+def test_measured_free_still_reads_noise_candidate():
+    """An attributed cost of exactly 0.0 is a measurement and must stay
+    distinguishable from 'nothing was attributed'."""
+    v = factory_log.cost_value_verdict({"g": {"runs": 5, "caught_distinct": 0}},
+                                       {"g": {"calls": 5, "cost_usd": 0.0}})
+    assert v["g"]["verdict"] == "noise-candidate"
+
+
+def test_text_render_shows_dash_not_dollar_zero_for_unattributed():
+    out = factory_log.render_report(factory_log.aggregate([_gate("g", 3)]))
+    assert "$0.00" not in out

--- a/tests/test_telemetry_isolation.py
+++ b/tests/test_telemetry_isolation.py
@@ -1,0 +1,46 @@
+"""The test suite must never write telemetry into the operator's real log.
+
+`factory_log.emit*` is enabled by an ambient `CW_TELEMETRY=1` — the env var an
+operator sets to measure a factory run. Running pytest in that shell used to
+send every fixture's gate/consult event to `~/.chief-wiggum/factory-log.jsonl`:
+in a real 32k-record log, ~95% of gate records were pytest fixtures (`repo`
+values like `epic`, `clean`, `dirty`, `test_cli_gate_exits_1_on_terra0`), and
+every value/noise verdict was computed over them.
+
+`tests/conftest.py` redirects the log per-test. These tests hold that line.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import factory_log  # noqa: E402
+
+
+def test_log_path_is_redirected_away_from_the_real_log():
+    assert factory_log.log_path() != factory_log.DEFAULT_LOG
+    assert str(factory_log.DEFAULT_LOG) not in str(factory_log.log_path())
+
+
+def test_emitting_does_not_touch_the_real_log(tmp_path):
+    """The regression itself: emit a gate event the way a gate test does, and
+    confirm it lands in the redirected file."""
+    before = factory_log.DEFAULT_LOG.stat().st_size if factory_log.DEFAULT_LOG.is_file() else 0
+
+    factory_log.emit("gate", repo="epic", name="check_traceability", result="fail", caught=12)
+
+    after = factory_log.DEFAULT_LOG.stat().st_size if factory_log.DEFAULT_LOG.is_file() else 0
+    assert after == before, "test telemetry leaked into the operator's real factory log"
+    assert factory_log.log_path().is_file()
+    assert "check_traceability" in factory_log.log_path().read_text()
+
+
+def test_fixture_applies_without_being_requested():
+    """It is autouse — a gate test that never mentions telemetry is still
+    isolated. That is the whole point: the 12 leaking test modules did not know
+    they were emitting."""
+    assert os.environ["CW_FACTORY_LOG"] != str(factory_log.DEFAULT_LOG)


### PR DESCRIPTION
## Why

Investigating "can you see CW token usage stats?" turned up that the gate cost/benefit machinery, while well-designed, produced **no usable signal**. Three independent causes.

## 1. Claude Code's own cost was never ingested

`ingest-claude-code` is referenced in exactly two places in the repo: the doc describing it, and its own argparse definition. **No skill, command, or script ever called it.** So `claude_code_cost_usd` read `$0.00` — not because sessions were free, but because no ingest had ever run.

New `ingest-claude-transcripts` reads what Claude Code already writes to `~/.claude/projects/`. On this machine:

| source | cost |
|---|---|
| consults (was the only visible number) | $237.91 |
| **Claude Code sessions (was $0.00)** | **$4,129.75** |

~95% of real spend was invisible. The transcript route needs no configuration, works **retroactively**, and unlike the OTEL recipe doesn't fight an interactive TUI.

Two correctness details that are load-bearing, not incidental:
- **Dedup by `requestId`** — a request's usage is repeated on *every* content-block line it emits (thinking, text, tool_use). 29,903 lines collapse to 13,093 requests; summing lines would nearly double the cost. Verified: 9,352/9,360 multi-line requests report identical usage. All-zero lines are skipped so dedup is order-independent.
- **Cache-aware pricing** (`cost_for_usage`) — 4.14B cache-read tokens vs 1.37M fresh input. Charging cache reads at the input rate would overstate cost by orders of magnitude. Multipliers (read 0.1x, write 1.25x/2x by TTL) are grounded in `config/model_pricing.json`, not hardcoded.

## 2. The log was ~95% pytest pollution

`emit` is gated on an ambient `CW_TELEMETRY=1` — the var an operator sets to measure a run — so **pytest in that shell wrote fixture events into the real log**. Proven by running one non-isolating test file with the log redirected: 62 tests emitted 12 gate records tagged `repo: "epic"` (a `tmp_path` fixture dir).

| bucket | gate records |
|---|---|
| real repos | 1,583 (5.5%) |
| pytest fixtures | 14,119 |
| no repo (`check_architecture`: 7,451 here, **zero** real runs) | 12,905 |

12 test modules leaked. One autouse fixture in `tests/conftest.py` fixes all of them.

## 3. Both denominators were fabricated

**Value re-counted.** `caught` is a per-run finding *count*, so summing counts the same unfixed finding once per run — `check_traceability` scored 75,517 across 140 real runs (539/run) for one repo's unchanged orphan list. Verdict now uses `caught_distinct`: the `finding_ids` union when emitted, else the largest single run (a lower bound re-runs can't inflate).

**Cost fabricated.** Unattributed cost defaulted to `0.0`, so every catching gate read `earning` at a confident `$0.000/catch` — and `demote-candidate`, the one verdict that says *switch this gate off*, was **structurally unreachable** because it requires cost > 0. Cost is now `None` when nothing was attributed, with a new `unpriced` verdict distinct from a measured-free `noise-candidate`. The text report prints `—`, not `$0.00`.

| verdict | meaning |
|---|---|
| `earning` | caught > 0 |
| `demote-candidate` | ≥3 runs, 0 caught, **measured** cost > 0 |
| `noise-candidate` | ≥3 runs, 0 caught, **measured** cost 0 |
| `unpriced` | ≥3 runs, 0 caught, **no cost attributed** |
| `unproven` | too few runs |

Also adds `claude-opus-5` to the pricing table — it was absent, so every turn on the current model recorded `cost_usd: null`.

## What the real data says once filtered

`check_patterns` (354 runs), `check_infra_writer` (251), and `check_portability` (44) have **zero catches on real repos** — the one trustworthy signal in the old output, and unaffected by the cost blindness.

## Verification

- `2375 passed, 0 failed` with `CW_TELEMETRY=1` set
- 26 new tests covering cache pricing, ingest idempotency, worktree attribution, distinct counting, and the null-vs-zero cost distinction
- One existing assertion updated: `test_cost_value_verdict` asserted `cost_per_catch == 0.0` for a gate with no cost record — the exact conflation being fixed. Rewritten with both a measured-free and an unattributed case.
- Ingest exercised against real transcripts (13,063 turns) into a scratch log; the real log was never written to

## Known limitation

Gate-level cost attribution still depends on a loop/skill name on the cost record, which transcripts don't carry — so most gates report `unpriced` rather than a dollar figure. That's the honest state: `unpriced` says "we don't know", where the old `$0.000` said "it's free". Wiring per-loop attribution is follow-up work.