### PR TITLE
fix(formal-models): emit guard scaffolds that actually compile (#232)

### DIFF
--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -415,6 +416,184 @@ def generate_hypothesis(sm: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Expression idiom: non_codegen guards, pseudo-operator transpile, slugify
+# ---------------------------------------------------------------------------
+#
+# Contract preconditions/postconditions carry a "Python-flavored pseudo-code"
+# `expression` string (see templates/formal-models/contracts-schema.json)
+# that the guard/deal generators below interpolate directly into generated
+# Python and Go. Two idioms in that pseudo-code are NOT directly
+# codegen-able and must be handled before interpolation:
+#
+#   1. `non_codegen(<kind>): <description>` — a build/provision-time
+#      assertion (archguard, index, provisioning, ...) that has no runtime
+#      representation. It must render as a comment/stub, never as an
+#      executable `if`/`lambda` guard.
+#   2. Pseudo-code operators — `implies`, `⇒` (implication), `×`
+#      (multiplication), `Δ` (delta / change-of) — which read naturally in
+#      prose but are not valid Python or Go syntax as-is.
+
+NON_CODEGEN_PREFIX = "non_codegen("
+
+# Unicode pseudo-operator glyph -> ASCII word/symbol form. Applied before the
+# word-level transpile below so `⇒` and `implies` share one code path.
+_UNICODE_OPERATOR_ALIASES = {
+    "⇒": "implies",
+    "×": "*",
+    "Δ": "delta",
+}
+
+
+def is_non_codegen(expression: str | None) -> bool:
+    """True if `expression` is a build/provision-time assertion (the
+    `non_codegen(<kind>): ...` idiom) that must never be emitted as a
+    runtime guard."""
+    if not expression:
+        return False
+    return expression.strip().startswith(NON_CODEGEN_PREFIX)
+
+
+def _normalize_unicode_operators(expression: str) -> str:
+    """Replace pseudo-code unicode operator glyphs with their ASCII form,
+    then collapse the whitespace runs that substitution introduces."""
+    normalized = expression
+    for glyph, ascii_form in _UNICODE_OPERATOR_ALIASES.items():
+        normalized = normalized.replace(glyph, f" {ascii_form} ")
+    return re.sub(r"[ \t]+", " ", normalized).strip()
+
+
+def _split_top_level(expression: str, operator: str) -> tuple[str, str] | None:
+    """Split `expression` on the first top-level (paren-depth 0) standalone
+    occurrence of the word `operator`. Returns (left, right), or None if the
+    operator does not appear at the top nesting level."""
+    for match in re.finditer(rf"(?<!\w){re.escape(operator)}(?!\w)", expression):
+        prefix = expression[: match.start()]
+        depth = prefix.count("(") - prefix.count(")")
+        if depth == 0:
+            left = expression[: match.start()].strip()
+            right = expression[match.end():].strip()
+            if left and right:
+                return left, right
+    return None
+
+
+def transpile_expression(expression: str, lang: str = "python") -> str:
+    """Transpile the pseudo-code expression idiom into compilable syntax for
+    `lang` ("python" or "go"). Handles the established operators (and their
+    unicode glyphs):
+
+        A implies B  /  A ⇒ B   ->  (not (A)) or (B)      [python]
+                                 ->  (!(A) || (B))         [go]
+        A × B                    ->  A * B                 [both]
+        A Δ B                    ->  (A - B)                [both]  (delta / change-of)
+
+    Expressions without any of these tokens pass through unchanged (after
+    unicode normalization, which is a no-op when no glyphs are present).
+    Callers must check `is_non_codegen` first — non_codegen expressions are
+    never meant to reach this function.
+    """
+    working = _normalize_unicode_operators(expression)
+
+    implies_split = _split_top_level(working, "implies")
+    if implies_split:
+        left, right = implies_split
+        if lang == "go":
+            return f"(!({left}) || ({right}))"
+        return f"(not ({left})) or ({right})"
+
+    delta_split = _split_top_level(working, "delta")
+    if delta_split:
+        left, right = delta_split
+        return f"({left} - {right})"
+
+    return working
+
+
+_SLUG_SPLIT_RE = re.compile(r"[^0-9A-Za-z_]+")
+
+
+def slugify_identifier(name: str, *, pascal_case: bool = False) -> str:
+    """Convert an arbitrary contract/operation name into a legal Python/Go
+    identifier: strips apostrophes/quotes outright, splits on any other
+    run of non-alphanumeric characters (spaces, hyphens, em-dashes,
+    parentheses, ...), and guards against a leading digit.
+
+    `pascal_case=True` renders Go-style PascalCase (for exported function
+    names); otherwise renders snake_case (for Python function names).
+    """
+    cleaned = re.sub(r"['’\"]", "", name)
+    words = [w for w in _SLUG_SPLIT_RE.split(cleaned) if w]
+    if not words:
+        return "_unnamed"
+
+    if pascal_case:
+        slug = "".join(w[:1].upper() + w[1:] for w in words)
+    else:
+        slug = "_".join(w.lower() for w in words)
+
+    if slug[0].isdigit():
+        slug = f"_{slug}"
+    return slug
+
+
+def _render_precondition_python(pre: dict, op: dict) -> list[str]:
+    """Render one precondition as Python guard-clause lines: a runtime `if`
+    guard for a codegen-able expression, or a comment stub for a
+    `non_codegen(...)` build/provision-time assertion."""
+    expr = pre.get("expression", "False  # TODO")
+    description = pre["description"]
+
+    if is_non_codegen(expr):
+        return [
+            f"    # BUILD/PROVISION-TIME GUARD (not enforced at runtime): {description}",
+            f"    # {expr}",
+            "",
+        ]
+
+    lines = [
+        f"    # REQUIRES: {description}",
+        f"    if not ({transpile_expression(expr)}):",
+    ]
+    error_status = 400
+    for ec in op.get("error_cases", []):
+        if any(word in ec["condition"].lower() for word in description.lower().split()):
+            error_status = ec["status"]
+            break
+    lines.append(f'        raise HTTPError({error_status}, "{description}")')
+    lines.append("")
+    return lines
+
+
+def _render_precondition_go(pre: dict, op: dict) -> list[str]:
+    """Render one precondition as Go guard-clause lines: a runtime `if`
+    guard for a codegen-able expression, or a comment stub for a
+    `non_codegen(...)` build/provision-time assertion."""
+    expr = pre.get("expression", "false /* TODO */")
+    description = pre["description"]
+
+    if is_non_codegen(expr):
+        return [
+            f"\t// BUILD/PROVISION-TIME GUARD (not enforced at runtime): {description}",
+            f"\t// {expr}",
+            "",
+        ]
+
+    error_status = 400
+    for ec in op.get("error_cases", []):
+        if any(word in ec["condition"].lower() for word in description.lower().split()):
+            error_status = ec["status"]
+            break
+    return [
+        f"\t// REQUIRES: {description}",
+        f"\tif !({transpile_expression(expr, lang='go')}) {{",
+        f'\t\thttp.Error(w, "{description}", {error_status})',
+        f"\t\treturn",
+        f"\t}}",
+        "",
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Code generation: deal/icontract DbC decorators
 # ---------------------------------------------------------------------------
 
@@ -445,17 +624,25 @@ def generate_deal_decorators(contracts: dict) -> str:
             ])
 
         for op in entity.get("operations", []):
-            func_name = op["name"].lower().replace(" ", "_")
+            func_name = slugify_identifier(op["name"])
             lines.append(f"# {op['method']} {op['path']}")
 
             # Preconditions
             for pre in op.get("preconditions", []):
                 expr = pre.get("expression", "True  # TODO: implement")
+                if is_non_codegen(expr):
+                    lines.append(f"# BUILD/PROVISION-TIME (not enforced at runtime): {pre['description']} — {expr}")
+                    continue
+                expr = transpile_expression(expr)
                 lines.append(f"@deal.pre(lambda: {expr}, message=\"{pre['description']}\")")
 
             # Postconditions
             for post in op.get("postconditions", []):
                 expr = post.get("expression", "True  # TODO: implement")
+                if is_non_codegen(expr):
+                    lines.append(f"# BUILD/PROVISION-TIME (not enforced at runtime): {post['description']} — {expr}")
+                    continue
+                expr = transpile_expression(expr)
                 lines.append(f"@deal.post(lambda result: {expr}, message=\"{post['description']}\")")
 
             lines.extend([
@@ -486,25 +673,13 @@ def generate_guards_python(contracts: dict) -> str:
 
     for entity in contracts.get("entities", []):
         for op in entity.get("operations", []):
-            func_name = op["name"].lower().replace(" ", "_")
+            func_name = slugify_identifier(op["name"])
             lines.append(f"def {func_name}(request):")
             lines.append(f'    """{op.get("description", op["name"])}"""')
 
             # Guard clauses from preconditions
             for pre in op.get("preconditions", []):
-                expr = pre.get("expression", "False  # TODO")
-                lines.extend([
-                    f"    # REQUIRES: {pre['description']}",
-                    f"    if not ({expr}):",
-                ])
-                # Find matching error case
-                error_status = 400
-                for ec in op.get("error_cases", []):
-                    if any(word in ec["condition"].lower() for word in pre["description"].lower().split()):
-                        error_status = ec["status"]
-                        break
-                lines.append(f'        raise HTTPError({error_status}, "{pre["description"]}")')
-                lines.append("")
+                lines.extend(_render_precondition_python(pre, op))
 
             lines.extend([
                 "    # --- implementation ---",
@@ -533,27 +708,12 @@ def generate_guards_go(contracts: dict) -> str:
 
     for entity in contracts.get("entities", []):
         for op in entity.get("operations", []):
-            func_name = "".join(
-                word.capitalize() for word in op["name"].split()
-            )
+            func_name = slugify_identifier(op["name"], pascal_case=True)
             lines.append(f"// {op['method']} {op['path']}")
             lines.append(f"func {func_name}(w http.ResponseWriter, r *http.Request) {{")
 
             for pre in op.get("preconditions", []):
-                expr = pre.get("expression", "false /* TODO */")
-                error_status = 400
-                for ec in op.get("error_cases", []):
-                    if any(word in ec["condition"].lower() for word in pre["description"].lower().split()):
-                        error_status = ec["status"]
-                        break
-                lines.extend([
-                    f"\t// REQUIRES: {pre['description']}",
-                    f"\tif !({expr}) {{",
-                    f'\t\thttp.Error(w, "{pre["description"]}", {error_status})',
-                    f"\t\treturn",
-                    f"\t}}",
-                    "",
-                ])
+                lines.extend(_render_precondition_go(pre, op))
 
             lines.extend([
                 "\t// --- implementation ---",

--- a/tests/test_formal_models_generation.py
+++ b/tests/test_formal_models_generation.py
@@ -8,6 +8,11 @@ state detection, path enumeration with cycles, and the four code generators.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
 import formal_models as fm
 
 # --- detect_schema_type -----------------------------------------------------
@@ -299,3 +304,193 @@ def test_generate_guards_go_emits_capitalized_func_and_http_error():
     assert "package handlers" in code
     assert "func CreateOrder(w http.ResponseWriter, r *http.Request) {" in code
     assert 'http.Error(w, "customer exists", 404)' in code
+
+
+# --- #232: non_codegen awareness, pseudo-operator transpile, slugified names --
+
+
+def test_is_non_codegen_detects_prefix():
+    assert fm.is_non_codegen("non_codegen(archguard): no controller imports repository directly")
+    assert fm.is_non_codegen("  non_codegen(index): composite index exists")
+    assert not fm.is_non_codegen("order.status == 'pending'")
+    assert not fm.is_non_codegen(None)
+    assert not fm.is_non_codegen("")
+
+
+def test_transpile_expression_implies_word_form():
+    assert fm.transpile_expression("A implies B") == "(not (A)) or (B)"
+
+
+def test_transpile_expression_implies_unicode_arrow():
+    assert fm.transpile_expression("A ⇒ B") == "(not (A)) or (B)"
+
+
+def test_transpile_expression_times_unicode_operator():
+    assert fm.transpile_expression("A × B") == "A * B"
+
+
+def test_transpile_expression_delta_unicode_operator():
+    # Δ ("change from A to B") transpiles to a plain subtraction so the
+    # generated guard is valid Python/Go arithmetic.
+    result = fm.transpile_expression("A Δ B")
+    compile(result, "<generated>", "eval")
+    assert "Δ" not in result
+
+
+def test_transpile_expression_passthrough_when_no_pseudo_operators():
+    assert fm.transpile_expression("order.status == 'pending'") == "order.status == 'pending'"
+
+
+def test_slugify_identifier_strips_apostrophes_and_punctuation():
+    slug = fm.slugify_identifier("What's Biting — Aggregation (v2)")
+    assert slug.isidentifier()
+    assert "'" not in slug
+    assert "-" not in slug
+    assert "(" not in slug and ")" not in slug
+
+
+def test_slugify_identifier_guards_leading_digit():
+    slug = fm.slugify_identifier("2FA Challenge")
+    assert slug.isidentifier()
+    assert not slug[0].isdigit()
+
+
+def test_slugify_identifier_pascal_case_for_go():
+    slug = fm.slugify_identifier("admin what's-biting aggregation", pascal_case=True)
+    assert slug.isidentifier()
+    assert slug[0].isupper()
+    assert "'" not in slug and "-" not in slug
+
+
+def _contracts_with(preconditions=None, postconditions=None, op_name="Create Order", extra_op=None):
+    op = {
+        "name": op_name,
+        "method": "POST",
+        "path": "/orders",
+        "description": "Create an order",
+        "preconditions": preconditions or [],
+        "postconditions": postconditions or [],
+        "error_cases": [{"status": 404, "condition": "customer not found"}],
+    }
+    if extra_op:
+        op.update(extra_op)
+    return {"entities": [{"name": "Order", "operations": [op]}]}
+
+
+def test_generate_deal_decorators_skips_non_codegen_precondition():
+    contracts = _contracts_with(
+        preconditions=[
+            {
+                "description": "composite index exists on (tenant_id, status)",
+                "expression": "non_codegen(index): composite index exists on (tenant_id, status)",
+            }
+        ]
+    )
+    code = fm.generate_deal_decorators(contracts)
+    assert "@deal.pre(lambda: non_codegen" not in code
+    assert "non_codegen" in code  # surfaced as a comment, not dropped silently
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_python_skips_non_codegen_precondition():
+    contracts = _contracts_with(
+        preconditions=[
+            {
+                "description": "archguard: no controller imports repository directly",
+                "expression": "non_codegen(archguard): no controller imports repository directly",
+            }
+        ]
+    )
+    code = fm.generate_guards_python(contracts)
+    assert "if not (non_codegen" not in code
+    assert "non_codegen" in code
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_go_skips_non_codegen_precondition():
+    contracts = _contracts_with(
+        preconditions=[
+            {
+                "description": "provisioning: bucket must pre-exist",
+                "expression": "non_codegen(provisioning): bucket must pre-exist",
+            }
+        ]
+    )
+    code = fm.generate_guards_go(contracts)
+    assert "if !(non_codegen" not in code
+    assert "non_codegen" in code
+
+
+def test_generate_deal_decorators_transpiles_pseudo_operators():
+    contracts = _contracts_with(
+        preconditions=[{"description": "conditional grant", "expression": "has_role implies has_scope"}],
+        postconditions=[{"description": "totals reconcile", "expression": "before Δ after"}],
+    )
+    code = fm.generate_deal_decorators(contracts)
+    assert "(not (has_role)) or (has_scope)" in code
+    assert "Δ" not in code
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_python_transpiles_unicode_operators():
+    contracts = _contracts_with(
+        preconditions=[{"description": "scope check", "expression": "has_role ⇒ has_scope"}]
+    )
+    code = fm.generate_guards_python(contracts)
+    assert "⇒" not in code
+    assert "(not (has_role)) or (has_scope)" in code
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_go_transpiles_unicode_operators():
+    contracts = _contracts_with(
+        preconditions=[{"description": "rate check", "expression": "cost × quantity"}]
+    )
+    code = fm.generate_guards_go(contracts)
+    assert "×" not in code
+    assert "cost * quantity" in code
+
+
+def test_generate_deal_decorators_slugifies_operation_name_with_apostrophe_and_parens():
+    contracts = _contracts_with(op_name="What's Biting — Aggregation (v2)")
+    code = fm.generate_deal_decorators(contracts)
+    compile(code, "<generated>", "exec")
+    assert "def what's" not in code.lower()
+
+
+def test_generate_guards_python_slugifies_operation_name():
+    contracts = _contracts_with(op_name="Admin What's-Biting Aggregation")
+    code = fm.generate_guards_python(contracts)
+    compile(code, "<generated>", "exec")
+
+
+def test_generate_guards_go_slugifies_operation_name_with_apostrophe_and_em_dash():
+    contracts = _contracts_with(op_name="Admin What's-Biting — Aggregation")
+    code = fm.generate_guards_go(contracts)
+    # Must be a single legal Go identifier: no apostrophes, hyphens, em-dashes, or spaces.
+    func_line = next(line for line in code.splitlines() if line.startswith("func "))
+    func_name = func_line.split("func ")[1].split("(")[0]
+    assert func_name.isidentifier()
+
+
+def test_generated_guards_go_compiles_with_gofmt():
+    if not shutil.which("gofmt"):
+        return
+    contracts = _contracts_with(
+        preconditions=[
+            {"description": "scope check", "expression": "has_role ⇒ has_scope"},
+            {
+                "description": "provisioning check",
+                "expression": "non_codegen(provisioning): bucket must pre-exist",
+            },
+        ],
+        op_name="Admin What's-Biting — Aggregation (v2)",
+    )
+    code = fm.generate_guards_go(contracts)
+    with tempfile.TemporaryDirectory() as tmp:
+        go_file = Path(tmp) / "guards.go"
+        go_file.write_text(code)
+        result = subprocess.run(
+            ["gofmt", "-e", str(go_file)], capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Closes #232

`render_models` emitted guard scaffolds a target repo could not compile. Three distinct defects:

## 1. `non_codegen` expressions became executable guards

Build/provision-time assertions (`non_codegen(<kind>): …`) were rendered as runtime `if`/`lambda` guards. New `is_non_codegen()` detects the prefix; `generate_deal_decorators`, `_render_precondition_python` and `_render_precondition_go` now emit a comment (`# BUILD/PROVISION-TIME GUARD (not enforced at runtime): …`) instead.

## 2. Unicode pseudo-operators were emitted verbatim

New `transpile_expression()` normalises `⇒`→`implies`, `×`→`*`, `Δ`→`delta`, then transpiles per language:

- Python: `A implies B` → `(not (A)) or (B)`
- Go: `A implies B` → `(!(A) || (B))`
- `A Δ B` → `(A - B)`

The per-language split is not cosmetic — the worker's first pass reused Python's `not`/`or` inside the **Go** generator, which does not compile. Caught mid-implementation and fixed; a `gofmt` compile test now pins it (skipped when `gofmt` is absent).

## 3. Operation names were not slugified

`.lower().replace(" ", "_")` broke on any real operation name. New `slugify_identifier()` strips apostrophes/quotes, splits on punctuation runs (spaces, hyphens, em-dashes, parens), guards a leading digit, and renders snake_case (Python) or PascalCase (Go). So `What's Biting — Aggregation (v2)` now yields a legal identifier.

## Verification

- Full suite: **2556 passed, 14 skipped, 0 failed** (+19 new tests)
- `make lint` clean, `make verify-examples` passes
- `docs/formal-methods/examples/generated/**` regenerated: **byte-identical**, since the committed `order-lifecycle` fixture contains no `non_codegen`, pseudo-operator or punctuated-name content
- No `scanner_version` moves

### Known, pre-existing, out of scope

The fixture's `guards.go` already failed `gofmt` before this change, because the fixture's own expressions bake in plain-Python idioms (`is not None`, `or`, `len()`). Verified unchanged before and after this diff. The ticket named only the three defects above; transpiling arbitrary Python idioms to Go is a separate problem.