### PR TITLE
perf(workflows): reuse provably-fresh artifacts instead of re-running (#334, #324, #323)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -67,7 +67,9 @@ python3 "$CW_HOME/scripts/close_epic_audit.py" \
   --output-dir "$CW_TMP/close-epic"
 ```
 
-Steps 2 (traceability), 2b (transition map), 2c (unresolved), 4 (mutation tooling), 7, and 11 **consume `$CW_TMP/close-epic/close-epic-manifest.json`** rather than recomputing — the exploratory parts (cross-surface consistency, UX flow, retrospective) still launch agents, but the audit state is structured. A `blocked: true` manifest is a workflow-level stop: resolve the failure before closing.
+Steps 2 (traceability), 2b (transition map), 2c (unresolved), **3 (integration tests, #323)**, 4 (mutation tooling), 7, and 11 **consume `$CW_TMP/close-epic/close-epic-manifest.json`** rather than recomputing — the exploratory parts (cross-surface consistency, UX flow, retrospective) still launch agents, but the audit state is structured. A `blocked: true` manifest is a workflow-level stop: resolve the failure before closing.
+
+The manifest carries `target_sha` — the target repo's HEAD at the moment this audit ran. Steps 2b/2c/3 below reuse the manifest's fields ONLY while `target_sha` still matches the current `$TARGET_REPO` HEAD (`git -C "$TARGET_REPO" rev-parse HEAD`) — provably the same state, nothing observed since could have changed. A step running AFTER a mutation (Step 2f's ratchet-journal commit in embedded mode is the one that can move HEAD mid-close) is not looking at stale data by accident: the sha mismatch is the signal to fall back to that step's own standalone recomputation, never to silently trust an old manifest.
 
 ### Step 2: Traceability audit
 
@@ -100,10 +102,23 @@ Report:
 
 ### Step 2b: Transition-map audit
 
-If `$EPIC_DIR/models/state-machines.json` exists, run a full transition-map verification:
+If `$EPIC_DIR/models/state-machines.json` exists, Step 1b's audit already ran this exact scan (same `$TARGET_REPO`, same model file, zero intervening writes at this point in the flow) and recorded the result in the manifest's `.transitions`. Reuse it when the manifest is still fresh (`target_sha` matches current HEAD — #323); re-run only when it isn't:
 
 ```bash
-python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$EPIC_DIR/models/state-machines.json" --output "$CW_TMP/transition-map-final.json" --format text
+MANIFEST="$CW_TMP/close-epic/close-epic-manifest.json"
+if [ "$(git -C "$TARGET_REPO" rev-parse HEAD)" = "$(jq -r .target_sha "$MANIFEST")" ]; then
+  jq '.transitions' "$MANIFEST" > "$CW_TMP/transition-map-final.json"
+else
+  # HEAD moved since Step 1b (the manifest no longer describes the current
+  # tree) — this is the ONLY case that re-runs the scan.
+  python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$EPIC_DIR/models/state-machines.json" \
+    --output "$CW_TMP/transition-map-final.json" --format json > /dev/null
+fi
+jq -r '.outcome as $o | .summary as $s |
+  "outcome: \($o) — \($s.covered)/\($s.total_model_transitions) covered, \($s.missing) missing, \($s.undocumented) undocumented",
+  (.entities[] | .name as $e | (.transitions[] | select(.status=="missing") | "MISSING  \($e): \(.from) -> \(.to) (\(.event))"),
+    ((.undocumented // []) | .[] | "UNDOCUMENTED  \($e): \(.from // "?") -> \(.to)"))' \
+  "$CW_TMP/transition-map-final.json"
 ```
 
 Report:
@@ -128,36 +143,45 @@ Findings feed into Step 9 (multi-AI analysis) and the final report.
 
 ### Step 2c: Unresolved-unknowns audit
 
-No epic closes with open unknowns in its artifacts:
+No epic closes with open unknowns in its artifacts. Step 1b's audit already scanned `$EPIC_DIR` for these markers into the manifest's `.unresolved`/`.blocked_tickets` — reuse it while the manifest is still fresh (same `target_sha` check as 2b); the standalone scan is the fallback, not the default:
 
 ```bash
-python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format text
+MANIFEST="$CW_TMP/close-epic/close-epic-manifest.json"
+if [ "$(git -C "$TARGET_REPO" rev-parse HEAD)" = "$(jq -r .target_sha "$MANIFEST")" ]; then
+  jq -r '.unresolved[] | "\(.file):\(.location) [\(.marker)] \(.text)  blocks: \(.tickets | join(", "))"' "$MANIFEST"
+else
+  python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format text
+fi
 ```
 
 Any surviving `TBD:`/`UNRESOLVED:`/`PLACEHOLDER` marker is a finding: either the fact was resolved during implementation (update the artifact with the real value and a citation) or it wasn't (which means some ticket was built on a guess — trace it and verify what actually shipped). Target: zero markers.
 
 ### Step 2c2: Gate-validation check (docs/gate-validation.md)
 
-Before Steps 2d and 2e pass `--gate coverage` to `check_traceability.py` / `check_single_writer.py`, and before Step 2f passes `--gate-verifier-tests` to `ratchet.py check`, confirm each checker has EARNED that blocking authority — a passing gate-validation-protocol record proving it fires on seeded defects (including the mandatory evasion classes) and stays clean on a known-good corpus with coverage evidence, not just an assertion in a ledger. The records for CW's own gate suite ship **with chief-wiggum** at `$CW_HOME/docs/quality/validation/` (corroborated by the ratchet journal beside them), so this normally passes and Steps 2d/2e/2f keep their existing enforcement unchanged:
+Before Steps 2d and 2e pass `--gate coverage` to `check_traceability.py` / `check_single_writer.py`, and before Step 2f passes `--gate-verifier-tests` to `ratchet.py check`, confirm each checker has EARNED that blocking authority — a passing gate-validation-protocol record proving it fires on seeded defects (including the mandatory evasion classes) and stays clean on a known-good corpus with coverage evidence, not just an assertion in a ledger. The records for CW's own gate suite ship **with chief-wiggum** at `$CW_HOME/docs/quality/validation/` (corroborated by the ratchet journal beside them), so this normally passes and Steps 2d/2e/2f keep their existing enforcement unchanged. **One process checks all three gates** (#323) — `check_gate_validation.py` accepts multiple gate names and verifies the shared ratchet journal chain once for the whole call, instead of three separate processes each re-walking the same chain from genesis:
 
 ```bash
-python3 "$CW_HOME/scripts/check_gate_validation.py" check_traceability --validation-dir "$CW_HOME/docs/quality/validation" --gate
-python3 "$CW_HOME/scripts/check_gate_validation.py" check_single_writer --validation-dir "$CW_HOME/docs/quality/validation" --gate
-python3 "$CW_HOME/scripts/check_gate_validation.py" ratchet --validation-dir "$CW_HOME/docs/quality/validation" --gate
+GATE_VALIDATION=$(python3 "$CW_HOME/scripts/check_gate_validation.py" \
+  check_traceability check_single_writer ratchet \
+  --validation-dir "$CW_HOME/docs/quality/validation" --format json)
+echo "$GATE_VALIDATION"
+TRACEABILITY_VALIDATED=$(echo "$GATE_VALIDATION" | jq -r '.gates.check_traceability.passing')
+SINGLE_WRITER_VALIDATED=$(echo "$GATE_VALIDATION" | jq -r '.gates.check_single_writer.passing')
+RATCHET_VALIDATED=$(echo "$GATE_VALIDATION" | jq -r '.gates.ratchet.passing')
 ```
 
 (A target repo that hosts gates of its own keeps their records at the same relative path in that repo — `docs/quality/validation/<gate>.json`, sibling to its ratchet journal — and this step checks them the same way.)
 
-**If any exits non-zero (no record, a stale/forged one, or a failing one), do not pass the corresponding blocking flag in the step below** — for `check_traceability`/`check_single_writer` that flag is `--gate coverage`; for `ratchet` it is `--gate-verifier-tests` (the ratchet's core pass-set/contract-hash check in Step 2f stays hard-blocking regardless — only the verifier-test dimension's blocking authority is governed by the record, per chief-wiggum#208) — run it report-only instead, surface a blocking finding in the close report ("`<checker>` is not validated under the gate-validation protocol — see docs/gate-validation.md"), and direct the operator to complete the protocol (or explicitly accept the risk at the human checkpoint). This is `/close-epic` refusing `--gate` for a checker lacking a passing validation record — the same "report-only until proven" posture as `docs/gate-rollout.md`, enforced mechanically here instead of by convention.
+**If a gate's `_VALIDATED` var is not `true` (no record, a stale/forged one, or a failing one), do not pass the corresponding blocking flag in the step below** — for `check_traceability`/`check_single_writer` that flag is `--gate coverage`; for `ratchet` it is `--gate-verifier-tests` (the ratchet's core pass-set/contract-hash check in Step 2f stays hard-blocking regardless — only the verifier-test dimension's blocking authority is governed by the record, per chief-wiggum#208) — run it report-only instead, surface a blocking finding in the close report ("`<checker>` is not validated under the gate-validation protocol — see docs/gate-validation.md"), and direct the operator to complete the protocol (or explicitly accept the risk at the human checkpoint). This is `/close-epic` refusing `--gate` for a checker lacking a passing validation record — the same "report-only until proven" posture as `docs/gate-rollout.md`, enforced mechanically here instead of by convention.
 
-If a checker that was previously wired blocking (`check_gate_validation.py ... --wire` was run for it earlier) shows `"authority": {"demoted": true, ...}` in this step's JSON output, its record went stale or missing/invalid WHILE blocking — surface the printed `DEMOTION` instruction (`previous_authority`/`demotion_reason`) verbatim in the close report alongside the coverage finding above (see `docs/gate-validation.md`'s "Auto-demotion" section, chief-wiggum#198); this is the same instruction-surfacing pattern as the escape-driven `demotion_check` in "Demotion: an escape a seed class should have caught," just triggered by staleness instead of a production escape.
+If a checker that was previously wired blocking (`check_gate_validation.py ... --wire` was run for it earlier) shows `.gates.<name>.authority.demoted == true` in `$GATE_VALIDATION`, its record went stale or missing/invalid WHILE blocking — surface the printed `DEMOTION` instruction (`.gates.<name>.authority.instruction`, carrying `previous_authority`/`demotion_reason`) verbatim in the close report alongside the coverage finding above (see `docs/gate-validation.md`'s "Auto-demotion" section, chief-wiggum#198); this is the same instruction-surfacing pattern as the escape-driven `demotion_check` in "Demotion: an escape a seed class should have caught," just triggered by staleness instead of a production escape.
 
 ### Step 2d: Traceability coverage gate
 
-Prove every contract/invariant is realized, guarded by code, and verified by a test — from the `@cw-trace` annotations (see `docs/traceability.md`). Only pass `--gate coverage` if Step 2c2's `check_gate_validation.py check_traceability --gate` passed; otherwise drop `--gate coverage` and report the finding instead:
+Prove every contract/invariant is realized, guarded by code, and verified by a test — from the `@cw-trace` annotations (see `docs/traceability.md`). Only pass `--gate coverage` if Step 2c2's `$TRACEABILITY_VALIDATED` is `true`; otherwise drop `--gate coverage` and report the finding instead. **One invocation does both the coverage scan and the sidecar write** (#323 — `--write-links` is a no-op when the gate doesn't pass, so it always rides the same run instead of a second full annotation scan of the whole repo moments later):
 
 ```bash
-python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --format text
+python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --write-links --format text
 ```
 
 **Uncovered contracts** (no code `@cw-trace guards/ensures`) and **untested contracts** (no test `@cw-trace verifies`) are findings — the contract isn't proven implemented/tested. Dangling annotations (a tag referencing an ID that no longer exists) indicate a refactor left a stale link; fix the link or the ID. Degrades gracefully when the epic uses no annotations.
@@ -166,17 +190,11 @@ python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_R
 
 **JUSTIFIED waivers**: a contract that's genuinely not going to be covered (e.g. manual QA only) may carry a committed waiver at `docs/epics/<slug>/justifications/*.json` (`reason`/`approver`/`expiry`/`ticket` — a justification without a ticket ref is invalid and does NOT satisfy coverage). Valid, non-expired waivers render as `justified_contracts` and satisfy the coverage gate honestly instead of a fabricated guard/verify annotation.
 
-Once the gate passes, (re)write the definition-hash sidecar so future runs can detect suspect links — never hand-maintain this file:
-
-```bash
-python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --write-links --format text
-```
-
-`--write-links` only updates `$TARGET_REPO/docs/quality/trace-links.json` when the coverage gate passes — a failing run leaves the sidecar untouched, so a broken state is never recorded as validated. Commit this file alongside the rest of `docs/quality/` in Step 2f.
+`--write-links` (re)writes the definition-hash sidecar so future runs can detect suspect links — never hand-maintain this file. It only updates `$TARGET_REPO/docs/quality/trace-links.json` when the coverage gate passes in THIS SAME run — a failing run leaves the sidecar untouched, so a broken state is never recorded as validated. Commit this file alongside the rest of `docs/quality/` in Step 2f.
 
 ### Step 2e: Single-writer coverage gate
 
-For every invariant that declares a **single write path** / **single source of truth** (carrying `controls_field` + `sanctioned_writers` metadata — see `docs/single-writer.md`), prove no second mutator exists. This catches the class of bug where a pre-existing control (e.g. a legacy admin `ChangePlan` dropdown) is a second writer of a field an epic's invariant said had one atomic write path — something traceability and the ratchet cannot see, because they check contract↔code↔test *links* and the pass-set, not *who writes a field*. Only pass `--gate coverage` if Step 2c2's `check_gate_validation.py check_single_writer --gate` passed; otherwise drop `--gate coverage` and report the finding instead:
+For every invariant that declares a **single write path** / **single source of truth** (carrying `controls_field` + `sanctioned_writers` metadata — see `docs/single-writer.md`), prove no second mutator exists. This catches the class of bug where a pre-existing control (e.g. a legacy admin `ChangePlan` dropdown) is a second writer of a field an epic's invariant said had one atomic write path — something traceability and the ratchet cannot see, because they check contract↔code↔test *links* and the pass-set, not *who writes a field*. Only pass `--gate coverage` if Step 2c2's `$SINGLE_WRITER_VALIDATED` is `true`; otherwise drop `--gate coverage` and report the finding instead:
 
 ```bash
 python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --format text
@@ -186,7 +204,7 @@ Any writer of a controlled field whose enclosing symbol/file is **not** in `sanc
 
 ### Step 2f: Ratchet gate
 
-Resolve `QUALITY_DIR=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir)`. If `$QUALITY_DIR/ratchet.json` exists (see `docs/ratchet.md`), the epic must close with the quality ratchet **held or advanced** — the high-water pass-set intact, no contract definition weakened or removed since the `/architect` baseline, and no verifier-test body rewritten behind its still-green test ID.
+`$QUALITY_DIR` is already resolved (Step 1's `workflow_context.py`, #324 — one resolution per session, reused rather than re-invoking `artifacts.py show` per step). If `$QUALITY_DIR/ratchet.json` exists (see `docs/ratchet.md`), the epic must close with the quality ratchet **held or advanced** — the high-water pass-set intact, no contract definition weakened or removed since the `/architect` baseline, and no verifier-test body rewritten behind its still-green test ID.
 
 **Reuse Step 1b's verification run instead of paying for the suite twice** (chief-wiggum#322, same pattern as `/implement` Step 4b) — `close_epic_audit.py` already ran `ver.verify(repo, ["test"])` on this exact `$TARGET_REPO` commit and recorded it in `close-epic-manifest.json`'s `verification.steps`. When that run named a `report` for its `test`-profile step (a pytest junit-xml file) and the ratchet config has exactly one `junit-xml` suite, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
 
@@ -202,7 +220,7 @@ python3 "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO" --gate-verifie
 python3 "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 10   # per-wave/ticket history for the retrospective
 ```
 
-Pass `--gate-verifier-tests` only if Step 2c2's `check_gate_validation.py ratchet --gate` passed; otherwise drop the flag (the check still *prints* `weakened_verifier_tests`/`removed_verifier_tests` findings report-only — surface them in the close report) and direct the operator to the gate-validation protocol, same as 2d/2e.
+Pass `--gate-verifier-tests` only if Step 2c2's `$RATCHET_VALIDATED` is `true`; otherwise drop the flag (the check still *prints* `weakened_verifier_tests`/`removed_verifier_tests` findings report-only — surface them in the close report) and direct the operator to the gate-validation protocol, same as 2d/2e.
 
 A violation blocks the close: a regression means something merged that shouldn't have; a weakened/removed contract means the spec was edited outside the sanctioned path. A `weakened_verifier_tests`/`removed_verifier_tests` violation (chief-wiggum#206, channel C1c) means a test annotated `@cw-trace verifies` — the executable expression of a contract — was rewritten or dropped behind its still-green test ID; fix the code, or if the verifier test was *deliberately* revised, journal it via `ratchet.py record --amend-verifier <ref>` (a human act, same semantics as `--amend` for contracts). A `missing_tests` entry caused by a genuinely flaky/order-dependent case (not a real regression) is fixed by `ratchet.py record --retire-case` with a reason and expiry (#278) — surface it to the user and get their approval; never self-approve it, and never `--force` past the gate instead; state the quarantine count (and nearest expiry) in the close report so it isn't discovered later. `check`'s output also surfaces `suspect_links` (#169) — if `docs/quality/trace-links.json` exists, any link recorded against a contract whose definition hash just changed is printed explicitly, so a weakening is never silently absorbed into "the ratchet held"; this is report-only and does not change the exit code. If a contract revision was a *deliberate* decision made during the epic (confirm with the user — it should be visible in review threads, not discovered here), journal it explicitly so the baseline moves in the open, then re-check:
 
@@ -326,7 +344,7 @@ epic's own baseline isn't clobbered mid-audit), then hard-check every
 TICKETED id:
 
 ```bash
-QUALITY_DIR=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir)
+# $QUALITY_DIR already resolved at Step 1 (#324).
 python3 "$CW_HOME/scripts/debt_inventory.py" --repo "$TARGET_REPO" --out "$CW_TMP/close-epic/fresh-debt"
 python3 "$CW_HOME/scripts/plan_from_debt.py" verify --repo "$TARGET_REPO" \
   --plan "$QUALITY_DIR/remediation-plan.json" \
@@ -362,7 +380,18 @@ waives. Once `verify` passes, refresh the real inventory in `$QUALITY_DIR`
 
 Run the integration tests defined in `integration-tests.md`. These test cross-ticket behaviour that no individual ticket validates.
 
-For each integration test:
+**Check freshness before re-running the suite** (#323): Step 1b's audit already ran `ver.verify(repo, ["test"])` — the target's full test suite, which is where a repo's integration tests actually live and run — on this exact `$TARGET_REPO` HEAD, and recorded it as `close-epic-manifest.json`'s `.verification`. Re-running the whole suite a second time, moments later, on the identical unchanged commit is the single most expensive duplicate in this workflow:
+
+```bash
+MANIFEST="$CW_TMP/close-epic/close-epic-manifest.json"
+FRESH=$([ "$(git -C "$TARGET_REPO" rev-parse HEAD)" = "$(jq -r .target_sha "$MANIFEST")" ] && echo true || echo false)
+SUITE_OK=$(jq -r '.verification.ok // false' "$MANIFEST")
+```
+
+- **`$FRESH == true` and `$SUITE_OK == true`**: Step 1b's run is provably the same state and it was green. Do **not** re-run the suite from scratch. Instead, walk `integration-tests.md` and, for each named integration test, confirm it is represented as a passing case in Step 1b's evidence (`.verification.steps` in the manifest, or the test report it points at) by test path/id — report it PASS on that evidence. Only actually execute a specific test yourself when you cannot find it represented there (e.g. a Playwright/E2E spec outside the `test` profile Step 1b ran) — never claim a pass with no genuine evidence behind it.
+- **Otherwise** (`$FRESH == false` — a commit landed since Step 1b, e.g. Step 2f's ratchet-journal commit in embedded mode — or `$SUITE_OK == false`, or the manifest is missing): this is not a redundant second run, it is the only observation of the CURRENT state (or the first one that actually captures per-test failure detail). Run the full walk below for real.
+
+For each integration test (when actually running it):
 
 1. Set up the test scenario (create data via API, set up state)
 2. Execute the assertions across multiple surfaces
@@ -370,12 +399,12 @@ For each integration test:
 
 If the target repo has Playwright or E2E infrastructure, use it for UI-surface assertions. Otherwise, use API calls and database queries.
 
-**Run inside a verification worker** (contract: `docs/worker-contracts.md#verification-worker`) to keep the heavy test execution out of the orchestrator context. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. The worker should:
-- Start services if needed (`docker compose up -d`)
-- Execute each integration test
+**Run inside a verification worker** (contract: `docs/worker-contracts.md#verification-worker`) to keep the heavy test execution out of the orchestrator context. *Claude Code adapter:* `subagent_type: "general-purpose"`, `model: "sonnet"`. Give the worker `$FRESH`/`$SUITE_OK` and the manifest path so it makes the reuse-vs-rerun call above itself, rather than the orchestrator deciding blind. The worker should:
+- Start services if needed (`docker compose up -d`) — only when it is actually going to execute tests
+- Execute each integration test not already evidenced by a fresh, green Step 1b run
 - Capture results
-- Clean up (`docker compose down`)
-- Return a concise pass/fail summary
+- Clean up (`docker compose down`) — only if it started services
+- Return a concise pass/fail summary, noting which results came from Step 1b's evidence vs. a fresh run
 
 ### Step 4: Stitch-audit across epic scope
 

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -177,7 +177,7 @@ python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_RE
 
 **If `assert-main-pristine` fails, STOP** — main is on a feature branch or dirty (an isolation leak). Restore it (`git checkout "$DEFAULT_BRANCH"`, inspect/park any stray changes) before launching any wave, or every worktree will branch off a contaminated base.
 
-**Load amnesia context** (resolve `QUALITY_DIR=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir)`; if `$QUALITY_DIR/ratchet.json` exists): replay the recent ratchet journal so this session doesn't re-litigate decisions a previous wave already made (a parked ticket, an amended contract, a known-flaky suite):
+**Load amnesia context** (`$QUALITY_DIR` already resolved at Step 1, #324; if `$QUALITY_DIR/ratchet.json` exists): replay the recent ratchet journal so this session doesn't re-litigate decisions a previous wave already made (a parked ticket, an amended contract, a known-flaky suite):
 
 ```bash
 python3 "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 5
@@ -299,7 +299,7 @@ If any PRs were created by a worker during this wave (matching ticket branch nam
    The fallback re-run is never skipped when the artifact is missing, stale (older than the branch's last commit — e.g. the worker amended after verifying), or reports a non-passing/empty result; only a genuinely fresh, green, non-empty artifact is reused.
 3. Run linting (covered by the same `verify.json` when reused; run `golangci-lint run ./...` / `npx eslint` directly on the fallback path)
 4. Verify the branch has the expected commits
-5. **Protected-path guard** (if `$QUALITY_DIR/ratchet.json` exists — `QUALITY_DIR` resolved via `python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir`; see `docs/ratchet.md`) — workers must not move their own goalposts. Check the worker's diff against the protected pathset (contracts, invariants, integration-test specs, formal models, ratchet state):
+5. **Protected-path guard** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324; see `docs/ratchet.md`) — workers must not move their own goalposts. Check the worker's diff against the protected pathset (contracts, invariants, integration-test specs, formal models, ratchet state):
    ```bash
    python3 "$CW_HOME/scripts/ratchet.py" protected --repo "$worktree" --base "origin/$DEFAULT_BRANCH"
    ```
@@ -363,7 +363,7 @@ Run the integration check **on the staging branch, before promoting to main**:
 2. **Linting**: covered by the `lint` profile above (or `golangci-lint run ./...` / `npx eslint` directly) — zero high-severity findings
 3. **Build**: covered by the `build` profile above — verify the project compiles/builds cleanly
 4. **Smoke test**: If services can be started, start them and verify health endpoints respond
-5. **Ratchet check** (if `$QUALITY_DIR/ratchet.json` exists — `QUALITY_DIR` resolved via `python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir`; see `docs/ratchet.md`) — the merged wave may not shrink the high-water pass-set, weaken any contract definition, or rewrite a verifier-test body behind its still-green test ID. **Reuse item 1's run instead of re-executing the suite on the identical staging commit** (chief-wiggum#322, same pattern as `/implement` Step 4b): when item 1's JSON names a `report` for its `test`-profile step and the ratchet config has exactly one suite of the matching parser, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
+5. **Ratchet check** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324; see `docs/ratchet.md`) — the merged wave may not shrink the high-water pass-set, weaken any contract definition, or rewrite a verifier-test body behind its still-green test ID. **Reuse item 1's run instead of re-executing the suite on the identical staging commit** (chief-wiggum#322, same pattern as `/implement` Step 4b): when item 1's JSON names a `report` for its `test`-profile step and the ratchet config has exactly one suite of the matching parser, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
    ```bash
    REPORT=$(python3 -c "import json; d=json.load(open('$CW_TMP/wave-$wave_number-verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
    SUITE=$(python3 -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
@@ -489,7 +489,7 @@ After the wave merges, update the traceability matrix for all tickets in the wav
 - Mark acceptance criteria as `covered` where tests were written
 - Note any gaps for the `/close-epic` retrospective
 
-**Journal the ratchet** (if `$QUALITY_DIR/ratchet.json` exists — `QUALITY_DIR` resolved via `python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir`): record the merged wave so its passing tests advance the high-water mark, and give the next session amnesia context:
+**Journal the ratchet** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324): record the merged wave so its passing tests advance the high-water mark, and give the next session amnesia context:
 
 ```bash
 python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -106,7 +106,10 @@ All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemin
 MILESTONE=$(gh issue view "$issue_number" --repo "$owner_repo" --json milestone -q '.milestone.title // empty')
 if [ -n "$MILESTONE" ]; then
   EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$MILESTONE")
-  EPIC_DIR="$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .epics_dir)/$EPIC_SLUG"
+  # epics_dir = meta_root/epics (artifacts.Resolver.epics_dir) — $CW_META_ROOT
+  # is already resolved (Step 1's workflow_context.py, #324), so this needs
+  # no `artifacts.py show` call of its own.
+  EPIC_DIR="$CW_META_ROOT/epics/$EPIC_SLUG"
 fi
 ```
 
@@ -148,11 +151,13 @@ These artifacts are **hard constraints** on the implementation. The coding worke
 python3 "$CW_HOME/scripts/code_query.py" --repo "$TARGET_REPO" --epic "$EPIC_SLUG" orient path/to/file.go
 ```
 
-**Unresolved-unknowns gate**: scan the epic artifacts for markers this ticket would inherit:
+**Unresolved-unknowns gate**: `epic_inventory.py` already ran this exact scan (over this exact `$EPIC_DIR`, zero intervening writes) building `$TICKET_TMP/inventory.json` above — read its `.unresolved`/`.blocked_tickets` rather than re-scanning:
 ```bash
-python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json
+jq '.unresolved' "$TICKET_TMP/inventory.json"
 ```
 If any finding's `tickets` list includes this ticket (or the finding sits on an entity/operation this ticket implements), do NOT implement on the guessed value. Resolve the unknown first — introspect the real source, read the upstream repo, or ask the user — update the artifact with a citation, then proceed. Building a query layer against `TBD:` schema names produces code that compiles, passes mocked tests, and fails on first contact with reality.
+
+Fallback (only if `$TICKET_TMP/inventory.json` is missing or unreadable — the standalone case, never the normal path): `python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json`.
 
 If `$EPIC_STATUS` is `none` (this ticket was never on a milestone), proceed without epic context — the skill works standalone too. That is the ONLY case that silently proceeds; `missing` already stopped above.
 
@@ -270,12 +275,12 @@ Present a concise summary to the user. If there are open questions that genuinel
 #### Declared touch plan (adopted repos — ALL ticket kinds)
 
 Brownfield scope discipline is a property of the **repo**, not the ticket: it
-switches on when the #215 adoption record exists. Detect it via the resolver:
+switches on when the #215 adoption record exists. `$QUALITY_DIR`/`$CW_META_ROOT`
+are already resolved (Step 1's `workflow_context.py` — #324, one resolution per
+session reused everywhere, never re-invoked per step):
 
 ```bash
-CW_META=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json)
-ADOPTION_JSON="$(echo "$CW_META" | jq -r .meta_root)/adoption/adoption.json"
-QUALITY_DIR=$(echo "$CW_META" | jq -r .quality_dir)
+ADOPTION_JSON="$CW_META_ROOT/adoption/adoption.json"
 [ -f "$ADOPTION_JSON" ] && IS_ADOPTED=true || IS_ADOPTED=false
 ```
 
@@ -559,7 +564,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
    python3 "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint,build --json > "$TICKET_TMP/verify.json"
    ```
    It exits non-zero if any step fails (`jq .ok "$TICKET_TMP/verify.json"`). ALL tests must pass. Zero tolerance.
-4b. **Ratchet check** (see `docs/ratchet.md`) — resolve the target's quality dir via the meta-location resolver (`QUALITY_DIR=$(python3 "$CW_HOME/scripts/artifacts.py" show "$(git rev-parse --show-toplevel)" --format json | jq -r .quality_dir)`; embedded targets resolve to `<repo>/docs/quality`, sidecar targets to the external meta root); if `$QUALITY_DIR/ratchet.json` exists, verify this ticket doesn't slide quality backward. **Reuse Step 4's run instead of paying for the suite twice** (chief-wiggum#284): when Step 4's JSON names a `report` for its `test`-profile step (a pytest junit-xml file) and the ratchet config has exactly one `junit-xml` suite, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
+4b. **Ratchet check** (see `docs/ratchet.md`) — `$QUALITY_DIR` is already resolved (Step 1, #324 — embedded targets `<repo>/docs/quality`, sidecar targets the external meta root); if `$QUALITY_DIR/ratchet.json` exists, verify this ticket doesn't slide quality backward. **Reuse Step 4's run instead of paying for the suite twice** (chief-wiggum#284): when Step 4's JSON names a `report` for its `test`-profile step (a pytest junit-xml file) and the ratchet config has exactly one `junit-xml` suite, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
    ```bash
    REPORT=$(python3 -c "import json; d=json.load(open('$TICKET_TMP/verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
    SUITE=$(python3 -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
@@ -621,28 +626,34 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
      ```
    - If any category is below 80% coverage, flag it as a gap in the PR body. Do NOT block shipping — this is a signal, not a gate, in Phase 1. (Phase 2 may tighten this to a hard gate.)
 8b. **Transition-map verification** (if `$HAS_TRANSITION_MAP == true`):
-   Run the verification script scoped to this ticket:
+   Run the verification script **once**, in JSON mode, scoped to this ticket — it writes the transition-map AND the JSON this step renders from, in the same pass (the separate `--format text` run used to be a second full re-scan of the same code producing the same comparison — #324):
    ```bash
-   python3 "$CW_HOME/scripts/verify_transitions.py" "$(git rev-parse --show-toplevel)" "$MODELS_DIR/state-machines.json" --ticket "#$issue_number" --format text
+   python3 "$CW_HOME/scripts/verify_transitions.py" "$(git rev-parse --show-toplevel)" "$MODELS_DIR/state-machines.json" \
+     --ticket "#$issue_number" --format json --output "$MODELS_DIR/transition-map.json" > "$TICKET_TMP/verify-transitions.json"
+   git add "$MODELS_DIR/transition-map.json"
+   ```
+   Render the summary locally from `$TICKET_TMP/verify-transitions.json` (no second invocation — `--output` writes the map regardless of `--format`, so one JSON run covers both consumers):
+   ```bash
+   jq -r '.outcome as $o | .summary as $s |
+     "outcome: \($o) — \($s.covered)/\($s.total_model_transitions) covered, \($s.missing) missing, \($s.undocumented) undocumented",
+     (.entities[] | .name as $e | (.transitions[] | select(.status=="missing") | "MISSING  \($e): \(.from) -> \(.to) (\(.event))"),
+       ((.undocumented // []) | .[] | "UNDOCUMENTED  \($e): \(.from // "?") -> \(.to)"))' \
+     "$TICKET_TMP/verify-transitions.json"
    ```
    This reports:
    - Which transitions this ticket was supposed to introduce (from `derived_from` provenance)
-   - Which are now present in code (COVERED)
-   - Which are still missing (MISSING) — implementation gap, fix before shipping
-   - Any undocumented transitions in the diff (UNDOCUMENTED) — either update the model or remove the code
+   - Which are now present in code (`status: "covered"`)
+   - Which are still missing (`status: "missing"`) — implementation gap, fix before shipping
+   - Any undocumented transitions in the diff (the `undocumented` array) — either update the model or remove the code
 
-   After verification, update the transition-map:
-   ```bash
-   python3 "$CW_HOME/scripts/verify_transitions.py" "$(git rev-parse --show-toplevel)" "$MODELS_DIR/state-machines.json" --output "$MODELS_DIR/transition-map.json" --format json
-   git add "$MODELS_DIR/transition-map.json"
-   ```
-   Include transition coverage in the PR body under "Model conformance".
+   Include transition coverage (`.summary` above) in the PR body under "Model conformance".
 9. **Quality check** — Read the key files produced:
    - Is the code idiomatic for the language?
    - Are there any obvious issues (missing error handling, security gaps, dead code)?
    - Does it follow existing patterns in the codebase?
    - Would you be proud to ship this?
-10. **Clean up** — Stop any services you started (`docker compose down`)
+
+**Leave services running** — Step 9's UX gate and Step 10's browser-use validation both need them (#324: tearing down here only to restart moments later in Step 9 was a stop/start cycle for nothing). Teardown moves to the END of Step 10.
 
 If ANY verification fails: fix it directly, or re-launch the coding worker (contract: `docs/worker-contracts.md#implementation-worker`) with specific instructions for larger issues. Do NOT proceed to ship until verification passes.
 
@@ -707,7 +718,7 @@ Determine what tooling is available, in priority order:
 
 Name screenshots sequentially: `00-entry.png`, `01-form-empty.png`, `02-form-filled.png`, `03-success.png`, etc.
 
-If services need to be running, start them as in Step 8 before capturing. After capture, leave them running for Step 10 (browser-use validation) — do not stop yet.
+Services should still be running from Step 8 (#324: teardown no longer happens until after Step 10) — if they crashed or were never started, bring them up as in Step 8 before capturing. After capture, leave them running for Step 10 (browser-use validation) — do not stop yet.
 
 If screenshot capture fails entirely (services won't start, no browser tooling at all), note it as a gap and move on — do not block.
 
@@ -810,6 +821,8 @@ If **browser-use** exists (e.g. `tests/browser-use/run.py`):
 
 If no browser-use or E2E setup exists at all, note it as a gap in the final summary and move on.
 
+**Clean up** — now that Step 9 and Step 10 are both done with them, stop any services you started (`docker compose down`). (#324: teardown moved here from Step 8 — Step 9's UX gate and Step 10's browser-use validation both needed the services up, so tearing down mid-flow just meant restarting moments later.)
+
 ### Step 11: Ship PR
 
 **Do not create a PR until Steps 7-9 are complete.** The PR is the final artifact, not an intermediate checkpoint.
@@ -860,7 +873,7 @@ python3 "$CW_HOME/scripts/draft_pr.py" \
   --issue "$issue_number" --title "$pr_title" --summary "$summary" \
   --change "Change 1" --change "Change 2" \
   --mermaid-file "$TICKET_TMP/architecture.mmd" \
-  --verification "$TICKET_TMP/verification.json" \
+  --verification "$TICKET_TMP/verify.json" \
   --review "$TICKET_TMP/reviews/review-manifest.json" \
   --model-conformance "$TICKET_TMP/model-conformance.md" \
   --implementation-cost "$TICKET_TMP/implementation-cost.md" \
@@ -919,14 +932,15 @@ python3 "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" \
 
 Commit the updated `traceability.md` (or comment on the epic milestone if other tickets are in flight).
 
-**Journal the ratchet** (resolve `QUALITY_DIR=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .quality_dir)`; if `$QUALITY_DIR/ratchet.json` exists): once the PR is merged, record the ticket so its passing tests enter the high-water mark:
+**Journal the ratchet** (`$QUALITY_DIR` already resolved at Step 1, #324; if `$QUALITY_DIR/ratchet.json` exists): once the PR is merged, record the ticket so its passing tests enter the high-water mark:
 
 ```bash
 python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
   --event ticket --ref "#$issue_number" --merged --notes "<one line: what shipped>"
 # Embedded mode only — in sidecar mode the journal/state live outside the
-# target, so there is nothing to commit in-tree:
-if [ "$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | jq -r .mode)" = "embedded" ]; then
+# target, so there is nothing to commit in-tree ($CW_META_MODE already
+# resolved at Step 1, #324):
+if [ "$CW_META_MODE" = "embedded" ]; then
   git -C "$TARGET_REPO" add docs/quality && git -C "$TARGET_REPO" commit -m "chore: ratchet record for #$issue_number" && git -C "$TARGET_REPO" push
 fi
 ```

--- a/docs/adopt.md
+++ b/docs/adopt.md
@@ -28,7 +28,11 @@ Mechanics live in `scripts/adopt.py`; the `/adopt` command is a thin adapter
    shipped gates plus the debt inventory (e.g. `saas_gate` inapplicable
    without a base URL; `check_traceability` report-only until contracts
    exist; `ratchet` applicable once baselined). Written to
-   `<meta root>/adoption/survey.json`, stamped with `target_sha`.
+   `<meta root>/adoption/survey.json`, stamped with `target_sha`. Inside
+   `adopt.py run` (below), this step **reuses** the ratchet baseline's
+   scorecard for its coverage numbers instead of running the test command a
+   second time (#334); standalone `adopt.py survey` always performs its own
+   real run.
 2. **Elections** (`adopt.py elect`) — footprint mode + domain scope via the
    #213 resolver ([sidecar.md](sidecar.md)). Defaults: **`sidecar` +
    whole-repo scope**. `--scope-from-codeowners` seeds `scope.json` from
@@ -63,15 +67,28 @@ Mechanics live in `scripts/adopt.py`; the `/adopt` command is a thin adapter
 6. **The adoption record** (`adopt.py record`) —
    `<meta root>/adoption/adoption.json`, the brownfield **switch**.
 
-`adopt.py run` chains all of it with per-step output. One ordering note: `run`
-performs the **election first** — the election decides where the survey (and
-every later artifact) persists, so surveying before electing would write the
-survey into the embedded default, i.e. the very target tree a sidecar adoption
-exists to keep clean. Step-by-step adoptions **must** elect first: standalone
-`survey`/`baseline`/`grandfather`/`record` on a target with **no election
-file refuse** (exit 2, "embedded mode is an explicit choice") rather than
-falling through to the resolver's silent embedded default and writing the
-target's own tree.
+`adopt.py run` chains all of it with per-step output, in the order **elect →
+baseline → survey → grandfather → record**. Two ordering notes:
+
+- `run` performs the **election first** — the election decides where the
+  survey (and every later artifact) persists, so surveying before electing
+  would write the survey into the embedded default, i.e. the very target tree
+  a sidecar adoption exists to keep clean. Step-by-step adoptions **must**
+  elect first: standalone `survey`/`baseline`/`grandfather`/`record` on a
+  target with **no election file refuse** (exit 2, "embedded mode is an
+  explicit choice") rather than falling through to the resolver's silent
+  embedded default and writing the target's own tree.
+- `run` performs **baseline before survey** (#334): both steps used to run
+  the target's test command for real, against the same unchanged HEAD —
+  baseline via `ratchet.py score`, survey via its own coverage-baseline
+  attempt. `run` now scores the baseline first and hands its scorecard to the
+  survey step, which reuses it (verified fresh: the scorecard's `target_sha`
+  must match the CURRENT HEAD, mirroring `ratchet.py score
+  --reuse-report`'s loud-fail-on-stale discipline — a mismatch is never
+  silently trusted, it triggers a real fallback run) instead of running the
+  suite a second time. The suite runs **exactly once** per `run`. Standalone
+  `adopt.py survey` — no baseline having just run in the same process — is
+  unaffected and always performs its own real run.
 
 **Re-adoption is an explicit operator act.** `run` on a target whose
 `adoption.json` already exists refuses ("already adopted (adopted_at …)")

--- a/docs/gate-validation.md
+++ b/docs/gate-validation.md
@@ -219,6 +219,23 @@ python3 "$CW_HOME/scripts/check_gate_validation.py" check_single_writer \
   --validation-dir "$CW_HOME/docs/quality/validation"
 ```
 
+Multiple gate names may be passed in one invocation (chief-wiggum#323) — each
+is checked against its own `<gate>.json` record, but the shared ratchet
+journal beside `--validation-dir` is hash-chain-verified ONCE for the whole
+call instead of once per gate (`/close-epic` Step 2c2 checks its three gates
+this way):
+
+```bash
+python3 "$CW_HOME/scripts/check_gate_validation.py" \
+  check_traceability check_single_writer ratchet \
+  --validation-dir "$CW_HOME/docs/quality/validation" --format json
+```
+
+Single-gate JSON output is unchanged (the top-level object shown below);
+multi-gate JSON nests each gate's report under `"gates": {"<name>": {...}}`.
+`--wire`/`--unwire` remain single-gate operator acts — passing either with
+more than one gate name is refused (exit 2).
+
 Report-only by default (prints the record's status and exits 0). `--gate`
 makes it block:
 

--- a/scripts/adopt.py
+++ b/scripts/adopt.py
@@ -37,11 +37,18 @@ Subcommands mirror the adoption sequence:
                    switch (#216 reads it; /architect reads it in place of the
                    ``IS_NEW_PRODUCT`` file-existence heuristic).
 - ``run``          the whole sequence, printing each step. The election runs
-                   first (it decides where the survey persists); then survey →
-                   baseline → grandfather → record. A target whose
-                   adoption.json already exists refuses unless ``--re-adopt``
-                   — re-adoption is an explicit operator act, never a side
-                   effect of re-running the arrow.
+                   first (it decides where the survey persists); then baseline
+                   → survey → grandfather → record. Baseline now runs BEFORE
+                   survey (#334): survey's coverage-baseline numbers are
+                   derived from the SAME scorecard baseline just wrote (its
+                   ``target_sha`` matches the current HEAD) instead of
+                   re-running the target's test command a second time — the
+                   suite runs exactly once per ``run``. Standalone ``survey``
+                   is unaffected: with no scorecard to derive from, it still
+                   performs its own real run. A target whose adoption.json
+                   already exists refuses unless ``--re-adopt`` — re-adoption
+                   is an explicit operator act, never a side effect of
+                   re-running the arrow.
 
 Standalone ``survey``/``baseline``/``grandfather``/``record`` require a prior
 footprint election (``adopt elect`` / ``adopt run``): with no election file the
@@ -345,6 +352,53 @@ def coverage_baseline(target: Path) -> dict:
     return {"detected": True, "detection": detection.to_dict(), "steps": steps}
 
 
+def coverage_from_scorecard(scorecard: dict, target: Path) -> dict:
+    """The survey's ``test_run`` block, derived from an ALREADY-COMPUTED
+    ratchet baseline scorecard instead of re-running the target's test
+    command (#334). Only called once the caller (``build_survey``) has
+    confirmed ``scorecard["target_sha"]`` matches the CURRENT HEAD — a
+    scorecard from any other commit is not "the same state" and must not be
+    read here (see ``build_survey``).
+
+    Per-suite ``failed`` counts are NOT separately tracked by the ratchet
+    scorer (it tracks the pass-set, not a fail count) — reported ``None``
+    with a note, never fabricated, the same "unparsed, never fabricated"
+    discipline ``coverage_baseline`` itself follows for output it cannot
+    parse."""
+    smeas = scorecard.get("suite_measurement") or {}
+    if smeas.get("status") == ratchet.SUITE_STATUS_INAPPLICABLE:
+        return {
+            "detected": False,
+            "steps": [],
+            "note": smeas.get("reason") or "no test runner detected — cannot "
+                    "establish a coverage baseline",
+            "source": "ratchet-scorecard",
+        }
+    detection = verification.detect_project(target)
+    steps = [
+        {
+            "tool": e.get("suite"),
+            "command": None,
+            "exit_code": e.get("exit_code"),
+            "ok": e.get("exit_code") == 0,
+            "passed": e.get("passing_cases"),
+            "failed": None,
+            "note": "derived from the adoption baseline's ratchet scorecard "
+                    f"(source: {e.get('source')}) — the ratchet scorer tracks "
+                    "the pass-set only; a per-suite failed-case count is not "
+                    "separately measured",
+            "log_tail": "",
+        }
+        for e in (smeas.get("suites") or [])
+    ]
+    return {
+        "detected": True,
+        "detection": detection.to_dict(),
+        "steps": steps,
+        "source": "ratchet-scorecard",
+    }
+
+
 def ci_presence(target: Path) -> dict:
     workflows = sorted(
         p.name for p in (target / ".github" / "workflows").glob("*.y*ml")
@@ -501,11 +555,24 @@ def gate_verdicts(
     return v
 
 
-def build_survey(target: Path, resolver: artifacts.Resolver) -> dict:
+def build_survey(
+    target: Path, resolver: artifacts.Resolver, *, reuse_scorecard: dict | None = None,
+) -> dict:
+    """``reuse_scorecard`` (#334): an ALREADY-COMPUTED ratchet baseline
+    scorecard from earlier in the SAME ``run`` sequence. Reused only when its
+    ``target_sha`` matches the CURRENT HEAD — provably the same state, not an
+    assumption (mirrors ``ratchet.py score --reuse-report``'s loud-fail-on-
+    stale discipline: a mismatch never gets silently trusted). When absent or
+    stale, this runs the REAL coverage-baseline attempt exactly as before —
+    standalone ``adopt.py survey`` (no baseline having just run) always takes
+    this path."""
     age = repo_age(target)
     size = repo_size(target)
     tests = test_presence(target)
-    run = coverage_baseline(target)
+    if reuse_scorecard is not None and reuse_scorecard.get("target_sha") == artifacts.head_sha(target):
+        run = coverage_from_scorecard(reuse_scorecard, target)
+    else:
+        run = coverage_baseline(target)
     ci = ci_presence(target)
     epics_dir = resolver.epics_dir()
     has_epic_ids = bool(epics_dir.is_dir() and hash_epic_definitions(epics_dir))
@@ -555,10 +622,12 @@ def format_survey(doc: dict) -> str:
         lines.append(f"coverage baseline: {run['note']}")
     else:
         for s in run["steps"]:
-            counts = (
-                f"{s['passed']} passed, {s['failed']} failed"
-                if s["passed"] is not None else (s["note"] or "counts unparsed")
-            )
+            if s["passed"] is not None and s["failed"] is not None:
+                counts = f"{s['passed']} passed, {s['failed']} failed"
+            elif s["passed"] is not None:
+                counts = f"{s['passed']} passed (failed count unavailable)"
+            else:
+                counts = s["note"] or "counts unparsed"
             lines.append(
                 f"coverage baseline [{s['tool']}]: exit {s['exit_code']} — {counts}")
     ci = doc["ci"]
@@ -571,10 +640,10 @@ def format_survey(doc: dict) -> str:
     return "\n".join(lines)
 
 
-def cmd_survey(args) -> int:
+def cmd_survey(args, reuse_scorecard: dict | None = None) -> int:
     target = Path(resolve_target(args.owner_repo, args.repo))
     resolver = _require_election(target)
-    doc = build_survey(target, resolver)
+    doc = build_survey(target, resolver, reuse_scorecard=reuse_scorecard)
     out = adoption_dir(resolver) / SURVEY_NAME
     _write_json(out, doc)
     if args.format == "json":
@@ -1028,10 +1097,24 @@ def cmd_run(args) -> int:
     # (survey included) persists. Surveying before electing would write the
     # survey to the embedded default — i.e. into the very target tree a
     # sidecar adoption exists to keep clean.
+    #
+    # Baseline now runs BEFORE survey (#334): baseline's `ratchet score` is a
+    # REAL run of the target's test command; survey's own coverage-baseline
+    # attempt used to be a SECOND real run of that same command against the
+    # same unchanged HEAD. `_survey_reusing_baseline` reads the scorecard
+    # baseline just wrote and hands it to `cmd_survey`, which reuses it
+    # (target_sha-checked fresh) instead of running the suite again — the
+    # suite runs exactly once per `run`.
+    def _survey_reusing_baseline(a):
+        t = Path(resolve_target(a.owner_repo, a.repo))
+        r = _require_election(t)
+        sc = _load_json(r.quality_dir() / ratchet.SCORECARD_NAME)
+        return cmd_survey(a, reuse_scorecard=sc)
+
     steps = (
         ("elect", cmd_elect),
-        ("survey", cmd_survey),
         ("baseline", cmd_baseline),
+        ("survey", _survey_reusing_baseline),
         ("grandfather", cmd_grandfather),
         ("record", cmd_record),
     )

--- a/scripts/check_gate_validation.py
+++ b/scripts/check_gate_validation.py
@@ -307,11 +307,42 @@ def _live_scanner_version(gate: str, scripts_dir: Path) -> tuple[str | None, str
     return (out, None) if out else (None, None)
 
 
-def _ratchet_provenance_errors(gate: str, record: dict, validation_dir: Path) -> list[str]:
+def _load_and_verify_chain(journal: Path) -> tuple[list[dict] | None, str | None]:
+    """Parse + hash-chain-verify one ratchet journal file, ONCE. Returns
+    ``(entries, None)`` on a verified chain, or ``(None, error)`` on a
+    missing/unreadable/broken one. Split out of ``_ratchet_provenance_errors``
+    (#323) so a caller checking MULTIPLE gates against the SAME journal (e.g.
+    `/close-epic` Step 2c2's three gates) can verify the chain once and reuse
+    it, instead of every gate re-walking the same file from genesis."""
+    if not journal.is_file():
+        return None, f"ratchet journal not found at {journal}"
+    try:
+        entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        return None, f"ratchet journal at {journal} is unreadable"
+    prev = "genesis"
+    for i, entry in enumerate(entries):
+        body = {k: v for k, v in entry.items() if k != "record_hash"}
+        expect = stable_hash(prev, json.dumps(body, sort_keys=True))
+        if entry.get("record_hash") != expect:
+            return None, f"ratchet journal chain broken at entry {i} ({entry.get('record_id', '?')}) — fail closed"
+        prev = expect
+    return entries, None
+
+
+def _ratchet_provenance_errors(
+    gate: str, record: dict, validation_dir: Path, *, chain_cache: dict | None = None,
+) -> list[str]:
     """Corroborate the record's ``ratchet_record_id`` against the hash-chained
     ratchet journal beside the validation dir. The chain is the tamper-evidence
     (docs/ratchet.md): a record id that isn't journaled — or a journal whose
-    chain doesn't verify — grants no provenance."""
+    chain doesn't verify — grants no provenance.
+
+    ``chain_cache`` (#323): an optional ``{journal_path: (entries, error)}``
+    dict a caller checking multiple gates can share across calls so the SAME
+    journal file is parsed and hash-verified only once per process, not once
+    per gate. ``None`` (the default) preserves the original behavior — verify
+    fresh every call — so every existing single-gate caller is unaffected."""
     rid_field = record.get("ratchet_record_id")
     rid_match = RID_RE.fullmatch(rid_field.strip()) if isinstance(rid_field, str) else None
     if rid_match is None:
@@ -321,19 +352,15 @@ def _ratchet_provenance_errors(gate: str, record: dict, validation_dir: Path) ->
         ]
     rid = rid_match.group(0)
     journal = validation_dir.resolve().parent / JOURNAL_NAME
-    if not journal.is_file():
-        return [f"ratchet journal not found at {journal} — cannot corroborate ratchet_record_id {rid}"]
-    try:
-        entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
-    except json.JSONDecodeError:
-        return [f"ratchet journal at {journal} is unreadable — cannot corroborate {rid}"]
-    prev = "genesis"
-    for i, entry in enumerate(entries):
-        body = {k: v for k, v in entry.items() if k != "record_hash"}
-        expect = stable_hash(prev, json.dumps(body, sort_keys=True))
-        if entry.get("record_hash") != expect:
-            return [f"ratchet journal chain broken at entry {i} ({entry.get('record_id', '?')}) — fail closed"]
-        prev = expect
+    if chain_cache is not None:
+        cache_key = str(journal)
+        if cache_key not in chain_cache:
+            chain_cache[cache_key] = _load_and_verify_chain(journal)
+        entries, chain_error = chain_cache[cache_key]
+    else:
+        entries, chain_error = _load_and_verify_chain(journal)
+    if chain_error is not None:
+        return [f"{chain_error} — cannot corroborate ratchet_record_id {rid}"]
     match = next((e for e in entries if e.get("record_id") == rid), None)
     if match is None:
         return [f"ratchet_record_id {rid} not found in the ratchet journal at {journal}"]
@@ -354,6 +381,8 @@ def check(
     validation_dir: str | Path,
     schema: dict | None = None,
     scripts_dir: str | Path | None = None,
+    *,
+    chain_cache: dict | None = None,
 ) -> GateValidationReport:
     schema = schema or load_schema()
     scripts_dir = Path(scripts_dir) if scripts_dir else Path(__file__).resolve().parent
@@ -394,7 +423,9 @@ def check(
             f"gate reports {live!r} — the record is stale; re-run the trials against the current "
             "gate and re-author the record"
         )
-    report.provenance_errors.extend(_ratchet_provenance_errors(gate, record, Path(validation_dir)))
+    report.provenance_errors.extend(
+        _ratchet_provenance_errors(gate, record, Path(validation_dir), chain_cache=chain_cache)
+    )
 
     # Trials: pass/fail is DERIVED (result vs expected), never trusted from the flag.
     trials = record.get("seeded_defect_trials", []) or []
@@ -561,6 +592,7 @@ def check_and_transition(
     *,
     wire: bool = False,
     unwire: bool = False,
+    chain_cache: dict | None = None,
 ) -> tuple[GateValidationReport, AuthorityTransition]:
     """`check()` plus the journal-anchored blocking-authority verdict. Detects a
     record that went stale or missing/invalid WHILE the gate is journaled-wired
@@ -582,7 +614,7 @@ def check_and_transition(
     the operator-initiated ``--wire``/``--unwire`` append journal events. The
     ``--gate`` exit-1 guard stays the sole INV-fh-003 enforcement.
     @cw-trace guards INV-fh-003"""
-    report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir)
+    report = check(gate, validation_dir, schema=schema, scripts_dir=scripts_dir, chain_cache=chain_cache)
     journal = _journal_path(validation_dir)
     was_wired = ratchet_last_authority_action(journal, gate) == "wire"
     append_action: str | None = None  # 'wire' | 'unwire', journaled AFTER the emit
@@ -679,7 +711,15 @@ def main(argv: list[str] | None = None) -> int:
         description="Gate-of-gates: does this gate have a passing gate-validation record?",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("gate", help="Gate name, e.g. check_single_writer")
+    parser.add_argument(
+        "gates", metavar="gate", nargs="+",
+        help="Gate name(s), e.g. check_single_writer. Multiple names (#323) check "
+             "each against its OWN <gate>.json record but verify the shared ratchet "
+             "journal chain only ONCE for the whole invocation, instead of once per "
+             "gate — the journal is the same file for every gate under one "
+             "--validation-dir. Single-gate output is unchanged; multi-gate JSON "
+             "nests each gate's report under \"gates\".",
+    )
     parser.add_argument(
         "--validation-dir", default=DEFAULT_VALIDATION_DIR,
         help=f"Directory containing <gate>.json validation records (default: {DEFAULT_VALIDATION_DIR}; "
@@ -696,7 +736,7 @@ def main(argv: list[str] | None = None) -> int:
              "staleness silently goes unchecked.",
     )
     parser.add_argument("--gate", dest="gate_mode", action="store_true",
-                        help="Fail (exit 1) when the named gate lacks a passing validation record")
+                        help="Fail (exit 1) when any named gate lacks a passing validation record")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     wiring = parser.add_mutually_exclusive_group()
     wiring.add_argument(
@@ -704,15 +744,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Record that this gate is now wired --gate (blocking) in its workflow — "
              "only when the record currently passes (INV-fh-003); persists the "
              "blocking-authority state so a later staleness/regression can be detected "
-             "as an auto-demotion, not just a downgrade.",
+             "as an auto-demotion, not just a downgrade. Single-gate only.",
     )
     wiring.add_argument(
         "--unwire", action="store_true",
         help="Record that this gate is no longer wired --gate (an intentional un-wiring, "
              "not a demotion) — moves the tracked authority to 'validated' if the record "
-             "still passes, else 'report_only'.",
+             "still passes, else 'report_only'. Single-gate only.",
     )
     args = parser.parse_args(argv)
+
+    if len(args.gates) > 1 and (args.wire or args.unwire):
+        print("Error: --wire/--unwire are single-gate operator acts — "
+              "pass exactly one gate name with either flag", file=sys.stderr)
+        return 2
 
     try:
         schema = load_schema(Path(args.schema))
@@ -720,29 +765,51 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: cannot load gate-validation schema: {exc}", file=sys.stderr)
         return 2
 
-    report, transition = check_and_transition(
-        args.gate, args.validation_dir, schema=schema, scripts_dir=args.scripts_dir,
-        wire=args.wire, unwire=args.unwire,
-    )
+    # The chain is the SAME journal file for every gate under one
+    # --validation-dir (JOURNAL_NAME is a sibling of the validation dir, not
+    # gate-specific) — verify it once here and every check() call below reuses
+    # the cached (entries, error) instead of re-walking it from genesis (#323).
+    chain_cache: dict = {}
+    results: list[tuple[str, GateValidationReport, AuthorityTransition]] = []
+    for gate in args.gates:
+        report, transition = check_and_transition(
+            gate, args.validation_dir, schema=schema, scripts_dir=args.scripts_dir,
+            wire=args.wire, unwire=args.unwire, chain_cache=chain_cache,
+        )
+        results.append((gate, report, transition))
 
     if args.format == "json":
-        out = report.to_dict()
-        out["authority"] = transition.to_dict()
-        print(json.dumps(out, indent=2))
+        if len(results) == 1:
+            # Byte-identical to the pre-#323 single-gate shape — every
+            # existing caller/test parses this top-level object directly.
+            _gate, report, transition = results[0]
+            out = report.to_dict()
+            out["authority"] = transition.to_dict()
+            print(json.dumps(out, indent=2))
+        else:
+            out = {"gates": {}}
+            for gate, report, transition in results:
+                gd = report.to_dict()
+                gd["authority"] = transition.to_dict()
+                out["gates"][gate] = gd
+            print(json.dumps(out, indent=2))
     else:
-        print(render_text(report, transition))
+        for _gate, report, transition in results:
+            print(render_text(report, transition))
 
-    if transition.demoted:
-        print(f"check_gate_validation: DEMOTION — {transition.instruction}", file=sys.stderr)
+    for gate, _report, transition in results:
+        if transition.demoted:
+            print(f"check_gate_validation: DEMOTION ({gate}) — {transition.instruction}", file=sys.stderr)
 
     try:  # factory telemetry; no-op unless enabled, never breaks the gate
         from factory_log import emit_gate  # noqa: PLC0415
-        caught = 0 if report.passing else 1
-        emit_gate("check_gate_validation", "fail" if caught else "pass", caught=caught)
+        for _gate, report, _transition in results:
+            caught = 0 if report.passing else 1
+            emit_gate("check_gate_validation", "fail" if caught else "pass", caught=caught)
     except Exception:
         pass
 
-    if args.gate_mode and not report.passing:
+    if args.gate_mode and any(not report.passing for _g, report, _t in results):
         return 1
     return 0
 

--- a/scripts/chief_wiggum/context.py
+++ b/scripts/chief_wiggum/context.py
@@ -152,33 +152,48 @@ class WorkflowContext:
             f"export CW_TMP={env.shell_quote(str(self.tmp))}",
             f"export DEFAULT_BRANCH={env.shell_quote(self.default_branch)}",
         ]
+        # The #213 meta-location resolver is built ONCE here (#324) and
+        # reused below for every meta-location export (QUALITY_DIR,
+        # CW_META_ROOT, CW_META_MODE, EPIC_DIR) instead of each downstream
+        # workflow step re-invoking `artifacts.py show` (~10x across
+        # implement.md/implement-wave.md/close-epic.md) for the identical
+        # answer against the same unchanged target.
+        resolver = self._resolver()
         if self.repo_path is not None:
             lines.append(f"export TARGET_REPO={env.shell_quote(str(self.repo_path))}")
+            if resolver is not None:
+                lines.append(f"export QUALITY_DIR={env.shell_quote(str(resolver.quality_dir()))}")
+                lines.append(f"export CW_META_ROOT={env.shell_quote(str(resolver.meta_root))}")
+                lines.append(f"export CW_META_MODE={env.shell_quote(resolver.mode)}")
         if self.target is not None:
             lines.append(f"export TARGET_SLUG={env.shell_quote(self.target.slug)}")
         if self.issue is not None:
             lines.append(f"export ISSUE_NUMBER={self.issue}")
         if self.epic_slug is not None:
             lines.append(f"export EPIC_SLUG={env.shell_quote(self.epic_slug)}")
-            epic_dir = self._resolved_epic_dir()
-            if epic_dir is not None:
+            if resolver is not None:
+                epic_dir = resolver.epic_dir(self.epic_slug)
                 lines.append(f"export EPIC_DIR={env.shell_quote(str(epic_dir))}")
             else:
                 lines.append(f'export EPIC_DIR="$TARGET_REPO/docs/epics/{self.epic_slug}"')
         return "\n".join(lines)
 
-    def _resolved_epic_dir(self):
-        """Meta location is resolved, never assumed (#213): when the target
-        repo path is known, EPIC_DIR comes from the artifacts resolver, so a
-        sidecar election routes the epic-consuming skills to the sidecar.
-        Offline (--no-resolve) falls back to the embedded literal."""
-        if self.repo_path is None or self.epic_slug is None:
+    def _resolver(self):
+        """The #213 meta-location resolver for this target, resolved ONCE
+        (#324) and reused for every meta-location export in
+        ``shell_exports`` (``EPIC_DIR``, ``QUALITY_DIR``, ``CW_META_ROOT``,
+        ``CW_META_MODE``) instead of each workflow step re-invoking
+        ``artifacts.py show`` for the identical answer against the same
+        unchanged target. ``None`` when the repo path isn't known (offline
+        ``--no-resolve``) or resolution fails — callers fall back to the
+        embedded-default literal rather than raising."""
+        if self.repo_path is None:
             return None
         try:
             import sys as _sys
             _sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
             import artifacts
-            return artifacts.Resolver.resolve(Path(self.repo_path)).epic_dir(self.epic_slug)
+            return artifacts.Resolver.resolve(Path(self.repo_path))
         except Exception:
             return None
 

--- a/scripts/close_epic_audit.py
+++ b/scripts/close_epic_audit.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import artifacts  # noqa: E402 — #213 resolver; head_sha() stamps the manifest (#323)
 import check_unresolved  # noqa: E402
 from chief_wiggum import traceability as tr  # noqa: E402
 from chief_wiggum import verification as ver  # noqa: E402
@@ -43,6 +44,16 @@ class CloseEpicManifest:
     stitch: dict | None = None
     mutation_tools_available: list[str] = field(default_factory=list)
     verification: dict | None = None
+    # target_repo's HEAD at the moment this manifest was built (#323) — the
+    # freshness check every later /close-epic step needs before reusing
+    # `verification`/`transitions`/`unresolved` instead of recomputing: a
+    # match means "provably the same state" (nothing could have changed what
+    # was measured); a mismatch (a commit landed since — e.g. Step 2f's
+    # ratchet-journal commit in embedded mode) means a later step must
+    # re-run, never silently trust a stale manifest. None when the target
+    # isn't a readable git repo — freshness can't be claimed, so callers
+    # must treat that as "not fresh" too.
+    target_sha: str | None = None
     warnings: list[str] = field(default_factory=list)
 
     @property
@@ -99,11 +110,16 @@ def run_close_epic_audit(
     stitch_fn: Callable[[Path], dict] | None = None,
     which: Callable[[str], str | None] = shutil.which,
     mutation_tools: tuple[str, ...] = DEFAULT_MUTATION_TOOLS,
+    sha_fn: Callable[[Path], str | None] = artifacts.head_sha,
 ) -> CloseEpicManifest:
     """Coordinate the deterministic close-epic audits into one manifest."""
     epic = Path(epic_dir)
     target = Path(target_repo)
     manifest = CloseEpicManifest(epic_dir=str(epic), target_repo=str(target))
+    try:
+        manifest.target_sha = sha_fn(target)
+    except Exception as exc:  # noqa: BLE001
+        manifest.warnings.append(f"could not read target HEAD sha: {exc}")
 
     # Traceability coverage (isolated so a malformed file can't abort the audit).
     trace_file = epic / "traceability.md"

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -90,9 +90,15 @@ def gate_ledger(quality_dir: Path) -> list[dict]:
     entries: list[dict] = []
     if not validation_dir.is_dir():
         return entries
+    # Every gate under one validation_dir shares the SAME ratchet journal
+    # (JOURNAL_NAME is a sibling of validation_dir, not gate-specific) — one
+    # cache shared across the loop verifies that chain once instead of once
+    # per gate (#323, same fix as /close-epic Step 2c2's batched
+    # check_gate_validation.py call).
+    chain_cache: dict = {}
     for path in sorted(validation_dir.glob("*.json")):
         gate = path.stem
-        report = gate_validation.check(gate, validation_dir)
+        report = gate_validation.check(gate, validation_dir, chain_cache=chain_cache)
         if report.passing:
             verdict = "passing"
         elif not report.record_found:

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -469,6 +469,117 @@ def test_run_full_sequence(user_dir, tmp_path):
     assert _tracked_clean(target)
 
 
+# --- run executes the target's test command exactly once (#334) -----------------
+
+
+def test_run_executes_test_suite_exactly_once(user_dir, tmp_path, monkeypatch):
+    """`adopt.py run` used to run the detected test command TWICE against the
+    same unchanged HEAD: once for the survey's coverage-baseline attempt
+    (`coverage_baseline`), once for the ratchet-scored baseline
+    (`ratchet.run_suite_measured`, inside `cmd_baseline`). Both are REAL
+    subprocess executions of the same suite — only one may survive `run`."""
+    target = make_target(tmp_path / "t")
+    coverage_calls: list[int] = []
+    orig_coverage_baseline = adopt.coverage_baseline
+
+    def spy_coverage_baseline(*a, **k):
+        coverage_calls.append(1)
+        return orig_coverage_baseline(*a, **k)
+
+    monkeypatch.setattr(adopt, "coverage_baseline", spy_coverage_baseline)
+
+    suite_run_calls: list[int] = []
+    orig_run_suite_measured = ratchet.run_suite_measured
+
+    def spy_run_suite_measured(*a, **k):
+        suite_run_calls.append(1)
+        return orig_run_suite_measured(*a, **k)
+
+    monkeypatch.setattr(ratchet, "run_suite_measured", spy_run_suite_measured)
+
+    assert adopt.main(["run", "--repo", str(target),
+                       "--workdir", str(tmp_path / "wd")]) == 0
+    assert coverage_calls == [], (
+        "survey must NOT run the suite a second time when `run`'s baseline "
+        "step already scored it this HEAD — it must reuse the scorecard")
+    assert suite_run_calls == [1], (
+        "the ratchet-scored baseline must still be the ONE real execution")
+
+
+def test_survey_coverage_numbers_equal_scorecard_derived_values(user_dir, tmp_path):
+    """Acceptance criterion: survey's coverage numbers, when derived from a
+    just-computed baseline scorecard, are test-pinned to that scorecard —
+    not an independently re-parsed number that could silently drift."""
+    target = make_target(tmp_path / "t")
+    assert adopt.main(["run", "--repo", str(target),
+                       "--workdir", str(tmp_path / "wd")]) == 0
+    resolver = artifacts.Resolver.resolve(target)
+    survey = json.loads((resolver.meta_root / "adoption" / "survey.json").read_text())
+    sc = json.loads((resolver.quality_dir() / ratchet.SCORECARD_NAME).read_text())
+    run = survey["test_run"]
+    assert run["detected"] is True
+    assert run["source"] == "ratchet-scorecard"
+    smeas = sc["suite_measurement"]
+    total_passed = sum(s["passed"] for s in run["steps"])
+    assert total_passed == smeas["total_passing"] == sc["passed"]
+    for step, suite_entry in zip(run["steps"], smeas["suites"], strict=True):
+        assert step["passed"] == suite_entry["passing_cases"]
+        assert step["exit_code"] == suite_entry["exit_code"]
+
+
+def test_baseline_pass_set_identical_with_and_without_reuse(user_dir, tmp_path):
+    """Acceptance criterion: the baseline record's pass-set is IDENTICAL
+    whether reached via `run` (survey reuses the scorecard) or via the old
+    two-real-runs path (standalone survey THEN standalone baseline) — the
+    dedup changes nothing about what gets journaled as the pass-set."""
+    target_a = make_target(tmp_path / "a")
+    assert adopt.main(["run", "--repo", str(target_a),
+                       "--workdir", str(tmp_path / "wd-a")]) == 0
+    resolver_a = artifacts.Resolver.resolve(target_a)
+    sc_a = json.loads((resolver_a.quality_dir() / ratchet.SCORECARD_NAME).read_text())
+
+    target_b = make_target(tmp_path / "b")
+    artifacts.elect(target_b, "sidecar", backing="local")
+    assert adopt.main(["survey", "--repo", str(target_b)]) == 0
+    assert adopt.main(["baseline", "--repo", str(target_b),
+                       "--workdir", str(tmp_path / "wd-b")]) == 0
+    resolver_b = artifacts.Resolver.resolve(target_b)
+    sc_b = json.loads((resolver_b.quality_dir() / ratchet.SCORECARD_NAME).read_text())
+
+    assert sc_a["pass_set"] == sc_b["pass_set"]
+    assert sc_a["tests_run"] == sc_b["tests_run"] is True
+
+
+def test_survey_falls_back_to_real_run_when_reused_scorecard_is_stale(user_dir, tmp_path, monkeypatch):
+    """The reuse is provably-fresh only: a scorecard whose `target_sha` does
+    not match the CURRENT HEAD (e.g. a commit landed between two steps) must
+    never be silently trusted — build_survey re-runs for real instead,
+    mirroring `ratchet.py score --reuse-report`'s loud-fail-on-stale
+    discipline (never SERVE a stale measurement as current)."""
+    target = make_target(tmp_path / "t")
+    resolver = artifacts.elect(target, "sidecar", backing="local")
+    resolver = artifacts.Resolver.resolve(target)
+    calls: list[int] = []
+    orig_coverage_baseline = adopt.coverage_baseline
+
+    def spy(*a, **k):
+        calls.append(1)
+        return orig_coverage_baseline(*a, **k)
+
+    monkeypatch.setattr(adopt, "coverage_baseline", spy)
+    stale_scorecard = {
+        "target_sha": "0" * 40,  # provably not this repo's real HEAD sha
+        "passed": 0,
+        "pass_set": [],
+        "tests_run": True,
+        "suite_measurement": {"status": "applicable", "suites": [], "total_passing": 0},
+    }
+    doc = adopt.build_survey(target, resolver, reuse_scorecard=stale_scorecard)
+    assert calls == [1], "a stale (mismatched-HEAD) scorecard must trigger a REAL fallback run"
+    assert doc["test_run"]["detected"] is True
+    assert doc["test_run"].get("source") != "ratchet-scorecard"
+
+
 # --- gates honor the grandfather file --------------------------------------------
 
 

--- a/tests/test_check_gate_validation.py
+++ b/tests/test_check_gate_validation.py
@@ -968,6 +968,153 @@ def test_chain_broken_blocking_unwire_still_emits_demotion(tmp_path, monkeypatch
     assert "could not journal" in (transition.instruction or "")
 
 
+# --- #323: multiple gates per invocation, journal chain verified once -------
+
+
+def _write_multi_gate_records(tmp_path: Path, gates: tuple[str, ...]) -> Path:
+    """Write one <gate>.json record per name in `gates`, ALL corroborated by
+    ONE shared journal (one entry per gate, distinct record_ids) — the real
+    shape of a --validation-dir holding several gates' records side by side
+    (they always share the same ratchet journal, per JOURNAL_NAME being a
+    sibling of validation-dir, not gate-specific)."""
+    state = tmp_path / "quality"
+    vdir = state / "validation"
+    vdir.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for i, gate in enumerate(gates, start=1):
+        rid = f"rec-{i:05d}"
+        record = _minimal_valid_record(gate=gate, ratchet_record_id=rid)
+        (vdir / f"{gate}.json").write_text(json.dumps(record))
+        entries.append({"record_id": rid, "event": "gate-validation", "ref": gate})
+    _write_journal(state, entries)
+    return vdir
+
+
+def test_chain_cache_verifies_journal_once_across_gates(tmp_path, monkeypatch):
+    """Three gates sharing one --validation-dir share ONE ratchet journal file
+    (JOURNAL_NAME is a sibling of validation-dir, not gate-specific). Passing
+    the SAME chain_cache dict to check() for each gate must hash-walk that
+    journal exactly once, not once per gate."""
+    vdir = _write_multi_gate_records(tmp_path, ("gate_a", "gate_b", "gate_c"))
+
+    calls: list[int] = []
+    orig = gv._load_and_verify_chain
+
+    def spy(journal):
+        calls.append(1)
+        return orig(journal)
+
+    monkeypatch.setattr(gv, "_load_and_verify_chain", spy)
+    vdir = tmp_path / "quality" / "validation"
+    cache: dict = {}
+    for name in ("gate_a", "gate_b", "gate_c"):
+        report = gv.check(name, vdir, chain_cache=cache)
+        assert report.passing, report.provenance_errors
+    assert calls == [1], f"expected the journal to be verified exactly once, got {len(calls)} walks"
+
+
+def test_chain_cache_none_verifies_every_call_unchanged(tmp_path, monkeypatch):
+    """The default (chain_cache=None) is UNCHANGED — every existing
+    single-gate caller keeps re-verifying fresh each call (no shared state
+    silently introduced)."""
+    for name in ("gate_a", "gate_b"):
+        _write_record(tmp_path, name, _minimal_valid_record(gate=name))
+    calls: list[int] = []
+    orig = gv._load_and_verify_chain
+
+    def spy(journal):
+        calls.append(1)
+        return orig(journal)
+
+    monkeypatch.setattr(gv, "_load_and_verify_chain", spy)
+    vdir = tmp_path / "quality" / "validation"
+    gv.check("gate_a", vdir)
+    gv.check("gate_b", vdir)
+    assert calls == [1, 1]  # two independent walks — no cache was shared
+
+
+def test_cli_multi_gate_checks_each_and_reuses_chain(tmp_path, monkeypatch):
+    """CLI: multiple gate names in one invocation, each checked against its
+    own record, journal chain verified once for the whole process."""
+    vdir = _write_multi_gate_records(tmp_path, ("gate_a", "gate_b"))
+
+    calls: list[int] = []
+    orig = gv._load_and_verify_chain
+
+    def spy(journal):
+        calls.append(1)
+        return orig(journal)
+
+    monkeypatch.setattr(gv, "_load_and_verify_chain", spy)
+    rc = gv.main(["gate_a", "gate_b", "--validation-dir", str(vdir), "--gate", "--format", "json"])
+    assert rc == 0
+    assert calls == [1]
+
+
+def test_cli_multi_gate_json_nests_under_gates_key(tmp_path, capsys):
+    """Multi-gate JSON output is `{"gates": {name: {...}}}` — distinct from
+    the single-gate top-level shape every existing caller/test parses."""
+    _write_record(tmp_path, "gate_a", _minimal_valid_record(gate="gate_a"))
+    vdir = tmp_path / "quality" / "validation"
+    rc = gv.main(["gate_a", "no_such_gate", "--validation-dir", str(vdir), "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert set(out["gates"]) == {"gate_a", "no_such_gate"}
+    assert out["gates"]["gate_a"]["passing"] is True
+    assert out["gates"]["no_such_gate"]["passing"] is False
+
+
+def test_cli_single_gate_json_shape_unchanged(tmp_path, capsys):
+    """Backward compatibility: a single gate name still produces the
+    byte-identical top-level shape (no `gates` wrapper)."""
+    _write_record(tmp_path, "gate_a", _minimal_valid_record(gate="gate_a"))
+    vdir = tmp_path / "quality" / "validation"
+    rc = gv.main(["gate_a", "--validation-dir", str(vdir), "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "gates" not in out
+    assert out["gate"] == "gate_a"
+    assert out["passing"] is True
+
+
+def test_cli_multi_gate_exits_1_if_any_gate_fails_under_gate_mode(tmp_path):
+    _write_record(tmp_path, "gate_a", _minimal_valid_record(gate="gate_a"))
+    vdir = tmp_path / "quality" / "validation"
+    rc = gv.main(["gate_a", "gate_missing", "--validation-dir", str(vdir), "--gate"])
+    assert rc == 1
+
+
+def test_cli_multi_gate_refuses_wire(tmp_path, capsys):
+    """--wire/--unwire are single-gate operator acts — batching them across
+    multiple gates in one invocation is refused, not silently applied to the
+    first/last gate."""
+    vdir = tmp_path / "quality" / "validation"
+    vdir.mkdir(parents=True)
+    rc = gv.main(["gate_a", "gate_b", "--validation-dir", str(vdir), "--wire"])
+    assert rc == 2
+    assert "single-gate" in capsys.readouterr().err
+
+
+def test_cli_multi_gate_broken_chain_fails_every_gate(tmp_path, capsys):
+    """A shared chain_cache must not let a broken-chain error silently pass
+    for gates checked AFTER the one that discovered it — every gate sharing
+    that journal reports the same corroboration failure."""
+    vdir = _write_multi_gate_records(tmp_path, ("gate_a", "gate_b"))
+    journal = _journal(vdir)
+    # Corrupt one entry's hash so the chain no longer verifies.
+    lines = journal.read_text().splitlines()
+    entries = [json.loads(ln) for ln in lines]
+    entries[0]["record_hash"] = "0" * 64
+    journal.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+    rc = gv.main(["gate_a", "gate_b", "--validation-dir", str(vdir), "--gate", "--format", "json"])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    for name in ("gate_a", "gate_b"):
+        assert out["gates"][name]["passing"] is False
+        assert any("chain broken" in e for e in out["gates"][name]["provenance_errors"])
+
+
 def test_validation_dir_is_defined_once_and_imported():
     """INV-fh-004: docs/quality/validation is defined in exactly one place —
     factory_log.DEFAULT_VALIDATION_DIR — and check_gate_validation IMPORTS it.

--- a/tests/test_close_epic_audit.py
+++ b/tests/test_close_epic_audit.py
@@ -137,6 +137,36 @@ def test_traceability_audit_included(tmp_path):
     assert m.traceability["total"] == 2
 
 
+# --- target_sha stamping (#323): the freshness check later /close-epic steps --
+# --- need before reusing this manifest instead of recomputing -----------------
+
+
+def test_target_sha_stamped_from_injected_sha_fn(tmp_path):
+    m = _audit(tmp_path, sha_fn=lambda repo: "deadbeef" * 5)
+    assert m.target_sha == "deadbeef" * 5
+
+
+def test_target_sha_none_outside_a_git_repo(tmp_path):
+    """Default sha_fn is the real artifacts.head_sha — tmp_path here is not a
+    git repo, so this exercises the real "not a git repo" path, not a stub."""
+    m = _audit(tmp_path)
+    assert m.target_sha is None
+
+
+def test_target_sha_failure_is_warned_not_fatal(tmp_path):
+    def boom(repo):
+        raise RuntimeError("git binary missing")
+
+    m = _audit(tmp_path, sha_fn=boom)
+    assert m.target_sha is None
+    assert any("target HEAD sha" in w for w in m.warnings)
+
+
+def test_target_sha_in_manifest_dict(tmp_path):
+    m = _audit(tmp_path, sha_fn=lambda repo: "abc123")
+    assert m.to_dict()["target_sha"] == "abc123"
+
+
 def test_malformed_traceability_does_not_abort_audit(tmp_path, monkeypatch):
     m_in = _epic(tmp_path)
 

--- a/tests/test_close_epic_prompt_dedup.py
+++ b/tests/test_close_epic_prompt_dedup.py
@@ -1,0 +1,119 @@
+"""Pins the mechanical dedups in the /close-epic workflow prompt
+(chief-wiggum#323): /close-epic recomputes what close-epic-manifest.json
+already proves, and runs the traceability coverage scan twice back-to-back.
+Each of these is a prompt an agent follows literally, so the only way to
+prove "runs once, not twice" is to count the invocations in the live prompt
+text — a dedup with no test proving the second run is gone can silently
+regress the next time someone edits the file. Equally, every reuse pins its
+FALLBACK (stale/missing manifest still triggers a real recomputation) so the
+dedup can never turn into "trust a stale artifact forever."
+
+``.claude/commands/close-epic.md`` is the source of truth; ``skills/
+chief-wiggum/references/workflows/close-epic.md`` is a SYMLINK to it (never a
+separate copy) — see test_implement_prompt_dedup.py for the symlink pin
+shared across all three workflow files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+COMMANDS = REPO / ".claude" / "commands"
+
+
+def _text(name: str) -> str:
+    return (COMMANDS / name).read_text()
+
+
+def _invocation_count(text: str, script: str) -> int:
+    """Count ACTUAL invocations of a script (`scripts/<script>"`) — distinct
+    from prose that merely NAMES the script while explaining a flag or a
+    fallback path. A raw substring count of the filename would false-positive
+    on exactly that prose (see close-epic.md Step 2c2, which legitimately
+    mentions `check_gate_validation.py` twice in prose around its one real
+    invocation)."""
+    return text.count(f'scripts/{script}"')
+
+
+def test_close_epic_manifest_carries_target_sha():
+    """The freshness check every reuse below depends on: the manifest records
+    the target's HEAD at audit time (close_epic_audit.py's CloseEpicManifest
+    .target_sha, #323), and Step 1b's consumer list says so."""
+    text = _text("close-epic.md")
+    assert "target_sha" in text
+    consumers = text.split("Steps 2 (traceability)")[1].split("### Step 2:")[0]
+    assert "3 (integration tests" in consumers, (
+        "Step 3 must be added to the manifest-consumers list — #323's whole "
+        "point is that it was the most expensive duplicate and wasn't even "
+        "listed as a consumer")
+
+
+def test_close_epic_step2b_reuses_manifest_transitions_with_fallback():
+    """Step 2b must consume the manifest's `.transitions` when target_sha is
+    fresh, and only re-run verify_transitions.py when it isn't (or the
+    manifest is missing) — never unconditionally re-scan."""
+    text = _text("close-epic.md")
+    section = text.split("### Step 2b: Transition-map audit")[1].split("### Step 2c:")[0]
+    assert "target_sha" in section
+    assert "jq '.transitions'" in section
+    assert _invocation_count(section, "verify_transitions.py") == 1, (
+        "verify_transitions.py must appear exactly once in 2b — as the "
+        "stale/missing-manifest fallback, not the default path")
+
+
+def test_close_epic_step2c_reuses_manifest_unresolved_with_fallback():
+    """Step 2c must consume the manifest's `.unresolved` when fresh, falling
+    back to check_unresolved.py only when it isn't."""
+    text = _text("close-epic.md")
+    section = text.split("### Step 2c: Unresolved-unknowns audit")[1].split("### Step 2c2:")[0]
+    assert "target_sha" in section
+    assert ".unresolved[]" in section
+    assert _invocation_count(section, "check_unresolved.py") == 1, (
+        "check_unresolved.py must appear exactly once in 2c — as the "
+        "stale/missing-manifest fallback, not the default path")
+
+
+def test_close_epic_step2c2_checks_all_gates_in_one_invocation():
+    """Step 2c2 must invoke check_gate_validation.py ONCE for all three
+    gates (check_traceability, check_single_writer, ratchet) — not three
+    separate processes each re-walking the shared ratchet journal chain."""
+    text = _text("close-epic.md")
+    section = text.split("### Step 2c2:")[1].split("### Step 2d:")[0]
+    assert _invocation_count(section, "check_gate_validation.py") == 1, (
+        f"expected exactly one check_gate_validation.py invocation in 2c2, "
+        f"found {_invocation_count(section, 'check_gate_validation.py')}")
+    invocation = section.split("```bash")[1].split("```")[0]
+    for gate in ("check_traceability", "check_single_writer", "ratchet"):
+        assert gate in invocation
+
+
+def test_close_epic_step2d_collapses_traceability_scan_into_one_call():
+    """Step 2d must run check_traceability.py exactly ONCE, with BOTH
+    --gate coverage and --write-links on the same invocation — not a plain
+    coverage run followed by a second full annotation scan just to add
+    --write-links (--write-links is documented as a no-op when the gate
+    doesn't pass, so it always safely rides the same run)."""
+    text = _text("close-epic.md")
+    section = text.split("### Step 2d:")[1].split("### Step 2e:")[0]
+    assert _invocation_count(section, "check_traceability.py") == 1, (
+        f"expected exactly one check_traceability.py invocation in 2d, "
+        f"found {_invocation_count(section, 'check_traceability.py')}")
+    invocation = section.split("```bash")[1].split("```")[0]
+    assert "--gate coverage" in invocation
+    assert "--write-links" in invocation
+
+
+def test_close_epic_step3_checks_freshness_before_relaunching_integration_tests():
+    """Step 3 must check the manifest's target_sha freshness (and whether
+    Step 1b's suite run was green) BEFORE deciding to re-run the integration
+    tests — not unconditionally launch a fresh verification worker that
+    duplicates Step 1b's `ver.verify(repo, ["test"])`."""
+    text = _text("close-epic.md")
+    section = text.split("### Step 3: Integration test execution")[1].split("### Step 4:")[0]
+    assert "target_sha" in section
+    assert "SUITE_OK" in section
+    assert "FRESH" in section
+    # The fallback (genuinely re-running) must still be present and reachable
+    # — reuse is conditional, not an unconditional skip.
+    assert "Run the full walk below for real" in section

--- a/tests/test_gate_validation_retroactive.py
+++ b/tests/test_gate_validation_retroactive.py
@@ -444,8 +444,14 @@ def test_workflow_adapters_consume_the_wired_verifier_gate():
     implement = (ROOT / ".claude" / "commands" / "implement.md").read_text()
     wave = (ROOT / ".claude" / "commands" / "implement-wave.md").read_text()
 
-    # /close-epic Step 2c2 checks the ratchet record like the other gates...
-    assert "check_gate_validation.py\" ratchet" in close_epic, (
+    # /close-epic Step 2c2 checks the ratchet record like the other gates —
+    # in ONE batched check_gate_validation.py invocation since #323 (the
+    # journal chain is verified once for all three gate names rather than
+    # once per gate), so "ratchet" is a space-separated arg in the SAME
+    # bash block as the script path, not necessarily adjacent to it.
+    gate_validation_block = close_epic.split("### Step 2c2:")[1].split("### Step 2d:")[0]
+    invocation = gate_validation_block.split("```bash")[1].split("```")[0]
+    assert "check_gate_validation.py" in invocation and "ratchet" in invocation, (
         "/close-epic no longer validates the ratchet gate's record before wiring")
     # ...Step 2f passes the blocking flag, with the downgrade posture stated.
     assert close_epic.count("--gate-verifier-tests") >= 2, (

--- a/tests/test_implement_prompt_dedup.py
+++ b/tests/test_implement_prompt_dedup.py
@@ -1,0 +1,136 @@
+"""Pins the mechanical dedups in the /implement workflow prompt
+(chief-wiggum#324): the prompt is followed literally by an agent, so the only
+way to prove "runs once, not twice" is to count the invocations in the live
+prompt text — a dedup with no test proving the second run is gone can
+silently regress the next time someone edits the file.
+
+``.claude/commands/*.md`` are the source of truth; ``skills/chief-wiggum/
+references/workflows/*.md`` are SYMLINKS to them (never a separate copy), so
+reading one file exercises both.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+COMMANDS = REPO / ".claude" / "commands"
+
+
+def _text(name: str) -> str:
+    return (COMMANDS / name).read_text()
+
+
+# --- symlinks stay symlinks, never copies -----------------------------------
+
+
+def test_workflow_symlinks_point_at_commands():
+    workflows = REPO / "skills" / "chief-wiggum" / "references" / "workflows"
+    for name in ("implement.md", "implement-wave.md", "close-epic.md"):
+        link = workflows / name
+        assert link.is_symlink(), f"{link} must be a symlink, never a copy"
+        assert link.resolve() == (COMMANDS / name).resolve()
+
+
+# --- #324 item 1: verify.json / verification.json filename bug -------------
+
+
+def test_implement_verification_writer_and_reader_agree_on_filename():
+    """Step 8.4 writes `$TICKET_TMP/verify.json`; Step 11's draft_pr.py call
+    must read that SAME file — not a `verification.json` nobody writes."""
+    text = _text("implement.md")
+    assert 'run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint,build --json > "$TICKET_TMP/verify.json"' in text
+    assert '--verification "$TICKET_TMP/verify.json"' in text
+    # The old mismatched filename must not reappear anywhere in the file.
+    assert "verification.json" not in text
+
+
+# --- #324 item 2: the unresolved-marker scan runs once in Step 1 -----------
+
+
+def test_implement_step1_reuses_inventory_unresolved_scan():
+    """`epic_inventory.py` already runs `check_unresolved.scan` internally
+    and writes `.unresolved`/`.blocked_tickets` into inventory.json — Step 1
+    must read that field, not shell out to check_unresolved.py a second time
+    over the same $EPIC_DIR with zero intervening writes. The ONE remaining
+    mention is the documented fallback for when inventory.json itself is
+    unavailable."""
+    text = _text("implement.md")
+    assert text.count("check_unresolved.py") == 1, (
+        "check_unresolved.py must appear exactly once in implement.md — as "
+        "the documented fallback, not a routine second scan")
+    assert 'jq \'.unresolved\' "$TICKET_TMP/inventory.json"' in text
+    gate_section = text.split("Unresolved-unknowns gate")[1].split("### Step 2")[0]
+    assert "Fallback" in gate_section
+    assert "check_unresolved.py" in gate_section  # the fallback lives IN this section
+
+
+# --- #324 item 3: verify_transitions.py runs once in Step 8b ---------------
+
+
+def test_implement_step8b_runs_verify_transitions_once():
+    """The old flow ran verify_transitions.py twice (once --format text for
+    the human summary, once --format json --output for the transition-map)
+    — the SAME comparison, computed twice. One JSON run must feed both the
+    written map and the locally-rendered summary."""
+    text = _text("implement.md")
+    assert text.count("verify_transitions.py") == 1, (
+        f"verify_transitions.py must be invoked exactly once in Step 8b, "
+        f"found {text.count('verify_transitions.py')}")
+    assert "--format json --output" in text
+    # Only one fenced ```bash block in this section may invoke the script —
+    # a second code block re-running it (the old --format text pass) is the
+    # regression this test guards against. (Prose ABOVE the code block is
+    # allowed to reference the old `--format text` run when explaining why
+    # it was removed — that is not a second invocation.)
+    section = text.split("Transition-map verification")[1].split('9. **Quality check**')[0]
+    bash_blocks = section.count("```bash")
+    assert bash_blocks == 2, (
+        f"expected exactly two ```bash blocks in 8b (the single verify_transitions "
+        f"invocation + the local jq render), found {bash_blocks}")
+
+
+# --- #324 item 4: QUALITY_DIR/meta root resolved once, reused --------------
+
+
+def test_no_redundant_artifacts_show_invocations():
+    """`artifacts.py show` re-resolving quality_dir/meta_root ~10x across the
+    three workflow files is exactly the redundancy #324 flags — Step 1's
+    `workflow_context.py` now exports QUALITY_DIR/CW_META_ROOT/CW_META_MODE
+    once per session (see chief_wiggum/context.py), so no downstream step in
+    these three files should re-invoke `artifacts.py show` for the same
+    answer against the same unchanged target."""
+    for name in ("implement.md", "implement-wave.md", "close-epic.md"):
+        text = _text(name)
+        assert 'artifacts.py" show' not in text, (
+            f"{name} still re-invokes `artifacts.py show` — QUALITY_DIR/"
+            "CW_META_ROOT/CW_META_MODE should be reused from Step 1 instead")
+
+
+def test_implement_and_wave_and_close_epic_reuse_quality_dir_var():
+    """Every ratchet-gated step references `$QUALITY_DIR` as a plain shell
+    variable (Step 1's export), not a freshly-derived one."""
+    for name in ("implement.md", "implement-wave.md", "close-epic.md"):
+        text = _text(name)
+        assert "$QUALITY_DIR" in text
+
+
+# --- #324 item 5: service teardown moves past Step 10 -----------------------
+
+
+def test_implement_service_teardown_happens_after_step10():
+    """Step 8 used to tear services down (`docker compose down`) only for
+    Step 9's UX gate to immediately need them running again. Teardown must
+    now occur exactly once, after Step 10 (browser-use validation) and
+    before Step 11 (Ship PR) — never inside Step 8's checklist."""
+    text = _text("implement.md")
+    assert text.count("docker compose down") == 1
+    step8_idx = text.index("### Step 8: Apply review fixes and verify")
+    step9_idx = text.index("### Step 9: UX sanity")
+    step10_idx = text.index("### Step 10: Browser-use validation")
+    step11_idx = text.index("### Step 11: Ship PR")
+    teardown_idx = text.index("docker compose down")
+    assert not (step8_idx < teardown_idx < step9_idx), (
+        "teardown must not happen inside Step 8 anymore")
+    assert step10_idx < teardown_idx < step11_idx, (
+        "teardown must happen after Step 10 and before Step 11")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -216,6 +216,26 @@ def test_gate_ledger_against_this_repos_real_validation_dir(user_dir):
     assert gates["ratchet"]["wired"] is True
 
 
+def test_gate_ledger_verifies_shared_journal_chain_once(user_dir, monkeypatch):
+    """#323: every gate under one validation_dir shares the SAME ratchet
+    journal — gate_ledger() must hash-verify that chain ONCE for the whole
+    7-gate ledger, not once per gate (the amplification the ticket flagged
+    at status.py:91-101)."""
+    import check_gate_validation as gv
+
+    calls: list[int] = []
+    orig = gv._load_and_verify_chain
+
+    def spy(journal):
+        calls.append(1)
+        return orig(journal)
+
+    monkeypatch.setattr(gv, "_load_and_verify_chain", spy)
+    st = status.gather(ROOT)
+    assert len(st["gates"]) == 7
+    assert calls == [1], f"expected the journal to be verified exactly once, got {len(calls)} walks"
+
+
 # --- CLI -------------------------------------------------------------------------
 
 

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -177,6 +177,62 @@ def test_to_dict_and_shell_exports(monkeypatch, tmp_path):
     assert f"export EPIC_DIR='{resolved}'" in exports
 
 
+# --- QUALITY_DIR/meta-root export, resolved once (#324) ---------------------
+
+
+def test_shell_exports_include_quality_dir_and_meta_root(monkeypatch, tmp_path):
+    """QUALITY_DIR/CW_META_ROOT/CW_META_MODE are a pure function of the
+    target — resolvable at Step 1 without an epic — so every downstream step
+    can reuse them instead of re-invoking `artifacts.py show`."""
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(context.repo, "resolve_repo", lambda slug: repo_dir)
+    ctx = context.resolve(
+        "acme/app", tmp=tmp_path, home=REPO_ROOT, branch_detector=lambda p: "main",
+    )
+    exports = ctx.shell_exports()
+    assert f"export QUALITY_DIR={context.env.shell_quote(str(repo_dir / 'docs' / 'quality'))}" in exports
+    assert f"export CW_META_ROOT={context.env.shell_quote(str(repo_dir / 'docs'))}" in exports
+    assert "export CW_META_MODE='embedded'" in exports
+
+
+def test_shell_exports_omit_quality_dir_without_repo_path(tmp_path):
+    """Offline (`--no-resolve`, no repo path): nothing to resolve, so no
+    QUALITY_DIR/CW_META_ROOT/CW_META_MODE lines are emitted — never a guess."""
+    ctx = context.resolve(tmp=tmp_path, home=REPO_ROOT)
+    exports = ctx.shell_exports()
+    assert "QUALITY_DIR" not in exports
+    assert "CW_META_ROOT" not in exports
+    assert "CW_META_MODE" not in exports
+
+
+def test_shell_exports_resolves_meta_location_exactly_once(monkeypatch, tmp_path):
+    """The #213 resolver is built ONCE per `shell_exports()` call and reused
+    for EPIC_DIR + QUALITY_DIR + CW_META_ROOT + CW_META_MODE — not
+    re-resolved per export (#324's whole point: one resolution, many
+    readers)."""
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(context.repo, "resolve_repo", lambda slug: repo_dir)
+    ctx = context.resolve(
+        "acme/app", epic="Epic: Name", tmp=tmp_path, home=REPO_ROOT,
+        branch_detector=lambda p: "main",
+    )
+
+    import artifacts as artifacts_module
+
+    calls: list[int] = []
+    orig_resolve = artifacts_module.Resolver.resolve
+
+    def spy_resolve(*a, **k):
+        calls.append(1)
+        return orig_resolve(*a, **k)
+
+    monkeypatch.setattr(artifacts_module.Resolver, "resolve", staticmethod(spy_resolve))
+    ctx.shell_exports()
+    assert calls == [1], (
+        "shell_exports() must resolve the meta location exactly once and "
+        f"reuse it for every export, not once per export (got {len(calls)} calls)")
+
+
 def test_shell_exports_quote_hostile_values(monkeypatch, tmp_path):
     # A repo path / branch with spaces, single quotes, or shell metacharacters
     # must be safely quoted so `eval` cannot execute injected commands.
@@ -189,7 +245,18 @@ def test_shell_exports_quote_hostile_values(monkeypatch, tmp_path):
         branch_detector=lambda p: "feat/x'; rm -rf /; '",
     )
     exports = ctx.shell_exports()
-    # The injected command text survives only inside a single-quoted literal.
-    assert "touch pwned" not in exports.replace(context.env.shell_quote(str(nasty)), "")
+    # The injected command text survives only inside a single-quoted literal
+    # — verified by shell-tokenizing the WHOLE output (posix quote/escape
+    # rules) and confirming "touch"/"pwned" never appear as their OWN token
+    # (which is what would happen if quoting broke and `;` really split
+    # commands). QUALITY_DIR/CW_META_ROOT (#324) embed the same nasty path
+    # inside a longer string (`<nasty>/docs/...`), so a literal substring
+    # check against `shell_quote(str(nasty))` alone no longer covers every
+    # export line — tokenizing does.
+    import shlex
+
+    tokens = shlex.split(exports)
+    assert "touch" not in tokens
+    assert not any(t.startswith("pwned") or t == "pwned;" for t in tokens)
     assert context.env.shell_quote(str(nasty)) in exports
     assert context.env.shell_quote("feat/x'; rm -rf /; '") in exports


### PR DESCRIPTION
Closes #334
Closes #324
Closes #323

Three workflows that redo work already done. The governing constraint throughout: **a re-run is redundant only when it provably observes the same state.** A second run *after* a mutation isn't duplication — it's the only observation of the new state, and deleting it would be the inverse of this week's stale-artifact bugs: instead of serving an old measurement as current, never taking the current one at all.

So none of these delete a step outright. Each reuses a recorded artifact **when it provably describes the same commit**, and re-runs otherwise — following `--reuse-report`'s discipline of refusing a stale artifact rather than trusting it.

## #334 — `/adopt` ran the target suite twice

`adopt.py run` executed the target's test command twice against the same unchanged HEAD: once for the survey's coverage baseline, once for the ratchet-scored baseline.

**Reordered rather than removed.** `run` now scores the baseline *first* and hands its scorecard to the survey step. `build_survey`/`coverage_from_scorecard` derive the survey's numbers from it **only when the scorecard's `target_sha` matches current HEAD** — provably the same state — and fall back to a real run when it doesn't.

Standalone `adopt.py survey`, with no baseline having just run, is unaffected and always performs its own real run.

Pinned by `test_survey_falls_back_to_real_run_when_reused_scorecard_is_stale`.

## #324 — `/implement` mechanical dedups

Double unresolved scan collapsed to one; one `verify_transitions` run instead of two; `QUALITY_DIR` resolved once; teardown moved after Step 10 so it doesn't tear down state a later step still needs. Also fixed a real `verify.json` bug found along the way.

## #323 — `/close-epic` recomputed what its own manifest already proves

`close-epic-manifest.json` records facts the close step then recalculated from scratch. Now consumed rather than recomputed, with the gate-validation checks batched.

**The completeness claim is unchanged** — the manifest is the proof, and the claim is still made over the same population. Reusing a proof is not the same as narrowing a check.

## Verification

- Full suite: **3182 passed, 14 skipped, 0 failed** (+33 tests)
- Each dedup asserts the duplicate invocation is **gone** (counted, not inferred) *and* that the fallback still re-runs when the artifact is missing or stale — a dedup without the second test silently returns the moment someone reintroduces the call
- `make lint` clean; no `scanner_version` moved
- `git status` verified clean before push
