### PR TITLE
fix(consult): gemini-vertex reads the diff's files; blind providers are detected (#319)

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -4,63 +4,74 @@
     "codex": {
       "type": "tool",
       "tool": "codex",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": true
     },
     "gemini": {
       "type": "tool",
       "tool": "gemini",
-      "enabled": false
+      "enabled": false,
+      "reads_repo": true
     },
     "gemini-vertex": {
       "type": "tool",
       "tool": "gemini-vertex",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": true
     },
     "claude": {
       "type": "tool",
       "tool": "claude",
-      "enabled": false
+      "enabled": false,
+      "reads_repo": true
     },
     "claude-interactive": {
       "type": "delegate",
       "delegate": "claude-interactive",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": true
     },
     "opus": {
       "type": "tool",
       "tool": "claude",
       "model": "claude-opus-4-6",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": true
     },
     "deepseek": {
       "type": "tool",
       "tool": "openrouter",
       "model": "deepseek/deepseek-v4-pro",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": false
     },
     "kimi": {
       "type": "tool",
       "tool": "openrouter",
       "model": "moonshotai/kimi-k3",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": false
     },
     "glm": {
       "type": "tool",
       "tool": "openrouter",
       "model": "z-ai/glm-5.2",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": false
     },
     "qwen": {
       "type": "tool",
       "tool": "openrouter",
       "model": "qwen/qwen3.7-max",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": false
     },
     "minimax": {
       "type": "tool",
       "tool": "openrouter",
       "model": "minimax/minimax-m3",
-      "enabled": true
+      "enabled": true,
+      "reads_repo": false
     }
   },
   "roles": {
@@ -72,7 +83,8 @@
         "gemini-vertex",
         "claude-interactive"
       ],
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": true
     },
     "implementer": {
       "required": [
@@ -81,7 +93,8 @@
       "optional": [
         "claude-interactive"
       ],
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": true
     },
     "reviewer": {
       "required": [
@@ -96,7 +109,8 @@
         "claude-interactive": "adoption-cost",
         "gemini-vertex": "completeness"
       },
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": true
     },
     "architecture_critic": {
       "required": [
@@ -111,7 +125,8 @@
         "claude-interactive": "adoption-cost",
         "gemini-vertex": "completeness"
       },
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": true
     },
     "design_critic": {
       "required": [
@@ -121,7 +136,8 @@
         "codex",
         "claude-interactive"
       ],
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": false
     },
     "risky_diff_review": {
       "required": [
@@ -131,7 +147,8 @@
       "optional": [
         "claude-interactive"
       ],
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": true
     },
     "kill-review": {
       "required": [
@@ -146,7 +163,8 @@
         "opus": "steelman-the-kill",
         "claude-interactive": "is-recycle-better"
       },
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": false
     },
     "divergence": {
       "required": [
@@ -158,7 +176,8 @@
         "qwen",
         "minimax"
       ],
-      "optional_timeout_seconds": 300
+      "optional_timeout_seconds": 300,
+      "requires_repo_read": false
     }
   }
 }

--- a/scripts/chief_wiggum/review.py
+++ b/scripts/chief_wiggum/review.py
@@ -708,6 +708,12 @@ def run_review(
             providers.optional_provider_timeout(plan.role, p.name, optional_timeout_default),
         ),
         out,
+        # chief-wiggum#319: the SHARED (pre-lens) prompt + lens map, so the
+        # quorum also runs the blindness check and surfaces it in
+        # provider_manifest/review-manifest.json — the same prompt every
+        # provider above was rendered from via prompt_for_provider.
+        prompt=prompt,
+        lenses=lenses,
     )
     response_paths = [r.path for r in quorum.results if r.path]
 

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -533,6 +533,81 @@ def _parse_vertex_usage(response, requested_model: str) -> Usage:
     return Usage(tokens_in=tin, tokens_out=tout, usage_status="sdk-metadata", resolved_model=resolved)
 
 
+# chief-wiggum#319: consult_gemini_vertex is a single synchronous SDK call with
+# no tool loop, so it cannot browse the repo the way codex/claude's own exec
+# sandboxes can. What it CAN do reliably is retrieve exactly the files a
+# diff-review prompt is ABOUT: git always emits a `diff --git a/<path>
+# b/<path>` header per touched file, and every review-shaped prompt this
+# module's callers build (chief_wiggum.review.assemble_review_prompt's
+# {{DIFF}} substitution) embeds the literal diff. Extracting those paths and
+# reading each file's CURRENT full content from `cwd` gives gemini-vertex real
+# grounding for exactly the class of mistake chief-wiggum#319 documents (and
+# this repo's own #281 review corroborated: a false "pre-existing vs
+# introduced" attribution) — without pretending to a general repo-browsing
+# capability it doesn't have. A prompt with no diff header (an open-ended
+# exploration prompt, no bounded file set to retrieve) yields nothing and
+# falls back to prompt-only — never a guessed, unreliable file selection.
+_DIFF_GIT_HEADER_RE = re.compile(r"^diff --git a/(.+?) b/(.+?)$", re.MULTILINE)
+
+# Bounds so a huge diff can't blow the request past a usable size: at most
+# this many files, and at most this many bytes of any one file's content.
+MAX_RETRIEVED_FILES = 40
+MAX_RETRIEVED_FILE_BYTES = 60_000
+
+
+def _touched_files_from_diff(text: str) -> list[str]:
+    """Extract touched-file paths from a unified diff embedded in ``text``.
+
+    Deterministic and bounded to files the diff itself names — NOT a general
+    heuristic file-selector over an arbitrary prompt (that would be unreliable
+    for an open-ended prompt with no diff, exactly the trap chief-wiggum#319
+    warns against shipping). The post-image (``b/``) path is used — correct
+    for a modification or rename; for a deletion the file may no longer exist,
+    which ``_read_touched_files`` skips, never raises on.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for match in _DIFF_GIT_HEADER_RE.finditer(text):
+        path = match.group(2)
+        if path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def _read_touched_files(cwd: str | None, paths: list[str]) -> list[str]:
+    """Read each touched file's CURRENT full content from ``cwd``, best-effort.
+
+    Best-effort per file (CTR-fh-011 pattern applied to retrieval): a path
+    that no longer exists (deleted in the diff), isn't readable, resolves
+    outside ``cwd``, or decodes as binary is skipped, never raised — a
+    retrieval gap degrades the amount of context gemini-vertex gets, it never
+    fails the whole consult.
+    """
+    if not cwd:
+        return []
+    base = Path(cwd).resolve()
+    blocks: list[str] = []
+    for rel in paths[:MAX_RETRIEVED_FILES]:
+        candidate = (base / rel).resolve()
+        try:
+            candidate.relative_to(base)
+        except ValueError:
+            continue  # path escapes cwd — never follow it
+        try:
+            content = candidate.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        encoded = content.encode("utf-8")
+        if len(encoded) > MAX_RETRIEVED_FILE_BYTES:
+            content = (
+                encoded[:MAX_RETRIEVED_FILE_BYTES].decode("utf-8", errors="ignore")
+                + f"\n... [truncated at {MAX_RETRIEVED_FILE_BYTES} bytes]"
+            )
+        blocks.append(f"--- {rel} (current full content, chief-wiggum#319) ---\n{content}")
+    return blocks
+
+
 def consult_gemini_vertex(
     prompt: str, model: str | None = None, cwd: str | None = None, timeout: int | None = None,
 ) -> tuple[str, Usage]:
@@ -547,6 +622,16 @@ def consult_gemini_vertex(
     deadline was wired for it before this ticket either — a pre-existing gap,
     out of scope for #291 (which only threads the override chain through
     call sites that already had a real ``TOOL_TIMEOUTS`` read to replace).
+
+    chief-wiggum#319: this adapter used to call ``generate_content`` with
+    ``contents=prompt`` alone — ``cwd`` was accepted and never touched, so
+    every consult answered from the prompt text with zero repo access. It now
+    retrieves the CURRENT content of every file the prompt's embedded diff
+    touches (see ``_touched_files_from_diff``) and appends it to ``contents``.
+    This is bounded and diff-scoped, not general repo browsing: a prompt
+    carrying no diff (e.g. an open-ended exploration prompt) retrieves
+    nothing and this behaves exactly as before — an honest no-op, not a
+    pretended fix.
     """
     project = get_secret("GOOGLE_CLOUD_PROJECT")
     location = get_secret("GOOGLE_CLOUD_LOCATION") or "global"
