### PR TITLE
fix(traceability): zero-match update never rewrites the file — closes the data-loss path (#342)

### DIFF
--- a/scripts/chief_wiggum/traceability.py
+++ b/scripts/chief_wiggum/traceability.py
@@ -251,3 +251,196 @@ def render_markdown(matrix: TraceMatrix) -> str:
         escaped = [c.replace("|", "\\|") for c in cells]
         lines.append("| " + " | ".join(escaped) + " |")
     return "\n".join(lines) + "\n"
+
+
+# --- multi-table-safe update (chief-wiggum#342) ------------------------------
+#
+# ``parse_matrix``/``update_status``/``replace_table`` above operate on a
+# SINGLE "chosen" table (the first candidate satisfying ``_REQUIRED_COLUMNS``,
+# else the first table in the document at all) and blindly re-render it
+# through the fixed 6-column canonical schema. That is safe for the common
+# case this module was built for (one canonical table per file) but is a
+# data-loss trap for a richer/differently-shaped doc: an epic whose tables key
+# tickets into ``##`` headings rather than a ``Ticket`` column satisfies
+# NO candidate's required columns, so the fallback picks whatever table
+# happens to be first — often a non-canonical one — and force-renders it into
+# the canonical shape, silently dropping any column ``render_markdown``
+# doesn't know about. Observed live: an epic-level table (`AC | Contracts /
+# invariants | Planned tests | Status`) got its "Contracts / invariants" and
+# "Planned tests" columns dropped by an ``update`` call that matched ZERO
+# rows.
+#
+# ``update_file`` below is the safe replacement used by the CLI's ``update``
+# command: it never guesses at "the" table. It walks EVERY table in the
+# document, classifies each by its header (canonical == exactly the six
+# recognized columns, no more, no less — anything looser is a different
+# shape and must round-trip untouched), matches/updates rows only within
+# canonical tables, and re-renders only the individual tables that actually
+# had a row change. Everything else — non-canonical tables, canonical tables
+# with no match, and all surrounding prose — is copied verbatim from the
+# original line ranges, so it is byte-identical in the output by
+# construction, not by convention.
+CANONICAL_KEYS = frozenset({"ticket", "ac", "unit_test", "integration_test", "e2e_test", "status"})
+
+
+def _is_canonical_header(cells: list[str], col_index: dict[str, int]) -> bool:
+    """True only when every header cell maps to a recognized traceability
+    column and all six canonical columns are present exactly once — the
+    exact shape ``render_markdown`` emits.
+
+    Deliberately strict: a table with an EXTRA unrecognized column (e.g. a
+    "Contracts / invariants" column alongside AC/Status) is NOT canonical,
+    because re-rendering it through the fixed 6-column schema would silently
+    drop that column's data. A table missing one of the six is likewise not
+    canonical — it isn't the shape this tool round-trips, so it is left
+    alone rather than "helpfully" reshaped.
+    """
+    return len(cells) == len(CANONICAL_KEYS) and set(col_index) == CANONICAL_KEYS
+
+
+def _scan_tables(lines: list[str]) -> list[dict]:
+    """Walk ``lines`` once, returning one dict per ``| header |`` + separator
+    table found: ``{start, end, canonical, rows, warnings}`` (``start``/``end``
+    are inclusive 0-based line indices spanning the WHOLE table, header
+    through last row/separator). Only canonical tables get their rows parsed
+    into :class:`TraceRow` — a non-canonical table's ``rows`` stays empty
+    because its columns can't be trusted to mean what the canonical ones
+    mean (its ``end`` is still tracked precisely, so its line span can be
+    copied through untouched).
+
+    Scanning resumes immediately after each table's last line, so a data row
+    that happens to start with ``|`` is never mistaken for the start of a new
+    table.
+    """
+    tables: list[dict] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i].strip()
+        if not line.startswith("|"):
+            i += 1
+            continue
+        cells = _split_cells(line)
+        nxt = lines[i + 1].strip() if i + 1 < n else ""
+        if not (nxt.startswith("|") and _is_separator(_split_cells(nxt))):
+            i += 1
+            continue
+        col_index = {
+            _COLUMN_KEYS[c.lower()]: j for j, c in enumerate(cells) if c.lower() in _COLUMN_KEYS
+        }
+        canonical = _is_canonical_header(cells, col_index)
+        header_idx = i
+        end = i + 1  # separator row
+        rows: list[TraceRow] = []
+        warnings: list[str] = []
+        j = i + 2
+        while j < n:
+            row_line = lines[j].strip()
+            if not row_line.startswith("|"):
+                break
+            row_cells = _split_cells(row_line)
+            if _is_separator(row_cells):
+                end = j
+                j += 1
+                continue
+            if canonical:
+                status = _cell(row_cells, col_index, "status").lower() or "pending"
+                if status not in STATUSES:
+                    warnings.append(
+                        f"unknown status {status!r} for ticket "
+                        f"{_cell(row_cells, col_index, 'ticket')!r}"
+                    )
+                rows.append(
+                    TraceRow(
+                        ticket=_parse_ticket(_cell(row_cells, col_index, "ticket")),
+                        ac=_cell(row_cells, col_index, "ac"),
+                        unit_test=_cell(row_cells, col_index, "unit_test"),
+                        integration_test=_cell(row_cells, col_index, "integration_test"),
+                        e2e_test=_cell(row_cells, col_index, "e2e_test"),
+                        status=status,
+                    )
+                )
+            end = j
+            j += 1
+        tables.append(
+            {"start": header_idx, "end": end, "canonical": canonical, "rows": rows, "warnings": warnings}
+        )
+        i = end + 1
+    return tables
+
+
+def update_file(
+    markdown: str,
+    *,
+    ticket: int,
+    status: str,
+    ac_contains: str | None = None,
+    test_contains: str | None = None,
+) -> tuple[str | None, int, list[str]]:
+    """Apply an in-place status update across every CANONICAL-schema table in
+    ``markdown``. Returns ``(new_text, updated_count, warnings)``.
+
+    ``new_text`` is ``None`` when ``updated_count`` is 0 — the caller MUST
+    treat that as "do not write the file at all" (chief-wiggum#342): this
+    function performs no I/O itself, and returning the original text
+    unchanged instead of ``None`` would invite a caller to "helpfully" write
+    it back out, which is exactly the silent-rewrite failure mode this
+    function exists to prevent. Zero matches happens both for "ticket not
+    present in any canonical table" and "no canonical table exists in this
+    document at all" (e.g. an epic that keys tickets into ``##`` headings) —
+    both are non-events, not partial successes.
+
+    Only the individual tables that had at least one row change are
+    re-rendered (in the canonical 6-column form); every other table —
+    non-canonical ones, and canonical ones with zero matches — is copied
+    verbatim from ``markdown``'s original lines, as is all surrounding
+    prose. This is what makes the byte-identical round-trip guarantee hold
+    per-table rather than only for a whole-file no-op.
+    """
+    if status not in STATUSES:
+        raise ValueError(f"invalid status: {status!r} (expected one of {', '.join(STATUSES)})")
+
+    lines = markdown.splitlines()
+    tables = _scan_tables(lines)
+    warnings: list[str] = []
+    total = 0
+    if not tables:
+        warnings.append("no traceability table found")
+
+    for table in tables:
+        if not table["canonical"]:
+            continue
+        warnings.extend(table["warnings"])
+        matched = 0
+        for row in table["rows"]:
+            if row.ticket != ticket:
+                continue
+            if ac_contains and ac_contains.lower() not in row.ac.lower():
+                continue
+            if test_contains:
+                joined = " ".join((row.unit_test, row.integration_test, row.e2e_test)).lower()
+                if test_contains.lower() not in joined:
+                    continue
+            row.status = status
+            matched += 1
+        table["updated"] = matched
+        total += matched
+
+    if total == 0:
+        return None, 0, warnings
+
+    new_lines: list[str] = []
+    cursor = 0
+    for table in tables:
+        new_lines.extend(lines[cursor : table["start"]])
+        if table["canonical"] and table.get("updated", 0) > 0:
+            rendered = render_markdown(TraceMatrix(rows=table["rows"])).rstrip("\n").splitlines()
+            new_lines.extend(rendered)
+        else:
+            new_lines.extend(lines[table["start"] : table["end"] + 1])
+        cursor = table["end"] + 1
+    new_lines.extend(lines[cursor:])
+    text = "\n".join(new_lines)
+    if markdown.endswith("\n"):
+        text += "\n"
+    return text, total, warnings

