### PR TITLE
feat(cost): nominal implementation cost on issues, measured actual on PRs

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -62,6 +62,14 @@ Using the template at `$CW_HOME/templates/issue.md`, fill in:
 
 - **Labels**: Suggest appropriate labels based on type and severity.
 
+- **Nominal cost**: After picking the Effort size, derive the estimate mechanically — never from intuition:
+
+  ```bash
+  python3 "$CW_HOME/scripts/ticket_cost.py" estimate --effort <S|M|L|XL>
+  ```
+
+  Stamp its output line verbatim into the template's `Nominal cost` field. An `UNRESOLVED (N prior ... tickets logged, need >=3)` answer is a valid value — leave it as-is; it self-calibrates as `/implement` records actuals on merged PRs (see `docs/ticket-cost.md`). Never replace UNRESOLVED with a guessed dollar figure.
+
 ### Step 3: Preview and confirm
 
 Show the user the full issue markdown and ask:

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -74,6 +74,13 @@ TICKET_TMP="$CW_TMP/$issue_number"
 mkdir -p "$TICKET_TMP"
 ```
 
+**Meter this build** (per-ticket implementation cost, `docs/ticket-cost.md`): enable telemetry so consults log their token cost, and stamp the build-start time — Step 11 slices the ledger from this stamp to price the PR's `## Implementation Cost` section:
+
+```bash
+export CW_TELEMETRY=1
+date +%s > "$TICKET_TMP/build-start-ts"
+```
+
 All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemini.md`, `approach-opus.md`, `implementation-plan.md`, `review-prompt.md`, `reviews/reviewer-*.md`, `impl-diff.txt`) go in `$TICKET_TMP`, not `$CW_TMP`. Shared session files (e.g., epic context) remain in `$CW_TMP`.
 
 **Load epic context** (if this ticket belongs to an epic):
@@ -817,7 +824,20 @@ If no browser-use or E2E setup exists at all, note it as a gap in the final summ
 
    Include at minimum a **Component Relationship Diagram** showing what was added/modified. Add a **Sequence Diagram** if data flow changed (pass `--mermaid-sequence` to `draft_pr.py`). Keep diagrams focused (max 15 nodes).
 
-3. Draft the PR body with the tested helper. It folds in the verification evidence and (when present) the review/UX/model-conformance manifests, themes the Mermaid diagram with the shared palette automatically, validates the required sections, and links the issue:
+3. **Price the build** (`docs/ticket-cost.md`). Fold this session's own token spend into the factory ledger — windowed to this ticket's build-start stamp so a multi-ticket session doesn't cross-bill — then render the measured actual:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+  --repo "$owner_repo" --ticket "$issue_number" \
+  --since-ts "$(cat "$TICKET_TMP/build-start-ts")"
+python3 "$CW_HOME/scripts/ticket_cost.py" actual \
+  --repo "$owner_repo" --ticket "$issue_number" \
+  --format markdown > "$TICKET_TMP/implementation-cost.md"
+```
+
+   If the issue body carries a `Nominal cost: ~$X.XX` line (stamped by `/create-issue`), add `--estimate X.XX` to the `actual` call so the section shows estimate-vs-actual variance. If the output says **Unmetered**, keep it — that is absence of telemetry, never a $0 build.
+
+4. Draft the PR body with the tested helper. It folds in the verification evidence and (when present) the review/UX/model-conformance manifests plus the implementation-cost section, themes the Mermaid diagram with the shared palette automatically, validates the required sections, and links the issue:
 
 ```bash
 python3 "$CW_HOME/scripts/draft_pr.py" \
@@ -827,6 +847,7 @@ python3 "$CW_HOME/scripts/draft_pr.py" \
   --verification "$TICKET_TMP/verification.json" \
   --review "$TICKET_TMP/reviews/review-manifest.json" \
   --model-conformance "$TICKET_TMP/model-conformance.md" \
+  --implementation-cost "$TICKET_TMP/implementation-cost.md" \
   --base "$DEFAULT_BRANCH" --out "$TICKET_TMP/pr-body.md"
 ```
 
@@ -836,7 +857,14 @@ python3 "$CW_HOME/scripts/draft_pr.py" \
 gh pr create --repo "$owner_repo" --title "$pr_title" --body-file "$TICKET_TMP/pr-body.md" --base "$DEFAULT_BRANCH"
 ```
 
-4. The helper links the original issue via `Closes #N` from `--issue`.
+5. The helper links the original issue via `Closes #N` from `--issue`.
+
+6. **Record the calibration point** so future `/create-issue` estimates ground in this build's actual. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure:
+
+```bash
+python3 "$CW_HOME/scripts/ticket_cost.py" record \
+  --repo "$owner_repo" --ticket "$issue_number" --effort "$effort"
+```
 
 ### Step 12: Verify CI green
 

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -227,6 +227,12 @@ sub-agent), `requestId`, and `cwd`. The ingest:
 
 Re-run it whenever you want the log current; `0 new` means up to date.
 
+For per-ticket cost (`scripts/ticket_cost.py`, see [ticket-cost.md](ticket-cost.md))
+the ingest also accepts `--ticket` with an attribution guard (`--cwd-prefix` for
+worktree-precise tagging, else a cwd-derived repo match against `--repo`) and
+`--since-ts <epoch>` to window on a build-start stamp. Turns already ingested
+untagged can't be re-tagged (dedup keeps the first record), so tag at first ingest.
+
 ### OTEL ingest (for an existing OTEL pipeline)
 
 `ingest-claude-code` remains for OTEL setups. It only captures a run you wrapped
@@ -266,6 +272,15 @@ python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app
 `aggregate` splits Claude Code cost by `query_source` (orchestrator vs subagent)
 and reports `cost_usd_total = consult_cost + claude_code_cost` — the nominal cost
 of a factory run end to end. `/reflect` surfaces it as a factory-log finding.
+
+## Ticket attribution (`scripts/ticket_cost.py`)
+
+The same ledger sliced per ticket: a nominal estimate stamped on issues at
+`/create-issue` time (p50 of recorded calibration actuals per Effort class,
+UNRESOLVED below 3 samples — never guessed) and the measured actual rendered
+into the PR's `## Implementation Cost` section by `/implement` Step 11, which
+then journals a `ticket_cost` calibration event to close the loop. No records
+is reported **unmetered**, never $0. See [ticket-cost.md](ticket-cost.md).
 
 ## Bet attribution (`scripts/build_cost.py`, chief-wiggum#257)
 