@@ -562,7 +647,22 @@ def consult_gemini_vertex(
 
     requested_model = model or DEFAULT_VERTEX_MODEL
     client = genai.Client(vertexai=True, project=project, location=location)
-    response = client.models.generate_content(model=requested_model, contents=prompt)
+
+    touched = _touched_files_from_diff(prompt)
+    file_blocks = _read_touched_files(cwd, touched)
+    if file_blocks:
+        contents = (
+            prompt
+            + "\n\n---\nRepo context (chief-wiggum#319): the CURRENT full content of "
+              "every file touched by the diff above, read from the repo. Use it to "
+              "judge whether code shown in the diff is pre-existing or newly "
+              "introduced, and to see context beyond the diff hunk.\n\n"
+            + "\n\n".join(file_blocks)
+        )
+    else:
+        contents = prompt
+
+    response = client.models.generate_content(model=requested_model, contents=contents)
     text = response.text or ""
     # @cw-trace guards CTR-fh-010 CTR-fh-011 — response.usage_metadata is a
     # usage-bearing source by construction; parsing failures never fail the
@@ -907,7 +1007,7 @@ def _emit_consult_telemetry(
 def consult_provider(
     provider: Provider, prompt: str, model: str | None, cwd: str | None,
     *, ticket: str | None = None, timeout_override: int | None = None,
-) -> str:
+) -> tuple[str, Usage]:
     """Run one provider's consult.
 
     ``timeout_override`` (chief-wiggum#188) only affects the claude-interactive
@@ -915,6 +1015,12 @@ def consult_provider(
     OPTIONAL slot, so a hung/slow interactive session fails fast instead of
     holding the whole role's wall-clock to its full 1800s budget. Tool providers
     ignore it; their own ``TOOL_TIMEOUTS`` entries are already well under that.
+
+    Returns ``(text, usage)`` (chief-wiggum#319) — previously this discarded
+    ``usage`` after telemetry, so a role quorum (``providers.run_role_quorum``)
+    had no way to see per-provider ``tokens_in`` at all. Both callers
+    (``consult_ai.py --role`` and ``scripts/run_review.py``) now propagate the
+    pair straight into the quorum's ``ProviderResult``.
     """
     if provider.type == "tool":
         if not provider.tool or provider.tool not in TOOLS:
@@ -925,13 +1031,13 @@ def consult_provider(
         effective_model = model or provider.model
         text, usage = TOOLS[provider.tool](prompt, model=effective_model, cwd=cwd)
         _emit_consult_telemetry(provider.tool, effective_model, cwd, usage, ticket=ticket)
-        return text
+        return text, usage
     if provider.type == "delegate":
         if provider.delegate != "claude-interactive":
             raise ValueError(f"unsupported delegate provider: {provider.name}")
         text, usage = consult_claude_interactive(prompt, model=model, cwd=cwd, timeout=timeout_override)
         _emit_consult_telemetry("claude-interactive", model, cwd, usage, ticket=ticket)
-        return text
+        return text, usage
     raise ValueError(f"unsupported provider type: {provider.type}")
 
 
@@ -1053,7 +1159,7 @@ def main():
         # provider gets the identical shared prompt; a provider mapped to a lens
         # (config/providers.json role.lenses) additionally gets its charter
         # appended (chief-wiggum#163) — the shared body itself never changes.
-        def execute(provider: Provider) -> str:
+        def execute(provider: Provider) -> tuple[str, Usage]:
             provider_prompt = prompt_for_provider(plan.role, provider.name, prompt, lenses)
             # An optional provider's delegate call is capped to a much shorter
             # wall-clock than a required one (chief-wiggum#188): it's allowed to
@@ -1075,6 +1181,13 @@ def main():
             args.output_dir,
             max_attempts=args.max_attempts,
             min_bytes=args.min_bytes,
+            # chief-wiggum#319: the SHARED prompt (pre-lens) + lens map, so the
+            # quorum can also run the blindness check and attach it to the
+            # manifest. Passing the identical inputs prompt_for_provider was
+            # already called with above keeps the per-provider token estimate
+            # honest.
+            prompt=prompt,
+            lenses=lenses,
         )
         for result in manifest.results:
             if result.status == "ok":
@@ -1083,6 +1196,13 @@ def main():
                 print(f"Error: required provider {result.name} failed: {result.error}", file=sys.stderr)
             else:
                 print(f"Warning: optional provider {result.name} failed: {result.error}", file=sys.stderr)
+        # chief-wiggum#319: a quorum can report every required provider "ok"
+        # while one of them never read anything beyond its own prompt — report
+        # that loudly, on the same stderr stream as every other quorum warning,
+        # regardless of whether the overall quorum passes.
+        if manifest.blindness is not None:
+            for finding in manifest.blindness.findings:
+                print(f"Warning: {finding.message}", file=sys.stderr)
         if not manifest.ok:
             print(
                 f"Role {args.role} quorum failed: {', '.join(manifest.failed_required)}",

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +35,18 @@ class Provider:
     # entries share one tool with different models (e.g. `opus` = the claude
     # CLI pinned to the opus model). A caller's explicit --model still wins.
     model: str | None = None
+    # Does this provider's call path ever give it a chance to read the target
+    # repo (chief-wiggum#319)? True for every CLI/delegate that runs with a
+    # real ``cwd`` and its own file access (codex, gemini CLI's --yolo tool
+    # loop, claude/claude-interactive) — including ``gemini-vertex``, which
+    # now retrieves touched-file content for diff-bearing prompts (still no
+    # arbitrary repo browsing, so a measured call can legitimately come back
+    # blind — see ``detect_blind_providers``). False for a provider whose
+    # ENTIRE call path is a plain text completion with no file access under
+    # any circumstance (the openrouter-backed models) — declared explicitly
+    # here rather than inferred, so a role can tell a code-reading provider
+    # from a text-only one without re-deriving it from behavior.
+    reads_repo: bool = True
 
 
 @dataclass(frozen=True)
@@ -53,6 +65,21 @@ class Role:
     # full budget (1800s for claude-interactive). ``None`` falls back to
     # ``consult_ai.DEFAULT_OPTIONAL_TIMEOUT_SECONDS``.
     optional_timeout_seconds: int | None = None
+    # Does this role's job actually require a provider to have read the repo
+    # (chief-wiggum#319)? True for the roles that explore, implement, or
+    # review CODE (``explorer``, ``implementer``, ``reviewer``,
+    # ``architecture_critic``, ``risky_diff_review``) — a required or
+    # optional member of one of these that comes back having plainly only
+    # seen its own prompt is a silent quorum gap, not a quiet success.
+    # False for a role whose job was never repo-grounded in the first place:
+    # ``design_critic`` reviews rendered SCREENSHOTS (an image-reading gap is
+    # a separate, real defect, filed rather than fixed here — see the final
+    # report), ``kill-review`` evaluates a business-bet writeup, and
+    # ``divergence`` exists purely to widen textual distribution (see its
+    # own docstring below). Declared per role rather than inferred so a role
+    # that never needed repo-reading is never reported as if a provider
+    # failed it.
+    requires_repo_read: bool = True
 
 
 @dataclass(frozen=True)
@@ -134,6 +161,7 @@ def providers_from_config(config: dict[str, Any]) -> dict[str, Provider]:
             tool=raw.get("tool"),
             delegate=raw.get("delegate"),
             model=raw.get("model"),
+            reads_repo=bool(raw.get("reads_repo", True)),
         )
     return providers
 
@@ -147,6 +175,7 @@ def roles_from_config(config: dict[str, Any]) -> dict[str, Role]:
             optional=tuple(raw.get("optional", [])),
             lenses=dict(raw.get("lenses", {})),
             optional_timeout_seconds=raw.get("optional_timeout_seconds"),
+            requires_repo_read=bool(raw.get("requires_repo_read", True)),
         )
     return roles
 
