### PR TITLE
fix(consult): design_critic can finally see the screenshots it critiques (#321)

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -114,7 +114,7 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role design_critic "$DESIGN_TMP/criti
 
 Responses land at `$DESIGN_TMP/critique/design_critic-<provider>.md` with status in `design_critic-manifest.json`.
 
-The prompt names the screenshot files (cwd is `$DESIGN_TMP` so the CLIs can open them) and asks for critique against:
+The prompt names the screenshot files (cwd is `$DESIGN_TMP`): a CLI tool provider (codex, claude-interactive) opens them itself via `cwd`; `gemini-vertex` — `design_critic`'s sole required provider — attaches each named image's bytes directly to the request (chief-wiggum#321; a diff-less/text-only role never triggers this and behaves exactly as before). It asks for critique against:
 - **Audience fit**: does this read right for the audience in `docs/domain-context.md`?
 - **Hierarchy**: is the most important thing on each screen visually the most important?
 - **Accessibility**: text contrast (WCAG AA), touch-target size on the mobile shots, focus/state affordances

--- a/config/providers.json
+++ b/config/providers.json
@@ -5,73 +5,84 @@
       "type": "tool",
       "tool": "codex",
       "enabled": true,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "gemini": {
       "type": "tool",
       "tool": "gemini",
       "enabled": false,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "gemini-vertex": {
       "type": "tool",
       "tool": "gemini-vertex",
       "enabled": true,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "claude": {
       "type": "tool",
       "tool": "claude",
       "enabled": false,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "claude-interactive": {
       "type": "delegate",
       "delegate": "claude-interactive",
       "enabled": true,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "opus": {
       "type": "tool",
       "tool": "claude",
       "model": "claude-opus-4-6",
       "enabled": true,
-      "reads_repo": true
+      "reads_repo": true,
+      "accepts_images": true
     },
     "deepseek": {
       "type": "tool",
       "tool": "openrouter",
       "model": "deepseek/deepseek-v4-pro",
       "enabled": true,
-      "reads_repo": false
+      "reads_repo": false,
+      "accepts_images": false
     },
     "kimi": {
       "type": "tool",
       "tool": "openrouter",
       "model": "moonshotai/kimi-k3",
       "enabled": true,
-      "reads_repo": false
+      "reads_repo": false,
+      "accepts_images": false
     },
     "glm": {
       "type": "tool",
       "tool": "openrouter",
       "model": "z-ai/glm-5.2",
       "enabled": true,
-      "reads_repo": false
+      "reads_repo": false,
+      "accepts_images": false
     },
     "qwen": {
       "type": "tool",
       "tool": "openrouter",
       "model": "qwen/qwen3.7-max",
       "enabled": true,
-      "reads_repo": false
+      "reads_repo": false,
+      "accepts_images": false
     },
     "minimax": {
       "type": "tool",
       "tool": "openrouter",
       "model": "minimax/minimax-m3",
       "enabled": true,
-      "reads_repo": false
+      "reads_repo": false,
+      "accepts_images": false
     }
   },
   "roles": {
@@ -137,7 +148,8 @@
         "claude-interactive"
       ],
       "optional_timeout_seconds": 300,
-      "requires_repo_read": false
+      "requires_repo_read": false,
+      "sends_images": true
     },
     "risky_diff_review": {
       "required": [

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -608,6 +608,95 @@ def _read_touched_files(cwd: str | None, paths: list[str]) -> list[str]:
     return blocks
 
 
+# chief-wiggum#321: design_critic sends rendered SCREENSHOTS, not diff text —
+# a different blindness shape than #319's diff-scoped text retrieval above,
+# which never touches image bytes at all. A CLI tool provider with real
+# filesystem access via ``cwd`` (codex, claude-interactive) can already open
+# a named screenshot itself; gemini-vertex's call path is a single
+# non-agentic SDK request with no tool loop, so it needs the bytes handed to
+# it directly. The google-genai SDK's multimodal ``contents`` accepts a list
+# mixing plain text with ``types.Part.from_bytes(data=..., mime_type=...)``
+# image parts (verified against the installed google-genai package) — this
+# reads exactly the image files named in the prompt from ``cwd``, bounded the
+# same way #319 bounds diff-file retrieval: a capped count, a capped
+# per-image byte size, and the same path-traversal guard. A prompt that names
+# no images, or whose named images don't exist under ``cwd``, retrieves
+# nothing and ``contents`` stays exactly what it would have been without
+# this — an honest no-op, not a pretended fix.
+_IMAGE_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+_IMAGE_PATH_RE = re.compile(
+    r"(?<![\w/])((?:[\w.\-]+/)*[\w.\-]+\.(?:png|jpe?g|webp|gif))\b",
+    re.IGNORECASE,
+)
+
+# Bounds mirroring MAX_RETRIEVED_FILES/MAX_RETRIEVED_FILE_BYTES above, sized
+# for images rather than source text: a handful of full-page screenshots per
+# design direction, capped well under Vertex's inline-request ceiling.
+MAX_RETRIEVED_IMAGES = 20
+MAX_RETRIEVED_IMAGE_BYTES = 8_000_000
+
+
+def _image_paths_from_prompt(text: str) -> list[str]:
+    """Extract image-file paths named in ``text`` (a design-critique prompt
+    names the screenshot files it wants critiqued — see ``design.md`` Step
+    4). Deterministic pattern match on a known set of image extensions,
+    deduped in first-seen order — NOT a general file-mention heuristic. A
+    path matched here that doesn't actually exist under ``cwd`` is simply
+    never retrieved (``_read_touched_images`` is best-effort), so a
+    false-positive match (e.g. a filename mentioned inside a URL) is
+    harmless.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for match in _IMAGE_PATH_RE.finditer(text):
+        path = match.group(1)
+        if path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def _read_touched_images(cwd: str | None, paths: list[str]) -> list[tuple[str, bytes, str]]:
+    """Read each named image's bytes + MIME type from ``cwd``, best-effort.
+
+    Mirrors ``_read_touched_files``'s discipline: a path that doesn't exist,
+    isn't readable, resolves outside ``cwd``, has an unrecognized extension,
+    or is over the per-image byte cap is skipped, never raised — a
+    retrieval gap degrades to fewer attached images, never fails the whole
+    consult. An oversized image is DROPPED rather than truncated (unlike the
+    text-file path): truncating binary image bytes would produce corrupt,
+    undecodable image data, not merely a shorter one.
+    """
+    if not cwd:
+        return []
+    base = Path(cwd).resolve()
+    images: list[tuple[str, bytes, str]] = []
+    for rel in paths[:MAX_RETRIEVED_IMAGES]:
+        candidate = (base / rel).resolve()
+        try:
+            candidate.relative_to(base)
+        except ValueError:
+            continue  # path escapes cwd — never follow it
+        mime = _IMAGE_MIME_TYPES.get(candidate.suffix.lower())
+        if mime is None:
+            continue
+        try:
+            data = candidate.read_bytes()
+        except OSError:
+            continue
+        if len(data) > MAX_RETRIEVED_IMAGE_BYTES:
+            continue
+        images.append((rel, data, mime))
+    return images
+
+
 def consult_gemini_vertex(
     prompt: str, model: str | None = None, cwd: str | None = None, timeout: int | None = None,
 ) -> tuple[str, Usage]:
@@ -632,6 +721,16 @@ def consult_gemini_vertex(
     carrying no diff (e.g. an open-ended exploration prompt) retrieves
     nothing and this behaves exactly as before — an honest no-op, not a
     pretended fix.
+
+    chief-wiggum#321: the same call had NO image-attachment path at all —
+    ``design_critic`` sends this adapter rendered screenshots and it never
+    saw a single pixel, only the filenames a text prompt happened to name.
+    It now also reads every image file the prompt names (see
+    ``_image_paths_from_prompt``) from ``cwd`` and attaches each as an inline
+    ``types.Part.from_bytes`` image part alongside the text. A prompt naming
+    no images (every non-``design_critic`` role today) retrieves nothing and
+    ``contents`` is unaffected — this is additive to, and independent of,
+    the diff-file retrieval above.
     """
     project = get_secret("GOOGLE_CLOUD_PROJECT")
     location = get_secret("GOOGLE_CLOUD_LOCATION") or "global"
@@ -661,6 +760,18 @@ def consult_gemini_vertex(
         )
     else:
         contents = prompt
+
+    image_paths = _image_paths_from_prompt(prompt)
+    images = _read_touched_images(cwd, image_paths)
+    if images:
+        # Deferred import, mirroring the ``genai`` import above: only needed
+        # on this path, so a caller that never sends images never needs the
+        # submodule to resolve — the honest-no-op path picks up no new
+        # import requirement.
+        from google.genai import types  # type: ignore
+        contents = [contents] + [
+            types.Part.from_bytes(data=data, mime_type=mime) for _rel, data, mime in images
+        ]
 
     response = client.models.generate_content(model=requested_model, contents=contents)
     text = response.text or ""
@@ -1202,6 +1313,13 @@ def main():
         # regardless of whether the overall quorum passes.
         if manifest.blindness is not None:
             for finding in manifest.blindness.findings:
+                print(f"Warning: {finding.message}", file=sys.stderr)
+        # chief-wiggum#321: the image-shaped sibling of the above — a role
+        # that sends images composed with a provider that can't receive
+        # them. Structural, so this is populated even when ``manifest.blindness``
+        # is None (no ``prompt`` was passed for the token-floor check).
+        if manifest.image_blindness is not None:
+            for finding in manifest.image_blindness.findings:
                 print(f"Warning: {finding.message}", file=sys.stderr)
         if not manifest.ok:
             print(

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -47,6 +47,18 @@ class Provider:
     # here rather than inferred, so a role can tell a code-reading provider
     # from a text-only one without re-deriving it from behavior.
     reads_repo: bool = True
+    # Can this provider's call path ever RECEIVE image bytes (chief-wiggum#321)?
+    # True for every CLI/delegate that has real filesystem access via ``cwd``
+    # and can open a named screenshot itself (codex, gemini CLI, claude,
+    # claude-interactive) and for ``gemini-vertex``, which now attaches image
+    # parts directly to the SDK request for any prompt that names images
+    # under ``cwd`` (see ``consult_ai._read_touched_images``). False for a
+    # provider whose ENTIRE call path is a plain text completion with no
+    # attachment mechanism at all (the openrouter-backed models) — declared
+    # explicitly, mirroring ``reads_repo``, so a role that SENDS images can
+    # tell an image-capable provider from a text-only one without waiting to
+    # observe a suspiciously text-only critique.
+    accepts_images: bool = True
 
 
 @dataclass(frozen=True)
@@ -80,6 +92,18 @@ class Role:
     # that never needed repo-reading is never reported as if a provider
     # failed it.
     requires_repo_read: bool = True
+    # Does this role's job send IMAGE bytes to its providers (chief-wiggum#321)?
+    # True only for ``design_critic`` (sends rendered screenshots to critique).
+    # This is deliberately a SEPARATE axis from ``requires_repo_read`` —
+    # ``design_critic`` is correctly ``requires_repo_read=False`` (it was
+    # never asking a provider to read the repo), which is exactly why #319's
+    # ``detect_blind_providers`` cannot see this role's blindness: it never
+    # sends a diff, so there is nothing repo-shaped to be blind to. The
+    # blindness here is image-shaped — a required provider with no
+    # image-attachment path critiquing a written description of screenshots
+    # it never saw. Declared per role, checked against each provider's
+    # ``accepts_images`` by ``detect_image_blind_providers``.
+    sends_images: bool = False
 
 
 @dataclass(frozen=True)
@@ -162,6 +186,7 @@ def providers_from_config(config: dict[str, Any]) -> dict[str, Provider]:
             delegate=raw.get("delegate"),
             model=raw.get("model"),
             reads_repo=bool(raw.get("reads_repo", True)),
+            accepts_images=bool(raw.get("accepts_images", True)),
         )
     return providers
 
@@ -176,6 +201,7 @@ def roles_from_config(config: dict[str, Any]) -> dict[str, Role]:
             lenses=dict(raw.get("lenses", {})),
             optional_timeout_seconds=raw.get("optional_timeout_seconds"),
             requires_repo_read=bool(raw.get("requires_repo_read", True)),
+            sends_images=bool(raw.get("sends_images", False)),
         )
     return roles
 
@@ -541,6 +567,124 @@ def detect_blind_providers(
 
 
 @dataclass
+class ImageBlindnessFinding:
+    """One provider composed into an image-sending role despite being
+    declared unable to receive images (chief-wiggum#321)."""
+
+    provider: str
+    required: bool
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ImageBlindnessReport:
+    """chief-wiggum#321: does every provider a role SENDS IMAGES to actually
+    declare that it can receive them? The same four-state gate vocabulary as
+    ``BlindnessReport`` (chief-wiggum#289): ``pass`` / ``findings`` /
+    ``inapplicable`` / ``error``. A report, never a gate — attached to the
+    quorum manifest alongside the repo-read ``BlindnessReport``, and computed
+    unconditionally (it needs no ``prompt``, unlike ``BlindnessReport``,
+    because it is a structural declaration check, not a per-call
+    measurement — see ``detect_image_blind_providers``).
+    """
+
+    role: str
+    sends_images: bool
+    findings: list[ImageBlindnessFinding] = field(default_factory=list)
+    providers_checked: int = 0
+    error: str | None = None
+
+    @property
+    def applicability(self) -> str:
+        if self.error:
+            return "error"
+        if not self.sends_images:
+            return "inapplicable"
+        return "applicable"
+
+    @property
+    def outcome(self) -> str:
+        """The standard four-state gate outcome (#289): pass | findings |
+        inapplicable | error. Derived, never stored."""
+        if self.applicability in ("error", "inapplicable"):
+            return self.applicability
+        return "findings" if self.findings else "pass"
+
+    def to_dict(self) -> dict:
+        return {
+            "role": self.role,
+            "sends_images": self.sends_images,
+            "applicability": self.applicability,
+            "outcome": self.outcome,
+            "providers_checked": self.providers_checked,
+            "error": self.error,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+def detect_image_blind_providers(
+    role: Role,
+    providers_by_name: dict[str, Provider],
+) -> ImageBlindnessReport:
+    """chief-wiggum#321: catch a role that SENDS images (``design_critic``
+    critiques rendered screenshots) composed with a required or optional
+    provider declared unable to RECEIVE images (``provider.accepts_images``
+    is ``False``) — the blindness shape #319's ``detect_blind_providers``
+    cannot see, because that check keys on ``requires_repo_read``/
+    ``reads_repo`` (a repo-reading gap), and ``design_critic`` is correctly
+    ``requires_repo_read=False``: it was never asking a provider to read the
+    repo, so nothing there is anomalous. The gap is a different axis
+    entirely — images, not repo access.
+
+    Unlike ``detect_blind_providers``, this is a STRUCTURAL/declaration
+    check, not a per-call measurement: whether a provider's call path can
+    receive image bytes at all is a fixed property of that call path (an
+    attachment mechanism either exists in the adapter or it doesn't), not
+    something that varies call to call. That means the defect this catches
+    — a role sending images to a provider wired to only ever see text — is
+    checkable from config alone, BEFORE any provider ever runs, which is
+    the whole point: the next role that sends images must be caught by
+    declaring it correctly, not by noticing after the fact that a critique
+    read suspiciously text-only (the ticket's own note that a token-floor
+    check can look "large enough" while carrying zero image content).
+
+    ``role.sends_images is False`` (every shipped role except
+    ``design_critic``) is ``inapplicable`` — a role that never sends images
+    was never asking a provider to look at one.
+    """
+    if not role.sends_images:
+        return ImageBlindnessReport(role=role.name, sends_images=False)
+
+    findings: list[ImageBlindnessFinding] = []
+    checked = 0
+    for name in list(role.required) + list(role.optional):
+        provider = providers_by_name.get(name)
+        if provider is None:
+            continue  # not enabled/available — a plan gap visible elsewhere
+        checked += 1
+        if provider.accepts_images:
+            continue
+        required = name in role.required
+        findings.append(ImageBlindnessFinding(
+            provider=name,
+            required=required,
+            message=(
+                f"{name} is a {'required' if required else 'optional'} provider "
+                f"of role {role.name!r}, which sends images, but {name} is "
+                "declared unable to accept images (provider.accepts_images="
+                "False) — it critiques a written description of the images, "
+                "never the rendered pixels (chief-wiggum#321)."
+            ),
+        ))
+    return ImageBlindnessReport(
+        role=role.name, sends_images=True, findings=findings, providers_checked=checked
+    )
+
+
+@dataclass
 class QuorumManifest:
     role: str
     results: list[ProviderResult] = field(default_factory=list)
@@ -548,6 +692,11 @@ class QuorumManifest:
     # passed to ``run_role_quorum``) — distinct from a check that RAN and
     # found nothing (chief-wiggum#319).
     blindness: BlindnessReport | None = None
+    # chief-wiggum#321: unlike ``blindness``, this needs no ``prompt`` (it's a
+    # static declaration check — see ``detect_image_blind_providers``), so it
+    # is always computed once there is at least one task to check. ``None``
+    # only when the plan had no tasks at all.
+    image_blindness: ImageBlindnessReport | None = None
 
     @property
     def ok(self) -> bool:
@@ -567,6 +716,8 @@ class QuorumManifest:
         }
         if self.blindness is not None:
             d["blindness"] = self.blindness.to_dict()
+        if self.image_blindness is not None:
+            d["image_blindness"] = self.image_blindness.to_dict()
         return d
 
 
@@ -696,9 +847,20 @@ def run_role_quorum(
     results.sort(key=lambda r: order.get(r.name, 1_000))
     manifest = QuorumManifest(plan.role.name, results)
 
+    providers_by_name = {p.name: p for p, _ in tasks}
+
+    # chief-wiggum#321: structural, needs no ``prompt`` — computed every run,
+    # unlike the token-floor ``blindness`` check below.
+    try:
+        manifest.image_blindness = detect_image_blind_providers(plan.role, providers_by_name)
+    except Exception as exc:  # noqa: BLE001 - the check itself must never break the quorum
+        manifest.image_blindness = ImageBlindnessReport(
+            role=plan.role.name, sends_images=plan.role.sends_images,
+            error=f"image blindness check failed: {exc}",
+        )
+
     if prompt is not None:
         try:
-            providers_by_name = {p.name: p for p, _ in tasks}
             prompt_tokens_by_provider = {
                 name: estimate_prompt_tokens(
                     prompt_for_provider(plan.role, name, prompt, lenses or {})

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -1439,6 +1439,201 @@ def test_consult_gemini_vertex_skips_retrieval_without_a_cwd(monkeypatch):
     assert captured["contents"] == prompt
 
 
+# --- chief-wiggum#321: design_critic's screenshots reach gemini-vertex as ---
+# --- real image bytes, not just filenames --------------------------------
+#
+# design_critic sends the SAME prompt every provider gets, but only NAMES the
+# screenshot files — a CLI tool provider with real filesystem access via cwd
+# can already open them itself (codex, claude-interactive); gemini-vertex's
+# call path is a single non-agentic SDK request with no tool loop, so before
+# this fix it never saw a single pixel. These tests assert on what is
+# actually SENT to the mocked SDK — the multimodal ``contents`` list must
+# carry real image Part objects with the real bytes, never a placeholder —
+# and that a prompt naming no images is an honest no-op, exactly like #319's
+# diff-less case.
+
+
+class _FakePart:
+    """Stand-in for ``google.genai.types.Part`` — records exactly what
+    ``from_bytes`` was called with so a test can assert on it without a real
+    SDK type."""
+
+    def __init__(self, data: bytes, mime_type: str):
+        self.data = data
+        self.mime_type = mime_type
+
+    @classmethod
+    def from_bytes(cls, *, data: bytes, mime_type: str) -> "_FakePart":
+        return cls(data, mime_type)
+
+
+def _mock_vertex_sdk_with_types(monkeypatch, captured: dict):
+    """Like ``_mock_vertex_sdk``, but the faked ``google.genai`` module also
+    exposes a ``types`` submodule with a fake ``Part.from_bytes`` — needed
+    only when a test expects the image-attachment path (``from google.genai
+    import types``) to actually resolve."""
+    project_secret = {"GOOGLE_CLOUD_PROJECT": "proj", "GOOGLE_CLOUD_LOCATION": "global"}
+    monkeypatch.setattr(consult_ai, "get_secret", lambda name: project_secret.get(name))
+
+    class _FakeModels:
+        def generate_content(self, model, contents):
+            captured["model"] = model
+            captured["contents"] = contents
+            resp = _FakeVertexResponse(
+                usage_metadata=_FakeUsageMetadata(prompt_token_count=1, candidates_token_count=1),
+                model_version=model,
+            )
+            resp.text = "a response"
+            return resp
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            self.models = _FakeModels()
+
+    fake_types = type("fake_types_module", (), {"Part": _FakePart})
+    fake_genai = type("fake_genai_module", (), {"Client": _FakeClient, "types": fake_types})
+    monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google", type("fake_google_module", (), {"genai": fake_genai}))
+
+
+def test_image_paths_from_prompt_extracts_and_dedupes_named_screenshots():
+    text = (
+        "Critique these screenshots:\n"
+        "- calm-home.png\n"
+        "- calm-home.png\n"  # duplicate
+        "- directions/bold/pricing.jpg\n"
+        "Also see reference.PNG for the brand kit.\n"
+    )
+    assert consult_ai._image_paths_from_prompt(text) == [
+        "calm-home.png", "directions/bold/pricing.jpg", "reference.PNG",
+    ]
+
+
+def test_image_paths_from_prompt_returns_empty_for_an_image_less_prompt():
+    assert consult_ai._image_paths_from_prompt("Review this diff for correctness.") == []
+
+
+def test_read_touched_images_reads_bytes_and_mime_from_cwd(tmp_path):
+    png_bytes = b"\x89PNG\r\n\x1a\nSENTINEL_PIXELS"
+    (tmp_path / "shot.png").write_bytes(png_bytes)
+
+    images = consult_ai._read_touched_images(str(tmp_path), ["shot.png"])
+
+    assert images == [("shot.png", png_bytes, "image/png")]
+
+
+def test_read_touched_images_skips_missing_file_without_raising(tmp_path):
+    images = consult_ai._read_touched_images(str(tmp_path), ["never/existed.png"])
+    assert images == []
+
+
+def test_read_touched_images_never_follows_a_path_that_escapes_cwd(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside_secret.png").write_bytes(b"secret pixels")
+
+    images = consult_ai._read_touched_images(str(repo), ["../outside_secret.png"])
+
+    assert images == []
+
+
+def test_read_touched_images_drops_an_oversized_image_rather_than_truncating(tmp_path):
+    big = b"\x00" * (consult_ai.MAX_RETRIEVED_IMAGE_BYTES + 1)
+    (tmp_path / "huge.png").write_bytes(big)
+
+    images = consult_ai._read_touched_images(str(tmp_path), ["huge.png"])
+
+    assert images == []
+
+
+def test_read_touched_images_caps_the_number_of_images_retrieved(tmp_path):
+    paths = []
+    for i in range(consult_ai.MAX_RETRIEVED_IMAGES + 10):
+        name = f"shot{i}.png"
+        (tmp_path / name).write_bytes(b"x")
+        paths.append(name)
+
+    images = consult_ai._read_touched_images(str(tmp_path), paths)
+
+    assert len(images) == consult_ai.MAX_RETRIEVED_IMAGES
+
+
+def test_read_touched_images_ignores_a_non_image_extension(tmp_path):
+    (tmp_path / "notes.txt") .write_bytes(b"not an image")
+    images = consult_ai._read_touched_images(str(tmp_path), ["notes.txt"])
+    assert images == []
+
+
+def test_consult_gemini_vertex_attaches_real_image_bytes_for_a_prompt_naming_screenshots(tmp_path, monkeypatch):
+    # @cw-trace verifies CTR-fh-010
+    png_bytes = b"\x89PNG\r\n\x1a\nSENTINEL_PIXELS_XYZ"
+    (tmp_path / "calm-home.png").write_bytes(png_bytes)
+    prompt = "Critique this screenshot against WCAG AA: calm-home.png"
+    captured: dict = {}
+    _mock_vertex_sdk_with_types(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    # contents must be a multimodal list: the text, plus a real image part
+    # carrying the ACTUAL bytes read from disk — never a filename-only stub.
+    contents = captured["contents"]
+    assert isinstance(contents, list)
+    assert contents[0] == prompt
+    image_parts = [p for p in contents[1:] if isinstance(p, _FakePart)]
+    assert len(image_parts) == 1
+    assert image_parts[0].data == png_bytes
+    assert image_parts[0].mime_type == "image/png"
+
+
+def test_consult_gemini_vertex_image_attachment_is_an_honest_noop_without_named_images(tmp_path, monkeypatch):
+    # A prompt naming no images (every non-design_critic role today) must
+    # behave EXACTLY as before this ticket — contents stays the plain prompt
+    # string, never a list, even though cwd has real image files sitting
+    # right there.
+    (tmp_path / "unrelated.png").write_bytes(b"must not leak in")
+    prompt = "Review this diff for correctness.\n\ndiff --git a/x.py b/x.py\n+y"
+    captured: dict = {}
+    _mock_vertex_sdk(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    assert not isinstance(captured["contents"], list)
+
+
+def test_consult_gemini_vertex_image_attachment_noop_when_named_file_does_not_exist(tmp_path, monkeypatch):
+    # The prompt names a screenshot, but it isn't actually sitting under cwd
+    # (e.g. a stale reference) — best-effort retrieval finds nothing to
+    # attach, so contents stays the prompt alone rather than guessing.
+    prompt = "Critique this screenshot: missing.png"
+    captured: dict = {}
+    _mock_vertex_sdk(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    assert captured["contents"] == prompt
+
+
+def test_consult_gemini_vertex_combines_diff_text_retrieval_and_image_retrieval(tmp_path, monkeypatch):
+    # The two retrieval paths (#319's diff-file text, #321's images) are
+    # independent and additive — a prompt that happens to carry both a diff
+    # header and an image filename gets both kinds of grounding.
+    (tmp_path / "app.py").write_text("SENTINEL_REPO_CONTENT_ABC123")
+    png_bytes = b"\x89PNG\r\nSENTINEL_PIXELS"
+    (tmp_path / "shot.png").write_bytes(png_bytes)
+    prompt = _diff_prompt("app.py") + "\nAlso see shot.png for the rendered result."
+    captured: dict = {}
+    _mock_vertex_sdk_with_types(monkeypatch, captured)
+
+    consult_ai.consult_gemini_vertex(prompt, cwd=str(tmp_path))
+
+    contents = captured["contents"]
+    assert isinstance(contents, list)
+    assert "SENTINEL_REPO_CONTENT_ABC123" in contents[0]
+    image_parts = [p for p in contents[1:] if isinstance(p, _FakePart)]
+    assert len(image_parts) == 1
+    assert image_parts[0].data == png_bytes
+
+
 # --- --ticket threading + telemetry emission (chief-wiggum#134) -------------
 
 

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -1463,7 +1463,7 @@ class _FakePart:
         self.mime_type = mime_type
 
     @classmethod
-    def from_bytes(cls, *, data: bytes, mime_type: str) -> "_FakePart":
+    def from_bytes(cls, *, data: bytes, mime_type: str) -> _FakePart:
         return cls(data, mime_type)
 
 

--- a/tests/test_provider_quorum.py
+++ b/tests/test_provider_quorum.py
@@ -9,19 +9,24 @@ import providers
 from providers import (
     BLIND_PROVIDER_MARGIN,
     BlindnessReport,
+    ImageBlindnessReport,
     Provider,
     ProviderResult,
     Role,
     RolePlan,
     detect_blind_providers,
+    detect_image_blind_providers,
     estimate_prompt_tokens,
     run_role_quorum,
     validate_output,
 )
 
 
-def _provider(name: str, *, reads_repo: bool = True) -> Provider:
-    return Provider(name=name, type="tool", enabled=True, tool=name, reads_repo=reads_repo)
+def _provider(name: str, *, reads_repo: bool = True, accepts_images: bool = True) -> Provider:
+    return Provider(
+        name=name, type="tool", enabled=True, tool=name,
+        reads_repo=reads_repo, accepts_images=accepts_images,
+    )
 
 
 def _plan(required: list[str], optional: list[str], *, requires_repo_read: bool = True) -> RolePlan:
@@ -415,3 +420,143 @@ def test_shipped_config_declares_reads_repo_and_requires_repo_read():
     for role_name in ("reviewer", "risky_diff_review"):
         assert "gemini-vertex" in roles[role_name].required
         assert roles[role_name].requires_repo_read is True
+
+
+# --- chief-wiggum#321: image-shaped blindness detection ---------------------
+
+
+def test_detect_image_blind_providers_inapplicable_when_role_never_sends_images():
+    role = Role(name="reviewer", required=("codex",), optional=(), sends_images=False)
+    providers_by_name = {"codex": _provider("codex")}
+
+    report = detect_image_blind_providers(role, providers_by_name)
+
+    assert report.outcome == "inapplicable"
+    assert report.findings == []
+
+
+def test_detect_image_blind_providers_flags_a_required_provider_that_cannot_accept_images():
+    # Reproduces #321's exact defect: design_critic's ONLY required provider
+    # is declared unable to receive images.
+    role = Role(
+        name="design_critic", required=("gemini-vertex",),
+        optional=("codex",), sends_images=True,
+    )
+    providers_by_name = {
+        "gemini-vertex": _provider("gemini-vertex", accepts_images=False),
+        "codex": _provider("codex", accepts_images=True),
+    }
+
+    report = detect_image_blind_providers(role, providers_by_name)
+
+    assert report.outcome == "findings"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.provider == "gemini-vertex"
+    assert finding.required is True
+    assert "gemini-vertex" in finding.message
+    assert "design_critic" in finding.message
+
+
+def test_detect_image_blind_providers_flags_an_optional_provider_too():
+    role = Role(
+        name="design_critic", required=("gemini-vertex",),
+        optional=("deepseek",), sends_images=True,
+    )
+    providers_by_name = {
+        "gemini-vertex": _provider("gemini-vertex", accepts_images=True),
+        "deepseek": _provider("deepseek", accepts_images=False),
+    }
+
+    report = detect_image_blind_providers(role, providers_by_name)
+
+    assert report.outcome == "findings"
+    assert report.findings[0].provider == "deepseek"
+    assert report.findings[0].required is False
+
+
+def test_detect_image_blind_providers_passes_when_every_provider_accepts_images():
+    role = Role(
+        name="design_critic", required=("gemini-vertex",),
+        optional=("codex",), sends_images=True,
+    )
+    providers_by_name = {
+        "gemini-vertex": _provider("gemini-vertex", accepts_images=True),
+        "codex": _provider("codex", accepts_images=True),
+    }
+
+    report = detect_image_blind_providers(role, providers_by_name)
+
+    assert report.outcome == "pass"
+    assert report.findings == []
+    assert report.providers_checked == 2
+
+
+def test_image_blindness_report_serializes_the_four_state_outcome():
+    report = ImageBlindnessReport(role="reviewer", sends_images=False)
+    d = report.to_dict()
+    assert d["applicability"] == "inapplicable"
+    assert d["outcome"] == "inapplicable"
+    assert d["findings"] == []
+
+
+def test_run_role_quorum_computes_image_blindness_without_needing_a_prompt(tmp_path):
+    # Unlike ``blindness`` (needs ``prompt`` for the token-floor estimate),
+    # image_blindness is a static declaration check — always populated.
+    role = Role(
+        name="design_critic", required=("gemini-vertex",),
+        optional=(), sends_images=True,
+    )
+    plan = RolePlan(
+        role=role,
+        required=(_provider("gemini-vertex", accepts_images=False),),
+        optional=(),
+        missing_required=(),
+        skipped_optional=(),
+    )
+
+    manifest = run_role_quorum(plan, lambda p: SUBSTANTIVE, tmp_path)
+
+    assert manifest.blindness is None  # no prompt was passed
+    assert manifest.image_blindness is not None
+    assert manifest.image_blindness.outcome == "findings"
+    assert manifest.image_blindness.findings[0].provider == "gemini-vertex"
+
+    data = json.loads((tmp_path / "design_critic-manifest.json").read_text())
+    assert data["image_blindness"]["outcome"] == "findings"
+    assert "blindness" not in data
+
+
+def test_run_role_quorum_image_blindness_inapplicable_for_a_non_image_role(tmp_path):
+    manifest = run_role_quorum(_plan(["codex"], []), lambda p: SUBSTANTIVE, tmp_path)
+    assert manifest.image_blindness is not None
+    assert manifest.image_blindness.outcome == "inapplicable"
+
+
+def test_shipped_config_declares_accepts_images_and_sends_images():
+    from pathlib import Path as _Path
+
+    config = providers.load_config(_Path(__file__).resolve().parents[1] / "config" / "providers.json")
+    providers_by_name = providers.providers_from_config(config)
+    roles = providers.roles_from_config(config)
+
+    text_only = {"deepseek", "kimi", "glm", "qwen", "minimax"}
+    for name in text_only:
+        assert providers_by_name[name].accepts_images is False, name
+    for name in ("codex", "gemini", "gemini-vertex", "claude", "claude-interactive", "opus"):
+        assert providers_by_name[name].accepts_images is True, name
+
+    assert roles["design_critic"].sends_images is True
+    for name in roles:
+        if name != "design_critic":
+            assert roles[name].sends_images is False, name
+
+    # The defect #321 fixes: design_critic's sole required provider must
+    # accept images now that it declares sends_images=True.
+    for name in roles["design_critic"].required:
+        assert providers_by_name[name].accepts_images is True, name
+
+    # And the structural check must actually pass on the shipped config —
+    # not just "the fields exist", but "the fields are consistent".
+    report = detect_image_blind_providers(roles["design_critic"], providers_by_name)
+    assert report.outcome == "pass"


### PR DESCRIPTION
Closes #321

Found while implementing #319. That fix gave `gemini-vertex` real repo access for **code-review** roles by attaching the diff's touched files. `design_critic` has a different blindness shape — **images, not text**.

## Worse than #319's case

`design_critic` sends screenshots to a quorum, but the prompt only *names* the PNG files. A CLI tool provider (codex, claude-interactive) can open them itself via `cwd`. `consult_gemini_vertex` is a single SDK `generate_content` call with no image-attachment path at all — and #319's retrieval doesn't reach it, being diff-scoped: it reads text files named in a unified-diff header, never arbitrary named files, never image bytes.

**`gemini-vertex` is the ONLY required provider on `design_critic`.** So the design-critique quorum was entirely blind to the design it exists to critique. In #319's case there was at least one informed voice; here there was none.

## The fix

`_image_paths_from_prompt` + `_read_touched_images` attach real `types.Part.from_bytes(...)` inline image parts alongside the text — the actual Vertex multimodal shape, verified against the installed `google-genai==1.65.0`. Bounded at 20 images / 8MB each, path-traversal guarded, same discipline as #319's text retrieval.

A prompt naming no images, or naming a file absent from `cwd`, leaves `contents` as the plain prompt string — an **honest no-op**, not a pretended fix.

Verified independently: sentinel bytes and the correct MIME type reach the attachment path; no-image prompts retrieve nothing; `../../etc/hosts.png` is blocked.

## The recurrence guard is structural, not measured

#319's `detect_blind_providers` keys on `requires_repo_read`/`reads_repo` — and `design_critic` is correctly `requires_repo_read: false`, so it **structurally could not see this**. A second blindness shape needed a second check.

New `Role.sends_images` / `Provider.accepts_images` + `detect_image_blind_providers`. Unlike the token-floor check, this needs **no measured call** — a role that sends images to a provider that cannot receive them is detectable from config alone, before anything runs. Same `pass | findings | inapplicable | error` vocabulary, computed unconditionally in `run_role_quorum`, surfaced in the manifest and as warnings.

Verified both directions: `pass` on the shipped config (because the real fix made gemini image-capable), `findings` the moment a text-only provider is required by an image-sending role.

Every provider now declares `accepts_images` — `false` for the OpenRouter-backed text-only models, matching the `reads_repo` split.

## Role composition unchanged

The honest fallback (dropping `gemini-vertex` from `design_critic.required`) was **not needed** — making it image-capable was achievable, so the sole-required-provider arrangement now works rather than merely appearing to.

Also corrected a line in `design.md` Step 4 that claimed "the CLIs can open them" for all providers; it now describes gemini-vertex's actual attachment path.

## Verification

- Full suite: **3131 passed, 14 skipped, 0 failed** (+20 tests)
- All offline — the SDK is mocked with a fake `types.Part` that records exactly what bytes and MIME type it received, so the assertion is on **what is actually sent**, not on a placeholder. No live Vertex credentials needed.
- `make lint` clean; no `scanner_version` moved
- `git status` verified clean before push
