### PR TITLE
fix(ship): price the build and stamp the Implementation Cost section (#348)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -14,7 +14,7 @@ Create a well-documented pull request with mermaid architecture diagrams, test e
 
 ## Disclosure (#317)
 
-The PR body drafted in Step 4 carries an AI-authorship disclosure line
+The PR body drafted in Step 5 carries an AI-authorship disclosure line
 automatically — `draft_pr.py` builds it via `chief_wiggum.shipping.build_pr_body`,
 which appends it. If any commit on this branch was authored outside `/implement`
 (so it never ran through that workflow's Disclosure step), append the trailer
@@ -28,6 +28,7 @@ See `docs/ai-act-posture.md`.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
 ```
 
@@ -128,9 +129,35 @@ It exits non-zero if any step fails. **If tests fail, stop and fix them** — do
 
 If browser-use screenshots exist, reference them.
 
-### Step 4: Draft the PR
+### Step 4: Price the build
 
-Assemble the PR body with the tested helper. It folds in the verification evidence, optional model-conformance/UX manifests, and a Mermaid diagram (themed with the shared palette automatically), validates the required sections, and can print the `gh pr create` command:
+Fold this session's token spend into the factory ledger and render the measured actual (`docs/ticket-cost.md`), so the PR carries the same cost evidence `/implement` produces.
+
+**Skip this step entirely when no issue number is known.** `--ticket` attribution is guarded, never blind — with nothing to attribute to, do not ingest with a ticket tag; the PR then carries no cost section, which is honest.
+
+`/ship` is standalone: there is no `/implement` build-start stamp to window the ingest to. Window it to this branch's first commit instead — mechanical and prompt-free, but best-effort: work before the branch existed is not counted, and unrelated sessions in this repo inside the window may be. That caveat ships **in the PR body**, appended to the cost section below, not just here.
+
+```bash
+branch_start_ts=$(git log "$DEFAULT_BRANCH..HEAD" --format=%ct | tail -1)
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+  --repo "$owner_repo" --ticket "$issue_number" \
+  --since-ts "$branch_start_ts"
+python3 "$CW_HOME/scripts/ticket_cost.py" actual \
+  --repo "$owner_repo" --ticket "$issue_number" \
+  --format markdown > "$CW_TMP/implementation-cost.md"
+cat >> "$CW_TMP/implementation-cost.md" <<'EOF'
+
+> **Attribution**: standalone `/ship` has no per-ticket build-start stamp, so this
+> ingest is windowed to the branch's first commit. Work done before the branch
+> existed is not counted; unrelated sessions in this repo inside the window may be.
+EOF
+```
+
+If the issue body carries a `Nominal cost: ~$X.XX` line (stamped by `/create-issue`), add `--estimate X.XX` to the `actual` call so the section shows estimate-vs-actual variance. If the output says **Unmetered**, keep it verbatim — that is absence of telemetry, never a $0 build; do not drop the section or render it as $0.
+
+### Step 5: Draft the PR
+
+Assemble the PR body with the tested helper. It folds in the verification evidence, optional model-conformance/UX manifests, the implementation-cost section from Step 4, and a Mermaid diagram (themed with the shared palette automatically), validates the required sections, and can print the `gh pr create` command:
 
 ```bash
 python3 "$CW_HOME/scripts/draft_pr.py" \
@@ -138,12 +165,13 @@ python3 "$CW_HOME/scripts/draft_pr.py" \
   --change "Change 1" --change "Change 2" \
   --mermaid-file "$CW_TMP/architecture.mmd" \
   --verification "$CW_TMP/verification.json" \
+  --implementation-cost "$CW_TMP/implementation-cost.md" \
   --base "$base_branch" --out "$CW_TMP/pr-body.md" --print-command
 ```
 
-The Mermaid palette no longer needs to be hand-copied — `draft_pr.py` injects the `%%{init}%%` theme (use `--mermaid-sequence` for sequence diagrams). The diagram *content* is still yours to author. It exits non-zero if a required section (Summary, Changes, Test Evidence) is missing.
+(Omit `--implementation-cost` when Step 4 was skipped — the section is then omitted.) The Mermaid palette no longer needs to be hand-copied — `draft_pr.py` injects the `%%{init}%%` theme (use `--mermaid-sequence` for sequence diagrams). The diagram *content* is still yours to author. It exits non-zero if a required section (Summary, Changes, Test Evidence) is missing.
 
-### Step 5: Preview and confirm
+### Step 6: Preview and confirm
 
 Show the user the full PR body and ask:
 1. Does the summary capture it?
@@ -151,7 +179,7 @@ Show the user the full PR body and ask:
 3. Any additional context to add?
 4. Ready to create?
 
-### Step 6: Create the PR
+### Step 7: Create the PR
 
 ```bash
 git push -u origin HEAD
@@ -167,7 +195,14 @@ gh pr create \
 
 If an issue was specified, it should be linked via "Closes #N" in the body.
 
-### Step 7: Report
+Then, if Step 4 priced the build, **record the calibration point** so standalone PRs feed the estimator too. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure:
+
+```bash
+python3 "$CW_HOME/scripts/ticket_cost.py" record \
+  --repo "$owner_repo" --ticket "$issue_number" --effort "$effort"
+```
+
+### Step 8: Report
 
 Show:
 - PR URL


### PR DESCRIPTION
## Summary

Closes #348. `/ship` now carries the same measured Implementation Cost evidence `/implement` produces, instead of silently shipping standalone PRs with no cost section and no calibration point.

Quick fix by request — workflow doc only, no script changes (`draft_pr.py` and `shipping.build_pr_body` already support the section; confirmed no `skills/ship/` copy exists).

## Changes

- **New Step 4 "Price the build"**: ingests this session's spend via `factory_log.py ingest-claude-transcripts`, renders `ticket_cost.py actual --format markdown`, and passes it to `draft_pr.py --implementation-cost`.
- **Attribution window** (the issue's substantive design question): windowed to the **branch's first commit** (`--since-ts`) rather than the draft's arbitrary `--since-days 1`. It is mechanical, exists at `/ship` time without prompting the operator, and adapts to multi-day builds. Trade-off is stated, not hidden: pre-branch exploration is under-counted, unrelated same-repo sessions in the window may be over-counted — and that caveat is appended **into the PR body's cost section**, per the issue's requirement that coverage caveats be visible in the artifact, not only the workflow doc.
- **Guarded skip**: when no issue number is known the pricing step is skipped entirely — no blind `--ticket` tagging; the PR then honestly carries no cost section.
- **Unmetered stays Unmetered**: the step instructs keeping `Unmetered` output verbatim — absence of telemetry, never `$0`.
- **Calibration point**: after `gh pr create`, `/ship` runs `ticket_cost.py record` (Effort from the issue's Labels section, `--estimate` when a nominal figure exists) so standalone PRs feed the estimator.
- Step 5's prose now lists the cost section among what the helper folds in; later steps renumbered (4–7 → 5–8) and the Disclosure section's step reference updated. `CW_TMP` is now resolved in Step 0 (it was used but never defined).

## Cost-flow after this change

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
graph TD
    A["/ship Step 4: price the build"]:::new --> B["factory_log.py ingest-claude-transcripts<br/>--since-ts branch first commit"]:::existing
    B --> C["ticket_cost.py actual --format markdown<br/>+ attribution caveat appended"]:::new
    C --> D["draft_pr.py --implementation-cost"]:::existing
    D --> E[PR body: Implementation Cost section]:::entry
    A --> F["Step 7: ticket_cost.py record<br/>calibration point"]:::new
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff
```

## Test Evidence

Markdown-only workflow change. Related suites pass: `pytest tests/test_shipping.py tests/test_ticket_cost.py tests/test_factory_log.py` → **98 passed**. All CLI flags used in the new step verified against the current `--help` of `factory_log.py ingest-claude-transcripts` and `ticket_cost.py actual`/`record`.

## Notes

- The issue's referenced draft branch `fix/ship-implementation-cost` (commit `ea026e7`) does not exist locally or on origin — implemented fresh off `origin/main` (`be754d7`).
- Option 3 (prompt the operator for a start time) was rejected as checkpoint friction; option 2 (stamp at Step 0) is wrong because `/ship` runs at the end of the work, not the start.

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