@@ -311,9 +340,16 @@ def validate_lenses(config: dict[str, Any], lenses: dict[str, Any]) -> list[str]
 # failed provider call, not a substantive response.
 INVALID_MARKERS = ("Timeout:", "Error:")
 
-# An ``execute`` callable runs a single provider and returns its response text.
-# It is injected so the quorum runner is testable without real provider calls.
-ExecuteFn = Callable[[Provider], str]
+# An ``execute`` callable runs a single provider and returns its response text
+# — OR, when the caller can supply it, a ``(text, usage)`` pair where ``usage``
+# is anything exposing ``.tokens_in``/``.tokens_out``/``.usage_status``/
+# ``.resolved_model`` (duck-typed against ``consult_ai.Usage`` so this module
+# never imports it — chief-wiggum#319). ``_run_one_provider`` accepts either
+# shape: existing callers (and every test) that return a bare string keep
+# working unchanged; ``consult_ai.consult_provider`` and the review pipeline
+# now return the pair, which is how per-provider token usage reaches the
+# manifest at all.
+ExecuteFn = Callable[[Provider], "str | tuple[str, object]"]
 
 
 @dataclass
@@ -325,6 +361,13 @@ class ProviderResult:
     attempts: int = 0
     error: str | None = None
     error_path: str | None = None
+    # Usage, threaded from whatever ``execute`` returned (chief-wiggum#319).
+    # ``None`` when the execute callable didn't supply usage (the plain-string
+    # contract) or the call failed — never fabricated, never zero-filled.
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    usage_status: str | None = None
+    resolved_model: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -335,13 +378,176 @@ class ProviderResult:
             "attempts": self.attempts,
             "error": self.error,
             "error_path": self.error_path,
+            "tokens_in": self.tokens_in,
+            "tokens_out": self.tokens_out,
+            "usage_status": self.usage_status,
+            "resolved_model": self.resolved_model,
         }