--- a/docs/ticket-cost.md
+++ b/docs/ticket-cost.md
@@ -1,0 +1,88 @@
+# Per-Ticket Implementation Cost
+
+Every issue gets a **nominal cost estimate** when it is written; every PR gets
+the **measured actual** when it ships; the actual feeds back into the estimator.
+`scripts/ticket_cost.py` is the whole surface — the metering underneath is the
+existing factory ledger (`scripts/factory_log.py`, see
+[factory-telemetry.md](factory-telemetry.md)), not a second cost system.
+
+```mermaid
+graph LR
+    classDef artifact fill:#003f5c,stroke:#2f4b7c,color:#fff
+    classDef mech fill:#d45087,stroke:#f95d6a,color:#fff
+
+    CI["/create-issue<br/>Nominal cost: ~$3.20<br/>(p50 of 14 prior M tickets)"]:::artifact
+    LED[("factory ledger<br/>consults + orchestrator<br/>+ subagent turns")]:::mech
+    PR["/implement Step 11<br/>## Implementation Cost<br/>actual $4.06 (+27%)"]:::artifact
+    CAL["ticket_cost record<br/>(calibration event)"]:::mech
+
+    CI -->|"estimate stamped<br/>on issue"| PR
+    LED -->|"ticket_cost actual<br/>(per-ticket slice)"| PR
+    PR --> CAL
+    CAL -->|"p50 by Effort class"| CI
+```
+
+## Cost basis
+
+**Nominal model spend only** — the same definition as `build_cost.py`'s
+`nominal_usd`: tokens × the grounded per-model rates in
+`config/model_pricing.json` (INV-fh-002: prices come from the table, never
+memory; an unpriced model's cost is *omitted* and flagged, never zeroed).
+Cache-aware for Claude Code layers (`cost_for_usage`). Three layers, summed:
+
+| Layer | Metered by | Tagged with the ticket |
+|--|--|--|
+| Orchestrator (`repl_main_thread`) | transcript/OTEL ingest | at ingest (`--ticket`) |
+| Subagents (+ `worker` events) | transcript/OTEL ingest | at ingest (`--ticket`) |
+| Consults (codex/gemini/…) | `consult_ai.py` | at call time (`--ticket`) |
+
+Human time, CI minutes, and plan-share economics are **out** — for the true
+economic cost of factory compute under a fixed plan, see `build_cost.py`
+(#257), which prices bets, not tickets.
+
+## Honesty rules
+
+The fail-open bug class (chief-wiggum#289) applies to money too:
+
+- **No records is UNMETERED, never $0.** An empty slice means telemetry didn't
+  flow — the PR section says so and tells you how to meter the next build.
+- **Unpriced calls flag `cost_partial`** and the rendered total says it
+  understates; the unpriced call count is printed with its denominator.
+- **An estimate below `--min-samples` (default 3) is UNRESOLVED, never
+  guessed.** `/create-issue` stamps the UNRESOLVED line verbatim; it
+  self-resolves as PRs merge and calibrations accumulate.
+- **Partial/unmetered actuals never feed the estimator** — a lower bound would
+  drag the p50 down; exclusions are counted in `excluded_partial`.
+
+## Attribution
+
+Consult records carry the ticket exactly (passed per call). Claude Code's own
+turns don't know the ticket, so the transcript ingest tags them under a guard,
+never blindly:
+
+- `--cwd-prefix <worktree>` — worktree-precise; what `/implement-wave` workers
+  should use, since parallel tickets on the same repo are only separable by cwd.
+- otherwise, cwd-derived repo must match `--repo` — right for a solo
+  `/implement` session windowed by `--since-ts` (the Step 1 build-start stamp).
+  A concurrent session on the *same* repo in the same window would bleed in;
+  pass `--cwd-prefix` when that matters.
+
+Dedup is by request id, so a turn ingested untagged earlier can't be re-tagged:
+tag at first ingest, which is what `/implement` Step 11 does.
+
+## Workflow wiring
+
+- **`/create-issue`** — after picking the Effort size:
+  `ticket_cost.py estimate --effort M` → stamp the output line into the issue's
+  `Nominal cost` field verbatim.
+- **`/implement` Step 1** — `export CW_TELEMETRY=1` (consults meter) and stamp
+  `$TICKET_TMP/build-start-ts`.
+- **`/implement` Step 11** — `factory_log.py ingest-claude-transcripts --repo …
+  --ticket … --since-ts …`, then `ticket_cost.py actual --format markdown`
+  (plus `--estimate` when the issue carries a nominal figure) →
+  `draft_pr.py --implementation-cost …` renders the PR's
+  `## Implementation Cost` section. After the PR exists:
+  `ticket_cost.py record --effort <size>` journals the calibration point.
+
+Report-only by construction: cost is information for the human on the issue and
+PR. It is never a gate, and there is no threshold that blocks a ship.

--- a/scripts/chief_wiggum/shipping.py
+++ b/scripts/chief_wiggum/shipping.py
@@ -104,6 +104,7 @@ def build_pr_body(
     review: dict | None = None,
     ux: dict | None = None,
     model_conformance: str | None = None,
+    implementation_cost: str | None = None,
 ) -> str:
     """Assemble a PR body from the upstream manifests + issue context."""
     parts: list[str] = ["## Summary", "", summary or "<!-- what was implemented and why -->"]
@@ -131,6 +132,9 @@ def build_pr_body(
     review_line = _review_summary(review)
     if review_line:
         parts += ["", "## Review", "", review_line]
+
+    if implementation_cost:
+        parts += ["", "## Implementation Cost", "", implementation_cost.strip()]
 
     parts += [
         "", "## Review Checklist", "",

--- a/scripts/draft_pr.py
+++ b/scripts/draft_pr.py
@@ -45,6 +45,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--review", help="review-manifest.json")
     parser.add_argument("--ux", help="UX gate manifest JSON")
     parser.add_argument("--model-conformance", help="Markdown text or file for the Model Conformance section")
+    parser.add_argument("--implementation-cost",
+                        help="Markdown text or file for the Implementation Cost section "
+                             "(from scripts/ticket_cost.py actual --format markdown)")
     parser.add_argument("--base")
     parser.add_argument("--out", help="Write the PR body to this file (else stdout)")
     parser.add_argument("--print-command", action="store_true", help="Also print the gh pr create command")
@@ -58,6 +61,10 @@ def main(argv: list[str] | None = None) -> int:
     if conformance and Path(conformance).exists():
         conformance = Path(conformance).read_text()
 
+    impl_cost = args.implementation_cost
+    if impl_cost and Path(impl_cost).exists():
+        impl_cost = Path(impl_cost).read_text()
+
     body = shipping.build_pr_body(
         issue=args.issue,
         summary=args.summary,
@@ -68,6 +75,7 @@ def main(argv: list[str] | None = None) -> int:
         review=_load_json(args.review),
         ux=_load_json(args.ux),
         model_conformance=conformance,
+        implementation_cost=impl_cost,
     )
 
     missing = shipping.validate_sections(body)

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -518,7 +518,8 @@ def ingested_request_ids() -> set[str]:
 
 
 def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
-                              since: float | None = None) -> int:
+                              since: float | None = None, ticket: str | None = None,
+                              cwd_prefix: str | None = None) -> int:
     """Fold Claude Code's own per-turn token usage into the factory log.
 
     This is the end-to-end cost half of the ledger. `factory_log` already records
@@ -549,8 +550,21 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
 
     Explicit ingest — always writes (does not require CW_TELEMETRY). Returns the
     number of NEW records written. See docs/factory-telemetry.md.
+
+    ``ticket`` tags matching turns for per-ticket cost slicing
+    (``scripts/ticket_cost.py``). Transcripts carry no ticket number, so the tag
+    is applied by attribution guard, never blindly: a turn is tagged only when
+    its ``cwd`` sits under ``cwd_prefix`` (worktree-precise — what
+    ``/implement-wave`` workers should pass) or, absent a prefix, when the
+    turn's cwd-derived repo matches ``repo`` (right for a solo ``/implement``
+    session windowed by ``since``; a concurrent session on the SAME repo in the
+    same window would bleed in — pass ``cwd_prefix`` when that matters).
+    Dedup is by request id, so already-ingested turns cannot be re-tagged by a
+    later run: tag at first ingest.
     """
     root = Path(root) if root is not None else DEFAULT_TRANSCRIPT_ROOT
+    if ticket is not None and repo is None and cwd_prefix is None:
+        raise ValueError("ingest ticket tagging needs an attribution guard: pass repo and/or cwd_prefix")
     pricing, multipliers = load_pricing(), load_cache_multipliers()
     seen = ingested_request_ids()
     n = 0
@@ -632,9 +646,21 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
             }
             if e.get("sessionId"):
                 rec["session_id"] = e["sessionId"]
-            attributed = repo or _repo_from_cwd(e.get("cwd"))
+            cwd = e.get("cwd")
+            derived = _repo_from_cwd(cwd)
+            attributed = repo or derived
             if attributed:
                 rec["repo"] = attributed
+            if ticket is not None:
+                # Attribution guard, never a blind stamp: worktree-precise when a
+                # cwd_prefix is given, else cwd-derived-repo match. `repo` may be
+                # owner/repo while the cwd only yields the basename.
+                if cwd_prefix is not None:
+                    tag = bool(cwd) and str(cwd).startswith(str(cwd_prefix).rstrip("/"))
+                else:
+                    tag = bool(derived) and derived in (repo, str(repo).split("/")[-1])
+                if tag:
+                    rec["ticket"] = str(ticket)
             cost = cost_for_usage(model, tin, tout, cache_read=cache_read,
                                   cache_write_5m=w5, cache_write_1h=w1,
                                   pricing=pricing, multipliers=multipliers)
@@ -657,7 +683,7 @@ def _parse_iso_ts(value) -> float | None:
         return None
 
 
-def ingest_claude_code(path: Path, repo: str | None = None) -> int:
+def ingest_claude_code(path: Path, repo: str | None = None, ticket: str | None = None) -> int:
     """Fold a Claude Code OTEL export (console-exporter stderr capture, or OTLP file)
     into the factory log so /reflect sees end-to-end orchestrator+subagent token cost
     alongside consult/gate telemetry.
@@ -667,6 +693,10 @@ def ingest_claude_code(path: Path, repo: str | None = None) -> int:
     both flat-key and OTLP attributes shapes; skips anything that isn't an
     api_request. Explicit ingest — always writes (does not require CW_TELEMETRY).
     Returns the number of records ingested. See docs/factory-telemetry.md.
+
+    ``ticket`` tags every ingested record — unconditional here (unlike the
+    transcript ingest's attribution guard) because an OTEL capture is a
+    deliberate wrap of exactly one run: the caller already scoped what's in it.
     """
     path = Path(path)
     if not path.is_file():
@@ -700,6 +730,8 @@ def ingest_claude_code(path: Path, repo: str | None = None) -> int:
                 rec[key] = v
         if repo:
             rec["repo"] = repo
+        if ticket is not None:
+            rec["ticket"] = str(ticket)
         if _append(rec):
             n += 1
     return n
@@ -1228,6 +1260,8 @@ def main() -> int:
     a.add_argument("--format", choices=["text", "json"], default="json")
 
     ic = sub.add_parser("ingest-claude-code", help="Fold a Claude Code OTEL export into the log")
+    ic.add_argument("--ticket", help="Tag every ingested record with this ticket number "
+                                     "(the capture is a deliberate wrap of one run)")
     ic.add_argument("otel_file", help="JSONL from `... 2>capture.jsonl` with the console OTEL exporter")
     ic.add_argument("--repo", help="Tag ingested records with this repo")
 
@@ -1238,6 +1272,16 @@ def main() -> int:
     it.add_argument("--repo", help="Force this repo tag instead of deriving it from each record's cwd")
     it.add_argument("--since-days", type=float,
                     help="Only ingest turns newer than N days ago")
+    it.add_argument("--since-ts", type=float,
+                    help="Only ingest turns newer than this epoch timestamp "
+                         "(e.g. a per-ticket build-start stamp; overrides --since-days)")
+    it.add_argument("--ticket",
+                    help="Tag matching turns with this ticket number for per-ticket cost "
+                         "slicing (scripts/ticket_cost.py). Guarded, never blind: needs "
+                         "--cwd-prefix or a cwd-derived repo match against --repo")
+    it.add_argument("--cwd-prefix",
+                    help="Only tag turns whose cwd starts with this path (worktree-precise "
+                         "attribution for parallel /implement-wave workers)")
 
     cr_ = sub.add_parser("cost-report",
                          help="What Claude Code session cost is made of (report-only, never a gate)")
@@ -1252,7 +1296,7 @@ def main() -> int:
         print(log_path())
         return 0
     if args.cmd == "ingest-claude-code":
-        n = ingest_claude_code(Path(args.otel_file), repo=args.repo)
+        n = ingest_claude_code(Path(args.otel_file), repo=args.repo, ticket=args.ticket)
         print(f"factory_log: ingested {n} api_request event(s) from {args.otel_file}")
         return 0
     if args.cmd == "cost-report":
@@ -1265,7 +1309,14 @@ def main() -> int:
         return 0
     if args.cmd == "ingest-claude-transcripts":
         since = (time.time() - args.since_days * 86400) if args.since_days else None
-        n = ingest_claude_transcripts(Path(args.root), repo=args.repo, since=since)
+        if args.since_ts:
+            since = args.since_ts
+        try:
+            n = ingest_claude_transcripts(Path(args.root), repo=args.repo, since=since,
+                                          ticket=args.ticket, cwd_prefix=args.cwd_prefix)
+        except ValueError as exc:
+            print(f"factory_log: {exc}", file=sys.stderr)
+            return 2
         # Re-running is expected and safe (dedup is by request id), so say
         # explicitly that "0 new" means up-to-date rather than broken.
         print(f"factory_log: ingested {n} new Claude Code turn(s) from {args.root}"

--- a/scripts/ticket_cost.py
+++ b/scripts/ticket_cost.py
@@ -119,8 +119,8 @@ def summarize_ticket(records: list[dict], repo: str, ticket: str) -> dict:
                 "cost_partial": None, "consult_providers": []}
     for layer in layers.values():
         layer["cost_usd"] = round(layer["cost_usd"], 4)
-    total = round(sum(l["cost_usd"] for l in layers.values()), 4)
-    partial = any(l["unpriced_calls"] for l in layers.values())
+    total = round(sum(layer["cost_usd"] for layer in layers.values()), 4)
+    partial = any(layer["unpriced_calls"] for layer in layers.values())
     return {"repo": repo, "ticket": str(ticket), "status": "metered",
             "records": matched, "layers": layers, "total_cost_usd": total,
             "cost_partial": partial, "consult_providers": sorted(providers)}
@@ -159,14 +159,14 @@ def render_actual_markdown(summary: dict, estimate_usd: float | None = None) -> 
     ]
     labels = {"orchestrator": "Orchestrator", "subagents": "Subagents", "consults": "Consults"}
     for key, label in labels.items():
-        l = summary["layers"][key]
-        if not l["calls"]:
+        layer = summary["layers"][key]
+        if not layer["calls"]:
             continue
         if key == "consults" and summary["consult_providers"]:
             label = f"Consults ({', '.join(summary['consult_providers'])})"
-        cost = f"${l['cost_usd']:.2f}" + (" *" if l["unpriced_calls"] else "")
-        rows.append(f"| {label} | {l['calls']} | {_fmt_tokens(l['tokens_in'])} | "
-                    f"{_fmt_tokens(l['cache_tokens'])} | {_fmt_tokens(l['tokens_out'])} | {cost} |")
+        cost = f"${layer['cost_usd']:.2f}" + (" *" if layer["unpriced_calls"] else "")
+        rows.append(f"| {label} | {layer['calls']} | {_fmt_tokens(layer['tokens_in'])} | "
+                    f"{_fmt_tokens(layer['cache_tokens'])} | {_fmt_tokens(layer['tokens_out'])} | {cost} |")
     total = f"**${summary['total_cost_usd']:.2f}**"
     rows.append(f"| **Total** | | | | | {total} |")
     lines = ["\n".join(rows), ""]
@@ -176,7 +176,7 @@ def render_actual_markdown(summary: dict, estimate_usd: float | None = None) -> 
     note = ("Nominal model spend (tokens × `config/model_pricing.json`, cache-aware "
             "for Claude Code layers). Human time and CI excluded.")
     if summary["cost_partial"]:
-        unpriced = sum(l["unpriced_calls"] for l in summary["layers"].values())
+        unpriced = sum(layer["unpriced_calls"] for layer in summary["layers"].values())
         note += (f" **Partial**: {unpriced} of {summary['records']} calls had no "
                  "priced model — the total understates.")
     lines.append(f"<sub>{note}</sub>")

--- a/scripts/ticket_cost.py
+++ b/scripts/ticket_cost.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Per-ticket implementation cost — nominal estimate on issues, measured actual on PRs.
+
+The factory ledger (``scripts/factory_log.py``) already meters everything a build
+spends — consult tokens (tagged with ``--ticket`` at call time), and the
+orchestrator + subagent turns folded in by the transcript/OTEL ingests (taggable
+with a ticket since the same change that added this script). What was missing is
+the per-ticket slice and the surfacing: this script answers "what did building
+owner/repo#42 cost" and "what will an M-sized ticket probably cost", so
+``/create-issue`` can stamp a nominal estimate on the issue and ``/implement``
+can stamp the measured actual on the PR.
+
+Cost basis — **nominal model spend only**, the same definition as
+``build_cost.py``'s ``nominal_usd``: tokens x ``config/model_pricing.json``
+(INV-fh-002: prices come from the grounded table, never memory; an unpriced
+model's cost is *omitted* and flagged ``cost_partial``, never zeroed). Human
+time, CI minutes, and plan-share economics are out of scope here.
+
+Honesty rules (the fail-open bug class this repo hunts, chief-wiggum#289):
+
+- **No records is UNMETERED, never $0.** An empty slice means telemetry didn't
+  flow (ingest not run, ``CW_TELEMETRY`` off at consult time), not that the
+  build was free. The markdown says so explicitly.
+- **An estimate below ``--min-samples`` calibration points is UNRESOLVED, never
+  guessed.** Partially-priced actuals are excluded from the estimator (a lower
+  bound would drag the p50 down) and the exclusion is reported.
+- **Denominators are printed**: every estimate names its sample count.
+
+Calibration closes the loop: ``record`` snapshots a ticket's measured actual
+(plus its Effort size and, when known, the estimate that was stamped on the
+issue) as a ``ticket_cost`` event in the same ledger; ``estimate`` is the p50 of
+those actuals for the same Effort class. Recording is an explicit act, so —
+like the ingests — it always writes, regardless of ``CW_TELEMETRY``.
+
+Usage:
+    ticket_cost.py actual   --repo owner/repo --ticket 42 [--estimate 3.20] \
+                            [--format json|markdown|text]
+    ticket_cost.py estimate --effort S|M|L|XL [--repo owner/repo] \
+                            [--min-samples 3] [--format json|markdown|text]
+    ticket_cost.py record   --repo owner/repo --ticket 42 [--effort M] [--estimate 3.20]
+
+Report-only by construction (exit 0; 2 on usage error) — cost is information
+for the human on the issue/PR, never a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import factory_log  # noqa: E402  (ledger reader + the single cost-derivation path)
+
+TICKET_COST = "ticket_cost"  # calibration event: one per shipped ticket
+EFFORTS = ("S", "M", "L", "XL")
+DEFAULT_MIN_SAMPLES = 3
+
+# Consults/workers are tagged per-call; claude_code records are tagged at ingest.
+_LAYERED_EVENTS = (factory_log.CONSULT, factory_log.WORKER, factory_log.CLAUDE_CODE)
+
+
+def _matches_ticket(r: dict, repo: str, ticket: str) -> bool:
+    """A record belongs to the slice when its ticket tag matches and its repo tag
+    doesn't contradict. Repo tags come from two vocabularies — consults carry the
+    ``owner/repo`` the workflow passed, transcript ingests may only derive the
+    basename from cwd — so both spellings match; an absent repo defers to the
+    ticket tag (which is only ever applied under an attribution guard)."""
+    if str(r.get("ticket")) != str(ticket):
+        return False
+    rrepo = r.get("repo")
+    return rrepo is None or rrepo in (repo, repo.split("/")[-1])
+
+
+def _layer_of(r: dict) -> str:
+    if r.get("event") == factory_log.CONSULT:
+        return "consults"
+    if r.get("event") == factory_log.WORKER:
+        return "subagents"
+    return "orchestrator" if r.get("query_source") == "repl_main_thread" else "subagents"
+
+
+def summarize_ticket(records: list[dict], repo: str, ticket: str) -> dict:
+    """Slice the ledger to one ticket and fold it into per-layer totals.
+
+    ``status: "unmetered"`` (with every total ``None``) when nothing matches —
+    absence of telemetry, not a $0 build. ``cost_partial`` is set when any
+    matched record carries tokens but no priced cost, so a table with a dollar
+    total can never silently understate."""
+    layers = {
+        name: {"calls": 0, "tokens_in": 0, "tokens_out": 0, "cache_tokens": 0,
+               "cost_usd": 0.0, "unpriced_calls": 0}
+        for name in ("orchestrator", "subagents", "consults")
+    }
+    providers: set[str] = set()
+    matched = 0
+    for r in records:
+        if r.get("event") not in _LAYERED_EVENTS or not _matches_ticket(r, repo, ticket):
+            continue
+        matched += 1
+        layer = layers[_layer_of(r)]
+        layer["calls"] += 1
+        layer["tokens_in"] += r.get("tokens_in") or 0
+        layer["tokens_out"] += r.get("tokens_out") or 0
+        layer["cache_tokens"] += (r.get("cache_read") or 0) + (r.get("cache_creation") or 0)
+        if r.get("cost_usd") is not None:
+            layer["cost_usd"] += r["cost_usd"]
+        else:
+            layer["unpriced_calls"] += 1
+        if r.get("event") == factory_log.CONSULT and r.get("provider"):
+            providers.add(r["provider"])
+    if not matched:
+        return {"repo": repo, "ticket": str(ticket), "status": "unmetered",
+                "records": 0, "layers": None, "total_cost_usd": None,
+                "cost_partial": None, "consult_providers": []}
+    for layer in layers.values():
+        layer["cost_usd"] = round(layer["cost_usd"], 4)
+    total = round(sum(l["cost_usd"] for l in layers.values()), 4)
+    partial = any(l["unpriced_calls"] for l in layers.values())
+    return {"repo": repo, "ticket": str(ticket), "status": "metered",
+            "records": matched, "layers": layers, "total_cost_usd": total,
+            "cost_partial": partial, "consult_providers": sorted(providers)}
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def _variance_line(estimate_usd: float, actual_usd: float) -> str:
+    if estimate_usd <= 0:
+        return f"Estimated ~${estimate_usd:.2f} → actual ${actual_usd:.2f}."
+    pct = (actual_usd - estimate_usd) / estimate_usd * 100
+    return (f"Estimated ~${estimate_usd:.2f} → actual ${actual_usd:.2f} "
+            f"({pct:+.0f}%).")
+
+
+def render_actual_markdown(summary: dict, estimate_usd: float | None = None) -> str:
+    """Markdown body for the PR's ``## Implementation Cost`` section (no heading —
+    ``shipping.build_pr_body`` owns the heading, like Model Conformance)."""
+    if summary["status"] == "unmetered":
+        return (
+            f"**Unmetered** — no cost records for {summary['repo']}#{summary['ticket']} "
+            "in the factory ledger. That is absence of telemetry, not a $0 build: "
+            "run `factory_log.py ingest-claude-transcripts --repo <owner/repo> "
+            "--ticket <n>` (and set `CW_TELEMETRY=1` before consults) to meter the "
+            "next one."
+        )
+    rows = [
+        "| Layer | Calls | Tokens in | Cache | Tokens out | Cost |",
+        "|---|---|---|---|---|---|",
+    ]
+    labels = {"orchestrator": "Orchestrator", "subagents": "Subagents", "consults": "Consults"}
+    for key, label in labels.items():
+        l = summary["layers"][key]
+        if not l["calls"]:
+            continue
+        if key == "consults" and summary["consult_providers"]:
+            label = f"Consults ({', '.join(summary['consult_providers'])})"
+        cost = f"${l['cost_usd']:.2f}" + (" *" if l["unpriced_calls"] else "")
+        rows.append(f"| {label} | {l['calls']} | {_fmt_tokens(l['tokens_in'])} | "
+                    f"{_fmt_tokens(l['cache_tokens'])} | {_fmt_tokens(l['tokens_out'])} | {cost} |")
+    total = f"**${summary['total_cost_usd']:.2f}**"
+    rows.append(f"| **Total** | | | | | {total} |")
+    lines = ["\n".join(rows), ""]
+    if estimate_usd is not None:
+        lines.append(_variance_line(estimate_usd, summary["total_cost_usd"]))
+        lines.append("")
+    note = ("Nominal model spend (tokens × `config/model_pricing.json`, cache-aware "
+            "for Claude Code layers). Human time and CI excluded.")
+    if summary["cost_partial"]:
+        unpriced = sum(l["unpriced_calls"] for l in summary["layers"].values())
+        note += (f" **Partial**: {unpriced} of {summary['records']} calls had no "
+                 "priced model — the total understates.")
+    lines.append(f"<sub>{note}</sub>")
+    return "\n".join(lines)
+
+
+# ---- calibration (estimate side) ---------------------------------------------
+
+
+def record_calibration(summary: dict, effort: str | None = None,
+                       estimate_usd: float | None = None) -> dict:
+    """Journal one ``ticket_cost`` calibration event from a measured summary.
+
+    Explicit act → always writes (``factory_log._append``, the same
+    does-not-require-CW_TELEMETRY shape as the ingests). An unmetered ticket is
+    still recorded — as ``actual_usd: None`` — so the calibration history shows
+    how often metering actually flowed, not just its successes."""
+    rec = {
+        "ts": time.time(),
+        "event": TICKET_COST,
+        "repo": summary["repo"],
+        "ticket": summary["ticket"],
+        "status": summary["status"],
+        "actual_usd": summary["total_cost_usd"],
+        "cost_partial": summary["cost_partial"],
+        "records": summary["records"],
+    }
+    if effort:
+        rec["effort"] = effort
+    if estimate_usd is not None:
+        rec["estimate_usd"] = estimate_usd
+    factory_log._append(rec)
+    return rec
+
+
+def estimate_for_effort(records: list[dict], effort: str, repo: str | None = None,
+                        min_samples: int = DEFAULT_MIN_SAMPLES) -> dict:
+    """p50 of fully-priced calibration actuals for one Effort class.
+
+    ``repo`` narrows to one repo's history when given; the default is
+    cross-repo — effort sizing is a factory-wide notion and per-repo samples
+    are scarce early on. Partial/unmetered calibrations are excluded (their
+    actuals are lower bounds) and counted in ``excluded`` so the denominator
+    stays honest. Below ``min_samples`` the estimate is UNRESOLVED."""
+    samples: list[float] = []
+    excluded = 0
+    for r in records:
+        if r.get("event") != TICKET_COST or r.get("effort") != effort:
+            continue
+        if repo and r.get("repo") != repo:
+            continue
+        if r.get("actual_usd") is None or r.get("cost_partial"):
+            excluded += 1
+            continue
+        samples.append(r["actual_usd"])
+    out = {"effort": effort, "samples": len(samples), "excluded_partial": excluded,
+           "min_samples": min_samples}
+    if len(samples) >= min_samples:
+        out["status"] = "ok"
+        out["p50_usd"] = round(statistics.median(samples), 2)
+    else:
+        out["status"] = "insufficient-samples"
+        out["p50_usd"] = None
+    return out
+
+
+def render_estimate_line(est: dict) -> str:
+    """One line for the issue template's ``Nominal cost`` field."""
+    if est["status"] == "ok":
+        return (f"~${est['p50_usd']:.2f} (p50 of {est['samples']} prior "
+                f"{est['effort']} tickets)")
+    return (f"UNRESOLVED ({est['samples']} prior {est['effort']} tickets logged, "
+            f"need >={est['min_samples']} — calibrates as PRs merge)")
+
+
+# ---- CLI ---------------------------------------------------------------------
+
+
+def _print_summary(summary: dict, fmt: str, estimate_usd: float | None) -> None:
+    if fmt == "json":
+        print(json.dumps(summary, indent=2))
+    elif fmt == "markdown":
+        print(render_actual_markdown(summary, estimate_usd))
+    else:
+        if summary["status"] == "unmetered":
+            print(f"ticket_cost: {summary['repo']}#{summary['ticket']} UNMETERED "
+                  "(no ledger records — not $0)")
+        else:
+            partial = " (partial — some calls unpriced)" if summary["cost_partial"] else ""
+            print(f"ticket_cost: {summary['repo']}#{summary['ticket']} "
+                  f"${summary['total_cost_usd']:.2f}{partial} over "
+                  f"{summary['records']} metered calls")
+            if estimate_usd is not None:
+                print("  " + _variance_line(estimate_usd, summary["total_cost_usd"]))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser("actual", help="Measured cost of one ticket from the ledger")
+    a.add_argument("--repo", required=True)
+    a.add_argument("--ticket", required=True)
+    a.add_argument("--estimate", type=float,
+                   help="The nominal estimate stamped on the issue, for the variance line")
+    a.add_argument("--format", choices=["json", "markdown", "text"], default="text")
+
+    e = sub.add_parser("estimate", help="Nominal estimate for an Effort class (p50 of calibrations)")
+    e.add_argument("--effort", required=True, choices=EFFORTS)
+    e.add_argument("--repo", help="Narrow calibration history to one repo (default: factory-wide)")
+    e.add_argument("--min-samples", type=int, default=DEFAULT_MIN_SAMPLES)
+    e.add_argument("--format", choices=["json", "markdown", "text"], default="text")
+
+    r = sub.add_parser("record", help="Journal one ticket's measured actual as a calibration point")
+    r.add_argument("--repo", required=True)
+    r.add_argument("--ticket", required=True)
+    r.add_argument("--effort", choices=EFFORTS,
+                   help="The issue's Effort label; omit if unknown (recorded but "
+                        "won't feed the estimator)")
+    r.add_argument("--estimate", type=float,
+                   help="The nominal estimate that was stamped on the issue")
+
+    args = p.parse_args()
+    records = factory_log.read_log()
+
+    if args.cmd == "actual":
+        summary = summarize_ticket(records, args.repo, args.ticket)
+        _print_summary(summary, args.format, args.estimate)
+        return 0
+    if args.cmd == "estimate":
+        est = estimate_for_effort(records, args.effort, repo=args.repo,
+                                  min_samples=args.min_samples)
+        if args.format == "json":
+            print(json.dumps(est, indent=2))
+        else:
+            print(render_estimate_line(est))
+        return 0
+    if args.cmd == "record":
+        summary = summarize_ticket(records, args.repo, args.ticket)
+        rec = record_calibration(summary, effort=args.effort, estimate_usd=args.estimate)
+        actual = (f"${rec['actual_usd']:.2f}" if rec["actual_usd"] is not None
+                  else "UNMETERED")
+        print(f"ticket_cost: recorded calibration for {args.repo}#{args.ticket} — "
+              f"actual {actual}" + (f", effort {args.effort}" if args.effort else ""))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/issue.md
+++ b/templates/issue.md
@@ -25,3 +25,4 @@ As a **[role]**, I want **[capability]** so that **[benefit]**.
 - **Type**: <!-- bug | feature | enhancement | chore -->
 - **Priority**: <!-- critical | high | medium | low -->
 - **Effort**: <!-- S | M | L | XL -->
+- **Nominal cost**: <!-- from `scripts/ticket_cost.py estimate --effort <size>` — either "~$X.XX (p50 of N prior <size> tickets)" or its UNRESOLVED line verbatim. Never invent a figure. -->

--- a/templates/pr.md
+++ b/templates/pr.md
@@ -34,6 +34,12 @@ graph TD
 |----------|--------|
 | <!-- scenario 1 --> | PASS/FAIL |
 
+## Implementation Cost
+
+<!-- From `scripts/ticket_cost.py actual --repo <owner/repo> --ticket <n> --format markdown`
+     (pass --estimate if the issue carries a "Nominal cost" line).
+     If it reports Unmetered, keep that line — never replace it with $0. -->
+
 ## Review Checklist
 
 - [ ] Tests pass locally

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -595,11 +595,15 @@ def test_capture_diff_against_stale_local_main_is_polluted_but_remote_tracking_i
     already-merged commits; diffing against the freshly-fetched remote-tracking
     ref does not. Built entirely under tmp_path — no real-repo git operations.
     """
+    # --initial-branch pins the fixture to `main` regardless of the machine's
+    # init.defaultBranch: on a stock Linux git (default `master`) a plain bare
+    # init leaves HEAD on an unborn master, the clones then check out nothing,
+    # and every later `push origin main` dies with "src refspec does not match".
     bare = tmp_path / "origin.git"
-    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+    subprocess.run(["git", "init", "-q", "--bare", "--initial-branch=main", str(bare)], check=True)
 
     seed = tmp_path / "seed"
-    subprocess.run(["git", "init", "-q", str(seed)], check=True)
+    subprocess.run(["git", "init", "-q", "--initial-branch=main", str(seed)], check=True)
     _git(seed, "config", "user.name", "Ada")
     _git(seed, "config", "user.email", "ada@example.com")
     (seed / "README.md").write_text("seed\n")

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -74,6 +74,17 @@ def test_model_conformance_omitted_when_absent():
     assert "## Model Conformance" not in body
 
 
+def test_implementation_cost_included_when_provided():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"],
+                                  implementation_cost="| Layer |\n**$4.06**")
+    assert "## Implementation Cost" in body and "**$4.06**" in body
+
+
+def test_implementation_cost_omitted_when_absent():
+    body = shipping.build_pr_body(issue=1, summary="x", changes=["a"])
+    assert "## Implementation Cost" not in body
+
+
 def test_ux_section_included_when_provided():
     body = shipping.build_pr_body(
         issue=1, summary="x", changes=["a"],

--- a/tests/test_ticket_cost.py
+++ b/tests/test_ticket_cost.py
@@ -1,0 +1,240 @@
+"""Tests for scripts/ticket_cost.py — per-ticket implementation cost: the ledger
+slice behind the PR's ## Implementation Cost section, the Effort-class estimator
+behind the issue's Nominal cost line, and the calibration loop between them.
+
+The honesty properties are the point (fail-open bug class, chief-wiggum#289):
+no records is UNMETERED (never $0), unpriced calls flag cost_partial (never
+silently understate), an estimate below min-samples is UNRESOLVED (never a
+guess), and partial actuals never feed the estimator's p50.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import factory_log  # noqa: E402
+import ticket_cost  # noqa: E402
+
+REPO = "acme/app"
+TICKET = "42"
+
+
+def _cc(ticket=TICKET, *, repo="app", source="repl_main_thread", cost=1.0,
+        tin=1000, tout=100, cache=5000):
+    r = {"event": factory_log.CLAUDE_CODE, "query_source": source,
+         "tokens_in": tin, "tokens_out": tout, "cache_read": cache,
+         "cost_usd": cost}
+    if repo:
+        r["repo"] = repo
+    if ticket:
+        r["ticket"] = ticket
+    return r
+
+
+def _consult(ticket=TICKET, *, provider="codex", cost=0.25, tin=800, tout=200):
+    return {"event": factory_log.CONSULT, "provider": provider, "repo": REPO,
+            "ticket": ticket, "tokens_in": tin, "tokens_out": tout,
+            "cost_usd": cost}
+
+
+def _calibration(effort="M", actual=3.0, *, partial=False, repo=REPO):
+    return {"event": ticket_cost.TICKET_COST, "repo": repo, "effort": effort,
+            "actual_usd": actual, "cost_partial": partial}
+
+
+# ---- summarize_ticket: the per-ticket slice ---------------------------------
+
+def test_summarize_slices_by_ticket_and_layers():
+    records = [
+        _cc(cost=2.0),                                    # orchestrator
+        _cc(cost=1.5, source="subagent"),                 # subagent
+        {"event": factory_log.WORKER, "repo": REPO, "ticket": TICKET,
+         "tokens_in": 10, "tokens_out": 5, "cost_usd": 0.5},  # worker -> subagents
+        _consult(cost=0.25),
+        _consult(cost=0.10, provider="gemini"),
+        _cc(ticket="99", cost=50.0),                      # other ticket: excluded
+        _cc(ticket=None, cost=50.0),                      # untagged: excluded
+        _consult(cost=50.0, ticket="99"),                 # other ticket: excluded
+    ]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    assert s["status"] == "metered"
+    assert s["records"] == 5
+    assert s["layers"]["orchestrator"]["cost_usd"] == pytest.approx(2.0)
+    assert s["layers"]["subagents"]["cost_usd"] == pytest.approx(2.0)
+    assert s["layers"]["consults"]["cost_usd"] == pytest.approx(0.35)
+    assert s["total_cost_usd"] == pytest.approx(4.35)
+    assert s["cost_partial"] is False
+    assert s["consult_providers"] == ["codex", "gemini"]
+
+
+def test_summarize_matches_repo_basename_and_full_name():
+    # Transcript ingests derive only the basename from cwd; consults carry owner/repo.
+    records = [_cc(repo="app", cost=1.0), _consult(cost=0.5)]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    assert s["records"] == 2
+    # A different repo with the same ticket number must NOT match.
+    s2 = ticket_cost.summarize_ticket([_cc(repo="otherapp")], REPO, TICKET)
+    assert s2["status"] == "unmetered"
+
+
+def test_no_records_is_unmetered_never_zero_dollars():
+    s = ticket_cost.summarize_ticket([], REPO, TICKET)
+    assert s["status"] == "unmetered"
+    assert s["total_cost_usd"] is None          # absence of telemetry, not $0
+    md = ticket_cost.render_actual_markdown(s)
+    assert "Unmetered" in md
+    assert "not a $0 build" in md      # says why, instead of showing a zero total
+    assert "**$" not in md             # no dollar total rendered at all
+
+
+def test_unpriced_calls_flag_partial_never_silently_understate():
+    records = [
+        _cc(cost=2.0),
+        {"event": factory_log.CONSULT, "provider": "codex", "repo": REPO,
+         "ticket": TICKET, "tokens_in": 500, "tokens_out": 100},  # no cost_usd
+    ]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    assert s["cost_partial"] is True
+    assert s["layers"]["consults"]["unpriced_calls"] == 1
+    assert s["total_cost_usd"] == pytest.approx(2.0)
+    md = ticket_cost.render_actual_markdown(s)
+    assert "understates" in md
+
+
+# ---- markdown rendering ------------------------------------------------------
+
+def test_markdown_has_table_total_and_no_heading():
+    s = ticket_cost.summarize_ticket([_cc(cost=2.0), _consult(cost=0.5)], REPO, TICKET)
+    md = ticket_cost.render_actual_markdown(s)
+    assert "| Layer |" in md
+    assert "**$2.50**" in md
+    # shipping.build_pr_body owns the section heading.
+    assert "## Implementation Cost" not in md
+
+
+def test_markdown_variance_line_when_estimate_given():
+    s = ticket_cost.summarize_ticket([_cc(cost=4.0)], REPO, TICKET)
+    md = ticket_cost.render_actual_markdown(s, estimate_usd=3.20)
+    assert "Estimated ~$3.20" in md
+    assert "actual $4.00" in md
+    assert "(+25%)" in md
+
+
+# ---- estimator + calibration loop -------------------------------------------
+
+def test_estimate_is_p50_of_matching_effort_class():
+    records = [_calibration(actual=2.0), _calibration(actual=3.0),
+               _calibration(actual=10.0), _calibration("L", actual=99.0)]
+    est = ticket_cost.estimate_for_effort(records, "M")
+    assert est["status"] == "ok"
+    assert est["p50_usd"] == pytest.approx(3.0)
+    assert est["samples"] == 3
+
+
+def test_estimate_below_min_samples_is_unresolved_never_guessed():
+    est = ticket_cost.estimate_for_effort([_calibration()], "M")
+    assert est["status"] == "insufficient-samples"
+    assert est["p50_usd"] is None
+    line = ticket_cost.render_estimate_line(est)
+    assert "UNRESOLVED" in line
+    assert "$" not in line          # no invented figure anywhere in the line
+    assert "need >=3" in line
+
+
+def test_partial_and_unmetered_calibrations_never_feed_the_p50():
+    records = [_calibration(actual=2.0), _calibration(actual=4.0),
+               _calibration(actual=3.0),
+               _calibration(actual=0.1, partial=True),      # lower bound: excluded
+               _calibration(actual=None)]                   # unmetered: excluded
+    est = ticket_cost.estimate_for_effort(records, "M")
+    assert est["samples"] == 3
+    assert est["excluded_partial"] == 2
+    assert est["p50_usd"] == pytest.approx(3.0)
+
+
+def test_estimate_repo_filter_narrows_history():
+    records = [_calibration(actual=1.0), _calibration(actual=1.0),
+               _calibration(actual=1.0, repo="other/repo")]
+    est = ticket_cost.estimate_for_effort(records, "M", repo=REPO)
+    assert est["samples"] == 2
+
+
+def test_record_calibration_always_writes_without_telemetry_env(tmp_path, monkeypatch):
+    # Recording is an explicit act, like the ingests — CW_TELEMETRY must not gate it.
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    s = ticket_cost.summarize_ticket([_cc(cost=2.5)], REPO, TICKET)
+    ticket_cost.record_calibration(s, effort="M", estimate_usd=3.2)
+    rec = json.loads(log.read_text().strip())
+    assert rec["event"] == ticket_cost.TICKET_COST
+    assert rec["actual_usd"] == pytest.approx(2.5)
+    assert rec["effort"] == "M"
+    assert rec["estimate_usd"] == pytest.approx(3.2)
+
+
+def test_record_then_estimate_closes_the_loop(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    for cost in (2.0, 3.0, 4.0):
+        s = ticket_cost.summarize_ticket([_cc(cost=cost)], REPO, TICKET)
+        ticket_cost.record_calibration(s, effort="S")
+    est = ticket_cost.estimate_for_effort(factory_log.read_log(), "S")
+    assert est["status"] == "ok"
+    assert est["p50_usd"] == pytest.approx(3.0)
+
+
+# ---- ingest ticket tagging (factory_log side) --------------------------------
+
+def _turn(request_id, *, cwd, sidechain=False):
+    return json.dumps({
+        "type": "assistant", "requestId": request_id, "sessionId": "sess-1",
+        "timestamp": "2026-08-03T06:15:00.000Z", "isSidechain": sidechain,
+        "cwd": cwd,
+        "message": {"model": "claude-opus-5", "usage": {
+            "input_tokens": 100, "output_tokens": 200,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {"ephemeral_5m_input_tokens": 0,
+                               "ephemeral_1h_input_tokens": 0},
+        }},
+    })
+
+
+def test_transcript_ingest_tags_ticket_only_for_matching_repo(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    root = tmp_path / "projects"
+    (root / "p").mkdir(parents=True)
+    (root / "p" / "s.jsonl").write_text(
+        _turn("r1", cwd="/repos/app") + "\n" + _turn("r2", cwd="/repos/unrelated") + "\n")
+    n = factory_log.ingest_claude_transcripts(root, repo=REPO, ticket=TICKET)
+    assert n == 2
+    recs = {r["request_id"]: r for r in factory_log.read_log()}
+    assert recs["r1"]["ticket"] == TICKET          # cwd-derived repo matches basename
+    assert "ticket" not in recs["r2"]              # different repo: never tagged
+
+
+def test_transcript_ingest_cwd_prefix_is_worktree_precise(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    root = tmp_path / "projects"
+    (root / "p").mkdir(parents=True)
+    wt = "/repos/app/.claude/worktrees/t42"
+    (root / "p" / "s.jsonl").write_text(
+        _turn("r1", cwd=wt) + "\n" + _turn("r2", cwd="/repos/app/.claude/worktrees/t99") + "\n")
+    factory_log.ingest_claude_transcripts(root, repo=REPO, ticket=TICKET, cwd_prefix=wt)
+    recs = {r["request_id"]: r for r in factory_log.read_log()}
+    assert recs["r1"]["ticket"] == TICKET
+    assert "ticket" not in recs["r2"]              # sibling worktree: not this ticket
+
+
+def test_transcript_ingest_ticket_without_guard_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    with pytest.raises(ValueError):
+        factory_log.ingest_claude_transcripts(tmp_path, ticket=TICKET)


### PR DESCRIPTION
## Summary

Every issue gets a **nominal cost estimate** at `/create-issue` time; every PR gets the **measured actual** at `/implement` Step 11; the actual feeds back into the estimator. No new cost system — this is a per-ticket slice + surfacing of the existing factory ledger (`factory_log.py` + `config/model_pricing.json`), extending the `nominal_usd` discipline `build_cost.py` (#257) established for bets down to tickets.

## Architecture

```mermaid
graph LR
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff

    CI["/create-issue<br/>stamps Nominal cost"]:::entry
    IMPL["/implement Step 1+11<br/>meters, stamps, records"]:::entry
    TC["ticket_cost.py<br/>actual / estimate / record"]:::new
    FL["factory_log.py<br/>ingests learn --ticket guard,<br/>--since-ts"]:::modified
    LED[("factory ledger<br/>consults + CC turns")]:::existing
    PRICE["config/model_pricing.json"]:::existing
    SHIP["shipping.py + draft_pr.py<br/>## Implementation Cost section"]:::modified

    CI --> TC
    IMPL --> FL --> LED
    LED --> TC
    PRICE --> LED
    TC --> SHIP
    TC -->|"ticket_cost calibration event"| LED
```

## Changes

- `scripts/ticket_cost.py` (new): `actual` slices the ledger per repo+ticket into orchestrator / subagents / consults layers; `estimate` is the p50 of calibration actuals per Effort class (S/M/L/XL), **UNRESOLVED below 3 samples — never guessed**; `record` journals a `ticket_cost` calibration event after each shipped PR (explicit act → always writes, like the ingests).
- Honesty rules (the #289 fail-open class, applied to money): an empty slice renders **UNMETERED, never $0**; unpriced calls flag `cost_partial` with the denominator printed ("the total understates"); partial/unmetered actuals are excluded from the estimator's p50 and the exclusion is counted.
- `factory_log.py`: transcript ingest accepts `--ticket` under an **attribution guard** — `--cwd-prefix` (worktree-precise, for parallel `/implement-wave` workers) or cwd-derived repo match against `--repo`; a ticket without any guard is rejected. `--since-ts` windows on the per-ticket build-start stamp. OTEL ingest tags unconditionally (a capture is a deliberate wrap of one run).
- `shipping.build_pr_body` / `draft_pr.py --implementation-cost`: optional `## Implementation Cost` section (markdown passthrough, `--model-conformance` precedent).
- `templates/issue.md` gains a `Nominal cost` field; `templates/pr.md` the cost section; `/create-issue` derives the estimate mechanically; `/implement` Step 1 exports `CW_TELEMETRY=1` + stamps `build-start-ts`, Step 11 ingests-tagged, renders the actual (with estimate-vs-actual variance when the issue carried a figure), and records the calibration point.
- `tests/test_review_pipeline.py`: pinned the #269/#281 git fixture to `--initial-branch=main` — **pre-existing CI failure** (every recent run on `main` was red): stock Linux git defaults the bare fixture's HEAD to an unborn `master`, so the clones check out nothing and `push origin main` fails. Passed locally only because Apple Git compiles `main` as the default. Reproduced via `GIT_CONFIG_*` injection; green under both defaults.
- `docs/ticket-cost.md` (new) + cross-refs in `docs/factory-telemetry.md`.

## Test Evidence

```
2947 passed, 14 skipped in 198.96s  (full suite)
check_cw_standards: CW meets its own standards.
Portability check passed: workflows are harness-neutral.
```

22 new tests (`tests/test_ticket_cost.py`, `tests/test_shipping.py`): slice/layer math, basename-vs-owner/repo matching, unmetered-never-$0, partial-never-understates-silently, estimator p50 + min-samples + partial exclusion, calibration round-trip without `CW_TELEMETRY`, ingest guard behaviour (repo match, cwd-prefix precision, guardless rejection).

End-to-end CLI smoke (real subprocess, real ledger file): unmetered → metered markdown table with `+25%` variance line → 3 `record`s → `estimate` resolves `~$4.00 (p50 of 3 prior M tickets)`; `draft_pr.py --implementation-cost` renders the section.

## Notes for review

- Turns already ingested untagged can't be re-tagged (dedup keeps the first record) — documented; `/implement` tags at first ingest.
- Cost basis is nominal model spend only (all three layers); plan-share economics stay in `build_cost.py`. Report-only by construction — cost never gates a ship.

## Review Checklist

- [x] Tests pass locally (full suite)
- [x] No new warnings or lint errors (`check_cw_standards`, `check_portability`)
- [x] No secrets or credentials committed
