### PR TITLE
fix(sidecar): honour the resolved meta location in epic inventory, tracker, and the skills (#286, #266, #267)

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -33,10 +33,11 @@ CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$e
 eval "$CW_CTX"
 ```
 
-Fetch all issues in the epic milestone:
+Fetch all issues in the epic via `tracker.py` instead of calling `gh issue` directly — this is what makes the skill usable against non-github tracker backends, including a repo whose upstream has issues disabled entirely (see `docs/tracker.md`):
 ```bash
-gh issue list --repo "$owner_repo" --milestone "$epic_name" --state open --limit 100 --json number,title,body,labels
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
 ```
+This returns every ticket currently grouped into the epic — `ref`, `title`, `body`, `state`, `labels`, `assignee`, `epic`, `url_or_path` — for ANY backend (`gh:owner/repo#N` refs for `github`, `local:docs/issues/NNNN.md` for `local`). Filter client-side to `state == "open"` (matching the previous open-only behavior) unless you deliberately want closed tickets in view too. Keep each ticket's `ref` — Step 8 needs it to post the architecture comment.
 
 Read each issue's full body to extract acceptance criteria, technical notes, and cross-references.
 
@@ -598,11 +599,11 @@ If the user later revises a contract (a legitimate re-architecture, not a workar
 
 ### Step 8: Update issue descriptions
 
-For each ticket in the epic, append a reference to the architectural artifacts. `install_epic_artifacts.py` (Step 7) already emits a ready-to-post `issue_comment` body in its JSON output — reuse it (it links every artifact, including the UI spec when present) rather than hand-writing the body:
+For each ticket in the epic (using the `ref` values from Step 1's `tracker.py members` call), append a reference to the architectural artifacts via `tracker.py comment` — never `gh` directly, or this step is unusable against a non-github backend. `install_epic_artifacts.py` (Step 7) already emits a ready-to-post `issue_comment` body in its JSON output — reuse it (it links every artifact, including the UI spec when present) rather than hand-writing the body:
 
 ```bash
 # Reuse the installer's issue_comment, or post the equivalent below:
-gh issue comment $issue_number --repo "$owner_repo" --body "## Epic Architecture
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" comment "$ref" "## Epic Architecture
 
 This ticket is part of **[Epic Name]**. Before implementing, read:
 - [Contracts](../docs/epics/$EPIC_SLUG/contracts.md) — REQUIRES/ENSURES for APIs and entities

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -49,12 +49,13 @@ python3 "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
 
 Exit 2 means the binding exists but is unreadable — stop and fix it rather than closing an epic as if the target had no conventions. Empty output means none are recorded (the greenfield default). Otherwise load each listed skill and apply its conventions throughout the epic-level review, alongside CW's own gates.
 
-Fetch the epic's tickets:
+Fetch the epic's tickets via `tracker.py` instead of calling `gh issue` directly — this is what makes the skill usable against non-github tracker backends, including a repo whose upstream has issues disabled entirely (see `docs/tracker.md`):
 ```bash
-gh issue list --repo "$owner_repo" --milestone "$epic_name" --state all --limit 100 --json number,title,state,labels
+python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
 ```
+This returns every ticket currently grouped into the epic — `ref`, `title`, `state`, `labels`, ... — for ANY backend.
 
-Verify all tickets are closed. If any are still open, report which ones and ask the user whether to proceed with a partial close or wait.
+Verify all tickets are closed (`state == "closed"` for every returned ticket). If any are still open, report which ones and ask the user whether to proceed with a partial close or wait.
 
 ### Step 1b: Run the deterministic audit
 

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -56,13 +56,14 @@ Load epic artifacts from `$EPIC_DIR/`:
 **Build the artifact inventory** — one tested pass that discovers prose/model/design artifacts, sets `HAS_FORMAL_MODELS`/`HAS_UI_SPEC`/`HAS_TRANSITION_MAP`, validates model JSON, and runs the unresolved-marker scan:
 
 ```bash
-python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "$EPIC_SLUG" > "$CW_TMP/inventory.json"
+python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "$EPIC_SLUG" \
+  ${EPIC_DIR:+--epic-dir "$EPIC_DIR"} > "$CW_TMP/inventory.json"
 # Tickets gated by unresolved markers, as a comma-separated list for the planner.
 BLOCKED_TICKETS=$(jq -r '.blocked_tickets | join(",")' "$CW_TMP/inventory.json")
 HAS_FORMAL_MODELS=$(jq -r '.flags.HAS_FORMAL_MODELS' "$CW_TMP/inventory.json")
 ```
 
-If `.flags.HAS_EPIC` is false, **STOP** (no contracts). Each unresolved finding carries the tickets it blocks (from `derived_from` provenance); tickets in `blocked_tickets` must NOT be implemented on a guess — they are passed to the planner in Step 2 and re-checked in Step 4.
+If `.flags.HAS_EPIC` is false, **STOP** (no contracts) — every wave run is always inside a named epic (`--epic` is required), so here `HAS_EPIC: false` always means `epic_status: missing` (chief-wiggum#286), never the standalone-ticket case `/implement` also has to consider. Each unresolved finding carries the tickets it blocks (from `derived_from` provenance); tickets in `blocked_tickets` must NOT be implemented on a guess — they are passed to the planner in Step 2 and re-checked in Step 4.
 
 ### Step 2: Build the wave plan
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -102,15 +102,21 @@ Also check for **formal model artifacts** in `$EPIC_DIR/models/`:
 - `test_state_machine.py` — Hypothesis RuleBasedStateMachine skeleton
 - `transition-map.json` — transition ↔ ticket mapping (updated by `/implement`)
 
-Build the artifact inventory once with the tested helper, then read its flags (it discovers prose/model/design artifacts, validates model JSON, and runs the unresolved-marker scan in one pass):
+Build the artifact inventory once with the tested helper, then read its flags (it discovers prose/model/design artifacts, validates model JSON, and runs the unresolved-marker scan in one pass — sidecar-aware: it resolves the epic/design location itself, but `$EPIC_DIR` is already resolved above, so pass it through rather than paying to re-derive it):
 ```bash
-python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "${EPIC_SLUG:-}" --issue "$issue_number" > "$TICKET_TMP/inventory.json"
+python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "${EPIC_SLUG:-}" \
+  ${EPIC_DIR:+--epic-dir "$EPIC_DIR"} --issue "$issue_number" > "$TICKET_TMP/inventory.json"
+EPIC_STATUS=$(jq -r '.epic_status' "$TICKET_TMP/inventory.json")
+if [ "$EPIC_STATUS" = "missing" ]; then
+  echo "This ticket's milestone ($MILESTONE) names an epic, but its artifacts were not found at $EPIC_DIR. That is always a defect — a moved epic, a wrong election, or a never-installed architecture — never a standalone ticket. STOP: do not proceed as if there were no epic context; fix the location (or run /architect) first." >&2
+  exit 1
+fi
 HAS_FORMAL_MODELS=$(jq -r '.flags.HAS_FORMAL_MODELS' "$TICKET_TMP/inventory.json")
 HAS_UI_SPEC=$(jq -r '.flags.HAS_UI_SPEC' "$TICKET_TMP/inventory.json")
 HAS_TRANSITION_MAP=$(jq -r '.flags.HAS_TRANSITION_MAP' "$TICKET_TMP/inventory.json")
 [ "$HAS_FORMAL_MODELS" = "true" ] && MODELS_DIR="$EPIC_DIR/models"
 ```
-The inventory's `blocked_tickets` and `warnings` (e.g. malformed model JSON) feed the unresolved-unknowns gate below.
+The inventory's `blocked_tickets` and `warnings` (e.g. malformed model JSON) feed the unresolved-unknowns gate below. `epic_status` is three-state (`none`/`present`/`missing`, chief-wiggum#286) precisely so a resolver that can't find a NAMED epic is never confused with a ticket that legitimately has none — the `flags.HAS_EPIC` boolean alone can't tell those apart, and conflating them is how a sidecar target used to silently drop every contract, invariant, and state machine the epic produced while `/implement` reported normal standalone operation.
 
 These artifacts are **hard constraints** on the implementation. The coding worker MUST satisfy them. The review checklist MUST verify them. When formal models exist, test generation in Step 5 uses them for mechanical path coverage.
 
@@ -125,7 +131,7 @@ python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json
 ```
 If any finding's `tickets` list includes this ticket (or the finding sits on an entity/operation this ticket implements), do NOT implement on the guessed value. Resolve the unknown first — introspect the real source, read the upstream repo, or ask the user — update the artifact with a citation, then proceed. Building a query layer against `TBD:` schema names produces code that compiles, passes mocked tests, and fails on first contact with reality.
 
-If no epic context exists, proceed without it — the skill works standalone too.
+If `$EPIC_STATUS` is `none` (this ticket was never on a milestone), proceed without epic context — the skill works standalone too. That is the ONLY case that silently proceeds; `missing` already stopped above.
 
 All subsequent steps should work within `$TARGET_REPO`. Use `$CW_HOME` for chief-wiggum scripts/templates. Use `$CW_TMP` for temporary files (not `/tmp/`). Use `$DEFAULT_BRANCH` instead of hardcoding `main`.
 

--- a/scripts/chief_wiggum/artifacts.py
+++ b/scripts/chief_wiggum/artifacts.py
@@ -16,6 +16,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+import artifacts as _meta  # scripts/artifacts.py — the meta-location resolver (#213)
 import check_unresolved
 
 # Prose artifacts written into docs/epics/<slug>/ by /architect and /close-epic.
@@ -58,6 +59,14 @@ class ArtifactInventory:
     epic_slug: str | None = None
     epic_dir: str | None = None
     epic_dir_exists: bool = False
+    # Three-state outcome (chief-wiggum#286, mirroring check_traceability's
+    # applicability idiom): "none" (no epic requested — a supported, silent
+    # standalone configuration) vs "missing" (an epic WAS requested but
+    # couldn't be found — always a defect, never indistinguishable from
+    # "none") vs "present". Callers like /implement must branch on this, not
+    # on HAS_EPIC alone, or a named-but-unlocatable epic renders identically
+    # to a ticket that was never in an epic.
+    epic_status: str = "none"
     issue: int | None = None
     markdown_artifacts: dict[str, bool] = field(default_factory=dict)
     model_artifacts: dict[str, bool] = field(default_factory=dict)
@@ -114,26 +123,46 @@ def build_inventory(
     repo_path: str | Path,
     *,
     epic_slug: str | None = None,
+    epic_dir: str | Path | None = None,
     issue: int | None = None,
     scanner: Scanner = check_unresolved.scan,
     blocked_fn: BlockedFn = check_unresolved.blocked_tickets,
 ) -> ArtifactInventory:
-    """Discover epic / model / design artifacts and unresolved gates."""
+    """Discover epic / model / design artifacts and unresolved gates.
+
+    Meta location is resolved, never assumed (chief-wiggum#286): both the
+    epic dir and the design dir are asked of ``artifacts.Resolver`` rather
+    than string-concatenated against ``repo_path``, so a sidecar-elected
+    target's artifacts are found where the resolver actually put them
+    instead of silently reading as absent. ``Resolver.resolve`` raises
+    ``ValueError`` on a malformed election/scope — that is NOT caught here,
+    so a resolver error always aborts discovery loudly rather than falling
+    through to the embedded default and misclassifying the repo (fail
+    closed, matching ``.claude/commands/architect.md`` Step 1).
+
+    ``epic_dir`` lets a caller that has ALREADY resolved the location (e.g.
+    ``/implement`` Step 1, which computes it via ``artifacts.py show``)
+    pass it directly instead of having it re-derived here.
+    """
     repo = Path(repo_path)
     inv = ArtifactInventory(target_repo=str(repo), epic_slug=epic_slug, issue=issue)
+    resolver = _meta.Resolver.resolve(repo)
 
-    epic_dir: Path | None = None
-    if epic_slug:
-        epic_dir = repo / "docs" / "epics" / epic_slug
-        inv.epic_dir = str(epic_dir)
-        inv.epic_dir_exists = epic_dir.exists()
+    epic_path: Path | None = None
+    if epic_slug or epic_dir is not None:
+        epic_path = Path(epic_dir) if epic_dir is not None else resolver.epic_dir(epic_slug)
+        inv.epic_dir = str(epic_path)
+        inv.epic_dir_exists = epic_path.exists()
+        inv.epic_status = "present" if inv.epic_dir_exists else "missing"
+    else:
+        inv.epic_status = "none"
 
     # Models that are present AND parse — only these drive the HAS_* flags, so a
     # malformed model can't make a downstream step read/generate from broken JSON.
     valid_models: set[str] = set()
-    if epic_dir and epic_dir.exists():
-        inv.markdown_artifacts = _presence(epic_dir, EPIC_MARKDOWN)
-        models_dir = epic_dir / "models"
+    if epic_path and epic_path.exists():
+        inv.markdown_artifacts = _presence(epic_path, EPIC_MARKDOWN)
+        models_dir = epic_path / "models"
         inv.model_artifacts = _presence(models_dir, EPIC_MODELS)
         for name, present in inv.model_artifacts.items():
             if not present:
@@ -149,16 +178,16 @@ def build_inventory(
         if epic_slug:
             inv.warnings.append(f"epic directory does not exist: {inv.epic_dir}")
 
-    design_dir = repo / "docs" / "design"
+    design_dir = resolver.design_dir()
     if design_dir.exists():
         inv.design_artifacts = _presence(design_dir, DESIGN_ARTIFACTS, DESIGN_DIRS)
     else:
         inv.design_artifacts = dict.fromkeys(DESIGN_ARTIFACTS, False)
 
     # Unresolved-marker scan over the epic dir (models + prose).
-    if epic_dir and epic_dir.exists():
+    if epic_path and epic_path.exists():
         try:
-            findings = scanner([epic_dir])
+            findings = scanner([epic_path])
         except Exception as exc:  # noqa: BLE001 - never let a scan error abort discovery
             inv.warnings.append(f"unresolved scan failed: {exc}")
             findings = []
@@ -179,7 +208,7 @@ def build_inventory(
         inv.blocked_tickets = sorted(set(parsed))
 
     inv.flags = {
-        "HAS_EPIC": bool(epic_dir and epic_dir.exists()),
+        "HAS_EPIC": bool(epic_path and epic_path.exists()),
         "HAS_FORMAL_MODELS": "state-machines.json" in valid_models
         or "contracts.json" in valid_models,
         "HAS_UI_SPEC": "ui-spec.json" in valid_models,

--- a/scripts/epic_inventory.py
+++ b/scripts/epic_inventory.py
@@ -28,6 +28,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Epic artifact inventory")
     parser.add_argument("repo_path", help="Local path to the target repo")
     parser.add_argument("--epic-slug", help="Epic slug (docs/epics/<slug>)")
+    parser.add_argument(
+        "--epic-dir",
+        help="Pre-resolved epic directory (e.g. from 'artifacts.py show'); "
+        "overrides deriving it from --epic-slug, so a caller that already "
+        "resolved the meta location doesn't pay for it twice",
+    )
     parser.add_argument("--issue", type=int, help="Ticket number for context")
     out = parser.add_mutually_exclusive_group()
     out.add_argument("--json", action="store_true", help="Emit JSON (default)")
@@ -36,7 +42,10 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         inv = artifacts.build_inventory(
-            args.repo_path, epic_slug=args.epic_slug, issue=args.issue
+            args.repo_path,
+            epic_slug=args.epic_slug,
+            epic_dir=args.epic_dir,
+            issue=args.issue,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"Error: {exc}", file=sys.stderr)

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -55,6 +55,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import artifacts as _meta_location  # noqa: E402 - meta-location resolver (#213)
 from chief_wiggum import github as gh_meta  # noqa: E402
 
 Runner = Callable[..., subprocess.CompletedProcess]
@@ -359,10 +360,27 @@ def _split_comments(full_body: str) -> tuple[str, str | None]:
 
 
 class LocalBackend:
-    """One markdown file per issue, YAML frontmatter, under docs/issues/."""
+    """One markdown file per issue, YAML frontmatter, under docs/issues/.
+
+    Storage location is meta-location resolved, never assumed
+    (chief-wiggum#266): ``root`` is the TARGET repo checkout, but issues are
+    stored under ``<meta root>/issues`` — identical to
+    ``<target>/docs/issues`` in embedded mode (the status quo), but under the
+    sidecar meta root (``~/.chief-wiggum/meta/<owner>/<repo>/docs/issues``)
+    on a sidecar-elected target, so a local-backend target never has to
+    dirty its own tree to store issues.
+    """
 
     def __init__(self, root: Path | str):
-        self.root = Path(root).resolve()
+        target_repo = Path(root).resolve()
+        resolver = _meta_location.Resolver.resolve(target_repo)
+        # meta_root is "<base>/docs" in both modes (embedded: <target>/docs;
+        # sidecar: <sidecar dir>/docs) — its parent is the base that
+        # ISSUES_SUBDIR ("docs/issues") is relative to, so the SAME relative
+        # arithmetic below yields <target>/docs/issues in embedded mode
+        # (self.root == target_repo, unchanged) and the sidecar issues dir
+        # in sidecar mode, with no other code path to diverge.
+        self.root = resolver.meta_root.parent
         self.issues_dir = self.root / ISSUES_SUBDIR
 
     def _path_for_id(self, issue_id: int) -> Path:
@@ -480,11 +498,16 @@ DEFAULT_CW_CONFIG = Path.home() / ".chief-wiggum" / "config.json"
 def resolve_backend_name(repo_root: Path | str, *, cw_config: Path | None = None) -> str:
     """Resolve which backend a target repo uses.
 
-    1. ``<repo_root>/docs/cw/tracker.json``'s ``"backend"`` key.
+    1. ``<meta root>/cw/tracker.json``'s ``"backend"`` key — meta-location
+       resolved (chief-wiggum#266) via ``artifacts.Resolver``: identical to
+       ``<repo_root>/docs/cw/tracker.json`` in embedded mode (today's
+       behavior, unchanged), but the SIDECAR meta root on a sidecar-elected
+       target, where the target tree never carries a ``docs/`` at all.
     2. CW-side fallback: ``~/.chief-wiggum/config.json``'s ``tracker.backend``.
     3. Default: ``"github"`` (today's behavior).
     """
-    config_path = Path(repo_root) / "docs" / "cw" / "tracker.json"
+    resolver = _meta_location.Resolver.resolve(Path(repo_root))
+    config_path = resolver.meta_root / "cw" / "tracker.json"
     if config_path.is_file():
         try:
             data = json.loads(config_path.read_text())

--- a/tests/test_epic_inventory.py
+++ b/tests/test_epic_inventory.py
@@ -3,15 +3,47 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
+import artifacts as resolver_mod  # scripts/artifacts.py, the meta-location resolver (#213)
 import epic_inventory
+import pytest
 from chief_wiggum import artifacts
+
+
+@pytest.fixture(autouse=True)
+def user_dir(tmp_path, monkeypatch):
+    """Isolate every test from the real ~/.chief-wiggum — tests must never
+    touch it (build_inventory now consults the resolver on every call)."""
+    d = tmp_path / "cw-user"
+    monkeypatch.setenv("CHIEF_WIGGUM_USER_DIR", str(d))
+    return d
 
 
 def _epic_dir(repo, slug="order-lifecycle"):
     d = repo / "docs" / "epics" / slug
     (d / "models").mkdir(parents=True)
     return d
+
+
+def _git(repo, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def make_sidecar_target(tmp_path, remote="https://github.com/acme/app.git"):
+    """A tmp git repo elected into sidecar mode — its epic/design artifacts
+    live under the sidecar meta root, NOT under <repo>/docs."""
+    repo = tmp_path / "target"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+    _git(repo, "remote", "add", "origin", remote)
+    resolver_mod.elect(repo, "sidecar", backing="local")
+    return repo
 
 
 # --- no epic / missing docs -------------------------------------------------
@@ -175,3 +207,159 @@ def test_cli_emits_json(tmp_path, capsys):
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["flags"]["HAS_EPIC"] is True
+
+
+# --- epic_status: distinguishing "no epic" from "epic requested but missing" (#286) ---
+
+
+def test_epic_status_none_when_no_slug_requested(tmp_path):
+    inv = artifacts.build_inventory(tmp_path)
+    assert inv.epic_status == "none"
+
+
+def test_epic_status_missing_when_slug_not_found(tmp_path):
+    inv = artifacts.build_inventory(tmp_path, epic_slug="ghost")
+    assert inv.epic_status == "missing"
+
+
+def test_epic_status_present_when_slug_found(tmp_path):
+    _epic_dir(tmp_path)
+    inv = artifacts.build_inventory(tmp_path, epic_slug="order-lifecycle")
+    assert inv.epic_status == "present"
+
+
+# --- sidecar awareness (#286) -------------------------------------------------
+
+
+def test_sidecar_epic_resolves_through_meta_location_resolver(tmp_path):
+    """On a sidecar-elected target, build_inventory must find the epic under
+    the sidecar meta root, not under <repo>/docs/epics — and nothing must be
+    written into the target tree in the process."""
+    repo = make_sidecar_target(tmp_path)
+    resolver = resolver_mod.Resolver.resolve(repo)
+    assert resolver.mode == "sidecar"
+    epic = resolver.epic_dir("order-lifecycle")
+    (epic / "models").mkdir(parents=True)
+    (epic / "contracts.md").write_text("# Contracts")
+    (epic / "invariants.md").write_text("# Invariants")
+    (epic / "models" / "state-machines.json").write_text('{"states": []}')
+
+    inv = artifacts.build_inventory(repo, epic_slug="order-lifecycle", issue=42)
+
+    assert inv.flags["HAS_EPIC"] is True
+    assert inv.flags["HAS_FORMAL_MODELS"] is True
+    assert inv.epic_status == "present"
+    assert inv.epic_dir == str(epic)
+    assert inv.markdown_artifacts["contracts.md"] is True
+    assert not (repo / "docs").exists()  # zero footprint in the target tree
+
+
+def test_sidecar_epic_requested_but_missing_is_loud(tmp_path):
+    repo = make_sidecar_target(tmp_path)
+    inv = artifacts.build_inventory(repo, epic_slug="ghost")
+    assert inv.epic_status == "missing"
+    assert inv.flags["HAS_EPIC"] is False
+    assert any("epic directory does not exist" in w for w in inv.warnings)
+    # the warning must point at the SIDECAR path, not a bogus in-tree one
+    assert str(resolver_mod.Resolver.resolve(repo).meta_root) in inv.epic_dir
+
+
+def test_sidecar_design_artifacts_detected(tmp_path):
+    repo = make_sidecar_target(tmp_path)
+    resolver = resolver_mod.Resolver.resolve(repo)
+    design = resolver.design_dir()
+    design.mkdir(parents=True)
+    (design / "design.json").write_text("{}")
+
+    inv = artifacts.build_inventory(repo)
+    assert inv.flags["HAS_DESIGN"] is True
+    assert inv.design_artifacts["design.json"] is True
+    assert not (repo / "docs").exists()
+
+
+def test_embedded_mode_unchanged_by_resolver_adoption(tmp_path):
+    """Embedded (no election) must resolve to the exact same paths as before
+    the resolver was wired in."""
+    epic = _epic_dir(tmp_path)
+    (epic / "contracts.md").write_text("# Contracts")
+    inv = artifacts.build_inventory(tmp_path, epic_slug="order-lifecycle")
+    assert inv.epic_dir == str(tmp_path / "docs" / "epics" / "order-lifecycle")
+    assert inv.flags["HAS_EPIC"] is True
+
+
+# --- explicit epic_dir override (#286 proposal item 2) ------------------------
+
+
+def test_explicit_epic_dir_override_is_used_instead_of_resolving(tmp_path):
+    """A caller that has ALREADY resolved EPIC_DIR (as /implement Step 1 does)
+    can pass it directly rather than have build_inventory re-derive it."""
+    override = tmp_path / "elsewhere" / "order-lifecycle"
+    (override / "models").mkdir(parents=True)
+    (override / "contracts.md").write_text("# Contracts")
+
+    inv = artifacts.build_inventory(
+        tmp_path, epic_slug="order-lifecycle", epic_dir=override
+    )
+    assert inv.epic_dir == str(override)
+    assert inv.epic_status == "present"
+    assert inv.flags["HAS_EPIC"] is True
+    assert inv.markdown_artifacts["contracts.md"] is True
+
+
+def test_cli_accepts_epic_dir_override(tmp_path, capsys):
+    override = tmp_path / "elsewhere" / "order-lifecycle"
+    override.mkdir(parents=True)
+    (override / "contracts.md").write_text("# Contracts")
+
+    rc = epic_inventory.main(
+        [str(tmp_path), "--epic-slug", "order-lifecycle", "--epic-dir", str(override)]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["epic_dir"] == str(override)
+    assert data["flags"]["HAS_EPIC"] is True
+
+
+# --- fail closed on resolver errors (malformed election) ----------------------
+
+
+def test_malformed_election_propagates_instead_of_defaulting_to_embedded(tmp_path):
+    """Never silently fall through to embedded on a resolver error — a
+    malformed election must abort discovery loudly (matching
+    Resolver.resolve's own fail-closed contract)."""
+    repo = tmp_path / "target"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+
+    target_id = resolver_mod.derive_target_id(repo)
+    election = resolver_mod.election_path(target_id)
+    election.parent.mkdir(parents=True, exist_ok=True)
+    election.write_text("{not json")
+
+    with pytest.raises(ValueError, match="election"):
+        artifacts.build_inventory(repo)
+
+
+def test_cli_reports_error_on_malformed_election(tmp_path, capsys):
+    repo = tmp_path / "target"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+
+    target_id = resolver_mod.derive_target_id(repo)
+    election = resolver_mod.election_path(target_id)
+    election.parent.mkdir(parents=True, exist_ok=True)
+    election.write_text("{not json")
+
+    rc = epic_inventory.main([str(repo)])
+    assert rc == 1
+    assert "election" in capsys.readouterr().err

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -847,7 +847,6 @@ class TestCommandMarkdownMigration:
         text = (CW_ROOT / ".claude" / "commands" / "architect.md").read_text()
         assert "gh issue list" not in text
         assert "gh issue comment" not in text
-        assert "gh issue" not in text
         assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" members' in text
         assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" comment' in text
 
@@ -856,7 +855,6 @@ class TestCommandMarkdownMigration:
         they're all closed — same substitution as /architect."""
         text = (CW_ROOT / ".claude" / "commands" / "close-epic.md").read_text()
         assert "gh issue list" not in text
-        assert "gh issue" not in text
         assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" members' in text
 
     def test_no_gh_issue_milestone_listing_in_architect_or_close_epic(self):

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 from pathlib import Path
 
+import artifacts  # scripts/artifacts.py — the meta-location resolver (#213)
 import pytest
 import tracker
 from tracker import (
@@ -20,6 +21,35 @@ from tracker import (
 )
 
 CW_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def user_dir(tmp_path, monkeypatch):
+    """Isolate every test from the real ~/.chief-wiggum — tests must never
+    touch it (resolve_backend_name/LocalBackend now consult the resolver)."""
+    d = tmp_path / "cw-user"
+    monkeypatch.setenv("CHIEF_WIGGUM_USER_DIR", str(d))
+    return d
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def make_sidecar_target(tmp_path, remote="https://github.com/acme/app.git"):
+    """A tmp git repo elected into sidecar mode — tracker config and issue
+    storage must resolve OUTSIDE this tree, in the sidecar meta root."""
+    repo = tmp_path / "target"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+    _git(repo, "remote", "add", "origin", remote)
+    artifacts.elect(repo, "sidecar", backing="local")
+    return repo
 
 # --- fake gh CLI (statefully mocks the subprocess boundary) ------------------
 
@@ -366,6 +396,103 @@ class TestGetTracker:
             tracker.get_tracker("acme/app", repo_root=tmp_path)
 
 
+# --- sidecar awareness (#266) --------------------------------------------------
+
+
+class TestSidecarAwareness:
+    def test_resolve_backend_name_reads_sidecar_meta_root(self, tmp_path):
+        """Placing docs/cw/tracker.json in the TARGET tree must NOT select the
+        local backend on a sidecar-elected repo — the config has to live in
+        the sidecar meta root to be honored (and placing it there dirties the
+        tree the sidecar footprint exists to keep clean)."""
+        repo = make_sidecar_target(tmp_path)
+        (repo / "docs" / "cw").mkdir(parents=True)
+        (repo / "docs" / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        assert resolve_backend_name(repo) == "github"  # wrong location: ignored
+
+        resolver = artifacts.Resolver.resolve(repo)
+        sidecar_cfg = resolver.meta_root / "cw" / "tracker.json"
+        sidecar_cfg.parent.mkdir(parents=True, exist_ok=True)
+        sidecar_cfg.write_text(json.dumps({"backend": "local"}))
+        assert resolve_backend_name(repo) == "local"
+
+    def test_sidecar_local_backend_stores_and_lists_from_meta_root(self, tmp_path):
+        repo = make_sidecar_target(tmp_path)
+        resolver = artifacts.Resolver.resolve(repo)
+        (resolver.meta_root / "cw").mkdir(parents=True)
+        (resolver.meta_root / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        backend = tracker.get_tracker("acme/app", repo_root=repo)
+        assert isinstance(backend, LocalBackend)
+        ref = backend.create(IssueDraft(title="Sidecar issue"))
+
+        # the file physically lives under the SIDECAR meta root...
+        expected = resolver.meta_root / "issues" / "0001.md"
+        assert expected.is_file()
+        # ...never under the target tree.
+        assert not (repo / "docs").exists()
+
+        titles = {i.title for i in backend.list()}
+        assert titles == {"Sidecar issue"}
+        assert backend.get(ref).title == "Sidecar issue"
+
+    def test_sidecar_local_backend_writes_zero_files_into_target_tree(self, tmp_path):
+        repo = make_sidecar_target(tmp_path)
+        resolver = artifacts.Resolver.resolve(repo)
+        (resolver.meta_root / "cw").mkdir(parents=True)
+        (resolver.meta_root / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        backend = tracker.get_tracker("acme/app", repo_root=repo)
+        ref = backend.create(IssueDraft(title="Clean tree"))
+        backend.comment(ref, "a comment")
+        backend.update(ref, {"state": "closed"})
+
+        status = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert status == "", f"sidecar tracker writes leaked into the target tree: {status!r}"
+
+    def test_sidecar_local_backend_used_even_when_upstream_issues_disabled(self, tmp_path, monkeypatch):
+        """Prove the local backend is reached WITHOUT ever falling through to
+        the github default: the (unused) github path is wired to explode with
+        the exact error an issues-disabled upstream returns, so a resolver
+        regression that silently defaults to github fails loudly here rather
+        than passing by accident."""
+        repo = make_sidecar_target(tmp_path)
+        resolver = artifacts.Resolver.resolve(repo)
+        (resolver.meta_root / "cw").mkdir(parents=True)
+        (resolver.meta_root / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        def exploding_gh(args, **kwargs):
+            raise subprocess.CalledProcessError(
+                1, args, output="", stderr="the 'acme/app' repository has disabled issues"
+            )
+
+        monkeypatch.setattr(subprocess, "run", exploding_gh)
+
+        backend = tracker.get_tracker("acme/app", repo_root=repo)
+        assert isinstance(backend, LocalBackend)
+        ref = backend.create(IssueDraft(title="Works despite disabled issues"))
+        assert backend.get(ref).title == "Works despite disabled issues"
+
+    def test_embedded_mode_unchanged_by_resolver_adoption(self, tmp_path):
+        """No election at all (today's status quo) must resolve identically
+        to before sidecar-awareness was wired in."""
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "local"}))
+        assert resolve_backend_name(tmp_path) == "local"
+
+        backend = tracker.get_tracker("acme/app", repo_root=tmp_path)
+        assert isinstance(backend, LocalBackend)
+        assert backend.root == tmp_path.resolve()
+        assert backend.issues_dir == tmp_path.resolve() / "docs" / "issues"
+        ref = backend.create(IssueDraft(title="Embedded issue"))
+        assert (tmp_path / "docs" / "issues" / "0001.md").is_file()
+        assert backend.get(ref).title == "Embedded issue"
+
+
 # --- local backend frontmatter format -----------------------------------------
 
 
@@ -512,6 +639,38 @@ class TestCLI:
         out = capsys.readouterr().out
         assert exit_code == 0
         assert json.loads(out)[0]["title"] == "CLI issue"
+
+    def test_create_get_list_via_cli_sidecar_target(self, tmp_path, capsys):
+        """AC (#266): 'tracker.py --repo-root <target> list' finds issues
+        stored in the sidecar meta root on a sidecar-elected target."""
+        repo = make_sidecar_target(tmp_path)
+        resolver = artifacts.Resolver.resolve(repo)
+        (resolver.meta_root / "cw").mkdir(parents=True)
+        (resolver.meta_root / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        exit_code = tracker.main(
+            ["--repo-root", str(repo), "create", "acme/app", "--title", "CLI sidecar issue"]
+        )
+        assert exit_code == 0
+        ref = capsys.readouterr().out.strip()
+
+        exit_code = tracker.main(["--repo-root", str(repo), "list", "acme/app"])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert json.loads(out)[0]["title"] == "CLI sidecar issue"
+
+        exit_code = tracker.main(["--repo-root", str(repo), "get", ref])
+        out = capsys.readouterr().out
+        assert exit_code == 0
+        assert json.loads(out)["title"] == "CLI sidecar issue"
+
+        # zero footprint in the target tree
+        assert not (repo / "docs").exists()
+        status = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert status == ""
 
     def test_get_via_cli_github_backend(self, tmp_path, monkeypatch, capsys):
         fake = FakeGh()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -464,10 +464,17 @@ class TestSidecarAwareness:
         (resolver.meta_root / "cw").mkdir(parents=True)
         (resolver.meta_root / "cw" / "tracker.json").write_text(json.dumps({"backend": "local"}))
 
+        real_run = subprocess.run
+
         def exploding_gh(args, **kwargs):
-            raise subprocess.CalledProcessError(
-                1, args, output="", stderr="the 'acme/app' repository has disabled issues"
-            )
+            # Only the (unused) `gh` path explodes — plain `git` calls (the
+            # resolver's own bookkeeping) must keep working for real, or this
+            # stub would fail the test for the wrong reason.
+            if args and args[0] == "gh":
+                raise subprocess.CalledProcessError(
+                    1, args, output="", stderr="the 'acme/app' repository has disabled issues"
+                )
+            return real_run(args, **kwargs)
 
         monkeypatch.setattr(subprocess, "run", exploding_gh)
 
@@ -491,6 +498,47 @@ class TestSidecarAwareness:
         ref = backend.create(IssueDraft(title="Embedded issue"))
         assert (tmp_path / "docs" / "issues" / "0001.md").is_file()
         assert backend.get(ref).title == "Embedded issue"
+
+
+# --- epic membership via tracker.py, not gh issue (#267) -----------------------
+
+
+class TestEpicMembershipViaTracker:
+    """The mechanized half of #267: /architect and /close-epic now fetch epic
+    tickets via `tracker.py members`, not `gh issue list --milestone`. Proves
+    that primitive works end to end for a local-backend target — including
+    one whose upstream has issues disabled, so the github default can't mask
+    a regression that silently falls back to it."""
+
+    def test_members_works_against_local_backend_with_issues_disabled_upstream(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        cw_dir = tmp_path / "docs" / "cw"
+        cw_dir.mkdir(parents=True)
+        (cw_dir / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+        real_run = subprocess.run
+
+        def exploding_gh(args, **kwargs):
+            if args and args[0] == "gh":
+                raise subprocess.CalledProcessError(
+                    1, args, output="", stderr="the 'acme/app' repository has disabled issues"
+                )
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", exploding_gh)
+
+        run = lambda *a: tracker.main(["--repo-root", str(tmp_path), *a])  # noqa: E731
+        refs = []
+        for title in ("In the epic", "Also in the epic", "Not in the epic"):
+            assert run("create", "acme/app", "--title", title) == 0
+            refs.append(capsys.readouterr().out.strip())
+        assert run("group", "Epic: Orders", refs[0], refs[1]) == 0
+        capsys.readouterr()
+
+        assert run("members", "acme/app", "Epic: Orders") == 0
+        members = json.loads(capsys.readouterr().out)
+        assert {m["title"] for m in members} == {"In the epic", "Also in the epic"}
 
 
 # --- local backend frontmatter format -----------------------------------------
@@ -790,3 +838,33 @@ class TestCommandMarkdownMigration:
                 # every milestone-mutating gh api call must live in a
                 # backend=github conditional block
                 assert 'if [ "$backend" = "github" ]' in line_block
+
+    def test_architect_uses_tracker_not_gh_issue_for_epic_tickets(self):
+        """(#267) /architect Step 1 fetches epic tickets and Step 8 posts
+        per-ticket comments — both used to shell out to `gh issue` directly,
+        making the skill unusable against a non-github tracker backend (or a
+        repo with issues disabled). Both must go through tracker.py."""
+        text = (CW_ROOT / ".claude" / "commands" / "architect.md").read_text()
+        assert "gh issue list" not in text
+        assert "gh issue comment" not in text
+        assert "gh issue" not in text
+        assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" members' in text
+        assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" comment' in text
+
+    def test_close_epic_uses_tracker_not_gh_issue_for_epic_tickets(self):
+        """(#267) /close-epic Step 1 fetches the epic's tickets to verify
+        they're all closed — same substitution as /architect."""
+        text = (CW_ROOT / ".claude" / "commands" / "close-epic.md").read_text()
+        assert "gh issue list" not in text
+        assert "gh issue" not in text
+        assert 'scripts/tracker.py" --repo-root "$TARGET_REPO" members' in text
+
+    def test_no_gh_issue_milestone_listing_in_architect_or_close_epic(self):
+        """Grep-based audit (#267 AC): neither skill fetches epic membership
+        via `gh issue list --milestone` anywhere in its documented flow —
+        tracker.py's `members` is the only sanctioned path now."""
+        for name in ("architect.md", "close-epic.md"):
+            text = (CW_ROOT / ".claude" / "commands" / name).read_text()
+            assert not re.search(r"gh issue list[^\n]*--milestone", text), (
+                f"{name} still lists epic tickets via gh issue directly"
+            )


### PR DESCRIPTION
Closes #286
Closes #266
Closes #267

Three tickets in the same cluster: CW's "meta location is resolved, never assumed" doctrine was not actually honoured in three places, so **sidecar mode silently degraded**.

---

## #286 — `build_inventory` not sidecar-aware

The epic and design dirs were string-concatenated against the repo path instead of asked of the resolver. In sidecar mode `/implement` therefore found no epic artifacts and **proceeded as though the ticket simply had no contracts** — indistinguishable from a genuinely standalone ticket. Every contract, invariant and state machine silently dropped out of the build.

- Resolution now goes through `artifacts.Resolver`. Embedded mode is byte-identical.
- A malformed election/scope propagates as `ValueError` rather than defaulting to embedded — **fail closed**, matching the doctrine `architect.md` Step 1 already documents.
- New three-state `epic_status` (`none` / `present` / `missing`), mirroring `check_traceability`'s applicability idiom, so *a named-but-unlocatable epic is mechanically distinguishable from a standalone ticket*. `/implement` Step 1 now hard-stops on `missing` instead of quietly continuing standalone.
- Optional `epic_dir` override + `--epic-dir` flag so a caller that already resolved the location doesn't re-derive it.

This was the #289 shape: not-measured rendering as clean.

## #266 — local tracker backend not sidecar-aware

`resolve_backend_name()` read `<repo_root>/docs/cw/tracker.json` directly, and `LocalBackend` stored issues inside the target tree — both wrong in sidecar mode, where the whole point is that CW state lives outside the target.

Both now resolve through the resolver (`<meta root>/cw/tracker.json`; `root = resolver.meta_root.parent`), identical to the target repo in embedded mode. Tests include a `git status --porcelain` zero-footprint assertion, plus a regression guard that makes the unused `gh` path explode with a distinctive "issues disabled" error — proving the fix never falls through to the github default.

## #267 — `/architect` and `/close-epic` bypassed `tracker.py`

Both called `gh issue` directly, making non-GitHub backends unusable regardless of configuration. Migrated to `tracker.py members` / `tracker.py comment`, following the existing `create-issue.md`/`plan-epic.md` precedent. Tests assert the migration per skill, plus one mechanized end-to-end run against a local backend with a simulated issues-disabled upstream.

### Scope note — follow-up needed

`implement.md` and `implement-wave.md` still call `gh issue view`/`list`/`close` directly. Deliberately left alone: the ticket named only architect/close-epic, and implement-wave's ticket handling is GitHub-numeric throughout (worktree naming, `gh issue close`), so migrating just the epic-listing lines would be cosmetic rather than actually backend-agnostic. Worth its own ticket if full tracker-agnosticism for the implement flow is wanted.

## Verification

- Full suite: **2471 passed, 14 skipped, 0 failed**
- `make lint` clean
- **No `scanner_version` moves**: verified none of the eight gate scripts hash `chief_wiggum/artifacts.py`, `tracker.py` or `epic_inventory.py` — they hash only the top-level `scripts/artifacts.py` resolver, which is unchanged. No record re-authoring needed.
- Only canonical `.claude/commands/*.md` edited; `skills/` symlinks intact
- `git status` verified clean before push