+
+
+# A provider's tokens_in may exceed the estimated size of its OWN prompt by up
+# to this factor and still count as "answered from the prompt alone, never
+# touched the repo" (chief-wiggum#319). Real repo reading — even one opened
+# file — inflates tokens_in by orders of magnitude (the ticket's own evidence:
+# 613k-1.1M vs ~1.3k-1.4k, a ~165:1 ratio); a small multiplier here is
+# generous headroom for SDK-added wrapping, not a real detection risk.
+BLIND_PROVIDER_MARGIN = 1.5
+
+
+def estimate_prompt_tokens(text: str) -> int:
+    """Coarse, model-agnostic token estimate (~4 chars/token — the standard
+    rough heuristic for English prose/code) used ONLY as a floor-check
+    denominator, never for billing. Precision doesn't matter here: the gap
+    this is built to catch is two-plus orders of magnitude wide."""
+    return max(1, len(text) // 4)
+
+
+@dataclass
+class BlindnessFinding:
+    """One provider whose measured usage contradicts what the role required
+    of it (chief-wiggum#319) — either it answered from the prompt alone
+    (``kind="blind"``), or its usage could not be measured at all
+    (``kind="unmeasured"``), which is NOT the same as measured-and-fine and
+    must never be reported as a quiet pass."""
+
+    provider: str
+    kind: str  # "blind" | "unmeasured"
+    tokens_in: int | None
+    prompt_tokens_estimate: int | None
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class BlindnessReport:
+    """chief-wiggum#319: did every provider a role DECLARED needs repo
+    reading actually read anything beyond its own prompt? Follows the
+    established four-state gate vocabulary (chief-wiggum#289,
+    ``check_traceability.py`` is the reference): ``pass`` / ``findings`` /
+    ``inapplicable`` / ``error``. This is a REPORT, never a gate — it
+    surfaces into the existing consult/review manifest and never blocks a
+    quorum on its own.
+    """
+
+    role: str
+    requires_repo_read: bool
+    findings: list[BlindnessFinding] = field(default_factory=list)
+    providers_checked: int = 0
+    error: str | None = None
+
+    @property
+    def applicability(self) -> str:
+        if self.error:
+            return "error"
+        if not self.requires_repo_read:
+            return "inapplicable"
+        return "applicable"
+
+    @property
+    def outcome(self) -> str:
+        """The standard four-state gate outcome (#289): pass | findings |
+        inapplicable | error. Derived, never stored."""
+        if self.applicability in ("error", "inapplicable"):
+            return self.applicability
+        return "findings" if self.findings else "pass"
+
+    def to_dict(self) -> dict:
+        return {
+            "role": self.role,
+            "requires_repo_read": self.requires_repo_read,
+            "applicability": self.applicability,
+            "outcome": self.outcome,
+            "providers_checked": self.providers_checked,
+            "error": self.error,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+def detect_blind_providers(
+    role: Role,
+    providers_by_name: dict[str, Provider],
+    results: list[ProviderResult],
+    prompt_tokens_by_provider: dict[str, int],
+    *,
+    margin: float = BLIND_PROVIDER_MARGIN,
+) -> BlindnessReport:
+    """chief-wiggum#319: catch a quorum reporting healthy while a required
+    voice never opened a file — the review-layer shape of chief-wiggum#289
+    (absence-of-reading rendering as success).
+
+    Applies only when ``role.requires_repo_read`` — a role like
+    ``design_critic`` (reviews rendered screenshots) or ``divergence``
+    (exists to widen textual distribution) was never asked to read the repo,
+    so never touching it is not a finding, it's ``inapplicable``.
+
+    Within a repo-reading role, a provider declared text-only
+    (``provider.reads_repo is False``) is skipped too — it already told the
+    config it can't read files; that's not a silent surprise. Everything else
+    is measured per call, not assumed from a static label: a provider capable
+    of reading the repo under SOME conditions (e.g. ``gemini-vertex``'s
+    diff-scoped retrieval, chief-wiggum#319) that got nothing to retrieve on
+    THIS call is still reported blind on THIS call.
+
+    Two distinct findings, both loud, neither a pass:
+      - ``"blind"`` — ``tokens_in`` measured and within ``margin``x of the
+        provider's own prompt's estimated size: it answered from the prompt
+        alone, by definition (the ticket's own detection note).
+      - ``"unmeasured"`` — usage could not be measured at all. A provider that
+        cannot be measured is not the same as one measured and fine.
+    """
+    if not role.requires_repo_read:
+        return BlindnessReport(role=role.name, requires_repo_read=False)
+
+    findings: list[BlindnessFinding] = []
+    checked = 0
+    for result in results:
+        if result.status != "ok":
+            continue  # already visible as a quorum failure
+        provider = providers_by_name.get(result.name)
+        if provider is None or not provider.reads_repo:
+            continue  # declared text-only — not a surprise, nothing to detect
+        checked += 1
+        prompt_tokens = prompt_tokens_by_provider.get(result.name)
+        if result.tokens_in is None:
+            findings.append(BlindnessFinding(
+                provider=result.name, kind="unmeasured", tokens_in=None,
+                prompt_tokens_estimate=prompt_tokens,
+                message=(
+                    f"{result.name} is declared repo-reading and required by role "
+                    f"{role.name!r}, but its tokens_in could not be measured "
+                    f"(usage_status={result.usage_status!r}). A provider that cannot "
+                    "be measured is not the same as one measured and fine — do not "
+                    "count this voice as confirmed-informed."
+                ),
+            ))
+            continue
+        if prompt_tokens is not None and result.tokens_in <= prompt_tokens * margin:
+            findings.append(BlindnessFinding(
+                provider=result.name, kind="blind", tokens_in=result.tokens_in,
+                prompt_tokens_estimate=prompt_tokens,
+                message=(
+                    f"{result.name}'s tokens_in ({result.tokens_in}) is within {margin}x "
+                    f"of its own prompt's estimated size (~{prompt_tokens} tokens) in role "
+                    f"{role.name!r} — it answered from the prompt text alone, not the repo. "
+                    "A provider whose tokens_in is ~the prompt size did not read the repo, "
+                    "by definition (chief-wiggum#319)."
+                ),
+            ))
+    return BlindnessReport(
+        role=role.name, requires_repo_read=True, findings=findings, providers_checked=checked
+    )
 
 
 @dataclass
 class QuorumManifest:
     role: str
     results: list[ProviderResult] = field(default_factory=list)
+    # None when the caller didn't ask for the blindness check (no ``prompt``
+    # passed to ``run_role_quorum``) — distinct from a check that RAN and
+    # found nothing (chief-wiggum#319).
+    blindness: BlindnessReport | None = None
 
     @property
     def ok(self) -> bool:
@@ -353,12 +559,15 @@ class QuorumManifest:
         return [r.name for r in self.results if r.required and r.status != "ok"]
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "role": self.role,
             "ok": self.ok,
             "failed_required": self.failed_required,
             "results": [r.to_dict() for r in self.results],
         }
+        if self.blindness is not None:
+            d["blindness"] = self.blindness.to_dict()
+        return d
 
 
 def validate_output(text: str | None, *, min_bytes: int = 20) -> str | None:
@@ -396,16 +605,31 @@ def _run_one_provider(
     attempt = 0
     for attempt in range(1, attempts_allowed + 1):
         try:
-            text = execute(provider)
+            outcome = execute(provider)
         except Exception as exc:  # noqa: BLE001 - any provider failure is retryable
             last_error = f"execution failed: {exc}"
             continue
+        # ``execute`` may return a bare string (the original contract, still
+        # used by every pre-#319 caller/test) or a ``(text, usage)`` pair
+        # (consult_ai.consult_provider and the review pipeline, chief-wiggum#319).
+        # Usage is read duck-typed, never imported, so this module stays
+        # decoupled from consult_ai.Usage.
+        if isinstance(outcome, tuple):
+            text, usage = outcome
+        else:
+            text, usage = outcome, None
         problem = validate_output(text, min_bytes=min_bytes)
         if problem:
             last_error = problem
             continue
         ok_path.write_text(text)
-        return ProviderResult(provider.name, required, "ok", str(ok_path), attempt, None)
+        return ProviderResult(
+            provider.name, required, "ok", str(ok_path), attempt, None,
+            tokens_in=getattr(usage, "tokens_in", None),
+            tokens_out=getattr(usage, "tokens_out", None),
+            usage_status=getattr(usage, "usage_status", None),
+            resolved_model=getattr(usage, "resolved_model", None),
+        )
 
     err_path.write_text(last_error or "unknown error")
     return ProviderResult(
@@ -422,12 +646,23 @@ def run_role_quorum(
     min_bytes: int = 20,
     max_workers: int | None = None,
     write_manifest: bool = True,
+    prompt: str | None = None,
+    lenses: dict[str, Any] | None = None,
+    blindness_margin: float = BLIND_PROVIDER_MARGIN,
 ) -> QuorumManifest:
     """Run a role's providers concurrently with retries and output validation.
 
     Required and optional providers run in parallel. Required providers are
     retried up to ``max_attempts`` times; optional providers fail without
     blocking the quorum. A ``{role}-manifest.json`` records per-provider status.
+
+    ``prompt`` (chief-wiggum#319): the SHARED prompt every provider in this
+    role started from, BEFORE per-provider lens rendering — pass it (with
+    ``lenses`` when the role uses any) to also run the blindness check
+    (``detect_blind_providers``) and attach its ``BlindnessReport`` to the
+    manifest. Omitted (the default) means "the caller didn't ask" — the
+    manifest's ``blindness`` stays ``None``, distinct from a check that ran
+    and found nothing.
     """
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -460,6 +695,25 @@ def run_role_quorum(
     # Deterministic order: required (config order) then optional.
     results.sort(key=lambda r: order.get(r.name, 1_000))
     manifest = QuorumManifest(plan.role.name, results)
+
+    if prompt is not None:
+        try:
+            providers_by_name = {p.name: p for p, _ in tasks}
+            prompt_tokens_by_provider = {
+                name: estimate_prompt_tokens(
+                    prompt_for_provider(plan.role, name, prompt, lenses or {})
+                )
+                for name in seen
+            }
+            manifest.blindness = detect_blind_providers(
+                plan.role, providers_by_name, results, prompt_tokens_by_provider,
+                margin=blindness_margin,
+            )
+        except Exception as exc:  # noqa: BLE001 - the check itself must never break the quorum
+            manifest.blindness = BlindnessReport(
+                role=plan.role.name, requires_repo_read=plan.role.requires_repo_read,
+                error=f"blindness check failed: {exc}",
+            )
 
     if write_manifest:
         (out / f"{plan.role.name}-manifest.json").write_text(

--- a/scripts/run_review.py
+++ b/scripts/run_review.py
@@ -92,6 +92,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
+    # chief-wiggum#319: a reviewer quorum can report every required provider
+    # "ok" while one of them never read anything beyond its own prompt —
+    # surface that as loudly as any other quorum warning, independent of
+    # whether the review itself passes.
+    blindness = manifest.provider_manifest.get("blindness") or {}
+    for finding in blindness.get("findings", []):
+        print(f"Warning: {finding.get('message')}", file=sys.stderr)
+
     print(json.dumps(manifest.to_dict(), indent=2))
     return 0 if manifest.ok else 1
 

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -128,6 +128,47 @@ def test_role_consult_writes_required_and_optional_outputs(tmp_path, monkeypatch
     assert (output_dir / "reviewer-gemini.md").read_text() == f"gemini: {PROMPT_TEXT}"
 
 
+def test_role_consult_prints_blind_provider_warning_and_writes_it_to_manifest(tmp_path, monkeypatch, capsys):
+    """chief-wiggum#319: a quorum where every required provider is "ok" must
+    still surface, loudly, that one of them answered from the prompt alone."""
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(PROMPT_TEXT)
+    config = tmp_path / "providers.json"
+    output_dir = tmp_path / "out"
+    write_config(config)  # reviewer: required=[codex], optional=[gemini]; requires_repo_read defaults True
+
+    response_text = "A substantive response with several findings to report."
+
+    def fake_consult_provider(provider, prompt_text, model, cwd, ticket=None, timeout_override=None):
+        if provider.name == "gemini":
+            # tokens_in == exactly the prompt's own estimated size: the
+            # textbook "answered from the prompt alone" signature.
+            blind_tokens = len(prompt_text.strip()) // 4
+            return response_text, consult_ai.Usage(tokens_in=blind_tokens, usage_status="sdk-metadata")
+        return response_text, consult_ai.Usage(tokens_in=5_000_000, usage_status="provider-json")
+
+    monkeypatch.setattr(consult_ai, "consult_provider", fake_consult_provider)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "consult_ai.py", "--role", "reviewer", str(prompt),
+            "--config", str(config), "--output-dir", str(output_dir), "--min-bytes", "1",
+        ],
+    )
+
+    consult_ai.main()
+
+    captured = capsys.readouterr()
+    assert "did not read the repo" in captured.err
+    assert "gemini" in captured.err
+
+    manifest = json.loads((output_dir / "reviewer-manifest.json").read_text())
+    assert manifest["blindness"]["outcome"] == "findings"
+    assert manifest["blindness"]["findings"][0]["provider"] == "gemini"
+    assert manifest["ok"] is True  # blindness is a report, never a gate
+
+
 def test_role_consult_does_not_fail_when_optional_provider_is_disabled(tmp_path, monkeypatch):
     prompt = tmp_path / "prompt.md"
     prompt.write_text(PROMPT_TEXT)
@@ -1240,6 +1281,162 @@ def test_vertex_usage_parse_exception_never_fails_the_consult(monkeypatch):
     text, usage = consult_ai.consult_gemini_vertex("prompt")
     assert text == "PONG"
     assert usage.usage_status == "unavailable"
+
+
+# --- diff-scoped repo retrieval (chief-wiggum#319) ---------------------------
+#
+# consult_gemini_vertex used to call generate_content(contents=prompt) alone —
+# cwd was accepted and never touched, so every call answered from the prompt
+# text with zero repo access (the ticket's measured 165:1 tokens_in ratio vs
+# codex on the same consult). These tests assert on what is actually SENT to
+# the mocked SDK client — the one thing testable without live Vertex
+# credentials — for both the diff-bearing case (retrieval should attach real
+# file content) and the no-diff case (retrieval must NOT guess; it is an
+# honest no-op, not a pretended fix).
+
+
+def _diff_prompt(*paths: str) -> str:
+    """A minimal review-shaped prompt embedding a unified diff header per
+    path, matching what chief_wiggum.review.assemble_review_prompt's
+    {{DIFF}} substitution actually produces."""
+    header = "\n".join(f"diff --git a/{p} b/{p}\n@@ -1,1 +1,2 @@\n+touched" for p in paths)
+    return "Review this change for correctness.\n\n" + header
+
+
+def test_touched_files_from_diff_extracts_and_dedupes_paths():
+    text = (
+        "diff --git a/src/foo.py b/src/foo.py\n+x\n"
+        "diff --git a/src/bar.py b/src/bar.py\n+y\n"
+        "diff --git a/src/foo.py b/src/foo.py\n+z\n"  # duplicate header
+    )
+    assert consult_ai._touched_files_from_diff(text) == ["src/foo.py", "src/bar.py"]
+
+
+def test_touched_files_from_diff_returns_empty_for_a_diffless_prompt():
+    # An open-ended exploration prompt has no diff to bound retrieval from —
+    # must yield nothing, never a guessed file selection.
+    assert consult_ai._touched_files_from_diff("Explore this repo and report back.") == []
+
+
+def test_read_touched_files_reads_current_content_from_cwd(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("SENTINEL_CONTENT_1234")
+
+    blocks = consult_ai._read_touched_files(str(tmp_path), ["src/foo.py"])
+
+    assert len(blocks) == 1
+    assert "SENTINEL_CONTENT_1234" in blocks[0]
+    assert "src/foo.py" in blocks[0]
+
+
+def test_read_touched_files_skips_missing_file_without_raising(tmp_path):
+    # The diff's a/-side (or a delete) may name a path gone from the worktree.
+    blocks = consult_ai._read_touched_files(str(tmp_path), ["never/existed.py"])
+    assert blocks == []
+
+
+def test_read_touched_files_never_follows_a_path_that_escapes_cwd(tmp_path):
+    secret = tmp_path.parent / "outside_secret.txt"
+    secret.write_text("SHOULD_NEVER_BE_READ")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    blocks = consult_ai._read_touched_files(str(repo), ["../outside_secret.txt"])
+
+    assert blocks == []
+
+
+def test_read_touched_files_truncates_an_oversized_file(tmp_path):
+    big = "A" * (consult_ai.MAX_RETRIEVED_FILE_BYTES + 5_000)
+    (tmp_path / "big.py").write_text(big)
+
+    blocks = consult_ai._read_touched_files(str(tmp_path), ["big.py"])
+
+    assert len(blocks) == 1
+    assert "[truncated" in blocks[0]
+    assert len(blocks[0].encode("utf-8")) < len(big)
+
+
+def test_read_touched_files_caps_the_number_of_files_retrieved(tmp_path):
+    paths = []
+    for i in range(consult_ai.MAX_RETRIEVED_FILES + 10):
+        p = tmp_path / f"f{i}.py"
+        p.write_text(f"content {i}")
+        paths.append(f"f{i}.py")
+
+    blocks = consult_ai._read_touched_files(str(tmp_path), paths)
+
+    assert len(blocks) == consult_ai.MAX_RETRIEVED_FILES
+
+
+def _mock_vertex_sdk(monkeypatch, captured: dict):
+    """Patch consult_gemini_vertex's google.genai import + secrets so
+    generate_content's arguments can be inspected without live credentials."""
+    project_secret = {"GOOGLE_CLOUD_PROJECT": "proj", "GOOGLE_CLOUD_LOCATION": "global"}
+    monkeypatch.setattr(consult_ai, "get_secret", lambda name: project_secret.get(name))
+
+    class _FakeModels:
+        def generate_content(self, model, contents):
+            captured["model"] = model
+            captured["contents"] = contents
+            resp = _FakeVertexResponse(
+                usage_metadata=_FakeUsageMetadata(prompt_token_count=1, candidates_token_count=1),
+                model_version=model,
+            )
+            resp.text = "a response"
+            return resp
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            self.models = _FakeModels()
+
+    fake_genai = type("fake_genai_module", (), {"Client": _FakeClient})
+    monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google", type("fake_google_module", (), {"genai": fake_genai}))
+
+
+def test_consult_gemini_vertex_attaches_touched_file_content_for_diff_bearing_prompt(tmp_path, monkeypatch):
+    # @cw-trace verifies CTR-fh-010
+    (tmp_path / "app.py").write_text("SENTINEL_REPO_CONTENT_ABC123")
+    prompt = _diff_prompt("app.py")
+    captured: dict = {}
+    _mock_vertex_sdk(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    # The real fix: contents sent to the SDK carries the file's CURRENT
+    # content, not just the prompt text (the pre-fix behavior, and the exact
+    # gap the ticket's tokens_in evidence measured).
+    assert "SENTINEL_REPO_CONTENT_ABC123" in captured["contents"]
+    assert prompt in captured["contents"]
+    assert len(captured["contents"]) > len(prompt)
+
+
+def test_consult_gemini_vertex_is_an_honest_noop_without_a_diff(tmp_path, monkeypatch):
+    # An open-ended prompt with no diff header has no bounded file set to
+    # retrieve — contents must be the prompt UNCHANGED, never a guess, even
+    # though cwd has real files sitting right there.
+    (tmp_path / "app.py").write_text("unrelated content that must not leak in")
+    prompt = "Explore this repo and report what you find."
+    captured: dict = {}
+    _mock_vertex_sdk(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    assert captured["contents"] == prompt
+
+
+def test_consult_gemini_vertex_skips_retrieval_without_a_cwd(monkeypatch):
+    # No cwd at all (the pre-#319 call shape, e.g. a bare CLI invocation with
+    # no --cwd) — retrieval has nowhere to read from, so contents stays the
+    # prompt alone rather than raising.
+    prompt = _diff_prompt("app.py")
+    captured: dict = {}
+    _mock_vertex_sdk(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=None)
+
+    assert captured["contents"] == prompt
 
 
 # --- --ticket threading + telemetry emission (chief-wiggum#134) -------------

--- a/tests/test_kill_review.py
+++ b/tests/test_kill_review.py
@@ -462,8 +462,9 @@ def test_opus_provider_pins_claude_tool_to_opus_model(monkeypatch):
         return "ok", consult_ai.Usage(usage_status="unavailable")
 
     monkeypatch.setitem(consult_ai.TOOLS, "claude", fake_claude)
-    text = consult_ai.consult_provider(opus, "prompt body", None, None)
+    text, usage = consult_ai.consult_provider(opus, "prompt body", None, None)
     assert text == "ok"
+    assert usage.usage_status == "unavailable"
     assert seen["model"] == "claude-opus-4-6"
     # an explicit --model override still wins
     consult_ai.consult_provider(opus, "prompt body", "claude-opus-4-7", None)

--- a/tests/test_provider_quorum.py
+++ b/tests/test_provider_quorum.py
@@ -3,17 +3,32 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
 import providers
-from providers import Provider, Role, RolePlan, run_role_quorum, validate_output
+from providers import (
+    BLIND_PROVIDER_MARGIN,
+    BlindnessReport,
+    Provider,
+    ProviderResult,
+    Role,
+    RolePlan,
+    detect_blind_providers,
+    estimate_prompt_tokens,
+    run_role_quorum,
+    validate_output,
+)
 
 
-def _provider(name: str) -> Provider:
-    return Provider(name=name, type="tool", enabled=True, tool=name)
+def _provider(name: str, *, reads_repo: bool = True) -> Provider:
+    return Provider(name=name, type="tool", enabled=True, tool=name, reads_repo=reads_repo)
 
 
-def _plan(required: list[str], optional: list[str]) -> RolePlan:
-    role = Role(name="reviewer", required=tuple(required), optional=tuple(optional))
+def _plan(required: list[str], optional: list[str], *, requires_repo_read: bool = True) -> RolePlan:
+    role = Role(
+        name="reviewer", required=tuple(required), optional=tuple(optional),
+        requires_repo_read=requires_repo_read,
+    )
     return RolePlan(
         role=role,
         required=tuple(_provider(n) for n in required),
@@ -183,3 +198,220 @@ def test_disabled_provider_absent_from_plan_is_not_run(tmp_path):
     manifest = run_role_quorum(plan, execute, tmp_path)
     assert ran == ["codex"]
     assert manifest.ok is True
+
+
+# --- usage threading (chief-wiggum#319) --------------------------------------
+
+
+@dataclass
+class _FakeUsage:
+    """Duck-typed stand-in for consult_ai.Usage — providers.py never imports
+    it, so a minimal object with the same attributes proves the threading
+    works without pulling consult_ai into this test module."""
+
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    usage_status: str = "provider-json"
+    resolved_model: str | None = None
+
+
+def test_execute_returning_usage_pair_populates_provider_result(tmp_path):
+    def execute(provider):
+        return SUBSTANTIVE, _FakeUsage(tokens_in=500_000, tokens_out=200, resolved_model="gpt-5.5")
+
+    manifest = run_role_quorum(_plan(["codex"], []), execute, tmp_path)
+    result = manifest.results[0]
+    assert result.tokens_in == 500_000
+    assert result.tokens_out == 200
+    assert result.usage_status == "provider-json"
+    assert result.resolved_model == "gpt-5.5"
+
+
+def test_execute_returning_bare_string_leaves_usage_fields_none(tmp_path):
+    # Back-compat: every pre-#319 execute callable (and every test above)
+    # returns a bare string — must keep working, with usage simply absent.
+    manifest = run_role_quorum(_plan(["codex"], []), lambda p: SUBSTANTIVE, tmp_path)
+    result = manifest.results[0]
+    assert result.tokens_in is None
+    assert result.usage_status is None
+
+
+def test_manifest_serializes_usage_fields(tmp_path):
+    def execute(provider):
+        return SUBSTANTIVE, _FakeUsage(tokens_in=1234, tokens_out=56, resolved_model="m")
+
+    run_role_quorum(_plan(["codex"], []), execute, tmp_path)
+    data = json.loads((tmp_path / "reviewer-manifest.json").read_text())
+    assert data["results"][0]["tokens_in"] == 1234
+    assert data["results"][0]["resolved_model"] == "m"
+
+
+# --- blindness detection (chief-wiggum#319) ----------------------------------
+
+
+def test_estimate_prompt_tokens_is_coarse_chars_over_four():
+    assert estimate_prompt_tokens("a" * 400) == 100
+    assert estimate_prompt_tokens("") == 1  # never zero — avoids a divide-by-zero downstream
+
+
+def _result(name, *, tokens_in=None, status="ok", usage_status=None, required=True):
+    return ProviderResult(
+        name=name, required=required, status=status, tokens_in=tokens_in, usage_status=usage_status,
+    )
+
+
+def test_detect_blind_providers_flags_tokens_in_near_prompt_size():
+    role = Role(name="reviewer", required=("gemini-vertex",), optional=(), requires_repo_read=True)
+    providers_by_name = {"gemini-vertex": _provider("gemini-vertex")}
+    results = [_result("gemini-vertex", tokens_in=1400, usage_status="sdk-metadata")]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"gemini-vertex": 1300})
+
+    assert report.outcome == "findings"
+    assert report.applicability == "applicable"
+    assert len(report.findings) == 1
+    assert report.findings[0].kind == "blind"
+    assert report.findings[0].provider == "gemini-vertex"
+    assert "did not read the repo" in report.findings[0].message
+
+
+def test_detect_blind_providers_passes_when_tokens_in_far_exceeds_prompt():
+    # The ticket's own evidence shape: codex ingests ~1M tokens against a
+    # ~1.3k-token prompt — nowhere near the margin, a clean pass.
+    role = Role(name="explorer", required=("codex",), optional=(), requires_repo_read=True)
+    providers_by_name = {"codex": _provider("codex")}
+    results = [_result("codex", tokens_in=1_000_000, usage_status="provider-json")]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"codex": 1300})
+
+    assert report.outcome == "pass"
+    assert report.findings == []
+    assert report.providers_checked == 1
+
+
+def test_detect_blind_providers_unmeasured_is_a_finding_not_a_pass():
+    role = Role(name="reviewer", required=("gemini-vertex",), optional=(), requires_repo_read=True)
+    providers_by_name = {"gemini-vertex": _provider("gemini-vertex")}
+    results = [_result("gemini-vertex", tokens_in=None, usage_status="unavailable")]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"gemini-vertex": 1300})
+
+    assert report.outcome == "findings"
+    assert report.findings[0].kind == "unmeasured"
+    assert "not the same as one measured and fine" in report.findings[0].message
+
+
+def test_detect_blind_providers_inapplicable_when_role_does_not_require_repo_read():
+    role = Role(name="design_critic", required=("gemini-vertex",), optional=(), requires_repo_read=False)
+    providers_by_name = {"gemini-vertex": _provider("gemini-vertex")}
+    # Even a textbook-blind measurement must not surface as a finding — this
+    # role was never asked to read the repo.
+    results = [_result("gemini-vertex", tokens_in=100, usage_status="sdk-metadata")]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"gemini-vertex": 1300})
+
+    assert report.applicability == "inapplicable"
+    assert report.outcome == "inapplicable"
+    assert report.findings == []
+
+
+def test_detect_blind_providers_skips_declared_text_only_providers():
+    # A provider that already told the config it can't read files is not a
+    # silent surprise when it answers from the prompt alone.
+    role = Role(name="some-role", required=("deepseek",), optional=(), requires_repo_read=True)
+    providers_by_name = {"deepseek": _provider("deepseek", reads_repo=False)}
+    results = [_result("deepseek", tokens_in=50, usage_status="provider-json")]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"deepseek": 1300})
+
+    assert report.outcome == "pass"
+    assert report.providers_checked == 0
+
+
+def test_detect_blind_providers_skips_failed_providers():
+    # A failed provider is already visible as a quorum failure — don't double
+    # report it as blind on top.
+    role = Role(name="reviewer", required=("gemini-vertex",), optional=(), requires_repo_read=True)
+    providers_by_name = {"gemini-vertex": _provider("gemini-vertex")}
+    results = [_result("gemini-vertex", tokens_in=None, status="failed", usage_status=None)]
+
+    report = detect_blind_providers(role, providers_by_name, results, {"gemini-vertex": 1300})
+
+    assert report.findings == []
+
+
+def test_blindness_report_serializes_the_four_state_outcome():
+    report = BlindnessReport(role="reviewer", requires_repo_read=False)
+    d = report.to_dict()
+    assert d["applicability"] == "inapplicable"
+    assert d["outcome"] == "inapplicable"
+    assert d["findings"] == []
+
+
+def test_blind_provider_margin_is_generous_but_not_unbounded():
+    # A provider whose tokens_in is exactly at the margin boundary is still
+    # "blind"; comfortably past it is a pass. Documents the constant's intent
+    # rather than pinning an exact magic number elsewhere.
+    assert BLIND_PROVIDER_MARGIN < 5  # nowhere near the ticket's 165:1 gap
+    role = Role(name="reviewer", required=("gemini-vertex",), optional=(), requires_repo_read=True)
+    providers_by_name = {"gemini-vertex": _provider("gemini-vertex")}
+    at_boundary = [_result("gemini-vertex", tokens_in=int(1000 * BLIND_PROVIDER_MARGIN), usage_status="sdk-metadata")]
+    past_boundary = [_result("gemini-vertex", tokens_in=int(1000 * BLIND_PROVIDER_MARGIN) + 1000, usage_status="sdk-metadata")]
+
+    assert detect_blind_providers(role, providers_by_name, at_boundary, {"gemini-vertex": 1000}).outcome == "findings"
+    assert detect_blind_providers(role, providers_by_name, past_boundary, {"gemini-vertex": 1000}).outcome == "pass"
+
+
+def test_run_role_quorum_computes_blindness_when_prompt_is_supplied(tmp_path):
+    role_prompt = "x" * 4000  # estimate_prompt_tokens -> 1000
+
+    def execute(provider):
+        if provider.name == "gemini-vertex":
+            return SUBSTANTIVE, _FakeUsage(tokens_in=1000, usage_status="sdk-metadata")
+        return SUBSTANTIVE, _FakeUsage(tokens_in=900_000, usage_status="provider-json")
+
+    plan = _plan(["codex", "gemini-vertex"], [])
+    manifest = run_role_quorum(plan, execute, tmp_path, prompt=role_prompt)
+
+    assert manifest.blindness is not None
+    assert manifest.blindness.outcome == "findings"
+    assert {f.provider for f in manifest.blindness.findings} == {"gemini-vertex"}
+    # blindness never fails the quorum on its own — it's a report, not a gate.
+    assert manifest.ok is True
+
+    data = json.loads((tmp_path / "reviewer-manifest.json").read_text())
+    assert data["blindness"]["outcome"] == "findings"
+
+
+def test_run_role_quorum_blindness_stays_none_without_prompt(tmp_path):
+    # A caller that doesn't pass ``prompt`` gets the pre-#319 manifest shape
+    # exactly — "didn't ask" must never look identical to "asked and clean".
+    manifest = run_role_quorum(_plan(["codex"], []), lambda p: SUBSTANTIVE, tmp_path)
+    assert manifest.blindness is None
+    data = json.loads((tmp_path / "reviewer-manifest.json").read_text())
+    assert "blindness" not in data
+
+
+def test_shipped_config_declares_reads_repo_and_requires_repo_read():
+    from pathlib import Path as _Path
+
+    config = providers.load_config(_Path(__file__).resolve().parents[1] / "config" / "providers.json")
+    providers_by_name = providers.providers_from_config(config)
+    roles = providers.roles_from_config(config)
+
+    text_only = {"deepseek", "kimi", "glm", "qwen", "minimax"}
+    for name in text_only:
+        assert providers_by_name[name].reads_repo is False, name
+    for name in ("codex", "gemini", "gemini-vertex", "claude", "claude-interactive", "opus"):
+        assert providers_by_name[name].reads_repo is True, name
+
+    for name in ("design_critic", "kill-review", "divergence"):
+        assert roles[name].requires_repo_read is False, name
+    for name in ("explorer", "implementer", "reviewer", "architecture_critic", "risky_diff_review"):
+        assert roles[name].requires_repo_read is True, name
+
+    # The two roles gemini-vertex is REQUIRED on both need repo reading —
+    # exactly the roles chief-wiggum#319's diff-scoped retrieval targets.
+    for role_name in ("reviewer", "risky_diff_review"):
+        assert "gemini-vertex" in roles[role_name].required
+        assert roles[role_name].requires_repo_read is True

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -1034,3 +1035,62 @@ def test_run_review_honors_per_role_optional_timeout_on_review_path(tmp_path, mo
     )
 
     assert captured_timeouts["claude-interactive"] == 42 + 30