--- a/scripts/traceability.py
+++ b/scripts/traceability.py
@@ -11,6 +11,16 @@ Examples:
     # Mark a ticket's rows covered (in place)
     python3 scripts/traceability.py update docs/epics/x/traceability.md \
       --ticket 42 --status covered --ac "GET /health"
+
+    # Preview an update without writing (chief-wiggum#342)
+    python3 scripts/traceability.py update docs/epics/x/traceability.md \
+      --ticket 42 --status covered --dry-run
+
+Exit codes for ``update``: 0 on a successful write (or a dry-run preview of
+one), 1 on a usage/parse error (bad status, file not found), 2 when ZERO
+rows matched the ticket — the file is never written in that case
+(chief-wiggum#342), matching this repo's fail-closed discipline: "0 matched
+rows" must never be treated as "helpfully normalize whatever I did find".
 """
 
 from __future__ import annotations
@@ -41,6 +51,10 @@ def main(argv: list[str] | None = None) -> int:
     p_update.add_argument("--status", required=True, choices=tr.STATUSES)
     p_update.add_argument("--ac", help="Narrow to rows whose AC contains this text")
     p_update.add_argument("--test", help="Narrow to rows whose test refs contain this text")
+    p_update.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would change without writing the file (chief-wiggum#342)",
+    )
 
     args = parser.parse_args(argv)
     path = Path(args.path)
@@ -48,26 +62,48 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: file not found: {path}", file=sys.stderr)
         return 1
 
-    matrix = tr.parse_matrix(path.read_text())
-
     if args.command == "audit":
+        matrix = tr.parse_matrix(path.read_text())
         print(json.dumps(tr.audit(matrix), indent=2))
-    elif args.command == "render":
+        return 0
+    if args.command == "render":
+        matrix = tr.parse_matrix(path.read_text())
         print(tr.render_markdown(matrix))
-    elif args.command == "update":
-        try:
-            n = tr.update_status(
-                matrix, ticket=args.ticket, status=args.status,
-                ac_contains=args.ac, test_contains=args.test,
-            )
-        except ValueError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            return 1
-        if n == 0:
-            print(f"Warning: no rows matched ticket #{args.ticket}", file=sys.stderr)
-        # Rewrite only the table span, preserving surrounding prose.
-        path.write_text(tr.replace_table(path.read_text(), matrix))
-        print(f"OK: updated {n} row(s) to {args.status}")
+        return 0
+
+    # command == "update" — routed through tr.update_file (chief-wiggum#342),
+    # NOT the single-table parse_matrix/update_status/replace_table combo
+    # audit/render still use above: update_file is the only path that (a)
+    # never re-renders a non-canonical table and (b) never writes the file at
+    # all when zero rows matched, across every table in the document.
+    try:
+        new_text, n, warnings = tr.update_file(
+            path.read_text(), ticket=args.ticket, status=args.status,
+            ac_contains=args.ac, test_contains=args.test,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    for w in warnings:
+        print(f"Warning: {w}", file=sys.stderr)
+
+    if n == 0:
+        prefix = "DRY RUN: " if args.dry_run else ""
+        print(
+            f"{prefix}Error: no rows matched ticket #{args.ticket} — nothing written",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.dry_run:
+        print(f"DRY RUN: would update {n} row(s) to {args.status} (no file written)")
+        return 0
+
+    # new_text is guaranteed non-None here — update_file only returns None
+    # alongside n == 0, handled above.
+    path.write_text(new_text)
+    print(f"OK: updated {n} row(s) to {args.status}")
     return 0
 
 

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -190,3 +190,130 @@ def test_audit_does_not_count_covered_without_test():
     a = tr.audit(m)
     assert a["covered"] == 0  # covered status but no test ref
     assert a["gaps"]  # still flagged as a gap
+
+
+# --- chief-wiggum#342: zero-match update must never rewrite the file --------
+
+CANONICAL_TABLE_413 = """\
+| Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status |
+|--------|---------------------|-----------|-----------------|----------|--------|
+| #413 | Dunning ladder fires | dunning_test.go:TestLadder | — | — | pending |
+"""
+
+# Shape observed live in chief-wiggum#342: an epic table that keys tickets
+# into a heading, not a `Ticket` column — `AC`/`Status` are recognized, but
+# `Contracts / invariants` and `Planned tests` are NOT, so this must never be
+# treated as canonical (those two columns would be silently dropped by
+# render_markdown's fixed 6-column schema).
+NON_CANONICAL_TABLE = """\
+## #413 — 5/6 Dunning ladder
+
+| AC | Contracts / invariants | Planned tests | Status |
+|----|------------------------|----------------|--------|
+| #413-AC1 — ladder fires on day 7 | CTR-fh-020 | unit: TestLadder | pending |
+"""
+
+
+def test_update_file_zero_matches_returns_none():
+    text, n, warnings = tr.update_file(NON_CANONICAL_TABLE, ticket=413, status="covered")
+    assert text is None
+    assert n == 0
+
+
+def test_cli_update_non_canonical_table_leaves_file_byte_identical(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(NON_CANONICAL_TABLE)
+    before = f.read_text()
+    rc = cli.main(["update", str(f), "--ticket", "413", "--status", "covered"])
+    after = f.read_text()
+    assert rc == 2
+    assert after == before  # byte-identical — nothing written
+    err = capsys.readouterr().err
+    assert "nothing written" in err
+
+
+def test_cli_update_non_matching_ticket_in_canonical_table_is_also_a_no_op(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(CANONICAL_TABLE_413)
+    before = f.read_text()
+    rc = cli.main(["update", str(f), "--ticket", "999", "--status", "covered"])
+    after = f.read_text()
+    assert rc == 2
+    assert after == before
+    assert "nothing written" in capsys.readouterr().err
+
+
+def test_cli_update_canonical_table_matching_ticket_updates_rows(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(CANONICAL_TABLE_413)
+    rc = cli.main(["update", str(f), "--ticket", "413", "--status", "covered"])
+    assert rc == 0
+    m = tr.parse_matrix(f.read_text())
+    assert m.rows[0].status == "covered"
+    assert "OK: updated 1 row(s)" in capsys.readouterr().out
+
+
+def test_mixed_file_only_canonical_table_changes_non_canonical_round_trips(tmp_path, capsys):
+    mixed = NON_CANONICAL_TABLE + "\n" + CANONICAL_TABLE_413
+    f = tmp_path / "traceability.md"
+    f.write_text(mixed)
+    rc = cli.main(["update", str(f), "--ticket", "413", "--status", "covered"])
+    after = f.read_text()
+    assert rc == 0
+    # The non-canonical table's exact original text survives verbatim.
+    assert NON_CANONICAL_TABLE.rstrip("\n") in after
+    # The canonical table's matching row was updated.
+    assert "| #413 | Dunning ladder fires | dunning_test.go:TestLadder | — | — | covered |" in after
+    # And the non-canonical row's own status cell was NOT touched.
+    assert "#413-AC1 — ladder fires on day 7 | CTR-fh-020 | unit: TestLadder | pending |" in after
+
+
+def test_cli_dry_run_never_writes_on_a_match(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(CANONICAL_TABLE_413)
+    before = f.read_text()
+    rc = cli.main(["update", str(f), "--ticket", "413", "--status", "covered", "--dry-run"])
+    after = f.read_text()
+    assert rc == 0
+    assert after == before  # dry run never writes
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "would update 1 row(s)" in out
+
+
+def test_cli_dry_run_on_zero_matches_still_reports_and_never_writes(tmp_path, capsys):
+    f = tmp_path / "traceability.md"
+    f.write_text(NON_CANONICAL_TABLE)
+    before = f.read_text()
+    rc = cli.main(["update", str(f), "--ticket", "413", "--status", "covered", "--dry-run"])
+    after = f.read_text()
+    assert rc == 2
+    assert after == before
+    assert "DRY RUN" in capsys.readouterr().err
+
+
+def test_update_file_only_rerenders_tables_with_a_match():
+    """A second canonical table with NO matching row must also round-trip
+    byte-identical — only the table that actually changed is touched."""
+    other_ticket_table = (
+        "| Ticket | Acceptance Criterion | Unit Test | Integration Test | E2E Test | Status |\n"
+        "|--------|---------------------|-----------|-----------------|----------|--------|\n"
+        "| #77 | unrelated | — | — | — | pending |\n"
+    )
+    text = CANONICAL_TABLE_413 + "\n" + other_ticket_table
+    new_text, n, _warnings = tr.update_file(text, ticket=413, status="covered")
+    assert n == 1
+    assert other_ticket_table.rstrip("\n") in new_text
+
+
+def test_update_file_cwd_independent_prose_preserved():
+    doc = "Intro.\n\n" + CANONICAL_TABLE_413 + "\nOutro.\n"
+    new_text, n, _ = tr.update_file(doc, ticket=413, status="covered")
+    assert n == 1
+    assert "Intro." in new_text
+    assert "Outro." in new_text
+
+
+def test_update_file_invalid_status_raises():
+    with pytest.raises(ValueError):
+        tr.update_file(CANONICAL_TABLE_413, ticket=413, status="bogus")


### PR DESCRIPTION
## Summary

Closes #342: `traceability.py update` with **zero matched rows** used to rewrite the whole file anyway — re-rendering every table into the tool's canonical 6-column schema and silently dropping non-canonical columns (observed destroying an epic's `Contracts / invariants` cells; caught in diff review before it reached a PR).

## Fix

New `update_file()` in `scripts/chief_wiggum/traceability.py`:
- Classifies each table: **canonical** (exactly the 6 recognized columns) vs not — an extra column disqualifies.
- Matches/updates rows **only inside canonical tables**; re-renders **only tables that actually changed**.
- Non-canonical tables, canonical-no-match tables, and all prose round-trip **byte-identical by construction** (copied verbatim from original lines).
- **Zero matches ⇒ returns `None` ⇒ no write at all**, exit code `2` (distinct from usage-error `1`) with an explicit "nothing written" message.
- `--dry-run` added.

The old single-table `parse_matrix`/`replace_table` path is untouched and still serves `audit`/`render`.

## Verification

`pytest tests/test_traceability.py tests/test_check_traceability.py tests/test_traceability_golden.py -q` → **99 passed** (20 pre-existing unmodified + 10 new: zero-match no-op, byte-identical round-trip for non-canonical and mixed files, dry-run, multi-table safety). `ruff check` clean.

## Note on #319

The sibling defect (gemini-vertex consulted blind) was found already fixed on main (PR #335 + follow-up `92420da`, with blindness detection and tests) — no duplicate work shipped; this PR is #342 only.