### PR TITLE
feat(bet): capacity-aware cap over the live fleet, explicit liability dimension (#274, #277)

### DIFF
--- a/docs/business-factory.md
+++ b/docs/business-factory.md
@@ -95,6 +95,20 @@ Per-bet typed loss caps, human-set, script-enforced, raisable only by a journale
   a bet in `probe` state may not incur exercise-scale costs.
 - The ratchet idiom applies verbatim: workers never touch the envelope; raises are journaled
   in the hash chain.
+- **`liability_exposure` addendum (chief-wiggum#277)**: Dew et al.'s field list has no
+  liability/exposure dimension, so an uncapped contractual indemnity records identically to
+  no exposure at all. Added as an enumerated field —
+  `capped_at(<amount>) | insured(<policy>, responds=yes|unverified|no) | uncapped_entity |
+  uncapped_personal` — never free text. Its total absence is a lintable finding; a STATED
+  value, including an uncapped one, is never itself a finding: the operator takes uncapped
+  risk deliberately as a competitive edge (§9.4 addendum, "terms as an attack surface"), and
+  the point of this field is to make that choice explicit, sized and counted, never to block
+  it. Insurability is a separate fact from insurance: `responds` defaults to `unverified` and
+  only a human answer moves it (a common PI-policy exclusion is contractually-assumed
+  liability, so holding a policy does not establish that it responds). The portfolio-level
+  concurrency count over every non-exited bet is the check that actually matters — one
+  uncapped exposure is a considered bet, several concurrently is a portfolio that cannot
+  survive one bad event.
 
 ### 2.2 The assumptions graph (traceability transplanted to business objects)
 
@@ -704,6 +718,15 @@ Ranked transferable mechanisms:
    equivalent.
 8. **Capital structure as strategy**: a solo operator can hold price points a VC-backed
    competitor structurally can't (they must raise prices into their valuation; you don't).
+9. **Terms as an attack surface** (chief-wiggum#277 addendum): risk appetite, liability
+   acceptance and indemnity posture can be undercut on exactly like price. A mid-size
+   competitor's legal function vetoes an uncapped indemnity as a matter of policy; a solo
+   operator can accept it deliberately and win work the incumbent is structurally unable to
+   bid — judo with **terms** rather than price as the lever. Sizing caveat: this is a real
+   mechanism, not a free one — an edge you can only play once (because one bad event ends
+   the portfolio) is a bet, not an edge, and it must be sized, recorded and counted like any
+   other (the affordable-loss envelope's `liability_exposure` field and the portfolio-level
+   uncapped-concurrency count exist for exactly this — never as a blocker on taking the risk).
 
 **Multi-host neutrality** (from the steer): integrating with several competing hosts defeats
 both the landlord (can't be evicted from rivals) and the bundle (no host can bundle across
@@ -893,10 +916,11 @@ resolution rather than left implicit.
 **Terminal states.** The Mandarin run surfaced a terminal the ledger does not model: a small
 vertical vendor's normal ending is not a sale but **hold, extract cash, then shut down or hand
 the product to a loyal customer** — routine among Japanese and Chinese sub-10-person vertical
-vendors, and erased by the Silicon-Valley exit narrative. `bet.py`'s terminals are
-`killed | parked | lifestyle | sold`; `lifestyle` currently absorbs this case but says nothing
-about the wind-down. Worth a distinct terminal so a planned graceful shutdown is not recorded
-as the same event as a kill.
+vendors, and erased by the Silicon-Valley exit narrative. `bet.py`'s terminals were
+`killed | parked | lifestyle | sold`; `lifestyle` absorbed this case but said nothing about the
+wind-down. **Resolved (chief-wiggum#274)**: `wound_down` is now a distinct terminal, reachable
+like every other terminal and carrying none of `killed`'s retrospective/harvest-check
+discipline — a planned graceful shutdown is not the same event as a kill.
 
 **Ledger gap found while checking this** (verified in code, not model-asserted):
 `bet.py`'s `IN_FLIGHT` is `{probing, validating, building}` and `TERMINALS` includes
@@ -905,7 +929,18 @@ while consuming operator hours forever — so a fleet of five lifestyle products
 reporting "room for two more bets" with 100% of the attention budget already spent. The
 `--max-in-flight` cap counts *bets being worked*, but §9.6.3 says the binding resource is
 *total attention including live products*. That is the exact arithmetic behind the zombie-fleet
-failure mode, and the ledger cannot currently see it.
+failure mode, and the ledger could not see it.
+
+**Resolved (chief-wiggum#274)**: `bet.py` now MEASURES `ongoing_load_hours_per_week` per
+`lifestyle` bet from the ledger's trailing hours entries (never a typed-in guess) and computes
+remaining capacity as `means.hours_per_week − Σ(ongoing_load of every lifestyle bet) −
+reserve_hours_per_week` — a second, independent bound alongside `--max-in-flight` (whichever
+binds first is visible), plus an addition rule (only start product *n+1* once the most
+recently added live product has run below its target load for two consecutive weekly
+periods) and an attention kill criterion (load above 2h/wk while MRR is under $2k flags a
+kill-or-redesign candidate). All three are new reinterpretations of the existing cap and so
+report-only-forever until validated against a real portfolio, never wired to `--gate`
+(docs/gate-rollout.md).
 
 ---
 

--- a/scripts/bet.py
+++ b/scripts/bet.py
@@ -37,7 +37,13 @@ Bet state machine (docs/business-factory.md §2.3)::
 
     proposed → probing → validating → building → scaling
     kill_pending reachable from any non-terminal state
-    terminals: killed | parked | lifestyle | sold
+    terminals: killed | parked | lifestyle | sold | wound_down
+
+``lifestyle`` is the LIVE terminal — a revenue-producing, support-consuming
+product that earns zero in-flight slots forever (#274, §9.6.3/9.6.5's
+zombie-fleet gap). ``wound_down`` (#274) is a distinct terminal for a
+PLANNED graceful hold-then-shutdown, never conflated with ``killed``'s
+harvest-check discipline.
 
 Verdicts at gates use Cooper's vocabulary — ``go | kill | hold | recycle`` —
 never binary pass/fail. **Pivot is a transition, not an edit**: it closes the
@@ -61,6 +67,20 @@ passing ``--gate`` until a ``validation/bet-gates.json`` record exists):
   (``transition <id> --override-kill --reason ...``) — both journaled acts.
 - **bets-in-flight cap** (transition/portfolio): bets in probing|validating|
   building, default 2 (``--max-in-flight``) — attention is the binding resource.
+- **capacity-based cap, addition rule, attention kill criterion** (#274,
+  §9.6.3 — transition/portfolio): the count-based cap above cannot see a
+  ``lifestyle`` bet, which consumes zero in-flight slots while consuming
+  operator hours forever (the zombie-fleet gap). Remaining capacity =
+  ``means.hours_per_week − Σ(measured ongoing_load of every lifestyle bet) −
+  reserve_hours_per_week`` — a SECOND, independent bound alongside
+  ``--max-in-flight``; whichever binds is visible. ``ongoing_load`` is always
+  MEASURED from the ledger's trailing hours (never a typed-in guess). The
+  addition rule flags starting a new bet before the most recently added live
+  product has run below its target load for two consecutive weekly periods.
+  The attention kill criterion flags a live bet costing more than 2h/wk while
+  earning (operator-entered) MRR under $2k. All three are brand-new
+  reinterpretations of the existing cap and so NEVER gate, even under
+  ``--gate``, until validated against a real portfolio (docs/gate-rollout.md).
 - **bet-selection lint** (create, #235 amendment): while means.json says
   sales AND marketing are novice and no channel across the portfolio has
   reached ``focused``, a bet whose acquisition plan has no ecosystem channel
@@ -81,6 +101,19 @@ passing ``--gate`` until a ``validation/bet-gates.json`` record exists):
   enthusiasm), computed by ``assumption.py``. No assumptions.json →
   ``skipped``. A pivot's ``--changed-elements`` re-opens (validated →
   untested) dependent assumptions in the successor (Bland's dependency rule).
+- **liability-exposure soundness lint** (create/rebaseline, #277):
+  ``envelope.liability_exposure`` (docs/business-factory.md §2.1 addendum) is
+  enumerated — ``capped_at``/``insured``/``uncapped_entity``/
+  ``uncapped_personal``. Its total ABSENCE is a finding; a STATED value —
+  including an uncapped one — is NEVER itself a finding anywhere in this
+  script: the operator's risk appetite is a deliberate, sized, counted choice,
+  not a defect. ``insured.responds`` defaults to ``unverified`` (insurability
+  is a separate fact from insurance — a policy may not respond to a
+  contractually-assumed liability) and only a human answer moves it.
+- **portfolio-level uncapped-liability concurrency count** (portfolio, #277):
+  always visible, never a finding/never gates — one uncapped exposure is a
+  considered bet, several concurrently is a portfolio that cannot survive one
+  bad event.
 
 Channel-experiment records themselves (Bullseye states, completeness,
 exactly-one-focused, CAC join, headcount filter) are ``scripts/channel.py``'s
@@ -144,7 +177,7 @@ import os
 import re
 import subprocess
 import sys
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -163,11 +196,64 @@ MEANS_NAME = "means.json"
 
 ACTIVE_ORDER = ["proposed", "probing", "validating", "building", "scaling"]
 IN_FLIGHT = {"probing", "validating", "building"}
-TERMINALS = {"killed", "parked", "lifestyle", "sold"}
+# `wound_down` (#274, §9.6.5): a planned, graceful hold-then-shutdown (or
+# handing the product to a loyal customer) is the normal ending for a small
+# vertical vendor — distinct from `killed`'s harvest-check discipline, which
+# assumes the ending is a loss to grade, not a deliberate wind-down.
+TERMINALS = {"killed", "parked", "lifestyle", "sold", "wound_down"}
 ALL_STATES = set(ACTIVE_ORDER) | {"kill_pending"} | TERMINALS
 VERDICTS = ("go", "kill", "hold", "recycle")
 COMPARATORS = {"<", "<=", ">", ">=", "==", "!="}
 DEFAULT_MAX_IN_FLIGHT = 2
+
+# Findings prefixed with any of these never gate — printed always, tagged
+# report-only even under --gate. "skipped:" is a missing OPTIONAL input
+# (pre-existing convention). "capacity:" is the #274 zombie-fleet arithmetic
+# (capacity-based cap, addition rule, attention kill criterion): brand-new
+# checks that reinterpret what the existing --max-in-flight cap reports, so
+# per docs/gate-rollout.md they ship report-only until validated against a
+# real portfolio — they must never harden into a blocker on their own.
+NEVER_GATES_PREFIXES = ("skipped:", "capacity:")
+
+# Live states whose products consume operator attention indefinitely despite
+# being a TERMINAL — the zombie-fleet gap (#274, docs/business-factory.md
+# §9.6.3/§9.6.5): `lifestyle` is a live, revenue-producing, support-consuming
+# product that earns zero in-flight slots forever. This is the set the
+# capacity accounting, addition rule and attention kill criterion all read.
+LIVE_STATES = {"lifestyle"}
+
+# Ongoing load is MEASURED from the ledger's trailing hours entries, never a
+# typed-in guess (#274 item 1) — averaged over this many trailing weeks.
+LOAD_WINDOW_WEEKS = 4
+
+# §9.6.3 proposed thresholds: the attention kill criterion (#274 item 4) flags
+# a live product whose measured steady-state load is above
+# ATTENTION_LOAD_THRESHOLD_HOURS while its (operator-entered) MRR is below
+# ATTENTION_REVENUE_THRESHOLD_USD — attention spent without being paid for.
+# The same load threshold doubles as the addition rule's (#274 item 3)
+# default "target load" a live product must run under for two consecutive
+# weekly periods before another bet may start, absent a per-bet override.
+ATTENTION_LOAD_THRESHOLD_HOURS = 2.0
+ATTENTION_REVENUE_THRESHOLD_USD = 2000.0
+
+# Liability-exposure enumeration (#277) — Dew et al.'s 2009 affordable-loss
+# field list omits it, so an uncapped indemnity records identically to no
+# exposure at all. Enumerated, never free text (docs/business-factory.md §2.1
+# addendum). A STATED value — including uncapped_entity/uncapped_personal —
+# is NEVER itself a finding: the operator's risk appetite is a deliberate,
+# sized, counted choice, not a defect. Only its total ABSENCE is a finding.
+LIABILITY_TYPES = {"capped_at", "insured", "uncapped_entity", "uncapped_personal"}
+# Insurability is a separate fact from insurance (#277 decision 2): a policy
+# does not establish that it responds to a contractually-assumed liability (a
+# common PI exclusion) — `responds` defaults to `unverified` and only a human
+# answer moves it.
+RESPONDS_VALUES = {"yes", "unverified", "no"}
+UNCAPPED_LIABILITY_TYPES = {"uncapped_entity", "uncapped_personal"}
+# A bet's contractual liability position is considered EXITED (no longer
+# counted in the portfolio-level concurrency count) only once it is killed,
+# sold (liability moves with the buyer/new entity) or wound down. Every other
+# state — including `parked` — may still carry an unresolved, live exposure.
+LIABILITY_EXITED_STATES = {"killed", "sold", "wound_down"}
 
 # Channel-engine ledger checks (#241 leg 3). While a bet is probing|validating,
 # ≥N Mom-Test conversations/week (default 3, per-bet `create --cadence`,
@@ -413,6 +499,60 @@ def envelope_soundness(envelope: dict) -> list[str]:
             "the tranche ladder exceeds the envelope"
         )
     return out
+
+
+def liability_soundness(envelope: dict) -> list[str]:
+    """Liability-exposure soundness lint (#277): every envelope must record an
+    explicit `liability_exposure` — its total ABSENCE is a finding (an
+    uncapped indemnity taken by oversight is indistinguishable from one taken
+    on purpose unless *something* is always recorded). A STATED value,
+    whatever it is — including uncapped_entity/uncapped_personal — is NEVER
+    itself a finding here or anywhere else: recording the operator's
+    deliberate risk appetite is the point, not a defect to flag. `insured`'s
+    `responds` defaults to `unverified` when absent (only a human answer
+    moves it) — that default is complete, not malformed."""
+    exposure = envelope.get("liability_exposure")
+    if exposure is None:
+        return [
+            "liability_exposure unset — the affordable-loss envelope's liability "
+            "dimension must be recorded explicitly (capped_at/insured/"
+            "uncapped_entity/uncapped_personal); a STATED value is never itself "
+            "a finding, only an unset one is (#277)"
+        ]
+    if not isinstance(exposure, dict) or exposure.get("type") not in LIABILITY_TYPES:
+        return [
+            f"liability_exposure malformed — type must be one of "
+            f"{sorted(LIABILITY_TYPES)}, got {exposure!r}"
+        ]
+    t = exposure["type"]
+    if t == "capped_at" and not isinstance(exposure.get("amount_usd"), (int, float)):
+        return ["liability_exposure malformed — capped_at requires a numeric amount_usd"]
+    if t == "insured":
+        if not exposure.get("policy"):
+            return ["liability_exposure malformed — insured requires a policy name/id"]
+        responds = exposure.get("responds", "unverified")
+        if responds not in RESPONDS_VALUES:
+            return [
+                f"liability_exposure malformed — insured.responds must be one of "
+                f"{sorted(RESPONDS_VALUES)}, got {responds!r}"
+            ]
+    return []
+
+
+def liability_concurrency(root: Path) -> dict:
+    """Portfolio-level concurrency count (#277 item 3) — the check that
+    actually matters: one unbounded exposure is a considered bet; several
+    concurrently is a portfolio that cannot survive one bad event. Counts
+    every bet whose contractual position has not definitively exited
+    (LIABILITY_EXITED_STATES); reported the way the in-flight cap reports
+    attention — always visible, never a gate."""
+    carriers = [
+        b["id"] for b in all_bets(root)
+        if b.get("state") not in LIABILITY_EXITED_STATES
+        and ((b.get("envelope") or {}).get("liability_exposure") or {}).get("type")
+        in UNCAPPED_LIABILITY_TYPES
+    ]
+    return {"count": len(carriers), "bets": sorted(carriers)}
 
 
 # ---- ledger --------------------------------------------------------------------
@@ -1218,15 +1358,171 @@ def cap_findings(root: Path, max_in_flight: int, entering: str | None = None) ->
     return []
 
 
+# ---- zombie-fleet capacity accounting (#274) ------------------------------------
+
+
+def ongoing_load_hours_per_week(
+    root: Path, bet_id: str, as_of: date | None = None, window_weeks: int = LOAD_WINDOW_WEEKS,
+) -> float:
+    """MEASURED, not guessed (#274 item 1): average weekly hours logged on this
+    bet's ledger over the trailing `window_weeks` — an optimistic operator
+    cannot simply type in a smaller number, because the field is never
+    settable at all. Untagged and tagged hours entries both count; rep entries
+    (which carry no `hours`) do not."""
+    as_of = as_of or date.today()
+    cutoff_days = window_weeks * 7
+    total = 0.0
+    for e in load_ledger(root, bet_id):
+        if not isinstance(e.get("hours"), (int, float)):
+            continue
+        try:
+            d = datetime.fromisoformat(str(e.get("ts"))).date()
+        except ValueError:
+            continue
+        if 0 <= (as_of - d).days < cutoff_days:
+            total += e["hours"]
+    return round(total / window_weeks, 2)
+
+
+def attention_capacity(root: Path, as_of: date | None = None) -> dict | None:
+    """The zombie-fleet arithmetic (#274 item 2, §9.6.3): remaining capacity =
+    means.hours_per_week − Σ(measured ongoing load of every LIVE_STATES bet) −
+    reserve_hours_per_week. `lifestyle` bets earn zero in-flight slots (by
+    design — they are a terminal) while consuming operator hours forever;
+    this is the accounting that makes that visible. None (never guessed) when
+    means.json is absent or has no numeric hours_per_week."""
+    means = load_means(root)
+    if means is None or not isinstance(means.get("hours_per_week"), (int, float)):
+        return None
+    reserve = means.get("reserve_hours_per_week", 0) or 0
+    loads = {
+        b["id"]: ongoing_load_hours_per_week(root, b["id"], as_of)
+        for b in all_bets(root) if b.get("state") in LIVE_STATES
+    }
+    total_load = sum(loads.values())
+    return {
+        "hours_per_week": means["hours_per_week"],
+        "reserve_hours_per_week": reserve,
+        "live_loads": loads,
+        "total_load_hours_per_week": total_load,
+        "remaining_hours_per_week": means["hours_per_week"] - total_load - reserve,
+    }
+
+
+def capacity_findings(root: Path, as_of: date | None = None) -> list[str]:
+    """Capacity-based cap (#274 item 2): fires when the live fleet alone has
+    exhausted (or exceeded) the attention budget — independent of, and a
+    second bound alongside, the integer --max-in-flight cap (whichever binds
+    first is visible; this one counts the fleet the other cannot see). Never
+    gates (NEVER_GATES_PREFIXES: "capacity:") — a brand-new reinterpretation
+    of what the existing cap reports, unvalidated until run against a real
+    portfolio (docs/gate-rollout.md)."""
+    cap = attention_capacity(root, as_of)
+    if cap is None:
+        return ["skipped: no means.json hours_per_week — capacity-based cap needs it"]
+    if cap["remaining_hours_per_week"] <= 0:
+        detail = ", ".join(
+            f"{bid} {h:g}h/wk" for bid, h in sorted(cap["live_loads"].items())
+        ) or "none"
+        return [
+            "capacity: attention exhausted — "
+            f"{cap['hours_per_week']:g}h/wk available − {cap['total_load_hours_per_week']:g}h/wk "
+            f"live-product load ({detail}) − {cap['reserve_hours_per_week']:g}h/wk reserve = "
+            f"{cap['remaining_hours_per_week']:g}h/wk remaining (§9.6.3) — the live fleet "
+            "alone consumes the attention budget; starting another bet has no slack"
+        ]
+    return []
+
+
+def addition_rule_findings(
+    root: Path, entering_id: str, as_of: date | None = None,
+) -> list[str]:
+    """Addition rule (#274 item 3, §9.6.3): only start product n+1 once
+    product n — the most recently added live (lifestyle) product — has run
+    below its target load for two consecutive trailing weekly measurement
+    periods. No live products yet → nothing to check. Never gates
+    ("capacity:" — unvalidated new check, docs/gate-rollout.md)."""
+    as_of = as_of or date.today()
+    live = [
+        b for b in all_bets(root)
+        if b.get("state") in LIVE_STATES and b["id"] != entering_id
+    ]
+    if not live:
+        return []
+
+    def _created(b: dict) -> datetime:
+        try:
+            return datetime.fromisoformat(str(b.get("created")))
+        except ValueError:
+            return datetime.min.replace(tzinfo=timezone.utc)
+
+    latest = max(live, key=_created)
+    target = latest.get("target_load_hours_per_week")
+    if not isinstance(target, (int, float)):
+        target = ATTENTION_LOAD_THRESHOLD_HOURS
+    entries = load_ledger(root, latest["id"])
+    periods = []
+    for k in range(2):
+        start = as_of - timedelta(days=7 * (k + 1))
+        end = as_of - timedelta(days=7 * k)
+        total = 0.0
+        for e in entries:
+            if not isinstance(e.get("hours"), (int, float)):
+                continue
+            try:
+                d = datetime.fromisoformat(str(e.get("ts"))).date()
+            except ValueError:
+                continue
+            if start <= d < end:
+                total += e["hours"]
+        periods.append(total)
+    if any(p >= target for p in periods):
+        return [
+            f"capacity: addition rule (§9.6.3) — the most recently added live "
+            f"product {latest['id']} has not run below its target load "
+            f"({target:g}h/wk) for two consecutive weekly periods (measured "
+            f"{periods[1]:g}h/wk then {periods[0]:g}h/wk, most recent last) — "
+            f"starting {entering_id} before {latest['id']} stabilizes risks the "
+            "zombie fleet"
+        ]
+    return []
+
+
+def attention_kill_findings(root: Path, as_of: date | None = None) -> list[str]:
+    """Attention kill criterion (#274 item 4, §9.6.3): a live product whose
+    measured steady-state load is above ATTENTION_LOAD_THRESHOLD_HOURS while
+    its (operator-entered) MRR is below ATTENTION_REVENUE_THRESHOLD_USD is a
+    kill-or-redesign candidate — attention spent without being paid for. No
+    `mrr_usd` recorded on a bet → silent for that bet (never guessed; a
+    finding must come from data, not its absence). Never gates."""
+    out = []
+    for bet in all_bets(root):
+        if bet.get("state") not in LIVE_STATES:
+            continue
+        mrr = bet.get("mrr_usd")
+        if not isinstance(mrr, (int, float)):
+            continue
+        load = ongoing_load_hours_per_week(root, bet["id"], as_of)
+        if load > ATTENTION_LOAD_THRESHOLD_HOURS and mrr < ATTENTION_REVENUE_THRESHOLD_USD:
+            out.append(
+                f"capacity: attention kill criterion (§9.6.3) — {bet['id']} costs "
+                f"{load:g}h/wk (> {ATTENTION_LOAD_THRESHOLD_HOURS:g}h/wk) while earning "
+                f"${mrr:g} MRR (< ${ATTENTION_REVENUE_THRESHOLD_USD:g}) — a kill-or-"
+                "redesign candidate, attention spent without being paid for"
+            )
+    return out
+
+
 # ---- reporting -----------------------------------------------------------------
 
 
 def report(findings: list[str], gate: bool, label: str = "bet") -> int:
     """docs/gate-rollout.md discipline: findings print always; exit 1 only under
-    --gate. Skipped checks are reported, never silently omitted."""
-    real = [f for f in findings if not f.startswith("skipped:")]
+    --gate. Skipped checks (and unvalidated new #274 capacity findings — see
+    NEVER_GATES_PREFIXES) are reported, never silently omitted, and never gate."""
+    real = [f for f in findings if not f.startswith(NEVER_GATES_PREFIXES)]
     for f in findings:
-        tag = "gated" if gate and not f.startswith("skipped:") else "report-only"
+        tag = "gated" if gate and not f.startswith(NEVER_GATES_PREFIXES) else "report-only"
         print(f"{label}: [{tag}] {f}")
     return 1 if gate and real else 0
 
@@ -1279,6 +1575,7 @@ def cmd_create(args) -> int:
 
     findings = [f"soundness: {f}" for f in criteria_soundness(criteria)]
     findings += [f"soundness: {f}" for f in envelope_soundness(envelope)]
+    findings += [f"soundness: {f}" for f in liability_soundness(envelope)]
     findings += [
         f if f.startswith("skipped:") else f"selection: {f}"
         for f in selection_lint(root, bet)
@@ -1682,6 +1979,11 @@ def cmd_transition(args) -> int:
 
     if to in IN_FLIGHT and bet["state"] not in IN_FLIGHT:
         findings += cap_findings(root, args.max_in_flight, entering=args.bet_id)
+        # #274: a second, independent bound — the live fleet's measured
+        # attention accounting and the §9.6.3 addition rule — visible
+        # alongside the integer cap; whichever binds first is seen.
+        findings += capacity_findings(root)
+        findings += addition_rule_findings(root, args.bet_id)
 
     if to == "building":
         # Evidence-strength floor (#236): ≥1 validated assumption at strength ≥4
@@ -1783,6 +2085,7 @@ def cmd_rebaseline(args) -> int:
         if not isinstance(envelope.get("cash_cap_usd"), (int, float)):
             raise BetError(f"{env_path}: envelope needs a numeric cash_cap_usd")
         findings += [f"soundness: {f}" for f in envelope_soundness(envelope)]
+        findings += [f"soundness: {f}" for f in liability_soundness(envelope)]
         details["old_envelope_hash"] = old_env_h
         details["new_envelope_hash"] = content_hash(envelope)
     if args.criteria:
@@ -1861,9 +2164,19 @@ def cmd_portfolio(args) -> int:
             "next_criterion": _next_due(criteria, today),
             "distribution": distribution_status(root, bid)["status"],
             "kill_pending_proposal": bool(pend),
+            # #274: measured (never guessed) ongoing load — only meaningful
+            # for a LIVE_STATES (lifestyle) bet, the zombie-fleet population.
+            "ongoing_load_hours_per_week": (
+                ongoing_load_hours_per_week(root, bid, today)
+                if bet["state"] in LIVE_STATES else None
+            ),
         })
 
     findings += cap_findings(root, args.max_in_flight)
+    findings += capacity_findings(root, today)
+    findings += attention_kill_findings(root, today)
+    attention = attention_capacity(root, today)
+    liab = liability_concurrency(root)
 
     # Loss distribution + kill hygiene per DEAD bet — process accountability
     # (Simonson & Staw), never a per-bet win/lose ranking.
@@ -1900,20 +2213,42 @@ def cmd_portfolio(args) -> int:
             "in_flight": in_flight_bets(root),
             "max_in_flight": args.max_in_flight,
             "dead_bets": dead,
+            "attention": attention,
+            "liability_concurrency": liab,
             "findings": findings,
         }, indent=2))
-        return 1 if args.gate and findings else 0
+        real = [f for f in findings if not f.startswith(NEVER_GATES_PREFIXES)]
+        return 1 if args.gate and real else 0
 
     print(f"portfolio: {root}")
     print(f"  bets: {len(bets)} — in flight: {len(in_flight_bets(root))}/{args.max_in_flight} "
           f"({', '.join(in_flight_bets(root)) or 'none'})")
+    if attention is not None:
+        # #274 zombie-fleet visibility: shown always, not only when exhausted —
+        # the whole point is that the live fleet's attention draw is COUNTED.
+        print(
+            f"  attention: {attention['hours_per_week']:g}h/wk available − "
+            f"{attention['total_load_hours_per_week']:g}h/wk live-product load "
+            f"({len(attention['live_loads'])} lifestyle bet(s)) − "
+            f"{attention['reserve_hours_per_week']:g}h/wk reserve = "
+            f"{attention['remaining_hours_per_week']:g}h/wk remaining"
+        )
+    print(
+        f"  uncapped liability: {liab['count']} bet(s) currently carrying an "
+        f"uncapped exposure ({', '.join(liab['bets']) or 'none'}) — a considered "
+        "bet alone, a portfolio-survival question concurrently (#277)"
+    )
     for r in rows:
         pend = "  [KILL PROPOSAL PENDING]" if r["kill_pending_proposal"] else ""
+        load_note = (
+            f"; ongoing load: {r['ongoing_load_hours_per_week']:g}h/wk"
+            if r["ongoing_load_hours_per_week"] is not None else ""
+        )
         print(
             f"  {r['id']:24s} {r['state']:12s} spend ${r['spend_usd']:g}/"
             f"${r['unlocked_usd']:g} unlocked (cap ${r['cash_cap_usd']:g}), "
             f"{r['hours']:g}h; next criterion: {r['next_criterion']}; "
-            f"distribution: {r['distribution']}{pend}"
+            f"distribution: {r['distribution']}{load_note}{pend}"
         )
     if dead:
         losses = sorted(d["loss_usd"] for d in dead)

--- a/templates/bet-schema.json
+++ b/templates/bet-schema.json
@@ -22,8 +22,8 @@
     "created": { "type": "string", "description": "ISO timestamp the bet was created." },
     "state": {
       "type": "string",
-      "enum": ["proposed", "probing", "validating", "building", "scaling", "kill_pending", "killed", "parked", "lifestyle", "sold"],
-      "description": "proposed → probing → validating → building → scaling; kill_pending reachable from anywhere; terminals killed|parked|lifestyle|sold. `killed` is blocked until retrospective.md exists non-trivially and a harvest check ran."
+      "enum": ["proposed", "probing", "validating", "building", "scaling", "kill_pending", "killed", "parked", "lifestyle", "sold", "wound_down"],
+      "description": "proposed → probing → validating → building → scaling; kill_pending reachable from anywhere; terminals killed|parked|lifestyle|sold|wound_down. `killed` is blocked until retrospective.md exists non-trivially and a harvest check ran. `wound_down` (chief-wiggum#274) is a distinct terminal for a PLANNED graceful hold-then-shutdown (or handing the product to a loyal customer) — the normal ending for a small vertical vendor, not a kill, and it carries no retrospective/harvest requirement of its own. `lifestyle` is the LIVE terminal: a revenue-producing, support-consuming product that earns zero in-flight slots forever — its measured ongoing_load feeds the portfolio's attention-capacity accounting (see `bet.py`'s LIVE_STATES)."
     },
     "envelope": { "$ref": "#/$defs/envelope" },
     "acquisition": {
@@ -75,6 +75,16 @@
       "minimum": 0,
       "description": "Paid heads on this bet (excluding the founder). The channel engine's zero-headcount filter flags sales-led channels (sales, business-development) while this is 0. Absent → falls back to means.json headcount, then 0."
     },
+    "target_load_hours_per_week": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "description": "Per-bet override of the addition-rule target load (chief-wiggum#274, §9.6.3): the most recently added LIVE (lifestyle) product must run below this for two consecutive trailing weekly periods before another bet may start. Absent → defaults to ATTENTION_LOAD_THRESHOLD_HOURS (2h/wk)."
+    },
+    "mrr_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Current monthly recurring revenue, USD — operator-entered (not derivable in-repo), unlike ongoing_load which is always measured. Feeds the attention kill criterion (chief-wiggum#274, §9.6.3): a live product costing more than ATTENTION_LOAD_THRESHOLD_HOURS/wk while earning less than ATTENTION_REVENUE_THRESHOLD_USD MRR is a kill-or-redesign candidate. Absent → the check is silent for this bet, never guessed."
+    },
     "predecessor": {
       "type": ["string", "null"],
       "description": "Bet id this bet succeeded via a pivot, or null."
@@ -95,6 +105,39 @@
         "time_cap_hours": { "type": "number", "minimum": 0 },
         "calendar_cap_days": { "type": "number", "minimum": 0 },
         "attention_slots": { "type": "number", "minimum": 0 },
+        "liability_exposure": {
+          "description": "The affordable-loss envelope's liability/exposure dimension (chief-wiggum#277) — Dew et al.'s 2009 field list omits it, so an uncapped contractual indemnity records identically to no exposure at all. Enumerated, never free text. `bet.py create`/`rebaseline` flag this field's total ABSENCE as a soundness finding; a STATED value — including uncapped_entity/uncapped_personal — is NEVER itself a finding, at create or anywhere else: the operator's risk appetite is a deliberate, sized, counted choice (docs/business-factory.md §9.4 addendum: terms as an undercutting mechanism), not a defect. See also the portfolio-level uncapped-liability concurrency count (`bet.py portfolio`) — one such bet is a considered risk, several concurrently is a portfolio-survival question.",
+          "oneOf": [
+            {
+              "type": "object", "required": ["type", "amount_usd"], "additionalProperties": false,
+              "properties": {
+                "type": { "const": "capped_at" },
+                "amount_usd": { "type": "number", "minimum": 0, "description": "The liability cap, USD." }
+              }
+            },
+            {
+              "type": "object", "required": ["type", "policy"], "additionalProperties": false,
+              "properties": {
+                "type": { "const": "insured" },
+                "policy": { "type": "string", "minLength": 1, "description": "Policy name/id covering this exposure." },
+                "responds": {
+                  "type": "string", "enum": ["yes", "unverified", "no"],
+                  "description": "Insurability is a separate fact from insurance (#277 decision 2): holding a policy does not establish that it responds to a contractually-assumed liability — a common PI exclusion. Defaults to `unverified` when absent; only a human answer moves it to yes/no."
+                }
+              }
+            },
+            {
+              "type": "object", "required": ["type"], "additionalProperties": false,
+              "properties": { "type": { "const": "uncapped_entity" } },
+              "description": "Unbounded liability held by the operating entity."
+            },
+            {
+              "type": "object", "required": ["type"], "additionalProperties": false,
+              "properties": { "type": { "const": "uncapped_personal" } },
+              "description": "Unbounded liability with personal exposure (no entity shield, or the entity does not cure it)."
+            }
+          ]
+        },
         "tranches": {
           "type": "array",
           "description": "Gompers (1995) staging: the cash cap released stepwise. A tranche with unlock_milestone_id null is unlocked from creation; others unlock via a journaled `--unlock-milestone` act. Invariant: cumulative spend ≤ cumulative unlocked tranches.",

--- a/templates/means-schema.json
+++ b/templates/means-schema.json
@@ -27,7 +27,16 @@
       "items": { "type": "string" },
       "description": "Audiences already owned (lists, followings, communities) — the bet-selection lint accepts a plan that draws on one."
     },
-    "hours_per_week": { "type": "number", "minimum": 0 },
+    "hours_per_week": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total operator hours/week available — the numerator in the capacity-based cap (chief-wiggum#274, §9.6.3): remaining capacity = hours_per_week − Σ(measured ongoing load of every live/lifestyle bet) − reserve_hours_per_week."
+    },
+    "reserve_hours_per_week": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Hours/week held back from the capacity-based cap's arithmetic for factory ops, marketing on the current bet, or anything else not itself a bet (chief-wiggum#274). Absent → 0."
+    },
     "cash_available": {
       "type": "number",
       "minimum": 0,

--- a/tests/test_bet.py
+++ b/tests/test_bet.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -30,11 +31,52 @@ ENVELOPE = {
     "time_cap_hours": 120,
     "calendar_cap_days": 90,
     "attention_slots": 1,
+    # A stated liability_exposure (chief-wiggum#277) — most tests in this file
+    # are not about the liability dimension, so the shared fixture carries a
+    # valid one and the dedicated liability tests below override it.
+    "liability_exposure": {"type": "capped_at", "amount_usd": 900},
     "tranches": [
         {"amount_usd": 300, "unlock_milestone_id": None},
         {"amount_usd": 600, "unlock_milestone_id": "M1"},
     ],
 }
+
+
+def _envelope(**overrides):
+    env = json.loads(json.dumps(ENVELOPE))
+    env.update(overrides)
+    return env
+
+
+def _envelope_without_liability():
+    env = json.loads(json.dumps(ENVELOPE))
+    del env["liability_exposure"]
+    return env
+
+
+def _iso(days_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat(timespec="seconds")
+
+
+def _ledger_entry(portfolio: Path, bet_id: str, *, hours=None, amount_usd=None,
+                   ts: str | None = None, tag: str | None = None, note: str = "") -> None:
+    """Append a ledger entry directly (bypassing `spend`, whose ts is always
+    'now') so tests can construct trailing-window measurement history."""
+    entry = {"ts": ts or _iso(0), "type": "spend", "amount_usd": amount_usd,
+              "hours": hours, "note": note}
+    if tag:
+        entry["tag"] = tag
+    path = portfolio / "bets" / bet_id / "ledger.jsonl"
+    with path.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _write_means(portfolio: Path, **fields) -> None:
+    """Raw means.json writer for the capacity/zombie-fleet tests (#274) — the
+    existing `_means()` helper further down is specific to the selection-lint
+    tests' skills shape."""
+    portfolio.mkdir(parents=True, exist_ok=True)
+    (portfolio / "means.json").write_text(json.dumps(fields))
 
 CRITERIA = {
     "criteria": [
@@ -545,3 +587,314 @@ def test_journal_chain_matches_ratchet_format(portfolio, tmp_path):
         body = {k: v for k, v in rec.items() if k != "record_hash"}
         assert rec["record_hash"] == stable_hash(prev, json.dumps(body, sort_keys=True))
         prev = rec["record_hash"]
+
+
+# ---- zombie fleet: measured ongoing load + capacity-based cap (#274) -----------
+
+
+def test_ongoing_load_measured_from_trailing_ledger_hours(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "lifestyle")
+    # 3h/wk spread evenly over the trailing 4 weeks -> measured average 3h/wk,
+    # never a typed-in guess.
+    for wk in range(4):
+        _ledger_entry(portfolio, "b1", hours=3, ts=_iso(7 * wk))
+    js = _run(portfolio, "portfolio", "--format", "json")
+    assert js.returncode == 0, js.stderr
+    data = json.loads(js.stdout)
+    row = next(r for r in data["bets"] if r["id"] == "b1")
+    assert row["ongoing_load_hours_per_week"] == 3.0
+
+
+def test_ongoing_load_is_none_for_non_live_states(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "spend", "b1", "--hours", "5")
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    row = next(r for r in data["bets"] if r["id"] == "b1")
+    assert row["ongoing_load_hours_per_week"] is None
+
+
+def test_capacity_cap_sees_the_zombie_fleet_the_in_flight_cap_misses(portfolio, tmp_path):
+    """The exact #274 gap: five lifestyle products consume zero in-flight
+    slots (the count-based cap reports room) while eating the whole
+    attention budget — the capacity cap is the thing that sees it."""
+    _write_means(portfolio, hours_per_week=15)
+    for i in range(5):
+        bid = f"L{i}"
+        _create(portfolio, tmp_path, bid)
+        _run(portfolio, "transition", bid, "lifestyle")
+        for wk in range(4):
+            _ledger_entry(portfolio, bid, hours=4, ts=_iso(7 * wk))  # 4h/wk each x5 = 20h/wk
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0, proc.stderr
+    assert "exceed the cap of 2" not in proc.stdout  # old cap: 0 bets in flight, "room"
+    assert "capacity" in proc.stdout and "exhausted" in proc.stdout
+    # a brand-new gate: never blocks even under --gate until validated (docs/gate-rollout.md)
+    gated = _run(portfolio, "portfolio", "--gate")
+    assert gated.returncode == 0, gated.stdout
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["attention"]["total_load_hours_per_week"] == 20.0
+    assert data["attention"]["remaining_hours_per_week"] == -5.0
+
+
+def test_capacity_cap_skipped_without_means_hours_per_week(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "lifestyle")
+    for wk in range(4):
+        _ledger_entry(portfolio, "b1", hours=40, ts=_iso(7 * wk))
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0
+    assert "skipped: no means.json" in proc.stdout
+
+
+def test_capacity_cap_reported_at_transition_into_flight(portfolio, tmp_path):
+    _write_means(portfolio, hours_per_week=10)
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    for wk in range(4):
+        _ledger_entry(portfolio, "L0", hours=15, ts=_iso(7 * wk))  # already over 10h/wk alone
+    _create(portfolio, tmp_path, "b2")
+    proc = _run(portfolio, "transition", "b2", "probing")
+    assert proc.returncode == 0
+    assert "capacity" in proc.stdout and "exhausted" in proc.stdout
+
+
+# ---- fleet mechanics: addition rule (§9.6.3, #274) ------------------------------
+
+
+def test_addition_rule_flags_starting_before_the_latest_live_product_stabilizes(
+    portfolio, tmp_path,
+):
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    # both trailing weekly periods over the default 2h/wk target
+    _ledger_entry(portfolio, "L0", hours=5, ts=_iso(3))   # this week
+    _ledger_entry(portfolio, "L0", hours=5, ts=_iso(10))  # last week
+    _create(portfolio, tmp_path, "b2")
+    proc = _run(portfolio, "transition", "b2", "probing")
+    assert proc.returncode == 0
+    assert "addition rule" in proc.stdout
+    assert "L0" in proc.stdout
+
+
+def test_addition_rule_silent_once_the_latest_live_product_stabilizes(portfolio, tmp_path):
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    # both trailing weekly periods under the default 2h/wk target
+    _ledger_entry(portfolio, "L0", hours=1, ts=_iso(3))
+    _ledger_entry(portfolio, "L0", hours=1, ts=_iso(10))
+    _create(portfolio, tmp_path, "b2")
+    proc = _run(portfolio, "transition", "b2", "probing")
+    assert proc.returncode == 0
+    assert "addition rule" not in proc.stdout
+
+
+def test_addition_rule_silent_with_no_live_products_yet(portfolio, tmp_path):
+    _create(portfolio, tmp_path, "b1")
+    proc = _run(portfolio, "transition", "b1", "probing")
+    assert proc.returncode == 0
+    assert "addition rule" not in proc.stdout
+
+
+# ---- attention kill criterion (§9.6.3, #274) ------------------------------------
+
+
+def test_attention_kill_criterion_flags_high_load_low_revenue(portfolio, tmp_path):
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    bet_path = portfolio / "bets" / "L0" / "bet.json"
+    bet = json.loads(bet_path.read_text())
+    bet["mrr_usd"] = 100  # well below the $2k proposed threshold
+    bet_path.write_text(json.dumps(bet))
+    for wk in range(4):
+        _ledger_entry(portfolio, "L0", hours=5, ts=_iso(7 * wk))  # > 2h/wk threshold
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0
+    assert "attention kill criterion" in proc.stdout
+    assert "L0" in proc.stdout
+
+
+def test_attention_kill_criterion_silent_without_mrr_recorded(portfolio, tmp_path):
+    """Never guessed: no mrr_usd means no finding, not an assumed one."""
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    for wk in range(4):
+        _ledger_entry(portfolio, "L0", hours=5, ts=_iso(7 * wk))
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0
+    assert "attention kill criterion" not in proc.stdout
+
+
+def test_attention_kill_criterion_silent_when_revenue_clears_the_bar(portfolio, tmp_path):
+    _create(portfolio, tmp_path, "L0")
+    _run(portfolio, "transition", "L0", "lifestyle")
+    bet_path = portfolio / "bets" / "L0" / "bet.json"
+    bet = json.loads(bet_path.read_text())
+    bet["mrr_usd"] = 5000
+    bet_path.write_text(json.dumps(bet))
+    for wk in range(4):
+        _ledger_entry(portfolio, "L0", hours=5, ts=_iso(7 * wk))
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0
+    assert "attention kill criterion" not in proc.stdout
+
+
+# ---- new terminal: wound_down (§9.6.5, #274) ------------------------------------
+
+
+def test_wound_down_is_a_distinct_terminal_from_killed(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    proc = _run(portfolio, "transition", "b1", "wound_down", "--reason",
+               "planned graceful wind-down; handed to a loyal customer")
+    assert proc.returncode == 0, proc.stderr
+    assert _state(portfolio, "b1") == "wound_down"
+    # a distinct event from `killed` — no retrospective/harvest discipline required
+    assert not (portfolio / "bets" / "b1" / "retrospective.md").exists()
+    events = [r["event"] for r in _journal(portfolio) if r["ref"] == "b1"]
+    assert events == ["bet-create", "transition"]
+    trans = [r for r in _journal(portfolio) if r["event"] == "transition"][-1]
+    assert trans["details"]["to"] == "wound_down"
+    # frozen like every other terminal
+    assert _run(portfolio, "transition", "b1", "probing").returncode == 2
+    assert _run(portfolio, "spend", "b1", "--amount-usd", "1").returncode == 2
+
+
+def test_wound_down_not_counted_as_killed_in_portfolio_dead_bets(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    _run(portfolio, "transition", "b1", "wound_down", "--reason", "graceful shutdown")
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["dead_bets"] == []  # dead_bets tracks `killed` only, never wound_down
+
+
+# ---- liability exposure (#277) --------------------------------------------------
+
+
+def test_liability_exposure_unset_is_flagged_report_only(portfolio, tmp_path):
+    proc = _create(portfolio, tmp_path, envelope=_envelope_without_liability())
+    assert proc.returncode == 0
+    assert "liability_exposure unset" in proc.stdout
+
+
+def test_liability_exposure_unset_blocks_under_gate(portfolio, tmp_path):
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=_envelope_without_liability())
+    assert proc.returncode == 1
+    assert "liability_exposure unset" in proc.stdout
+    assert not (portfolio / "bets" / "b1").exists()
+
+
+def test_liability_exposure_uncapped_choice_is_never_a_finding(portfolio, tmp_path):
+    """The load-bearing distinction (#277): a DELIBERATE uncapped exposure must
+    never itself read as a problem — only its total absence does."""
+    env = _envelope(liability_exposure={"type": "uncapped_entity"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 0, proc.stdout
+    assert "liability_exposure" not in proc.stdout
+
+
+def test_liability_exposure_uncapped_personal_is_never_a_finding(portfolio, tmp_path):
+    env = _envelope(liability_exposure={"type": "uncapped_personal"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_liability_exposure_capped_at_recorded_cleanly(portfolio, tmp_path):
+    env = _envelope(liability_exposure={"type": "capped_at", "amount_usd": 50000})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_liability_exposure_insured_defaults_responds_to_unverified(portfolio, tmp_path):
+    """Insurability is a separate fact from insurance (#277 decision 2): a
+    stated `insured` exposure with no `responds` is complete, not malformed —
+    the default is `unverified`, moved only by a human answer."""
+    env = _envelope(liability_exposure={"type": "insured", "policy": "PI-12345"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 0, proc.stdout
+    assert "liability_exposure" not in proc.stdout  # a stated value is never a finding
+
+
+def test_liability_exposure_insured_bad_responds_is_malformed(portfolio, tmp_path):
+    env = _envelope(
+        liability_exposure={"type": "insured", "policy": "PI-1", "responds": "maybe"}
+    )
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 1
+    assert "malformed" in proc.stdout
+    assert not (portfolio / "bets" / "b1").exists()
+
+
+def test_liability_exposure_missing_policy_on_insured_is_malformed(portfolio, tmp_path):
+    env = _envelope(liability_exposure={"type": "insured"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 1
+    assert "malformed" in proc.stdout
+
+
+def test_liability_exposure_bad_type_is_malformed(portfolio, tmp_path):
+    env = _envelope(liability_exposure={"type": "whatever"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 1
+    assert "malformed" in proc.stdout
+
+
+def test_liability_exposure_capped_at_missing_amount_is_malformed(portfolio, tmp_path):
+    env = _envelope(liability_exposure={"type": "capped_at"})
+    proc = _create(portfolio, tmp_path, "b1", "--gate", envelope=env)
+    assert proc.returncode == 1
+    assert "malformed" in proc.stdout
+
+
+def test_liability_soundness_also_checked_at_rebaseline(portfolio, tmp_path):
+    _create(portfolio, tmp_path)
+    bad_env = tmp_path / "bad-envelope.json"
+    bad_env.write_text(json.dumps(_envelope_without_liability()))
+    proc = _run(portfolio, "rebaseline", "b1", "--envelope", str(bad_env),
+                "--reason", "re-scoping", "--gate")
+    assert proc.returncode == 1
+    assert "liability_exposure unset" in proc.stdout
+
+
+# ---- portfolio-level uncapped-liability concurrency count (#277) ---------------
+
+
+def test_portfolio_reports_uncapped_liability_concurrency(portfolio, tmp_path):
+    uncapped = _envelope(liability_exposure={"type": "uncapped_entity"})
+    capped = _envelope(liability_exposure={"type": "capped_at", "amount_usd": 1000})
+    _create(portfolio, tmp_path, "b1", envelope=uncapped)
+    _create(portfolio, tmp_path, "b2", envelope=capped)
+    _create(portfolio, tmp_path, "b3", envelope=uncapped)
+    proc = _run(portfolio, "portfolio")
+    assert proc.returncode == 0, proc.stderr
+    assert "uncapped liability" in proc.stdout
+    assert "b1" in proc.stdout and "b3" in proc.stdout
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["liability_concurrency"]["count"] == 2
+    assert sorted(data["liability_concurrency"]["bets"]) == ["b1", "b3"]
+
+
+def test_liability_concurrency_excludes_exited_positions(portfolio, tmp_path):
+    uncapped = _envelope(liability_exposure={"type": "uncapped_personal"})
+    _create(portfolio, tmp_path, "b1", envelope=uncapped)
+    _retro(portfolio, "b1")
+    _run(portfolio, "transition", "b1", "killed")
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["liability_concurrency"]["count"] == 0
+    assert data["liability_concurrency"]["bets"] == []
+
+
+def test_liability_concurrency_counts_parked_bets_as_still_carrying_exposure(
+    portfolio, tmp_path,
+):
+    """A paused (parked) bet's contract may still be outstanding — an
+    unresolved position, not an exited one."""
+    uncapped = _envelope(liability_exposure={"type": "uncapped_entity"})
+    _create(portfolio, tmp_path, "b1", envelope=uncapped)
+    _run(portfolio, "transition", "b1", "parked")
+    js = _run(portfolio, "portfolio", "--format", "json")
+    data = json.loads(js.stdout)
+    assert data["liability_concurrency"]["count"] == 1


### PR DESCRIPTION
Closes #274
Closes #277

## #274 — the cap could not see the zombie fleet

Shipped-but-unattended products consume real attention while occupying **zero** in-flight slots, so the cap read "green, room for more" exactly when the attention budget was gone. Another #289 instance: the thing that mattered was not being measured.

- **Measured, never declared.** `ongoing_load_hours_per_week()` averages a live bet's ledger `hours` over a trailing 4-week window. It is recomputed, never a settable field — a self-reported load would defeat the purpose.
- **Capacity as a second, independent bound**: `means.hours_per_week − Σ(live-fleet load) − reserve_hours_per_week`, alongside `--max-in-flight`. Enforced on entering an in-flight state and surfaced in `portfolio`.
- **Addition rule**: flags starting a new bet before the most recently added live product has run two consecutive weeks under its target load.
- **Attention kill criterion**: flags a live bet costing >2h/wk while MRR is <$2k — and stays **silent when `mrr_usd` is not recorded**, rather than guessing.
- **New terminal `wound_down`**, distinct from `killed`: exiting a live product is not the same event as killing a bet, and carries none of `killed`'s retrospective/harvest discipline.

**These ship non-blocking.** Items 2–4 are new reinterpretations of the cap, so they route through a new `NEVER_GATES_PREFIXES = ("skipped:", "capacity:")` convention: they always print, but never set exit 1 even under `--gate`, until validated against a real portfolio. That is `docs/gate-rollout.md` applied to a judgement-heavy signal.

## #277 — a deliberate risk edge was indistinguishable from an oversight

The envelope had no liability dimension, so an uncapped indemnity taken **on purpose** looked identical to one nobody noticed.

The fix records the choice; it never second-guesses it:

| envelope state | result |
|---|---|
| `uncapped_personal` | **no finding** |
| `uncapped_entity` | **no finding** |
| `capped_at` / `insured` | **no finding** |
| *unset* | finding |

Only **silence** is a defect. I verified this behaviour directly rather than trusting the description — a stated uncapped exposure produces no finding anywhere, under any flag.

- `insured.responds` defaults to `unverified`; only a human answer moves it off that.
- `liability_concurrency()` gives an always-visible portfolio count of bets currently carrying uncapped exposure (excluding `killed`/`sold`/`wound_down` — positions exited). It is a **counter, never a gate**: sized and countable, never blocked.
- `docs/business-factory.md` §9.4 gains terms/risk-appetite as an undercutting mechanism, plus a §2.1 addendum.

## Verification

- Full suite: **2583 passed, 14 skipped, 0 failed** (+27 new tests)
- `make lint` clean
- No `docs/quality/` changes, no `scanner_version` moves
- `git status` verified clean before push