+
+
+# --- blindness detection surfaces through the review manifest (chief-wiggum#319) --
+
+
+def test_run_review_surfaces_blind_provider_in_the_manifest(tmp_path, monkeypatch):
+    """A reviewer quorum where every required provider is "ok" must still
+    report, in review-manifest.json, that one of them answered from the
+    prompt alone — the review-pipeline half of chief-wiggum#319."""
+    role = Role(
+        name="reviewer", required=("codex", "gemini-vertex"), optional=(),
+        requires_repo_read=True,
+    )
+    plan = RolePlan(
+        role=role,
+        required=(
+            Provider("codex", "tool", True, tool="codex"),
+            Provider("gemini-vertex", "tool", True, tool="gemini-vertex"),
+        ),
+        optional=(),
+        missing_required=(),
+        skipped_optional=(),
+    )
+    monkeypatch.setattr(review.providers, "plan_role", lambda r, c: plan)
+
+    @dataclass
+    class _Usage:
+        tokens_in: int | None = None
+        tokens_out: int | None = None
+        usage_status: str = "provider-json"
+        resolved_model: str | None = None
+
+    def execute(provider, prompt, timeout_override=None):
+        text = "A substantive review with findings to report here."
+        if provider.name == "gemini-vertex":
+            blind_tokens = len(prompt.strip()) // 4
+            return text, _Usage(tokens_in=blind_tokens, usage_status="sdk-metadata")
+        return text, _Usage(tokens_in=2_000_000, usage_status="provider-json")
+
+    runner = _runner(
+        {
+            "rev-parse --show-toplevel": (0, str(tmp_path)),
+            "rev-parse --verify": (0, "abc"),
+            "diff": (0, "diff --git a b\n+added line"),
+        }
+    )
+
+    manifest = review.run_review(
+        _ticket(), tmp_path, "main", tmp_path / "out",
+        template=TEMPLATE, config={}, execute=execute, runner=runner,
+    )
+
+    assert manifest.ok is True  # blindness never blocks the quorum on its own
+    blindness = manifest.provider_manifest["blindness"]
+    assert blindness["outcome"] == "findings"
+    assert blindness["findings"][0]["provider"] == "gemini-vertex"
+
+    on_disk = json.loads((tmp_path / "out" / "review-manifest.json").read_text())
+    assert on_disk["provider_manifest"]["blindness"]["outcome"] == "findings"


### PR DESCRIPTION
Closes #319

## The bug

`consult_gemini_vertex()` accepted a `cwd` argument and **never used it** — `generate_content(model=..., contents=prompt)`, no file access, no tools, no repo context. It answered every consultation from the prompt text alone.

Measured on three consecutive consults: codex ingests ~1M `tokens_in`; gemini ingests ~1.4k. A **165:1 ratio that reads as efficiency and is blindness.**

`gemini-vertex` is **required** on the `reviewer` role. So `explorer` and `reviewer` were running on one informed voice plus one blind one while reporting a healthy 2-of-2 quorum — a confident, plausible, unfalsifiable signal, which is precisely what `docs/gate-rollout.md` says destroys trust in a gate.

**Independently corroborated in this repo**: in #281's own review, gemini's finding was a false attribution — it flagged pre-existing content as introduced by the PR. I caught it at the time and attributed it to the stale-base bug (#269). Both were true; this was the other half.

## Part A — detection (the part that prevents recurrence)

The quorum reporting "2 of 2" while one voice never opened a file is the #289 shape in the review layer. Now measurable:

- `ProviderResult` carries `tokens_in`/`tokens_out`/`usage_status`/`resolved_model`
- `detect_blind_providers` asserts a floor — a provider whose `tokens_in` is within 1.5× of its *own* prompt's estimated size did not read the repo, **by definition**
- Four-state `BlindnessReport` (`pass | findings | inapplicable | error`), surfaced in `{role}-manifest.json` / `review-manifest.json` and printed to stderr **independently of whether the quorum itself passes**

Two distinct finding kinds, and the second matters as much as the first:

| kind | meaning |
|---|---|
| `blind` | measured, and near prompt size |
| `unmeasured` | usage could not be measured at all — **explicitly not a pass** |

> *"A provider that cannot be measured is not the same as one measured and fine — do not count this voice as confirmed-informed."*

New declared config: `requires_repo_read` per role, `reads_repo` per provider — so a role can state whether it needs a code-reading voice. `design_critic`/`kill-review`/`divergence` are `false`; the OpenRouter-backed models are `reads_repo: false`.

**Verified live across all three states**: blind → `findings`; both informed → `pass`; unmeasurable → `findings` with the distinct kind.

## Part B — Option 1, scoped honestly

`consult_gemini_vertex` extracts touched paths from the `diff --git` headers every review-shaped prompt already embeds, reads each file's current content from `cwd`, and appends it to `contents`. Bounded: 40 files, 60KB/file, path-traversal guarded.

**A diff-less prompt retrieves nothing and behaves exactly as before** — an honest no-op, not a pretended fix. That scoping is deliberate: Option 1 is reliable precisely where gemini is *required* (`reviewer`, `risky_diff_review`), because those roles are diff-bounded rather than open-ended.

Verified independently: sentinel file content reaches `contents` for a diff-bearing prompt; a diff-less prompt retrieves `[]`; `../../etc/passwd` is blocked.

No provider moved between required/optional — Option 3 wasn't needed, because Option 1 works where it counts.

## Found while fixing: a second, different blindness

`design_critic`'s prompt only *names* screenshot files; nothing attaches image bytes. That is image-shaped blindness this fix does not reach, and folding it in would have muddied both. Filed as **#321**.

## Verification

- Full suite: **3026 passed, 14 skipped, 0 failed** (+27 tests)
- All tests offline — the SDK is mocked and assertions are on **what is actually sent**, so no live Vertex credentials are needed and nothing skips into vacuity
- `make lint` clean; no gate script touched, no `scanner_version` moved
- `git status` verified clean before push
