### PR TITLE
feat(costing): full-layer capture, coverage denominator, review-consult attribution (#345)

### DIFF
--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -43,6 +43,14 @@ CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
   echo "workflow_context failed for $owner_repo" >&2; exit 1; }
 eval "$CW_CTX"
+
+# Per-ticket implementation costing (docs/ticket-cost.md, chief-wiggum#345): every
+# worker sets this itself too, but exporting it here means anything this wave
+# script consults directly (outside a worker's own /implement Step 1) is metered.
+export CW_TELEMETRY=1
+# Wave-level catch-up ingest: fold in Claude Code turns from BEFORE this wave
+# starts, so no worker's Step-11 slice has to recover them by cwd+window alone.
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 7 || true
 ```
 
 `$EPIC_DIR/` holds this epic's artifacts:
@@ -270,6 +278,7 @@ For each ticket in the current wave (up to `--max-parallel`):
      - Step 8: Apply review fixes, run full test suite, run linting, verify acceptance criteria
      - Step 9: UX sanity + design-fidelity gate for frontend tickets — render the app, capture screenshots to `$TICKET_TMP/ux-screenshots/`, review against the ui-spec design contract. Save the screenshots; the orchestrator attaches them to the wave report.
      - Step 10: Browser-use/E2E validation (unless `--skip-browser-use` was passed)
+   - **Costing attribution** (chief-wiggum#345): if the worker's own `/implement` flow reaches its Step-11 transcript ingest, it MUST pass `--cwd-prefix "<its own worktree path>"` (never bare `--repo`) — every worker in this wave shares the same target repo, so a cwd-derived repo match alone would cross-bill a sibling ticket's spend onto this one. `ticket_cost.py actual` should get the matching `--cwd-prefix`/`--since-ts` pair for the same reason.
    - **HARD RULES**:
      - Do NOT create or merge pull requests. Return the branch name and a summary.
      - You are in a git worktree. Assert isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"` (it aborts if you are in the main checkout). Never operate on the main checkout.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -95,6 +95,13 @@ mkdir -p "$TICKET_TMP"
 ```bash
 export CW_TELEMETRY=1
 date +%s > "$TICKET_TMP/build-start-ts"
+
+# Catch-up ingest: fold in any Claude Code turns from BEFORE this build started,
+# bounded by --until-ts so it can never consume this ticket's own turns (dedup is
+# by request id and tagging happens at first ingest — an unbounded catch-up here
+# would permanently strand this build's Claude layer untagged, chief-wiggum#345).
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+  --since-days 7 --until-ts "$(cat "$TICKET_TMP/build-start-ts")" || true
 ```
 
 All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemini.md`, `approach-opus.md`, `implementation-plan.md`, `review-prompt.md`, `reviews/reviewer-*.md`, `impl-diff.txt`) go in `$TICKET_TMP`, not `$CW_TMP`. Shared session files (e.g., epic context) remain in `$CW_TMP`.
@@ -504,11 +511,12 @@ The worker should:
      --ticket-context "$TICKET_TMP/ticket.json" \
      --worktree "$(git rev-parse --show-toplevel)" --base "$DEFAULT_BRANCH" \
      --output-dir "$TICKET_TMP/reviews" \
+     --ticket "$issue_number" \
      --epic-artifact "Contracts=$EPIC_DIR/contracts.md" \
      --epic-artifact "Invariants=$EPIC_DIR/invariants.md" \
      --epic-artifact "Target review authorities=$TICKET_TMP/review-authorities.md"
    ```
-   (The last one is what actually puts the target's house rules in front of every provider — #264. `--epic-artifact` silently skips a path that doesn't exist, so it is safe to pass unconditionally when no authorities were recorded.)
+   (The last one is what actually puts the target's house rules in front of every provider — #264. `--epic-artifact` silently skips a path that doesn't exist, so it is safe to pass unconditionally when no authorities were recorded. `--ticket` is what makes the reviewer quorum's spend attribute to this ticket — without it the review consults land untagged and the PR's cost section shows a fraction of the real spend, chief-wiggum#345.)
    Outputs land in `$TICKET_TMP/reviews/`: `impl-diff.txt`, `review-prompt.md`, `reviewer-<provider>.md`, and `review-manifest.json`. It refuses to run outside a git repo or when `--base` can't be resolved; a non-zero exit means a required provider never produced valid output (note the gap, proceed with available reviews).
 
 3. **Hotspot-aware review depth (#187, report-only — NEVER a gate).** Check whether any changed file is a measured hotspot (or coupled to one) via `code_query.py orient` — a top-decile churn×complexity file, or one tightly coupled to it, deserves deeper scrutiny than a routine diff, same as a file with a governing invariant would:
@@ -874,10 +882,14 @@ python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
   --since-ts "$(cat "$TICKET_TMP/build-start-ts")"
 python3 "$CW_HOME/scripts/ticket_cost.py" actual \
   --repo "$owner_repo" --ticket "$issue_number" \
+  --cwd-prefix "$(git rev-parse --show-toplevel)" \
+  --since-ts "$(cat "$TICKET_TMP/build-start-ts")" \
   --format markdown > "$TICKET_TMP/implementation-cost.md"
 ```
 
    If the issue body carries a `Nominal cost: ~$X.XX` line (stamped by `/create-issue`), add `--estimate X.XX` to the `actual` call so the section shows estimate-vs-actual variance. If the output says **Unmetered**, keep it — that is absence of telemetry, never a $0 build.
+
+   The output now carries a **Coverage** block naming which layers were captured and which were not (chief-wiggum#345). If it says UNCAPTURED, **do not hand-edit it away and never substitute "see ledger"** — an uncaptured layer is data the reader needs. Fix the gap if you can (re-run the ingest named in the coverage line), otherwise ship the honest coverage line.
 
 4. Draft the PR body with the tested helper. It folds in the verification evidence and (when present) the review/UX/model-conformance manifests plus the implementation-cost section, themes the Mermaid diagram with the shared palette automatically, validates the required sections, and links the issue:
 
@@ -890,6 +902,7 @@ python3 "$CW_HOME/scripts/draft_pr.py" \
   --review "$TICKET_TMP/reviews/review-manifest.json" \
   --model-conformance "$TICKET_TMP/model-conformance.md" \
   --implementation-cost "$TICKET_TMP/implementation-cost.md" \
+  --require-cost \
   --base "$DEFAULT_BRANCH" --out "$TICKET_TMP/pr-body.md"
 ```
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -914,11 +914,13 @@ gh pr create --repo "$owner_repo" --title "$pr_title" --body-file "$TICKET_TMP/p
 
 5. The helper links the original issue via `Closes #N` from `--issue`.
 
-6. **Record the calibration point** so future `/create-issue` estimates ground in this build's actual. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure:
+6. **Record the calibration point** so future `/create-issue` estimates ground in this build's actual. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure. Pass the **same** `--cwd-prefix`/`--since-ts` pair used for the `actual` call above — `record` computes its own slice independently, and without the matching window flags it silently reverts to tag-match-only, journaling a consult-only "clean" sample into the estimator while the real windowed slice (Claude Code layers included) is far larger (chief-wiggum#345):
 
 ```bash
 python3 "$CW_HOME/scripts/ticket_cost.py" record \
-  --repo "$owner_repo" --ticket "$issue_number" --effort "$effort"
+  --repo "$owner_repo" --ticket "$issue_number" --effort "$effort" \
+  --cwd-prefix "$(git rev-parse --show-toplevel)" \
+  --since-ts "$(cat "$TICKET_TMP/build-start-ts")"
 ```
 
 ### Step 12: Verify CI green

--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -39,6 +39,16 @@ CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
 TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
+### Step 1b: Catch up the Claude-layer cost ingest
+
+`/reflect`'s own telemetry-health finding (Step 3, "Factory-log health") reads the ledger's `claude_code` layer as-is — a factory that ran on Claude Code but never had its transcripts ingested reads as "no AI cost logged", which is silence, not a measurement (chief-wiggum#345). Fold in a wide catch-up window before the analysis so the finding reflects reality:
+
+```bash
+python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 30 || true
+```
+
+30 days (wider than `/implement`'s 7-day catch-up) because `/reflect` looks back across a whole factory run, not one build.
+
 ### Step 2: Collect the evidence
 
 Fetch merged-PR history (review outcomes + bodies carry gate signal) and run the miner:

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -133,3 +133,15 @@ python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --scaffold
 ```
 
 The stack is auto-detected (Go / Python / Node — possibly several) from `go.mod`, `pyproject.toml`/`requirements.txt`/`setup.py`, and `package.json`. Commit the generated `.github/workflows/ci.yml` so CI runs on the next push.
+
+### Step 6b: Verify Claude-layer cost capture
+
+Per-ticket implementation costing (`docs/ticket-cost.md`) needs the full Claude Code layer ingested — orchestrator turns AND every delegated turn — not just consult spend; chief-wiggum#345 found this had silently never run. Check, then provision if needed:
+
+```bash
+python3 $CW_HOME/scripts/check_deps.py --for telemetry
+# If the Claude layer has never been ingested:
+python3 $CW_HOME/scripts/install_deps.py --tool telemetry-capture
+```
+
+The default route is the **transcript** ingest — zero-config and retroactive over whatever's already on disk at `~/.claude/projects/`; `install_deps.py --tool telemetry-capture` runs a bounded 7-day catch-up automatically. The OTEL console-exporter route is optional and suits headless (`claude -p`) runs only — it fights an interactive TUI session (`docs/factory-telemetry.md`). **`/setup` prints the OTEL env + wrapper snippet for operators who want it but never edits `~/.claude/settings.json` or a shell rc file — those stay the operator's own files.**

--- a/docs/factory-telemetry.md
+++ b/docs/factory-telemetry.md
@@ -224,6 +224,28 @@ sub-agent), `requestId`, and `cwd`. The ingest:
   All-zero usage lines are skipped, which makes dedup order-independent.
 - **attributes worktrees to their parent repo**, so a `<repo>/.claude/worktrees/<branch>`
   cwd doesn't register as a separate project.
+- **recurses through every sub-agent transcript, not just the top level**
+  (chief-wiggum#345). Claude Code writes the orchestrator's turns to
+  `<project>/<session>.jsonl`, but every sub-agent's turns to a deeper path —
+  `<project>/<session>/subagents/agent-<id>.jsonl`, and workflow sub-agents
+  deeper still (`.../subagents/workflows/<wf>/agent-<id>.jsonl`). Measured
+  against a real corpus: the sub-agent level carried **~75% of turn volume**
+  while an earlier two-level glob (`*/*.jsonl`) saw only the top level — the
+  sub-agent layer read $0 not because delegated work was free, but because it
+  was never looked at. Recursing is safe: request ids don't repeat across
+  levels, so widening the scan cannot double-count. **History ingested before
+  this fix under-reports the sub-agent layer and is not back-filled
+  silently** — re-run the ingest over the window you care about to pick it up.
+  `query_source` is derived from `isSidechain` OR the record living under a
+  `/subagents/` path (belt-and-braces, so an older record shape missing the
+  flag still lands in the right layer).
+- **records `cwd` and `agent_type` on every ingested record.** `cwd` lets
+  `ticket_cost.py` recover an untagged turn later by where it ran (read-time
+  window slicing, see [ticket-cost.md](ticket-cost.md)); `agent_type` is the
+  sub-agent TYPE name Claude Code stamps as `attributionAgent` (e.g.
+  `general-purpose`, `Explore`) — never message content, and deliberately
+  **not** stored in the `skill` field (`aggregate()`'s cost-by-loop join is
+  keyed by gate name and would be polluted by agent-type keys).
 
 Re-run it whenever you want the log current; `0 new` means up to date.
 
@@ -232,6 +254,16 @@ the ingest also accepts `--ticket` with an attribution guard (`--cwd-prefix` for
 worktree-precise tagging, else a cwd-derived repo match against `--repo`) and
 `--since-ts <epoch>` to window on a build-start stamp. Turns already ingested
 untagged can't be re-tagged (dedup keeps the first record), so tag at first ingest.
+
+`--until-ts <epoch>` bounds a CATCH-UP ingest so it can never consume an
+in-flight ticket's own turns — `/implement` Step 1 passes its own build-start
+stamp here before the build even begins, so an automatic catch-up can never
+strand this build's turns untagged (chief-wiggum#345).
+
+`count_transcript_turns()` (library-only, no CLI subcommand) answers "how many
+turns are visible in the corpus" WITHOUT ingesting them — the independent
+evidence `ticket_cost.py`'s coverage line uses to tell "nothing happened" apart
+from "nothing was captured" (see [ticket-cost.md](ticket-cost.md)).
 
 ### OTEL ingest (for an existing OTEL pipeline)
 
@@ -272,6 +304,15 @@ python3 "$CW_HOME/scripts/factory_log.py" aggregate --repo acme/app
 `aggregate` splits Claude Code cost by `query_source` (orchestrator vs subagent)
 and reports `cost_usd_total = consult_cost + claude_code_cost` — the nominal cost
 of a factory run end to end. `/reflect` surfaces it as a factory-log finding.
+
+**Nominal, not billed** — every dollar figure this log renders is list-price
+tokens × `config/model_pricing.json`, not what you were actually charged on a
+Claude Code subscription plan. The chief-wiggum#345 sub-agent ingest fix makes
+this total several times larger than anything reported before it (the
+sub-agent layer was previously invisible), which will read as alarming if you
+forget it's nominal. See [ticket-cost.md](ticket-cost.md)'s "Nominal, not
+billed" note and `build_cost.py`'s `plan_share_pct` for the number that
+actually reflects a fixed-plan budget.
 
 ## Ticket attribution (`scripts/ticket_cost.py`)
 

--- a/docs/harness-adapters.md
+++ b/docs/harness-adapters.md
@@ -40,3 +40,39 @@ clearly when it has none — never silently inherit a broken Claude assumption.
 This inventory is the basis for the deeper rewrites tracked in the Harness
 Generalization epic: harness-neutral worker contracts (#24) and portable skill
 packaging (#25).
+
+## Optional operator hooks CW does not ship
+
+Some harness capabilities would help a CW mechanism but are deliberately left
+as a documented, opt-in operator choice rather than a shipped default — they
+are harness-specific enough that shipping them would mean re-deriving an
+equivalent per harness for a marginal convenience gain.
+
+- **Claude Code `SessionEnd` hook, for automatic Claude-layer cost ingest**
+  (chief-wiggum#345). `factory_log.py ingest-claude-transcripts` already runs
+  as a catch-up step inside `/implement`, `/implement-wave`, and `/reflect`
+  (see `docs/ticket-cost.md`), which covers the ticket/build path without any
+  hook. An operator who wants EVERY session's turns ingested the moment it
+  ends — not just at the next workflow's catch-up step — can wire their own
+  `SessionEnd` hook to run the same command. CW does not install this for
+  three reasons: it is Claude Code-specific (the portability gate above
+  exists precisely to keep harness-only mechanisms out of adapter-neutral
+  prose); it would mutate the operator's own Claude Code settings, which no
+  chief-wiggum script does today (see "Secrets never touch env vars" and the
+  transcript-route rationale in `docs/factory-telemetry.md`); and it fires
+  *after* the workflow that would have used its output has already run, so it
+  adds nothing to the ticket-costing path itself. Example, for an operator who
+  wants it:
+  ```json
+  {
+    "hooks": {
+      "SessionEnd": [{
+        "hooks": [{
+          "type": "command",
+          "command": "python3 $HOME/repos/chief-wiggum/scripts/factory_log.py ingest-claude-transcripts --since-days 1"
+        }]
+      }]
+    }
+  }
+  ```
+  in `~/.claude/settings.json` — the operator's own file, never written by CW.

--- a/docs/ticket-cost.md
+++ b/docs/ticket-cost.md
@@ -147,7 +147,19 @@ longer ship with a hand-edited "see ledger" stub.
   issue carries a nominal figure) → `draft_pr.py --implementation-cost … --require-cost`
   renders the PR's `## Implementation Cost` section (with its Coverage block)
   and refuses to ship a stub. After the PR exists:
-  `ticket_cost.py record --effort <size>` journals the calibration point.
+  `ticket_cost.py record --effort <size> --cwd-prefix <worktree> --since-ts
+  <build-start>` journals the calibration point. **`record` computes its own
+  slice independently of `actual`** — it does not reuse `actual`'s output —
+  so it needs the SAME `--cwd-prefix`/`--since-ts` pair. Passing them (or
+  not) is not cosmetic: without them `record` silently reverts to
+  tag-match-only summarizing and journals a small consult-only "clean"
+  sample into the estimator, while the real windowed slice (Claude Code
+  layers included) is far larger — the exact understatement chief-wiggum#345
+  exists to fix, now leaking into the calibration/estimator loop if `record`
+  doesn't get the same flags as `actual`. A calibration recorded with the
+  window flags carries `"windowed": true` in the ledger, informational only
+  (the estimator doesn't filter on it) but useful for anyone auditing the
+  calibration history later.
 - **`/implement-wave`** — `export CW_TELEMETRY=1` and one wave-level catch-up
   ingest before the first wave starts; each worker's own transcript ingest and
   `ticket_cost.py actual` calls must pass `--cwd-prefix` pointed at their own

--- a/docs/ticket-cost.md
+++ b/docs/ticket-cost.md
@@ -32,13 +32,26 @@ Cache-aware for Claude Code layers (`cost_for_usage`). Three layers, summed:
 
 | Layer | Metered by | Tagged with the ticket |
 |--|--|--|
-| Orchestrator (`repl_main_thread`) | transcript/OTEL ingest | at ingest (`--ticket`) |
-| Subagents (+ `worker` events) | transcript/OTEL ingest | at ingest (`--ticket`) |
-| Consults (codex/gemini/…) | `consult_ai.py` | at call time (`--ticket`) |
+| Orchestrator (`repl_main_thread`) | transcript/OTEL ingest | at ingest (`--ticket`), or by cwd+window at read time |
+| Subagents (+ `worker` events) | transcript/OTEL ingest — recurses through `<session>/subagents/**` (chief-wiggum#345; a two-level glob missed ~75% of turn volume) | at ingest (`--ticket`), or by cwd+window at read time |
+| Consults (codex/gemini/…) | `consult_ai.py` | at call time (`--ticket`) — `run_review.py`'s `--ticket` flag is what makes review-quorum consults attribute (#345) |
 
 Human time, CI minutes, and plan-share economics are **out** — for the true
 economic cost of factory compute under a fixed plan, see `build_cost.py`
 (#257), which prices bets, not tickets.
+
+**Nominal, not billed.** Every figure this script renders is *nominal* API
+list pricing (tokens × `config/model_pricing.json`) — the same basis
+`build_cost.py`'s `nominal_usd` uses. On a metered API key that IS what you
+pay; on a Claude Code subscription plan it is not: the plan is a fixed
+periodic cost, and `build_cost.py`'s `plan_share_pct` (chief-wiggum#257) is
+the only number in this factory that expresses what a build cost against a
+fixed-plan budget. A PR section showing several dollars a day of nominal
+Claude-layer spend — now visible in full for the first time as of
+chief-wiggum#345's sub-agent capture fix — will read as an invoice to anyone
+who skims it unless they already know this. Every rendered surface keeps the
+"nominal model spend" wording for exactly this reason; do not read a
+`## Implementation Cost` total as a bill.
 
 ## Honesty rules
 
@@ -70,19 +83,79 @@ never blindly:
 Dedup is by request id, so a turn ingested untagged earlier can't be re-tagged:
 tag at first ingest, which is what `/implement` Step 11 does.
 
+### Read-time window slicing (recovering an untagged turn)
+
+An automatic catch-up ingest (`/implement` Step 1, `/implement-wave`'s
+wave-level catch-up, `/reflect`'s Step 1b) can sweep up a turn BEFORE the
+ticket it belongs to is known — that turn is ingested untagged, and dedup
+means it can never be tagged afterwards. `ticket_cost.py actual` recovers it
+at READ time instead: pass the same `--cwd-prefix`/`--since-ts`/`--until-ts`
+the build used, and `summarize_ticket` counts a record that matches EITHER the
+ticket tag OR falls inside that cwd+time window (never double-counting a
+record that matches both). This is what makes automatic catch-up ingest safe
+under concurrency — a wave worker's catch-up ingesting a sibling ticket's
+in-flight turns doesn't strand them, because the sibling's own `actual` call
+recovers them by window instead of by tag.
+
+## Coverage — the capture denominator (chief-wiggum#345)
+
+A rendered slice that silently omits a layer it never saw invites a reader to
+take a consult-only figure as the total — the #381 incident: two reviewer
+consults ran, `ticket_cost.py actual --ticket 381` read `$0.00`, and nothing
+in the output said why. `ticket_cost.py actual` now computes a **coverage**
+block alongside the cost table — printed above the footnote in markdown, as
+extra lines in text mode, and as `summary["coverage"]` in JSON — naming each
+layer's status from evidence INDEPENDENT of the rendered slice:
+
+| Status | Meaning |
+|--|--|
+| `captured` | records present, every call priced |
+| `captured-partial` | records present, some calls unpriced (both counts printed) |
+| `uncaptured` | zero records for this layer, AND independent evidence (a transcript-turn count for Claude layers, an untagged-consult count for the consult layer) says the layer actually ran |
+| `unknown` | zero records and no independent evidence source was scanned — never reported as `captured`, never as `$0` |
+
+The Claude-layer evidence comes from `factory_log.count_transcript_turns()` —
+a read-only scan of the transcript corpus, bounded by `--since-ts` (files
+older than the window are skipped by mtime without being read, so this stays
+cheap enough to run at PR time) and never run at all without a window (an
+unbounded corpus scan isn't worth its cost — no window means `unknown`, not a
+fabricated scan). The consult-layer evidence is the ledger itself: zero
+TAGGED consults for this ticket but untagged same-repo consults sitting in the
+window is exactly the #381 fingerprint — a review quorum that ran but never
+attributed.
+
+`--exit-code-on-gap` makes coverage enforceable for a caller that wants it
+(exits 3 when coverage isn't `complete`) — **opt-in only**; the default stays
+exit 0, because `ticket_cost.py` is report-only by construction (see below).
+`draft_pr.py --require-cost` is the sibling enforcement point: it fails loudly
+when the Implementation Cost section is missing or empty, so a PR can no
+longer ship with a hand-edited "see ledger" stub.
+
 ## Workflow wiring
 
 - **`/create-issue`** — after picking the Effort size:
   `ticket_cost.py estimate --effort M` → stamp the output line into the issue's
   `Nominal cost` field verbatim.
-- **`/implement` Step 1** — `export CW_TELEMETRY=1` (consults meter) and stamp
-  `$TICKET_TMP/build-start-ts`.
+- **`/implement` Step 1** — `export CW_TELEMETRY=1` (consults meter), stamp
+  `$TICKET_TMP/build-start-ts`, and run a catch-up transcript ingest bounded by
+  `--until-ts` on that stamp (so it can never consume this build's own turns).
+- **`/implement` Step 7** — `run_review.py --ticket "$issue_number"` so
+  review-phase consults attribute (chief-wiggum#345 AC2).
 - **`/implement` Step 11** — `factory_log.py ingest-claude-transcripts --repo …
-  --ticket … --since-ts …`, then `ticket_cost.py actual --format markdown`
-  (plus `--estimate` when the issue carries a nominal figure) →
-  `draft_pr.py --implementation-cost …` renders the PR's
-  `## Implementation Cost` section. After the PR exists:
+  --ticket … --since-ts …`, then `ticket_cost.py actual --format markdown
+  --cwd-prefix <worktree> --since-ts <build-start>` (plus `--estimate` when the
+  issue carries a nominal figure) → `draft_pr.py --implementation-cost … --require-cost`
+  renders the PR's `## Implementation Cost` section (with its Coverage block)
+  and refuses to ship a stub. After the PR exists:
   `ticket_cost.py record --effort <size>` journals the calibration point.
+- **`/implement-wave`** — `export CW_TELEMETRY=1` and one wave-level catch-up
+  ingest before the first wave starts; each worker's own transcript ingest and
+  `ticket_cost.py actual` calls must pass `--cwd-prefix` pointed at their own
+  worktree (workers share one target repo, so a bare cwd-derived repo match
+  would cross-bill a sibling ticket's spend).
+- **`/reflect`** — a Step 1b catch-up ingest (`--since-days 30`, wider than a
+  single build) before the factory-log analysis runs.
 
 Report-only by construction: cost is information for the human on the issue and
-PR. It is never a gate, and there is no threshold that blocks a ship.
+PR. It is never a gate by default, and there is no threshold that blocks a ship
+unless the caller opts in (`--exit-code-on-gap`, `draft_pr.py --require-cost`).

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -232,6 +232,16 @@ def check_capture(name: str, required: bool = True):
             warn_count += 1
         return
     if name == "factory-ledger":
+        # No transcript root at all means this probe can never be satisfied by
+        # running the ingest — inapplicable (like claude-transcripts above),
+        # not an actionable MISSING. Check this BEFORE reading the ledger so a
+        # non-Claude harness never fails a probe it structurally cannot pass
+        # (chief-wiggum#345 review: the two probes must degrade the same way).
+        if not factory_log.DEFAULT_TRANSCRIPT_ROOT.is_dir():
+            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<24s} no transcript root — capture "
+                  "inapplicable on this harness")
+            warn_count += 1
+            return
         records = [r for r in factory_log.read_log() if r.get("event") == factory_log.CLAUDE_CODE]
         if not records:
             print(f"{RED if required else YELLOW}[{'MISSING' if required else 'OPTIONAL'}]{NC}  "

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+import factory_log
 from chief_wiggum import languages as cw_languages
 from keychain import has_secret
 
@@ -125,6 +128,17 @@ WORKFLOW_REQUIREMENTS = {
         "pkgs": set(),
         "secrets": set(),
     },
+    # Claude-layer cost CAPTURE, not a command/package/secret — whether the
+    # transcript ingest is provisioned and has actually run at least once
+    # (chief-wiggum#345). "capture" is a fourth requirement kind alongside
+    # cmds/pkgs/secrets; required_items()/is_required() default an absent
+    # "capture" key to an empty set, so every OTHER profile is untouched.
+    "telemetry": {
+        "cmds": set(),
+        "pkgs": set(),
+        "secrets": set(),
+        "capture": {"claude-transcripts", "factory-ledger"},
+    },
 }
 
 # A profile per BUILT language tier (#162), derived from config/languages.json's
@@ -197,6 +211,65 @@ def check_secret(name: str, required: bool = False):
             warn_count += 1
 
 
+def check_capture(name: str, required: bool = True):
+    """Report whether the Claude-layer cost capture is provisioned AND has run.
+
+    Not a command or a package — a *state* check. The failure this catches is
+    silent: everything installs, every workflow runs, and the ledger's Claude
+    layer stays empty because no ingest ever happened (chief-wiggum#345).
+    Absent on a non-Claude harness is INAPPLICABLE, not a failure — a check
+    that fails closed on a harness it doesn't apply to teaches operators to
+    ignore it.
+    """
+    global pass_count, fail_count, warn_count
+    if name == "claude-transcripts":
+        if factory_log.DEFAULT_TRANSCRIPT_ROOT.is_dir():
+            print(f"{GREEN}[OK]{NC}  {name:<24s} transcript root present")
+            pass_count += 1
+        else:
+            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<24s} transcript root not present "
+                  "(non-Claude harness — capture inapplicable)")
+            warn_count += 1
+        return
+    if name == "factory-ledger":
+        records = [r for r in factory_log.read_log() if r.get("event") == factory_log.CLAUDE_CODE]
+        if not records:
+            print(f"{RED if required else YELLOW}[{'MISSING' if required else 'OPTIONAL'}]{NC}  "
+                  f"{name:<24s} 0 claude_code records — the Claude layer has never been "
+                  "ingested. Run: factory_log.py ingest-claude-transcripts --since-days 7")
+            if required:
+                fail_count += 1
+            else:
+                warn_count += 1
+            return
+        newest = max(r.get("ts") or 0 for r in records)
+        age_days = (time.time() - newest) / 86400
+        if age_days > 7:
+            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<24s} stale (newest {age_days:.0f} days old)")
+            warn_count += 1
+        else:
+            age_h = (time.time() - newest) / 3600
+            print(f"{GREEN}[OK]{NC}  {name:<24s} {len(records)} claude_code records, "
+                  f"newest {age_h:.0f}h ago")
+            pass_count += 1
+        return
+    # An unknown probe name never silently passes.
+    print(f"{RED}[MISSING]{NC}  {name:<24s} unknown capture probe")
+    fail_count += 1
+
+
+def check_telemetry_env():
+    """CW_TELEMETRY (or CW_FACTORY_LOG) gates whether a consult's cost gets
+    logged at all — unset, every consult still runs, it just never meters
+    (silent, not broken). `/implement`/`/implement-wave` set this themselves,
+    so its absence here is advisory, never a failure."""
+    global warn_count
+    if not (os.environ.get("CW_TELEMETRY") or os.environ.get("CW_FACTORY_LOG")):
+        print(f"{YELLOW}[OPTIONAL]{NC}  CW_TELEMETRY not set — consult spend will not be "
+              "logged (/implement sets it itself)")
+        warn_count += 1
+
+
 # Map a provider (config/providers.json) to the dependency profile that installs it.
 PROVIDER_PROFILE = {
     "codex": "codex",
@@ -215,8 +288,8 @@ WORKFLOW_PROFILES = {
     "design": ["core", "browser-validation", "codex", "gemini"],
     "architect": ["core", "codex", "gemini"],
     "plan-epic": ["core"],
-    "implement": ["core", "browser-validation", "codex", "gemini"],
-    "implement-wave": ["core", "browser-validation", "codex", "gemini"],
+    "implement": ["core", "browser-validation", "codex", "gemini", "telemetry"],
+    "implement-wave": ["core", "browser-validation", "codex", "gemini", "telemetry"],
     "close-epic": ["core", "codex", "gemini"],
     "create-issue": ["core"],
     "ship": ["core"],
@@ -227,6 +300,7 @@ WORKFLOW_PROFILES = {
     "saas-gate": ["core"],
     "update": ["core"],
     "keep-going": ["core"],
+    "reflect": ["core", "telemetry"],
 }
 
 
@@ -275,7 +349,10 @@ def expand_profiles(profiles: list[str]) -> set[str]:
 def required_items(kind: str, profiles: list[str]) -> set[str]:
     required: set[str] = set()
     for profile in expand_profiles(profiles):
-        required.update(WORKFLOW_REQUIREMENTS[profile][kind])
+        # .get(kind, set()) rather than [kind]: only the "telemetry" profile
+        # declares a "capture" kind (chief-wiggum#345) — every other profile
+        # dict has no such key and must resolve to empty, not KeyError.
+        required.update(WORKFLOW_REQUIREMENTS[profile].get(kind, set()))
     return required
 
 
@@ -435,6 +512,11 @@ def main():
     check_secret("GEMINI_API_KEY", is_required("secrets", "GEMINI_API_KEY", workflows))
     check_secret("GOOGLE_CLOUD_PROJECT", is_required("secrets", "GOOGLE_CLOUD_PROJECT", workflows))
     check_secret("GOOGLE_CLOUD_LOCATION", is_required("secrets", "GOOGLE_CLOUD_LOCATION", workflows))
+
+    print("\n--- Telemetry capture (per-ticket costing) ---")
+    check_capture("claude-transcripts", is_required("capture", "claude-transcripts", workflows))
+    check_capture("factory-ledger", is_required("capture", "factory-ledger", workflows))
+    check_telemetry_env()
 
     print(f"\n=== Results: {pass_count} ok, {fail_count} missing, {warn_count} warnings ===")
 

--- a/scripts/chief_wiggum/shipping.py
+++ b/scripts/chief_wiggum/shipping.py
@@ -165,6 +165,22 @@ def validate_sections(body: str, required: tuple[str, ...] = REQUIRED_SECTIONS) 
     return missing
 
 
+# The shapes `ticket_cost.py actual --format markdown` genuinely renders
+# (scripts/ticket_cost.py: render_actual_markdown's cost-table branch,
+# render_actual_markdown's unmetered branch, render_coverage_markdown) —
+# never all three required at once, any one is sufficient. A hand-typed
+# stub like "see ledger" matches none of them (chief-wiggum#345 review:
+# draft_pr.py --require-cost accepted any non-empty string).
+_GENUINE_COST_MARKERS = ("| Layer |", "**Unmetered**", "**Coverage —")
+
+
+def looks_like_genuine_cost_output(text: str) -> bool:
+    """True when ``text`` carries a shape only ``ticket_cost.py`` itself
+    renders — used by ``draft_pr.py --require-cost`` to refuse a hand-typed
+    placeholder that happens to be non-empty."""
+    return any(marker in text for marker in _GENUINE_COST_MARKERS)
+
+
 def suggest_title(issue_title: str | None, *, issue: int | None = None, prefix: str = "feat") -> str:
     base = (issue_title or "update").strip()
     if issue is not None and f"#{issue}" not in base:

--- a/scripts/draft_pr.py
+++ b/scripts/draft_pr.py
@@ -48,6 +48,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--implementation-cost",
                         help="Markdown text or file for the Implementation Cost section "
                              "(from scripts/ticket_cost.py actual --format markdown)")
+    parser.add_argument("--require-cost", action="store_true",
+                        help="Fail when the Implementation Cost section is missing or empty "
+                             "(chief-wiggum#345: PRs shipped with a 'see ledger' stub because "
+                             "the pipeline produced nothing usable at PR time)")
     parser.add_argument("--base")
     parser.add_argument("--out", help="Write the PR body to this file (else stdout)")
     parser.add_argument("--print-command", action="store_true", help="Also print the gh pr create command")
@@ -64,6 +68,14 @@ def main(argv: list[str] | None = None) -> int:
     impl_cost = args.implementation_cost
     if impl_cost and Path(impl_cost).exists():
         impl_cost = Path(impl_cost).read_text()
+
+    if args.require_cost and not (impl_cost or "").strip():
+        print("Error: --require-cost set but the Implementation Cost section is empty. "
+              "The Claude-layer ingest or the consult tagging did not produce a slice — "
+              "run `factory_log.py ingest-claude-transcripts` and re-run "
+              "`ticket_cost.py actual`. Do not hand-edit a placeholder into the PR.",
+              file=sys.stderr)
+        return 1
 
     body = shipping.build_pr_body(
         issue=args.issue,

--- a/scripts/draft_pr.py
+++ b/scripts/draft_pr.py
@@ -69,13 +69,22 @@ def main(argv: list[str] | None = None) -> int:
     if impl_cost and Path(impl_cost).exists():
         impl_cost = Path(impl_cost).read_text()
 
-    if args.require_cost and not (impl_cost or "").strip():
-        print("Error: --require-cost set but the Implementation Cost section is empty. "
-              "The Claude-layer ingest or the consult tagging did not produce a slice — "
-              "run `factory_log.py ingest-claude-transcripts` and re-run "
-              "`ticket_cost.py actual`. Do not hand-edit a placeholder into the PR.",
-              file=sys.stderr)
-        return 1
+    if args.require_cost:
+        stripped = (impl_cost or "").strip()
+        if not stripped:
+            print("Error: --require-cost set but the Implementation Cost section is empty. "
+                  "The Claude-layer ingest or the consult tagging did not produce a slice — "
+                  "run `factory_log.py ingest-claude-transcripts` and re-run "
+                  "`ticket_cost.py actual`. Do not hand-edit a placeholder into the PR.",
+                  file=sys.stderr)
+            return 1
+        if not shipping.looks_like_genuine_cost_output(stripped):
+            print("Error: --require-cost set but the Implementation Cost content doesn't look "
+                  "like genuine `ticket_cost.py actual` output (no cost table, **Unmetered** "
+                  "block, or Coverage line) — looks like a hand-typed stub (e.g. 'see ledger'). "
+                  "Run `ticket_cost.py actual --format markdown` and pass its output instead.",
+                  file=sys.stderr)
+            return 1
 
     body = shipping.build_pr_body(
         issue=args.issue,

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -482,10 +482,21 @@ def _repo_from_cwd(cwd: str | None) -> str | None:
 
 
 def _iter_transcript_files(root: Path):
-    """Every Claude Code transcript under ``root`` (``<project>/<session>.jsonl``)."""
+    """Every Claude Code transcript under ``root``.
+
+    Claude Code writes the orchestrator's turns to ``<project>/<session>.jsonl``
+    but every SUB-AGENT's turns to a deeper path —
+    ``<project>/<session>/subagents/agent-<id>.jsonl``, and workflow sub-agents
+    deeper still (``.../subagents/workflows/<wf>/agent-<id>.jsonl``). A
+    ``*/*.jsonl`` glob sees only the first level, which is why the sub-agent
+    layer read $0 while carrying ~75% of the turn volume (chief-wiggum#345).
+    Recursing is safe: the record filter below (``type == "assistant"`` plus a
+    ``message.usage`` object) is what decides what counts, not the path shape,
+    and request ids do not repeat across levels.
+    """
     if not root.is_dir():
         return
-    yield from sorted(root.glob("*/*.jsonl"))
+    yield from sorted(root.rglob("*.jsonl"))
 
 
 def ingested_request_ids() -> set[str]:
@@ -519,7 +530,8 @@ def ingested_request_ids() -> set[str]:
 
 def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
                               since: float | None = None, ticket: str | None = None,
-                              cwd_prefix: str | None = None) -> int:
+                              cwd_prefix: str | None = None,
+                              until: float | None = None) -> int:
     """Fold Claude Code's own per-turn token usage into the factory log.
 
     This is the end-to-end cost half of the ledger. `factory_log` already records
@@ -561,6 +573,11 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
     same window would bleed in — pass ``cwd_prefix`` when that matters).
     Dedup is by request id, so already-ingested turns cannot be re-tagged by a
     later run: tag at first ingest.
+
+    ``until`` bounds a CATCH-UP ingest so it can never consume an in-flight
+    ticket's turns. Dedup is by request id and tagging happens at first
+    ingest, so an unbounded catch-up run during a build would permanently
+    strand that build's turns untagged.
     """
     root = Path(root) if root is not None else DEFAULT_TRANSCRIPT_ROOT
     if ticket is not None and repo is None and cwd_prefix is None:
@@ -595,6 +612,8 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
 
             ts = _parse_iso_ts(e.get("timestamp"))
             if since is not None and ts is not None and ts < since:
+                continue
+            if until is not None and ts is not None and ts > until:
                 continue
 
             tin = _coerce_token(usage.get("input_tokens")) or 0
@@ -632,7 +651,12 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
                 "event": CLAUDE_CODE,
                 "request_id": req,
                 "model": model,
-                "query_source": "subagent" if e.get("isSidechain") else "repl_main_thread",
+                # Belt-and-braces: `isSidechain` is the primary signal, but a
+                # sub-agent transcript living under a `/subagents/` path
+                # counts too, even on an older record shape that omits the
+                # flag (chief-wiggum#345).
+                "query_source": ("subagent" if (e.get("isSidechain") or "/subagents/" in str(f))
+                                 else "repl_main_thread"),
                 "tokens_in": tin,
                 "tokens_out": tout,
                 "cache_read": cache_read,
@@ -647,6 +671,19 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
             if e.get("sessionId"):
                 rec["session_id"] = e["sessionId"]
             cwd = e.get("cwd")
+            if cwd:
+                # Recorded so a turn can be attributed to a ticket at READ time
+                # (ticket_cost's cwd+window slice) as well as by the tag applied
+                # here — dedup is by request id, so a turn ingested untagged by a
+                # catch-up run could otherwise never be attributed (#345).
+                rec["cwd"] = str(cwd)
+            agent = e.get("attributionAgent")
+            if agent:
+                # The sub-agent TYPE (e.g. general-purpose, Explore) — a type
+                # name, never prompt content. Deliberately NOT stored in `skill`:
+                # aggregate()'s cost_by_loop join is keyed by gate name and would
+                # be polluted by agent-type keys.
+                rec["agent_type"] = str(agent)
             derived = _repo_from_cwd(cwd)
             attributed = repo or derived
             if attributed:
@@ -670,6 +707,93 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
                 seen.add(req)
                 n += 1
     return n
+
+
+def count_transcript_turns(root: Path | None = None, *, since: float | None = None,
+                          until: float | None = None, repo: str | None = None,
+                          cwd_prefix: str | None = None) -> dict:
+    """Count billable assistant turns visible in the transcript corpus, WITHOUT
+    ingesting them — the independent evidence behind ticket_cost's coverage line.
+
+    "Zero records in the ledger" cannot by itself distinguish *no work happened*
+    from *nothing was captured*; this answers the second half from a source other
+    than the ledger. Returns
+    ``{"scanned": bool, "repl_main_thread": int, "subagent": int}``.
+    ``scanned: False`` means the corpus was not readable (no transcript root — a
+    non-Claude harness, or a fresh machine): the caller must report ``unknown``,
+    never ``captured`` and never ``$0``.
+
+    Bounded on purpose: with ``since`` set, files whose mtime precedes the window
+    are skipped without being read, so this stays cheap enough to run at PR time.
+    """
+    root = Path(root) if root is not None else DEFAULT_TRANSCRIPT_ROOT
+    if not root.is_dir():
+        return {"scanned": False, "repl_main_thread": 0, "subagent": 0}
+
+    counts = {"repl_main_thread": 0, "subagent": 0}
+    for f in _iter_transcript_files(root):
+        if since is not None:
+            try:
+                if f.stat().st_mtime < since:
+                    continue
+            except OSError:
+                continue
+        try:
+            lines = f.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if e.get("type") != "assistant":
+                continue
+            msg = e.get("message")
+            if not isinstance(msg, dict):
+                continue
+            usage = msg.get("usage")
+            if not isinstance(usage, dict):
+                continue
+
+            model = msg.get("model")
+            if not model or model == "<synthetic>":
+                continue
+
+            tin = _coerce_token(usage.get("input_tokens")) or 0
+            tout = _coerce_token(usage.get("output_tokens")) or 0
+            cache_read = _coerce_token(usage.get("cache_read_input_tokens")) or 0
+            creation = usage.get("cache_creation")
+            creation = creation if isinstance(creation, dict) else {}
+            w5 = _coerce_token(creation.get("ephemeral_5m_input_tokens"))
+            w1 = _coerce_token(creation.get("ephemeral_1h_input_tokens"))
+            if w5 is None and w1 is None:
+                w5 = _coerce_token(usage.get("cache_creation_input_tokens")) or 0
+                w1 = 0
+            w5, w1 = w5 or 0, w1 or 0
+            if (tin + tout + cache_read + w5 + w1) == 0:
+                continue
+
+            cwd = e.get("cwd")
+            if cwd_prefix is not None:
+                if not (cwd and str(cwd).startswith(str(cwd_prefix).rstrip("/"))):
+                    continue
+            elif repo is not None:
+                derived = _repo_from_cwd(cwd)
+                if not (derived and derived in (repo, str(repo).split("/")[-1])):
+                    continue
+
+            ts = _parse_iso_ts(e.get("timestamp"))
+            if until is not None and ts is not None and ts > until:
+                continue
+
+            bucket = "subagent" if (e.get("isSidechain") or "/subagents/" in str(f)) else "repl_main_thread"
+            counts[bucket] += 1
+
+    return {"scanned": True, **counts}
 
 
 def _parse_iso_ts(value) -> float | None:
@@ -1282,6 +1406,9 @@ def main() -> int:
     it.add_argument("--cwd-prefix",
                     help="Only tag turns whose cwd starts with this path (worktree-precise "
                          "attribution for parallel /implement-wave workers)")
+    it.add_argument("--until-ts", type=float,
+                    help="Only ingest turns at/before this epoch timestamp — bounds a "
+                         "catch-up ingest so it cannot consume an in-flight ticket's turns")
 
     cr_ = sub.add_parser("cost-report",
                          help="What Claude Code session cost is made of (report-only, never a gate)")
@@ -1313,7 +1440,8 @@ def main() -> int:
             since = args.since_ts
         try:
             n = ingest_claude_transcripts(Path(args.root), repo=args.repo, since=since,
-                                          ticket=args.ticket, cwd_prefix=args.cwd_prefix)
+                                          ticket=args.ticket, cwd_prefix=args.cwd_prefix,
+                                          until=args.until_ts)
         except ValueError as exc:
             print(f"factory_log: {exc}", file=sys.stderr)
             return 2

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -481,6 +481,22 @@ def _repo_from_cwd(cwd: str | None) -> str | None:
     return name or None
 
 
+def cwd_matches_prefix(cwd: str | None, prefix: str | None) -> bool:
+    """Exact match or true PATH CHILD of ``prefix`` — never a lexical prefix
+    match. ``str.startswith`` alone would match ``.../t420`` against a prefix
+    of ``.../t42``: a sibling worktree, not a child of it, and exactly the
+    cross-billing chief-wiggum#345's review caught (a bare startswith let a
+    sibling worktree's spend tag/count/slice onto this ticket). Shared by the
+    three cwd_prefix call sites: ``ingest_claude_transcripts``,
+    ``count_transcript_turns``, and ``ticket_cost._in_window``.
+    """
+    if not cwd or not prefix:
+        return False
+    prefix = str(prefix).rstrip("/")
+    cwd = str(cwd)
+    return cwd == prefix or cwd.startswith(prefix + "/")
+
+
 def _iter_transcript_files(root: Path):
     """Every Claude Code transcript under ``root``.
 
@@ -693,7 +709,7 @@ def ingest_claude_transcripts(root: Path | None = None, repo: str | None = None,
                 # cwd_prefix is given, else cwd-derived-repo match. `repo` may be
                 # owner/repo while the cwd only yields the basename.
                 if cwd_prefix is not None:
-                    tag = bool(cwd) and str(cwd).startswith(str(cwd_prefix).rstrip("/"))
+                    tag = cwd_matches_prefix(cwd, cwd_prefix)
                 else:
                     tag = bool(derived) and derived in (repo, str(repo).split("/")[-1])
                 if tag:
@@ -723,8 +739,14 @@ def count_transcript_turns(root: Path | None = None, *, since: float | None = No
     non-Claude harness, or a fresh machine): the caller must report ``unknown``,
     never ``captured`` and never ``$0``.
 
-    Bounded on purpose: with ``since`` set, files whose mtime precedes the window
-    are skipped without being read, so this stays cheap enough to run at PR time.
+    Bounded on purpose: with ``since`` set, whole FILES whose mtime precedes the
+    window are skipped without being read (a cheap pre-filter, sound for
+    append-only files — a stale mtime means every line predates it too), so
+    this stays cheap enough to run at PR time. The actual window membership is
+    still enforced per TURN once a file is read (symmetric with
+    ``ingest_claude_transcripts``'s own since/until checks), and a turn whose
+    timestamp can't be parsed is excluded whenever a window bound is active —
+    count only what can be confirmed to fall inside it.
     """
     root = Path(root) if root is not None else DEFAULT_TRANSCRIPT_ROOT
     if not root.is_dir():
@@ -779,16 +801,28 @@ def count_transcript_turns(root: Path | None = None, *, since: float | None = No
 
             cwd = e.get("cwd")
             if cwd_prefix is not None:
-                if not (cwd and str(cwd).startswith(str(cwd_prefix).rstrip("/"))):
+                if not cwd_matches_prefix(cwd, cwd_prefix):
                     continue
             elif repo is not None:
                 derived = _repo_from_cwd(cwd)
                 if not (derived and derived in (repo, str(repo).split("/")[-1])):
                     continue
 
+            # AC4 promises an IN-WINDOW denominator, so since/until are
+            # enforced per-turn here too (symmetric with the ingest's own
+            # since/until checks) — the mtime check above is only a cheap
+            # skip-whole-file pre-filter, not a substitute for this. A turn
+            # whose timestamp can't be parsed can't be placed in the window,
+            # so once a bound is active it is excluded, not counted on faith
+            # (chief-wiggum#345 review: count only what you can confirm).
             ts = _parse_iso_ts(e.get("timestamp"))
-            if until is not None and ts is not None and ts > until:
-                continue
+            if since is not None or until is not None:
+                if ts is None:
+                    continue
+                if since is not None and ts < since:
+                    continue
+                if until is not None and ts > until:
+                    continue
 
             bucket = "subagent" if (e.get("isSidechain") or "/subagents/" in str(f)) else "repl_main_thread"
             counts[bucket] += 1

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -12,6 +12,11 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import factory_log  # noqa: E402
 
 CLI_TOOLS = {
     "claude": ["npm", "install", "-g", "@anthropic-ai/claude-code"],
@@ -48,6 +53,49 @@ VERTEX_PKGS = {
 }
 
 
+def _install_telemetry_capture():
+    """Provision Claude-layer cost capture (chief-wiggum#345 AC1).
+
+    Two things, both idempotent: a ``~/.chief-wiggum/otel/`` directory for
+    operators who DO want the OTEL console-exporter route, and a bounded
+    catch-up ingest over the transcript route — zero-config, retroactive, and
+    the DEFAULT route (see docs/factory-telemetry.md; the OTEL route fights
+    an interactive TUI session and suits headless runs only).
+
+    Prints the OTEL opt-in snippet — NEVER writes ``~/.claude/settings.json``
+    or a shell rc file. Those stay the operator's own files; this is the
+    first time a chief-wiggum script would have touched a user dotfile, and
+    the transcript route makes it unnecessary (see the #345 implementation
+    plan's Open Question 1).
+    """
+    otel_dir = Path.home() / ".chief-wiggum" / "otel"
+    otel_dir.mkdir(parents=True, exist_ok=True)
+    print(f"  Provisioned {otel_dir} (for operators who use the OTEL console-exporter route)")
+
+    n = factory_log.ingest_claude_transcripts(since=time.time() - 7 * 86400)
+    print(f"  Catch-up ingest: {n} new Claude Code turn(s) from the last 7 days")
+
+    print(
+        "\n  Optional, for headless/OTEL-pipeline runs; the transcript route above "
+        "needs none of this. Print-only — apply it yourself if you want it:\n"
+        "    export CLAUDE_CODE_ENABLE_TELEMETRY=1\n"
+        "    export OTEL_METRICS_EXPORTER=console\n"
+        "    export OTEL_LOGS_EXPORTER=console\n"
+        "    export OTEL_METRIC_EXPORT_INTERVAL=10000\n"
+        "    claude() { command claude \"$@\" "
+        "2> >(tee -a ~/.chief-wiggum/otel/$(date +%s).jsonl >&2); }\n"
+    )
+
+
+# Provisioning actions that are neither a CLI tool install nor a pip install —
+# a `name -> callable` shape kept separate from CLI_TOOLS/PYTHON_PKGS rather
+# than forced into their `name -> argv` / `name -> (import_name, [argv])`
+# shapes.
+SETUP_ACTIONS = {
+    "telemetry-capture": _install_telemetry_capture,
+}
+
+
 def run(cmd: list[str]) -> bool:
     print(f"  Running: {shlex.join(cmd)}")
     result = subprocess.run(cmd)
@@ -78,7 +126,9 @@ def install_python_pkgs(pkgs: dict):
 
 
 def install_single(name: str):
-    if name in CLI_TOOLS:
+    if name in SETUP_ACTIONS:
+        SETUP_ACTIONS[name]()
+    elif name in CLI_TOOLS:
         run(CLI_TOOLS[name])
     elif name in PYTHON_PKGS:
         for cmd in PYTHON_PKGS[name][1]:

--- a/scripts/reflect.py
+++ b/scripts/reflect.py
@@ -278,8 +278,9 @@ def collect(repo: Path, commits_limit: int = 400, prs: list[dict] | None = None)
     else:
         findings.append(Finding("factory-logs", "info",
             "telemetry: no AI cost logged — if this factory ran on Claude Code, its own token "
-            "cost (usually the largest line item) has not been ingested. Run: "
-            "factory_log.py ingest-claude-transcripts"))
+            "cost (usually the largest line item) has not been ingested. /reflect's own "
+            "Step 1b catch-up ingest (--since-days 30) should have covered this; if it "
+            "still reads empty, re-run: factory_log.py ingest-claude-transcripts --since-days 30"))
 
     # What that cost is MADE of. Report-only: every finding here is something the
     # operator can act on and CW cannot (session shape, cache TTL, read width),

--- a/scripts/run_review.py
+++ b/scripts/run_review.py
@@ -55,6 +55,14 @@ def main(argv: list[str] | None = None) -> int:
             "every OTHER provider's unchanged output instead of re-paying it."
         ),
     )
+    parser.add_argument(
+        "--ticket",
+        help=(
+            "Issue number these review consults are for, so their spend "
+            "attributes to the ticket (chief-wiggum#345). Defaults to the "
+            "number in --ticket-context."
+        ),
+    )
     args = parser.parse_args(argv)
 
     # CTR-fh-002: a production ticket.json missing the `comments` key entirely
@@ -67,6 +75,12 @@ def main(argv: list[str] | None = None) -> int:
     for w in caught:
         if issubclass(w.category, review.MissingCommentsWarning):
             print(f"Warning: {w.message}", file=sys.stderr)
+
+    # Every consult a workflow makes on behalf of ticket N must carry N. The
+    # ticket.json already knows the number, so the flag is an override, not a
+    # requirement — an un-passed flag must never silently drop the tag (#345).
+    ticket_id = args.ticket or (str(ticket.number) if ticket.number is not None else None)
+
     template = Path(args.template).read_text()
     checklist = Path(args.checklist).read_text() if Path(args.checklist).exists() else None
 
@@ -100,7 +114,8 @@ def main(argv: list[str] | None = None) -> int:
             tool_name = provider.tool if provider.type == "tool" else "claude-interactive"
             timeout_override = reduced_retry_timeout(tool_name, timeout_override)
         return consult_provider(
-            provider, prompt, None, args.worktree, timeout_override=timeout_override
+            provider, prompt, None, args.worktree,
+            ticket=ticket_id, timeout_override=timeout_override,
         )
 
     try:

--- a/scripts/ticket_cost.py
+++ b/scripts/ticket_cost.py
@@ -96,8 +96,7 @@ def _in_window(r: dict, cwd_prefix: str | None, since: float | None,
     """
     if cwd_prefix is None:
         return False
-    cwd = r.get("cwd")
-    if not cwd or not str(cwd).startswith(str(cwd_prefix).rstrip("/")):
+    if not factory_log.cwd_matches_prefix(r.get("cwd"), cwd_prefix):
         return False
     ts = r.get("ts") or 0
     if since is not None and ts < since:

--- a/scripts/ticket_cost.py
+++ b/scripts/ticket_cost.py
@@ -84,13 +84,44 @@ def _layer_of(r: dict) -> str:
     return "orchestrator" if r.get("query_source") == "repl_main_thread" else "subagents"
 
 
-def summarize_ticket(records: list[dict], repo: str, ticket: str) -> dict:
+def _in_window(r: dict, cwd_prefix: str | None, since: float | None,
+              until: float | None) -> bool:
+    """A claude_code record attributable to the slice by WHERE and WHEN it ran.
+
+    Complements the ticket tag rather than replacing it. The tag is applied at
+    first ingest and dedup makes it un-reapplicable, so a turn swept up by a
+    catch-up ingest (or by a concurrent worker's ingest) can never be tagged
+    afterwards — but its cwd and timestamp still say which build it belongs to.
+    Consult records carry no cwd; they rely on the call-time tag (#345 AC2).
+    """
+    if cwd_prefix is None:
+        return False
+    cwd = r.get("cwd")
+    if not cwd or not str(cwd).startswith(str(cwd_prefix).rstrip("/")):
+        return False
+    ts = r.get("ts") or 0
+    if since is not None and ts < since:
+        return False
+    if until is not None and ts > until:
+        return False
+    return True
+
+
+def summarize_ticket(records: list[dict], repo: str, ticket: str, *,
+                     cwd_prefix: str | None = None, since: float | None = None,
+                     until: float | None = None) -> dict:
     """Slice the ledger to one ticket and fold it into per-layer totals.
 
     ``status: "unmetered"`` (with every total ``None``) when nothing matches —
     absence of telemetry, not a $0 build. ``cost_partial`` is set when any
     matched record carries tokens but no priced cost, so a table with a dollar
-    total can never silently understate."""
+    total can never silently understate.
+
+    ``cwd_prefix``/``since``/``until`` add a READ-TIME window slice on top of
+    the ticket tag (never a replacement — a record matching either counts once,
+    see ``_in_window``): a turn a catch-up ingest swept up untagged, or one a
+    sibling ``/implement-wave`` worker ingested, can still be recovered by
+    where and when it ran (chief-wiggum#345)."""
     layers = {
         name: {"calls": 0, "tokens_in": 0, "tokens_out": 0, "cache_tokens": 0,
                "cost_usd": 0.0, "unpriced_calls": 0}
@@ -99,7 +130,10 @@ def summarize_ticket(records: list[dict], repo: str, ticket: str) -> dict:
     providers: set[str] = set()
     matched = 0
     for r in records:
-        if r.get("event") not in _LAYERED_EVENTS or not _matches_ticket(r, repo, ticket):
+        if r.get("event") not in _LAYERED_EVENTS:
+            continue
+        if not (_matches_ticket(r, repo, ticket)
+                or _in_window(r, cwd_prefix, since, until)):
             continue
         matched += 1
         layer = layers[_layer_of(r)]
@@ -126,6 +160,149 @@ def summarize_ticket(records: list[dict], repo: str, ticket: str) -> dict:
             "cost_partial": partial, "consult_providers": sorted(providers)}
 
 
+# ---- coverage: the capture denominator (AC4) ----------------------------------
+
+COVERAGE_STATUSES = ("captured", "captured-partial", "uncaptured", "unknown")
+
+
+def _layer_coverage(calls: int, unpriced_calls: int, evidence_n: int | None,
+                    scanned: bool, *, fix: str | None) -> dict:
+    """One layer's coverage verdict, derived from evidence INDEPENDENT of the
+    slice being rendered (see ``coverage``'s docstring for the taxonomy)."""
+    if calls > 0:
+        if unpriced_calls:
+            return {"status": "captured-partial",
+                   "basis": f"{calls} calls, {unpriced_calls} unpriced", "fix": None}
+        return {"status": "captured", "basis": f"{calls} calls captured", "fix": None}
+    if not scanned:
+        return {"status": "unknown",
+               "basis": "no independent evidence available for this window", "fix": None}
+    if evidence_n:
+        return {"status": "uncaptured",
+               "basis": f"{evidence_n:,} transcript turns in window, 0 ingested", "fix": fix}
+    return {"status": "captured", "basis": "no turns in window", "fix": None}
+
+
+def coverage(summary: dict, records: list[dict], *, transcript_root=None,
+             since: float | None = None, until: float | None = None,
+             cwd_prefix: str | None = None) -> dict:
+    """Per-layer capture status for the rendered slice — the denominator.
+
+    A cost table that silently omits the layers it never saw invites a reader to
+    take a consult-only figure as the total (#345). Each layer's status is
+    derived from a source INDEPENDENT of the slice, and the four outcomes stay
+    distinct (the #289 taxonomy — "failed to observe" must never read as "pass"):
+
+      captured          — records present, every call priced
+      captured-partial  — records present, n of m calls unpriced (both printed)
+      uncaptured        — zero records AND independent evidence the layer ran
+      unknown           — zero records and no visible evidence source; never
+                          "captured", never $0
+
+    ``records`` is the FULL ledger slice (not just what matched the ticket) —
+    the consults check needs to see untagged same-repo consults to catch the
+    #381 fingerprint (a review quorum that ran but never attributed).
+    """
+    repo = summary.get("repo")
+    ticket = summary.get("ticket")
+    layers_in = summary.get("layers") or {}
+
+    # An unbounded scan of the whole transcript corpus at PR time is not worth
+    # its cost — with no window, the Claude layers report `unknown`, never a
+    # fabricated `captured`/`$0`.
+    if since is None:
+        evidence = {"scanned": False, "repl_main_thread": 0, "subagent": 0}
+    else:
+        evidence = factory_log.count_transcript_turns(
+            transcript_root, since=since, until=until, repo=repo, cwd_prefix=cwd_prefix)
+
+    fix_cmd = (f"factory_log.py ingest-claude-transcripts --repo {repo} "
+              f"--ticket {ticket} --since-ts <build-start>")
+    layers: dict[str, dict] = {}
+    for key, bucket in (("orchestrator", "repl_main_thread"), ("subagents", "subagent")):
+        layer = layers_in.get(key) or {"calls": 0, "unpriced_calls": 0}
+        layers[key] = _layer_coverage(layer.get("calls", 0), layer.get("unpriced_calls", 0),
+                                      evidence.get(bucket, 0), evidence["scanned"], fix=fix_cmd)
+
+    consult_layer = layers_in.get("consults") or {"calls": 0, "unpriced_calls": 0}
+    calls = consult_layer.get("calls", 0)
+    if calls > 0:
+        unpriced = consult_layer.get("unpriced_calls", 0)
+        if unpriced:
+            layers["consults"] = {"status": "captured-partial",
+                                  "basis": f"{calls} calls, {unpriced} unpriced", "fix": None}
+        else:
+            layers["consults"] = {"status": "captured", "basis": f"{calls} calls captured",
+                                  "fix": None}
+    elif since is None:
+        layers["consults"] = {"status": "unknown",
+                              "basis": "no window supplied — untagged-consult evidence not scanned",
+                              "fix": None}
+    else:
+        untagged = 0
+        for r in records:
+            if r.get("event") != factory_log.CONSULT or r.get("ticket") is not None:
+                continue
+            rrepo = r.get("repo")
+            if repo is not None and rrepo is not None and rrepo not in (repo, str(repo).split("/")[-1]):
+                continue
+            ts = r.get("ts") or 0
+            if ts < since or (until is not None and ts > until):
+                continue
+            untagged += 1
+        if untagged:
+            layers["consults"] = {
+                "status": "uncaptured",
+                "basis": (f"{untagged} untagged consult(s) in window for this repo — the "
+                         "review quorum's spend did not attribute"),
+                "fix": "pass --ticket to run_review.py / consult_ai.py",
+            }
+        else:
+            layers["consults"] = {"status": "captured", "basis": "no consult spend in window",
+                                  "fix": None}
+
+    captured_statuses = {"captured", "captured-partial"}
+    captured_layers = sum(1 for L in layers.values() if L["status"] in captured_statuses)
+    if captured_layers == 3:
+        top_status = "complete"
+    elif (layers["consults"]["status"] in captured_statuses
+          and layers["orchestrator"]["status"] not in captured_statuses
+          and layers["subagents"]["status"] not in captured_statuses):
+        top_status = "consults-only"
+    elif captured_layers > 0:
+        top_status = "partial"
+    elif any(L["status"] == "uncaptured" for L in layers.values()):
+        top_status = "uncaptured"
+    else:
+        top_status = "unknown"
+
+    return {"layers": layers, "captured_layers": captured_layers, "total_layers": 3,
+            "status": top_status}
+
+
+def render_coverage_markdown(cov: dict) -> str:
+    """Markdown table naming which layers were captured and which weren't — the
+    denominator that keeps a partial slice from being mistaken for the total
+    (chief-wiggum#345)."""
+    labels = {"orchestrator": "Orchestrator", "subagents": "Sub-agents", "consults": "Consults"}
+    status_labels = {
+        "captured": "captured",
+        "captured-partial": "captured (partial)",
+        "uncaptured": "UNCAPTURED",
+        "unknown": "unknown",
+    }
+    header = (f"**Coverage — {cov['captured_layers']} of {cov['total_layers']} "
+             "layers captured.**")
+    rows = ["| Layer | Status | Basis |", "|---|---|---|"]
+    for key in ("orchestrator", "subagents", "consults"):
+        layer = cov["layers"][key]
+        basis = layer["basis"]
+        if layer.get("fix"):
+            basis += f" — run `{layer['fix']}`"
+        rows.append(f"| {labels[key]} | {status_labels[layer['status']]} | {basis} |")
+    return header + "\n\n" + "\n".join(rows)
+
+
 def _fmt_tokens(n: int) -> str:
     if n >= 1_000_000:
         return f"{n / 1_000_000:.1f}M"
@@ -142,17 +319,25 @@ def _variance_line(estimate_usd: float, actual_usd: float) -> str:
             f"({pct:+.0f}%).")
 
 
-def render_actual_markdown(summary: dict, estimate_usd: float | None = None) -> str:
+def render_actual_markdown(summary: dict, estimate_usd: float | None = None,
+                           cov: dict | None = None) -> str:
     """Markdown body for the PR's ``## Implementation Cost`` section (no heading —
-    ``shipping.build_pr_body`` owns the heading, like Model Conformance)."""
+    ``shipping.build_pr_body`` owns the heading, like Model Conformance).
+
+    ``cov`` (from ``coverage()``) appends the layer-capture denominator above
+    the footnote — in BOTH branches, so a consult-only or fully-unmetered
+    slice still tells the reader which layers are known-missing (#345)."""
     if summary["status"] == "unmetered":
-        return (
+        md = (
             f"**Unmetered** — no cost records for {summary['repo']}#{summary['ticket']} "
             "in the factory ledger. That is absence of telemetry, not a $0 build: "
             "run `factory_log.py ingest-claude-transcripts --repo <owner/repo> "
             "--ticket <n>` (and set `CW_TELEMETRY=1` before consults) to meter the "
             "next one."
         )
+        if cov is not None:
+            md += "\n\n" + render_coverage_markdown(cov)
+        return md
     rows = [
         "| Layer | Calls | Tokens in | Cache | Tokens out | Cost |",
         "|---|---|---|---|---|---|",
@@ -172,6 +357,9 @@ def render_actual_markdown(summary: dict, estimate_usd: float | None = None) -> 
     lines = ["\n".join(rows), ""]
     if estimate_usd is not None:
         lines.append(_variance_line(estimate_usd, summary["total_cost_usd"]))
+        lines.append("")
+    if cov is not None:
+        lines.append(render_coverage_markdown(cov))
         lines.append("")
     note = ("Nominal model spend (tokens × `config/model_pricing.json`, cache-aware "
             "for Claude Code layers). Human time and CI excluded.")
@@ -255,11 +443,15 @@ def render_estimate_line(est: dict) -> str:
 # ---- CLI ---------------------------------------------------------------------
 
 
-def _print_summary(summary: dict, fmt: str, estimate_usd: float | None) -> None:
+def _print_summary(summary: dict, fmt: str, estimate_usd: float | None,
+                   cov: dict | None = None) -> None:
     if fmt == "json":
-        print(json.dumps(summary, indent=2))
+        out = dict(summary)
+        if cov is not None:
+            out["coverage"] = cov
+        print(json.dumps(out, indent=2))
     elif fmt == "markdown":
-        print(render_actual_markdown(summary, estimate_usd))
+        print(render_actual_markdown(summary, estimate_usd, cov=cov))
     else:
         if summary["status"] == "unmetered":
             print(f"ticket_cost: {summary['repo']}#{summary['ticket']} UNMETERED "
@@ -271,6 +463,14 @@ def _print_summary(summary: dict, fmt: str, estimate_usd: float | None) -> None:
                   f"{summary['records']} metered calls")
             if estimate_usd is not None:
                 print("  " + _variance_line(estimate_usd, summary["total_cost_usd"]))
+        if cov is not None:
+            for key, label in (("orchestrator", "orchestrator"), ("subagents", "subagents"),
+                               ("consults", "consults")):
+                layer = cov["layers"][key]
+                if layer["status"] not in ("captured", "captured-partial"):
+                    print(f"ticket_cost: coverage {cov['captured_layers']}/"
+                          f"{cov['total_layers']} layers — {label} "
+                          f"{layer['status'].upper()} ({layer['basis']})")
 
 
 def main() -> int:
@@ -284,6 +484,16 @@ def main() -> int:
     a.add_argument("--estimate", type=float,
                    help="The nominal estimate stamped on the issue, for the variance line")
     a.add_argument("--format", choices=["json", "markdown", "text"], default="text")
+    a.add_argument("--cwd-prefix", help="Also attribute claude_code turns whose cwd sits under "
+                                        "this path (worktree-precise read-time slicing)")
+    a.add_argument("--since-ts", type=float, help="Window start (epoch) for read-time slicing "
+                                                  "and for the coverage evidence scan")
+    a.add_argument("--until-ts", type=float, help="Window end (epoch)")
+    a.add_argument("--transcript-root", help="Transcript root for the coverage evidence scan "
+                                             "(default: ~/.claude/projects)")
+    a.add_argument("--exit-code-on-gap", action="store_true",
+                   help="Exit 3 when coverage is not complete (opt-in; the default stays "
+                        "report-only, exit 0)")
 
     e = sub.add_parser("estimate", help="Nominal estimate for an Effort class (p50 of calibrations)")
     e.add_argument("--effort", required=True, choices=EFFORTS)
@@ -304,9 +514,14 @@ def main() -> int:
     records = factory_log.read_log()
 
     if args.cmd == "actual":
-        summary = summarize_ticket(records, args.repo, args.ticket)
-        _print_summary(summary, args.format, args.estimate)
-        return 0
+        summary = summarize_ticket(records, args.repo, args.ticket,
+                                   cwd_prefix=args.cwd_prefix, since=args.since_ts,
+                                   until=args.until_ts)
+        transcript_root = Path(args.transcript_root) if args.transcript_root else None
+        cov = coverage(summary, records, transcript_root=transcript_root,
+                       since=args.since_ts, until=args.until_ts, cwd_prefix=args.cwd_prefix)
+        _print_summary(summary, args.format, args.estimate, cov=cov)
+        return 3 if (args.exit_code_on_gap and cov["status"] != "complete") else 0
     if args.cmd == "estimate":
         est = estimate_for_effort(records, args.effort, repo=args.repo,
                                   min_samples=args.min_samples)

--- a/scripts/ticket_cost.py
+++ b/scripts/ticket_cost.py
@@ -374,13 +374,20 @@ def render_actual_markdown(summary: dict, estimate_usd: float | None = None,
 
 
 def record_calibration(summary: dict, effort: str | None = None,
-                       estimate_usd: float | None = None) -> dict:
+                       estimate_usd: float | None = None, *,
+                       windowed: bool = False) -> dict:
     """Journal one ``ticket_cost`` calibration event from a measured summary.
 
     Explicit act → always writes (``factory_log._append``, the same
     does-not-require-CW_TELEMETRY shape as the ingests). An unmetered ticket is
     still recorded — as ``actual_usd: None`` — so the calibration history shows
-    how often metering actually flowed, not just its successes."""
+    how often metering actually flowed, not just its successes.
+
+    ``windowed`` marks that ``summary`` was built with the read-time
+    cwd/since/until slice (``--cwd-prefix``/``--since-ts``/``--until-ts`` on
+    the CLI), not just the ticket tag — informational only (the estimator
+    doesn't filter on it), but it disambiguates a calibration history entry
+    for anyone reading the ledger later (chief-wiggum#345)."""
     rec = {
         "ts": time.time(),
         "event": TICKET_COST,
@@ -395,6 +402,8 @@ def record_calibration(summary: dict, effort: str | None = None,
         rec["effort"] = effort
     if estimate_usd is not None:
         rec["estimate_usd"] = estimate_usd
+    if windowed:
+        rec["windowed"] = True
     factory_log._append(rec)
     return rec
 
@@ -506,6 +515,23 @@ def main() -> int:
     r.add_argument("--effort", choices=EFFORTS,
                    help="The issue's Effort label; omit if unknown (recorded but "
                         "won't feed the estimator)")
+    # Same read-time window flags as `actual`, threaded into the SAME
+    # summarize path (chief-wiggum#345 orchestrator-verification finding): a
+    # calibration recorded without them silently reverts to tag-match-only,
+    # journaling a small "clean" consult-only sample into the estimator while
+    # the real windowed slice (claude_code layers included) is far larger —
+    # exactly the understatement this ticket exists to fix, now leaking into
+    # the calibration loop if `record` doesn't get the same flags as `actual`.
+    r.add_argument("--cwd-prefix", help="Also attribute claude_code turns whose cwd sits under "
+                                        "this path (worktree-precise read-time slicing) — pass "
+                                        "the same value given to `actual` for this ticket")
+    r.add_argument("--since-ts", type=float, help="Window start (epoch) for read-time slicing "
+                                                  "— pass the same value given to `actual`")
+    r.add_argument("--until-ts", type=float, help="Window end (epoch)")
+    r.add_argument("--transcript-root", help="Accepted for CLI-flag parity with `actual` (the "
+                                             "same argv template works for both subcommands); "
+                                             "`record` never runs the coverage evidence scan, "
+                                             "so this is otherwise unused")
     r.add_argument("--estimate", type=float,
                    help="The nominal estimate that was stamped on the issue")
 
@@ -530,8 +556,12 @@ def main() -> int:
             print(render_estimate_line(est))
         return 0
     if args.cmd == "record":
-        summary = summarize_ticket(records, args.repo, args.ticket)
-        rec = record_calibration(summary, effort=args.effort, estimate_usd=args.estimate)
+        summary = summarize_ticket(records, args.repo, args.ticket,
+                                   cwd_prefix=args.cwd_prefix, since=args.since_ts,
+                                   until=args.until_ts)
+        windowed = bool(args.cwd_prefix or args.since_ts is not None or args.until_ts is not None)
+        rec = record_calibration(summary, effort=args.effort, estimate_usd=args.estimate,
+                                 windowed=windowed)
         actual = (f"${rec['actual_usd']:.2f}" if rec["actual_usd"] is not None
                   else "UNMETERED")
         print(f"ticket_cost: recorded calibration for {args.repo}#{args.ticket} — "

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -190,11 +190,17 @@ def test_check_capture_absent_transcript_root_warns_never_fails(monkeypatch, tmp
     assert check_deps.warn_count == 1
 
 
-def test_check_capture_zero_claude_code_records_is_missing(capsys):
+def test_check_capture_zero_claude_code_records_is_missing(monkeypatch, tmp_path, capsys):
     """An empty Claude layer is exactly the silent failure this checker
     exists to catch: everything installs, every workflow runs, and the
-    ledger's Claude layer stays empty because no ingest ever happened."""
+    ledger's Claude layer stays empty because no ingest ever happened.
+
+    Must not depend on the real machine's ~/.claude/projects existing (true
+    on a dev Mac, false on CI) -- point the probe at a fake-but-present
+    transcript root, same hermetic discipline as the autouse CW_FACTORY_LOG
+    isolation."""
     _reset_dep_counts()
+    monkeypatch.setattr(factory_log, "DEFAULT_TRANSCRIPT_ROOT", tmp_path)
     check_deps.check_capture("factory-ledger", required=True)
     assert check_deps.fail_count == 1
     assert "ingest-claude-transcripts" in capsys.readouterr().out
@@ -226,7 +232,11 @@ def test_check_capture_factory_ledger_still_fails_when_root_present_but_never_in
 
 
 def test_check_capture_recent_records_is_ok(monkeypatch, tmp_path, capsys):
+    """Same hermetic requirement as the MISSING case above: point at a
+    fake-but-present transcript root rather than relying on the real
+    machine's ~/.claude/projects (absent on CI)."""
     _reset_dep_counts()
+    monkeypatch.setattr(factory_log, "DEFAULT_TRANSCRIPT_ROOT", tmp_path)
     log = tmp_path / "log.jsonl"
     monkeypatch.setenv("CW_FACTORY_LOG", str(log))
     factory_log._append({"ts": time.time(), "event": factory_log.CLAUDE_CODE,

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -200,6 +200,31 @@ def test_check_capture_zero_claude_code_records_is_missing(capsys):
     assert "ingest-claude-transcripts" in capsys.readouterr().out
 
 
+def test_check_capture_factory_ledger_degrades_when_no_transcript_root(monkeypatch, tmp_path):
+    """A harness with no ~/.claude/projects at all can never satisfy this
+    probe by running the ingest -- it is INAPPLICABLE, not missing. Must
+    downgrade to warn, never fail, the same way claude-transcripts already
+    does (chief-wiggum#345 reviewer finding: factory-ledger was unsatisfiable
+    on a non-Claude harness while its sibling correctly degraded)."""
+    _reset_dep_counts()
+    monkeypatch.setattr(factory_log, "DEFAULT_TRANSCRIPT_ROOT", tmp_path / "does-not-exist")
+    check_deps.check_capture("factory-ledger", required=True)
+    assert check_deps.fail_count == 0
+    assert check_deps.warn_count == 1
+
+
+def test_check_capture_factory_ledger_still_fails_when_root_present_but_never_ingested(
+        monkeypatch, tmp_path):
+    """Distinct from the inapplicable case above: a REAL Claude Code harness
+    (transcript root present) with zero ingested records is still an
+    actionable MISSING -- the operator can and should run the ingest."""
+    _reset_dep_counts()
+    monkeypatch.setattr(factory_log, "DEFAULT_TRANSCRIPT_ROOT", tmp_path)  # exists (tmp_path itself)
+    check_deps.check_capture("factory-ledger", required=True)
+    assert check_deps.fail_count == 1
+    assert check_deps.warn_count == 0
+
+
 def test_check_capture_recent_records_is_ok(monkeypatch, tmp_path, capsys):
     _reset_dep_counts()
     log = tmp_path / "log.jsonl"

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,4 +1,7 @@
+import time
+
 import check_deps
+import factory_log
 
 
 def test_core_profile_does_not_require_ai_or_browser_tools():
@@ -144,3 +147,65 @@ def test_list_languages_cli_prints_matrix(capsys, monkeypatch):
     assert "go" in out and "python" in out and "typescript" in out and "rust" in out
     assert "designed" in out  # rust's tier/status shows up
     assert "docs/languages.md" in out
+
+
+# --- telemetry capture profile + check_capture probe (chief-wiggum#345 AC1) --
+
+
+def test_telemetry_profile_requires_capture_items():
+    assert check_deps.is_required("capture", "factory-ledger", ["telemetry"])
+    assert check_deps.is_required("capture", "claude-transcripts", ["telemetry"])
+
+
+def test_implement_and_reflect_recommend_telemetry():
+    assert "telemetry" in check_deps.recommend_profiles(workflows=["implement"])
+    assert "telemetry" in check_deps.recommend_profiles(workflows=["reflect"])
+
+
+def test_existing_profiles_still_resolve_the_new_capture_kind():
+    """required_items's kind-lookup must not KeyError when a profile has no
+    "capture" key -- only the new "telemetry" profile has one; every other
+    profile must resolve to an empty set, not crash, once `required_items`
+    (or every profile dict) accounts for the new "capture" kind."""
+    for profile in check_deps.WORKFLOW_REQUIREMENTS:
+        if profile == "telemetry":
+            continue
+        assert check_deps.required_items("capture", [profile]) == set()
+
+
+def _reset_dep_counts():
+    check_deps.pass_count = 0
+    check_deps.fail_count = 0
+    check_deps.warn_count = 0
+
+
+def test_check_capture_absent_transcript_root_warns_never_fails(monkeypatch, tmp_path):
+    """Absent on a non-Claude harness is INAPPLICABLE, not a failure -- a check
+    that fails closed on a harness it doesn't apply to teaches operators to
+    ignore it."""
+    _reset_dep_counts()
+    monkeypatch.setattr(factory_log, "DEFAULT_TRANSCRIPT_ROOT", tmp_path / "does-not-exist")
+    check_deps.check_capture("claude-transcripts", required=True)
+    assert check_deps.fail_count == 0
+    assert check_deps.warn_count == 1
+
+
+def test_check_capture_zero_claude_code_records_is_missing(capsys):
+    """An empty Claude layer is exactly the silent failure this checker
+    exists to catch: everything installs, every workflow runs, and the
+    ledger's Claude layer stays empty because no ingest ever happened."""
+    _reset_dep_counts()
+    check_deps.check_capture("factory-ledger", required=True)
+    assert check_deps.fail_count == 1
+    assert "ingest-claude-transcripts" in capsys.readouterr().out
+
+
+def test_check_capture_recent_records_is_ok(monkeypatch, tmp_path, capsys):
+    _reset_dep_counts()
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    factory_log._append({"ts": time.time(), "event": factory_log.CLAUDE_CODE,
+                         "request_id": "r1", "tokens_in": 100, "tokens_out": 50})
+    check_deps.check_capture("factory-ledger", required=True)
+    assert check_deps.fail_count == 0
+    assert "[OK]" in capsys.readouterr().out

--- a/tests/test_draft_pr.py
+++ b/tests/test_draft_pr.py
@@ -51,3 +51,46 @@ def test_require_cost_passes_when_section_present(tmp_path):
     ])
     assert rc == 0
     assert "**$4.06**" in out.read_text()
+
+
+def test_require_cost_fails_on_a_hand_typed_stub(capsys, tmp_path):
+    """A non-empty string that isn't genuine ticket_cost.py output (e.g. a
+    hand-typed 'see ledger' placeholder) must still be rejected — accepting
+    any non-empty string was the loophole this flag existed to close
+    (chief-wiggum#345 reviewer finding)."""
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--implementation-cost", "see ledger",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 1
+    assert "stub" in capsys.readouterr().err.lower()
+    assert not out.exists()
+
+
+def test_require_cost_passes_for_genuine_unmetered_block(tmp_path):
+    """render_actual_markdown's unmetered branch is genuine ticket_cost.py
+    output with no cost table at all — must not be mistaken for a stub."""
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--implementation-cost",
+        "**Unmetered** — no cost records for acme/app#42 in the factory "
+        "ledger. That is absence of telemetry, not a $0 build.",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 0
+
+
+def test_require_cost_passes_for_coverage_line_without_a_cost_table(tmp_path):
+    """A bare coverage block (no priced layer table alongside it) is still
+    genuine — the marker set is an OR, not a requirement that all three
+    shapes appear together."""
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--implementation-cost", "**Coverage — 0 of 3 layers captured.**",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 0

--- a/tests/test_draft_pr.py
+++ b/tests/test_draft_pr.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/draft_pr.py --require-cost (chief-wiggum#345 item 4 / AC4).
+
+PRs went out with "see ledger" hand-edits because the costing pipeline
+produced nothing usable at PR time. --require-cost fails loudly on a
+missing/empty Implementation Cost section -- opt-in, so /ship (which has no
+ticket and no cost data) is unaffected and `shipping.REQUIRED_SECTIONS`
+stays untouched (tests/test_shipping.py's existing
+test_implementation_cost_omitted_when_absent / test_cli_writes_body_and_validates
+must keep passing unmodified).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import draft_pr  # noqa: E402
+
+
+def test_require_cost_fails_on_missing_section(capsys, tmp_path):
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cost" in err.lower()
+    assert not out.exists()
+
+
+def test_require_cost_fails_on_whitespace_only_section(tmp_path):
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--implementation-cost", "   \n  ",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 1
+    assert not out.exists()
+
+
+def test_require_cost_passes_when_section_present(tmp_path):
+    out = tmp_path / "pr.md"
+    rc = draft_pr.main([
+        "--issue", "9", "--summary", "Do X", "--change", "Add module",
+        "--implementation-cost", "| Layer |\n**$4.06**",
+        "--out", str(out), "--require-cost",
+    ])
+    assert rc == 0
+    assert "**$4.06**" in out.read_text()

--- a/tests/test_factory_log_cost.py
+++ b/tests/test_factory_log_cost.py
@@ -9,7 +9,9 @@ once per run, and an unattributed cost was reported as a measured $0.00.
 from __future__ import annotations
 
 import json
+import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -23,9 +25,14 @@ MULTS = {"cache_read": 0.1, "cache_write_5m": 1.25, "cache_write_1h": 2.0}
 
 
 def _turn(request_id, *, model="claude-opus-5", tin=100, tout=200, cache_read=0,
-          w5=0, w1=0, sidechain=False, cwd="/repos/acme", ts="2026-08-03T06:15:00.000Z"):
-    """One assistant turn as Claude Code writes it to a session transcript."""
-    return json.dumps({
+          w5=0, w1=0, sidechain=False, cwd="/repos/acme", ts="2026-08-03T06:15:00.000Z",
+          agent=None):
+    """One assistant turn as Claude Code writes it to a session transcript.
+
+    ``agent`` is the sub-agent TYPE Claude Code stamps as ``attributionAgent``
+    (e.g. ``general-purpose``, ``Explore``) — absent (``None``) for an
+    orchestrator turn, matching the real transcript shape."""
+    rec = {
         "type": "assistant", "requestId": request_id, "sessionId": "sess-1",
         "timestamp": ts, "isSidechain": sidechain, "cwd": cwd,
         "message": {"model": model, "usage": {
@@ -34,7 +41,10 @@ def _turn(request_id, *, model="claude-opus-5", tin=100, tout=200, cache_read=0,
             "cache_creation": {"ephemeral_5m_input_tokens": w5,
                                "ephemeral_1h_input_tokens": w1},
         }},
-    })
+    }
+    if agent is not None:
+        rec["attributionAgent"] = agent
+    return json.dumps(rec)
 
 
 @pytest.fixture
@@ -335,3 +345,174 @@ def test_cost_report_handles_an_empty_log():
     rep = factory_log.session_cost_report([])
     assert rep["turns"] == 0 and rep["findings"] == []
     assert "ingest-claude-transcripts" in factory_log.render_cost_report(rep)
+
+
+# ---- sub-agent transcript discovery (chief-wiggum#345) -----------------------
+#
+# Claude Code writes the orchestrator's turns to `<project>/<session>.jsonl`
+# but every sub-agent's turns to a DEEPER path -- `<project>/<session>/
+# subagents/agent-<id>.jsonl`, and workflow sub-agents deeper still
+# (`.../subagents/workflows/<wf>/agent-<id>.jsonl`). A `*/*.jsonl` glob only
+# sees the first level, which is why the sub-agent layer read $0 while
+# carrying ~75% of real turn volume (verified against the real corpus, see
+# the implementation plan). These tests fail against the old two-level glob.
+
+def test_ingest_finds_subagent_transcripts_at_the_third_level(monkeypatch, tmp_path):
+    """This test MUST fail on the old `root.glob("*/*.jsonl")` -- neither the
+    subagents/ nor the subagents/workflows/<wf>/ turn would ever be seen."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(_turn("top-1", cwd="/repos/app") + "\n")
+
+    subagents = proj / "s" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-a.jsonl").write_text(
+        _turn("sub-1", cwd="/repos/app", sidechain=True) + "\n")
+
+    wf = subagents / "workflows" / "wf1"
+    wf.mkdir(parents=True)
+    (wf / "agent-b.jsonl").write_text(
+        _turn("sub-2", cwd="/repos/app", sidechain=True) + "\n")
+
+    n = factory_log.ingest_claude_transcripts(root)
+    assert n == 3
+    ids = {r["request_id"] for r in factory_log.read_log()}
+    assert ids == {"top-1", "sub-1", "sub-2"}
+
+
+def test_subagent_turns_land_in_the_subagent_layer(monkeypatch, tmp_path):
+    """query_source must derive from isSidechain OR the /subagents/ path --
+    belt-and-braces, so a sub-agent transcript missing isSidechain (older
+    format) still lands in the right layer."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    subagents = root / "p" / "s" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-a.jsonl").write_text(
+        _turn("sub-1", sidechain=True) + "\n")
+    (subagents / "agent-b.jsonl").write_text(
+        _turn("sub-2", sidechain=False) + "\n")  # path alone must qualify
+
+    factory_log.ingest_claude_transcripts(root)
+    recs = {r["request_id"]: r for r in factory_log.read_log()}
+    assert recs["sub-1"]["query_source"] == "subagent"
+    assert recs["sub-2"]["query_source"] == "subagent"
+
+
+def test_no_double_count_across_transcript_levels(monkeypatch, tmp_path):
+    """Request-id overlap between the orchestrator and sub-agent levels is 0 in
+    the real corpus (see the plan's verification), so widening the glob cannot
+    double-count -- pinned here with a fixture that deliberately reuses one id."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(_turn("dup-1", cwd="/repos/app") + "\n")
+    subagents = proj / "s" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-a.jsonl").write_text(
+        _turn("dup-1", cwd="/repos/app", sidechain=True) + "\n")
+
+    n = factory_log.ingest_claude_transcripts(root)
+    assert n == 1
+    assert len([r for r in factory_log.read_log() if r["request_id"] == "dup-1"]) == 1
+
+
+def test_ingest_records_cwd_and_agent_type(monkeypatch, tmp_path):
+    """`cwd` lets ticket_cost's read-time window slicing recover an untagged
+    turn later; `agent_type` is the sub-agent TYPE name (never message
+    content) and must never be conflated with the gate-cost `skill` key."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(
+        _turn("r1", cwd="/repos/app", agent="general-purpose") + "\n")
+
+    factory_log.ingest_claude_transcripts(root)
+    rec = json.loads(Path(tmp_path / "log.jsonl").read_text().strip())
+    assert rec["cwd"] == "/repos/app"
+    assert rec["agent_type"] == "general-purpose"
+    assert "skill" not in rec
+
+
+def test_until_ts_excludes_in_flight_turns(monkeypatch, tmp_path):
+    """`--until-ts` bounds a catch-up ingest so it can never consume an
+    in-flight ticket's own turns (the tag-at-ingest race, chief-wiggum#345)."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(
+        _turn("early", ts="2026-08-03T06:00:00.000Z") + "\n"
+        + _turn("late", ts="2026-08-03T07:00:00.000Z") + "\n")
+
+    cutoff = factory_log._parse_iso_ts("2026-08-03T06:30:00.000Z")
+    n = factory_log.ingest_claude_transcripts(root, until=cutoff)
+    assert n == 1
+    assert {r["request_id"] for r in factory_log.read_log()} == {"early"}
+
+
+# ---- count_transcript_turns: independent evidence, never a write (#345 AC4) -
+
+def test_count_transcript_turns_reports_buckets_without_writing(monkeypatch, tmp_path):
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    log.write_text("")  # present but empty, so byte-identity is checkable
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(_turn("r1", sidechain=False) + "\n")
+    subagents = proj / "s" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-a.jsonl").write_text(_turn("r2", sidechain=True) + "\n")
+
+    before = log.read_bytes()
+    result = factory_log.count_transcript_turns(root)
+    assert result == {"scanned": True, "repl_main_thread": 1, "subagent": 1}
+    assert log.read_bytes() == before  # never writes -- a reader, not an ingest
+
+
+def test_count_transcript_turns_missing_root_is_not_scanned(tmp_path):
+    result = factory_log.count_transcript_turns(tmp_path / "does-not-exist")
+    assert result["scanned"] is False
+    # never crash, never claim zero as if it were a measured fact
+
+
+def test_count_transcript_turns_since_filters_by_file_mtime_not_turn_ts(monkeypatch, tmp_path):
+    """`since` is a CHEAP bound (plan §1e): whole FILES whose mtime precedes it
+    are skipped unread, so a bounded scan stays fast enough to run at PR time
+    -- this is a file-level filter, not a per-turn timestamp filter."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+
+    old_file = proj / "old.jsonl"
+    old_file.write_text(_turn("old-turn", cwd="/repos/app") + "\n")
+    old_mtime = time.time() - 30 * 86400
+    os.utime(old_file, (old_mtime, old_mtime))
+
+    new_file = proj / "new.jsonl"
+    new_file.write_text(_turn("new-turn", cwd="/repos/app") + "\n")
+
+    since = time.time() - 7 * 86400
+    result = factory_log.count_transcript_turns(root, since=since)
+    assert result["scanned"] is True
+    assert result["repl_main_thread"] == 1  # only the recently-touched file counted
+
+
+def test_count_transcript_turns_respects_repo_filter(monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(
+        _turn("keep", cwd="/repos/app") + "\n"
+        + _turn("other-repo", cwd="/repos/other") + "\n")
+
+    result = factory_log.count_transcript_turns(root, repo="app")
+    assert result["scanned"] is True
+    assert result["repl_main_thread"] == 1

--- a/tests/test_factory_log_cost.py
+++ b/tests/test_factory_log_cost.py
@@ -481,27 +481,57 @@ def test_count_transcript_turns_missing_root_is_not_scanned(tmp_path):
     # never crash, never claim zero as if it were a measured fact
 
 
-def test_count_transcript_turns_since_filters_by_file_mtime_not_turn_ts(monkeypatch, tmp_path):
-    """`since` is a CHEAP bound (plan §1e): whole FILES whose mtime precedes it
-    are skipped unread, so a bounded scan stays fast enough to run at PR time
-    -- this is a file-level filter, not a per-turn timestamp filter."""
+def test_count_transcript_turns_since_filters_by_turn_ts_with_mtime_as_cheap_prefilter(
+        monkeypatch, tmp_path):
+    """AC4 promises an IN-WINDOW denominator, so `since`/`until` must be
+    enforced per-turn (symmetric with ``ingest_claude_transcripts``) — the
+    file-mtime check is kept ONLY as a cheap skip-whole-file pre-filter
+    (sound for append-only files: an mtime that predates the window means
+    every line in the file predates it too), never a substitute for reading
+    a fresh file's actual turn timestamps. Reviewer finding on chief-wiggum#345."""
     monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
     root = tmp_path / "projects"
     proj = root / "p"
     proj.mkdir(parents=True)
 
-    old_file = proj / "old.jsonl"
-    old_file.write_text(_turn("old-turn", cwd="/repos/app") + "\n")
+    # Fresh-mtime file with two turns straddling the window: only the
+    # in-window turn's own timestamp should count, even though the FILE
+    # itself is fresh enough to pass the cheap pre-filter either way.
+    mixed_file = proj / "mixed.jsonl"
+    mixed_file.write_text(
+        _turn("in-window", cwd="/repos/app", ts="2026-08-04T12:00:00.000Z") + "\n"
+        + _turn("too-early", cwd="/repos/app", ts="2026-08-01T00:00:00.000Z") + "\n")
+
+    # Stale-mtime file: skipped UNREAD by the cheap pre-filter, even though it
+    # contains a turn whose own timestamp would otherwise be in-window --
+    # proves the mtime pre-filter still exists as a separate, cheaper gate.
+    stale_file = proj / "stale.jsonl"
+    stale_file.write_text(
+        _turn("stale-file-in-window-ts", cwd="/repos/app", ts="2026-08-04T12:00:00.000Z") + "\n")
     old_mtime = time.time() - 30 * 86400
-    os.utime(old_file, (old_mtime, old_mtime))
+    os.utime(stale_file, (old_mtime, old_mtime))
 
-    new_file = proj / "new.jsonl"
-    new_file.write_text(_turn("new-turn", cwd="/repos/app") + "\n")
-
-    since = time.time() - 7 * 86400
+    since = factory_log._parse_iso_ts("2026-08-02T00:00:00.000Z")
     result = factory_log.count_transcript_turns(root, since=since)
     assert result["scanned"] is True
-    assert result["repl_main_thread"] == 1  # only the recently-touched file counted
+    assert result["repl_main_thread"] == 1  # only "in-window"
+
+
+def test_count_transcript_turns_unparseable_ts_excluded_when_window_active(monkeypatch, tmp_path):
+    """A turn with no parseable timestamp can't be placed in the window, so it
+    must not silently count towards it once since/until is active — count
+    only what can be confirmed to fall inside the window."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text(
+        _turn("bad-ts", cwd="/repos/app", ts="not-a-timestamp") + "\n"
+        + _turn("good-ts", cwd="/repos/app", ts="2026-08-04T12:00:00.000Z") + "\n")
+
+    since = factory_log._parse_iso_ts("2026-08-01T00:00:00.000Z")
+    result = factory_log.count_transcript_turns(root, since=since)
+    assert result["repl_main_thread"] == 1  # only "good-ts"
 
 
 def test_count_transcript_turns_respects_repo_filter(monkeypatch, tmp_path):
@@ -514,5 +544,22 @@ def test_count_transcript_turns_respects_repo_filter(monkeypatch, tmp_path):
         + _turn("other-repo", cwd="/repos/other") + "\n")
 
     result = factory_log.count_transcript_turns(root, repo="app")
+    assert result["scanned"] is True
+    assert result["repl_main_thread"] == 1
+
+
+def test_count_transcript_turns_cwd_prefix_does_not_cross_bill_a_lexical_sibling(
+        monkeypatch, tmp_path):
+    """Same #345 fix-up as the ingest/ticket_cost sites: cwd_prefix `.../t42`
+    must not match cwd `.../t420` -- a bare `str.startswith` would."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    root = tmp_path / "projects"
+    proj = root / "p"
+    proj.mkdir(parents=True)
+    wt = "/repos/app/.claude/worktrees/t42"
+    (proj / "s.jsonl").write_text(
+        _turn("r1", cwd=wt) + "\n" + _turn("r2", cwd=wt + "0") + "\n")
+
+    result = factory_log.count_transcript_turns(root, cwd_prefix=wt)
     assert result["scanned"] is True
     assert result["repl_main_thread"] == 1

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/install_deps.py --tool telemetry-capture (chief-wiggum#345 AC1).
+
+Provisions `~/.chief-wiggum/otel/` and runs a catch-up transcript ingest so
+Claude-layer cost capture works with zero operator configuration -- the
+transcript route needs no dotfile edits. Must NEVER write
+`~/.claude/settings.json` or a shell rc file: those stay the operator's own
+files (the OTEL env + wrapper snippet is printed, never applied). See the
+implementation plan's Open Question 1 and `docs/harness-adapters.md`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import factory_log  # noqa: E402
+import install_deps  # noqa: E402
+
+
+def _patch_home_and_ingest(monkeypatch, tmp_path, calls=None):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # install_deps.py is expected to `import factory_log` for the catch-up
+    # ingest -- bind it explicitly so this test doesn't depend on the module
+    # having been wired yet (that wiring is exactly what's under test).
+    monkeypatch.setattr(install_deps, "factory_log", factory_log, raising=False)
+
+    def fake_ingest(*args, **kwargs):
+        if calls is not None:
+            calls.append((args, kwargs))
+        return 0
+
+    monkeypatch.setattr(factory_log, "ingest_claude_transcripts", fake_ingest)
+
+
+def test_telemetry_capture_provisions_otel_dir(monkeypatch, tmp_path):
+    _patch_home_and_ingest(monkeypatch, tmp_path)
+    monkeypatch.setattr("sys.argv", ["install_deps.py", "--tool", "telemetry-capture"])
+
+    install_deps.main()
+
+    assert (tmp_path / ".chief-wiggum" / "otel").is_dir()
+
+
+def test_telemetry_capture_runs_exactly_one_catch_up_ingest(monkeypatch, tmp_path):
+    calls: list = []
+    _patch_home_and_ingest(monkeypatch, tmp_path, calls=calls)
+    monkeypatch.setattr("sys.argv", ["install_deps.py", "--tool", "telemetry-capture"])
+
+    install_deps.main()
+
+    assert len(calls) == 1
+
+
+def test_telemetry_capture_never_writes_claude_settings_or_shell_rc(monkeypatch, tmp_path):
+    """The mitigation this ticket deliberately rejects (plan Open Question 1):
+    /setup and install_deps print the OTEL snippet, they never write it."""
+    _patch_home_and_ingest(monkeypatch, tmp_path)
+    monkeypatch.setattr("sys.argv", ["install_deps.py", "--tool", "telemetry-capture"])
+
+    install_deps.main()
+
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+    assert not (tmp_path / ".zshrc").exists()
+    assert not (tmp_path / ".bashrc").exists()
+    assert not (tmp_path / ".bash_profile").exists()
+
+
+def test_telemetry_capture_prints_the_otel_snippet(monkeypatch, tmp_path, capsys):
+    """Print -- never write -- the OTEL opt-in snippet for operators who do
+    want the console-exporter route."""
+    _patch_home_and_ingest(monkeypatch, tmp_path)
+    monkeypatch.setattr("sys.argv", ["install_deps.py", "--tool", "telemetry-capture"])
+
+    install_deps.main()
+
+    out = capsys.readouterr().out
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" in out
+    assert not (tmp_path / ".claude" / "settings.json").exists()

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/run_review.py -- ticket attribution for review-phase
+consults (chief-wiggum#345 AC2).
+
+Review-phase consults must carry the ticket they were run for. Untagged
+reviewer spend is why #381's cost slice read $0.00 while two reviewer
+consults ran (#345). `run_review.py`'s `execute` closure calls
+`consult_provider(...)` without a `ticket=` kwarg at all -- this file pins
+down that a `--ticket` flag (or the ticket-context's own `number`) reaches
+every one of those calls.
+
+These tests stub `chief_wiggum.review.run_review` itself rather than
+building a real git worktree + provider-quorum config: the bug under test is
+entirely inside run_review.py's own `execute` closure (whether it threads
+`ticket=` into `consult_provider`), which is independent of how the review
+quorum resolves providers or diffs a real repo -- `tests/test_review_pipeline.py`
+already covers that machinery. Stubbing `review.run_review` to simply invoke
+the `execute` callable it was handed keeps these tests deterministic and
+fast, with no dependency on a real `config/providers.json` reviewer role or
+installed codex/gemini CLIs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import run_review  # noqa: E402
+
+# A distinct sentinel (never `None`) so a call that omits `ticket=` entirely
+# is distinguishable from one that explicitly passes `ticket=None` -- the
+# unmodified `execute` closure never passes the kwarg at all, so without this
+# sentinel a "ticket should be None" assertion would pass even against
+# unimplemented code, which is not a real red test.
+_NOT_PASSED = object()
+
+
+def _write_ticket_context(path: Path, *, number=None) -> Path:
+    data = {
+        "number": number,
+        "title": "Do a thing",
+        "body": "body text",
+        "acceptance_criteria": ["AC one"],
+        "comments": [],
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _install_fake_run_review(monkeypatch, recorded_calls, *, providers=("codex", "gemini")):
+    """Replace chief_wiggum.review.run_review with a stub that calls the real
+    `execute` closure once per fake provider -- exercising run_review.py's own
+    ticket-threading logic without any real git/provider-quorum machinery."""
+
+    def fake_run_review(ticket, worktree, base, output_dir, *, template,
+                        checklist=None, epic_sections=(), role="reviewer",
+                        execute=None, force_fresh=False, epic_slug=None, **kwargs):
+        for name in providers:
+            provider = SimpleNamespace(name=name, type="tool", tool=name)
+            execute(provider, f"prompt for {name}")
+        return SimpleNamespace(
+            ok=True,
+            provider_manifest={"ok": True},
+            to_dict=lambda: {"ok": True},
+        )
+
+    monkeypatch.setattr(run_review.review, "run_review", fake_run_review)
+
+    def fake_consult_provider(provider, prompt, model, cwd, *, ticket=_NOT_PASSED,
+                              timeout_override=None):
+        recorded_calls.append({"provider": provider.name, "ticket": ticket})
+        return "a response", {"tokens_in": 1, "tokens_out": 1}
+
+    monkeypatch.setattr(run_review, "consult_provider", fake_consult_provider)
+
+
+def test_ticket_flag_reaches_every_consult_provider_call(tmp_path, monkeypatch):
+    """`--ticket 42` must reach EVERY `consult_provider` call the review
+    quorum makes, not just the first / a subset."""
+    ctx = _write_ticket_context(tmp_path / "ticket.json", number=None)
+    recorded: list[dict] = []
+    _install_fake_run_review(monkeypatch, recorded)
+
+    rc = run_review.main([
+        "--ticket-context", str(ctx),
+        "--worktree", str(tmp_path),
+        "--base", "main",
+        "--output-dir", str(tmp_path / "reviews"),
+        "--ticket", "42",
+    ])
+
+    assert rc == 0
+    assert len(recorded) == 2
+    assert all(c["ticket"] == "42" for c in recorded)
+
+
+def test_ticket_defaults_to_the_ticket_context_number(tmp_path, monkeypatch):
+    """No `--ticket` flag: fall back to `ticket.json`'s own `number` (the
+    natural default -- write_ticket_context.py already populates it in the
+    /implement Step 2 flow) instead of silently dropping the tag."""
+    ctx = _write_ticket_context(tmp_path / "ticket.json", number=42)
+    recorded: list[dict] = []
+    _install_fake_run_review(monkeypatch, recorded)
+
+    rc = run_review.main([
+        "--ticket-context", str(ctx),
+        "--worktree", str(tmp_path),
+        "--base", "main",
+        "--output-dir", str(tmp_path / "reviews"),
+    ])
+
+    assert rc == 0
+    assert recorded and all(c["ticket"] == "42" for c in recorded)
+
+
+def test_explicit_ticket_flag_overrides_the_ticket_context_number(tmp_path, monkeypatch):
+    """The flag is an override, not merely a fallback -- an explicit --ticket
+    must win over whatever ticket.json says."""
+    ctx = _write_ticket_context(tmp_path / "ticket.json", number=42)
+    recorded: list[dict] = []
+    _install_fake_run_review(monkeypatch, recorded)
+
+    rc = run_review.main([
+        "--ticket-context", str(ctx),
+        "--worktree", str(tmp_path),
+        "--base", "main",
+        "--output-dir", str(tmp_path / "reviews"),
+        "--ticket", "99",
+    ])
+
+    assert rc == 0
+    assert recorded and all(c["ticket"] == "99" for c in recorded)
+
+
+def test_missing_ticket_number_is_none_not_a_crash(tmp_path, monkeypatch):
+    """No --ticket flag AND ticket.json has no number: ticket=None must reach
+    consult_provider explicitly (never silently omitted, never a crash) so
+    the gap is visible in the ledger rather than papered over."""
+    ctx = _write_ticket_context(tmp_path / "ticket.json", number=None)
+    recorded: list[dict] = []
+    _install_fake_run_review(monkeypatch, recorded)
+
+    rc = run_review.main([
+        "--ticket-context", str(ctx),
+        "--worktree", str(tmp_path),
+        "--base", "main",
+        "--output-dir", str(tmp_path / "reviews"),
+    ])
+
+    assert rc == 0
+    assert recorded and all(c["ticket"] is None for c in recorded)

--- a/tests/test_ticket_cost.py
+++ b/tests/test_ticket_cost.py
@@ -185,6 +185,58 @@ def test_record_calibration_always_writes_without_telemetry_env(tmp_path, monkey
     assert rec["estimate_usd"] == pytest.approx(3.2)
 
 
+def test_record_cli_with_window_flags_journals_the_windowed_slice(tmp_path, monkeypatch):
+    """`record` must accept the same --cwd-prefix/--since-ts/--until-ts flags as
+    `actual` and thread them into the SAME summarize path — otherwise a
+    calibration recorded via the CLI silently reverts to tag-match-only,
+    journaling a small "clean" consult-only sample while the real windowed
+    slice (claude_code layers included) is far larger. This is the exact
+    escape #345 exists to fix, now leaking into the calibration/estimator
+    loop itself if left unfixed (chief-wiggum#345, orchestrator-verification
+    finding)."""
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    wt = "/repos/app/.claude/worktrees/t42"
+    # Untagged claude_code turn, recoverable only by cwd+window -- the whole
+    # point of the read-time slice (#345 §3).
+    factory_log._append({"event": factory_log.CLAUDE_CODE, "query_source": "repl_main_thread",
+                         "tokens_in": 100, "tokens_out": 50, "cost_usd": 190.0,
+                         "cwd": wt, "ts": 100})
+    # Tagged consult -- the only thing a tag-match-only summarize would see.
+    factory_log._append({"event": factory_log.CONSULT, "provider": "codex", "repo": REPO,
+                         "ticket": TICKET, "tokens_in": 800, "tokens_out": 200, "cost_usd": 3.85})
+
+    monkeypatch.setattr("sys.argv", [
+        "ticket_cost.py", "record", "--repo", REPO, "--ticket", TICKET,
+        "--cwd-prefix", wt, "--since-ts", "50", "--until-ts", "200",
+    ])
+    assert ticket_cost.main() == 0
+
+    rec = json.loads(log.read_text().splitlines()[-1])
+    assert rec["event"] == ticket_cost.TICKET_COST
+    assert rec["actual_usd"] == pytest.approx(193.85)  # windowed: claude_code + consult
+
+
+def test_record_cli_without_window_flags_is_unchanged(tmp_path, monkeypatch):
+    """Backward compat: no window flags on the CLI -> the same tag-match-only
+    summarize as before this fix (a record's own --cwd-prefix/--since-ts/
+    --until-ts default to None, exactly like `actual`'s)."""
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    wt = "/repos/app/.claude/worktrees/t42"
+    factory_log._append({"event": factory_log.CLAUDE_CODE, "query_source": "repl_main_thread",
+                         "tokens_in": 100, "tokens_out": 50, "cost_usd": 190.0,
+                         "cwd": wt, "ts": 100})  # untagged: must NOT be picked up without a window
+    factory_log._append({"event": factory_log.CONSULT, "provider": "codex", "repo": REPO,
+                         "ticket": TICKET, "tokens_in": 800, "tokens_out": 200, "cost_usd": 3.85})
+
+    monkeypatch.setattr("sys.argv", ["ticket_cost.py", "record", "--repo", REPO, "--ticket", TICKET])
+    assert ticket_cost.main() == 0
+
+    rec = json.loads(log.read_text().splitlines()[-1])
+    assert rec["actual_usd"] == pytest.approx(3.85)  # consult only, exactly as before
+
+
 def test_record_then_estimate_closes_the_loop(tmp_path, monkeypatch):
     log = tmp_path / "log.jsonl"
     monkeypatch.setenv("CW_FACTORY_LOG", str(log))

--- a/tests/test_ticket_cost.py
+++ b/tests/test_ticket_cost.py
@@ -26,7 +26,7 @@ TICKET = "42"
 
 
 def _cc(ticket=TICKET, *, repo="app", source="repl_main_thread", cost=1.0,
-        tin=1000, tout=100, cache=5000):
+        tin=1000, tout=100, cache=5000, cwd=None, ts=None):
     r = {"event": factory_log.CLAUDE_CODE, "query_source": source,
          "tokens_in": tin, "tokens_out": tout, "cache_read": cache,
          "cost_usd": cost}
@@ -34,6 +34,12 @@ def _cc(ticket=TICKET, *, repo="app", source="repl_main_thread", cost=1.0,
         r["repo"] = repo
     if ticket:
         r["ticket"] = ticket
+    if cwd is not None:
+        # Untagged (no `ticket`/`repo`) records still carry `cwd`+`ts` so
+        # read-time window slicing (#345 §3) can recover them.
+        r["cwd"] = cwd
+    if ts is not None:
+        r["ts"] = ts
     return r
 
 
@@ -238,3 +244,177 @@ def test_transcript_ingest_ticket_without_guard_is_rejected(tmp_path, monkeypatc
     monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
     with pytest.raises(ValueError):
         factory_log.ingest_claude_transcripts(tmp_path, ticket=TICKET)
+
+
+# ---- read-time window slicing (chief-wiggum#345 §3, conflict 3 half 2) ------
+#
+# Dedup is by request id and tagging happens at first ingest, so a turn swept
+# up by an automatic catch-up ingest (or a sibling /implement-wave worker's
+# ingest) can never be re-tagged afterwards — but its cwd and timestamp still
+# say which build it belongs to. summarize_ticket's cwd_prefix/since/until
+# params recover it at READ time, as a complement to the ticket tag, not a
+# replacement.
+
+_WT = "/repos/app/.claude/worktrees/t42"
+
+
+def test_window_slicing_matches_untagged_turns_by_cwd_and_time():
+    records = [
+        _cc(ticket=None, repo=None, cwd=_WT, ts=100, cost=1.0),  # in window, matching cwd
+        _cc(ticket=None, repo=None, cwd="/repos/app/.claude/worktrees/t99",
+            ts=100, cost=50.0),                                  # sibling worktree: excluded
+        _cc(ticket=None, repo=None, cwd=_WT, ts=5, cost=50.0),   # before the window: excluded
+        _cc(ticket=None, repo=None, cwd=_WT, ts=500, cost=50.0),  # after the window: excluded
+    ]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET, cwd_prefix=_WT, since=50, until=200)
+    assert s["status"] == "metered"
+    assert s["records"] == 1
+    assert s["total_cost_usd"] == pytest.approx(1.0)
+
+
+def test_window_slice_and_tag_never_double_count():
+    """A record matching BOTH the ticket tag and the cwd/time window (the
+    common case once tagging works) must still count once — `or` short-circuits."""
+    records = [_cc(cwd=_WT, ts=100, cost=2.0)]  # tagged AND in-window
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET, cwd_prefix=_WT, since=0, until=200)
+    assert s["records"] == 1
+    assert s["total_cost_usd"] == pytest.approx(2.0)
+
+
+# ---- coverage: the capture denominator (chief-wiggum#345 AC4) ---------------
+#
+# A cost table that silently omits the layers it never saw invites a reader to
+# take a consult-only figure as the total (#345, the #381 incident). Coverage
+# must derive each layer's status from evidence INDEPENDENT of the rendered
+# slice, and the four outcomes must stay distinct (the #289 taxonomy —
+# "failed to observe" must never read as "pass").
+
+def _stub_count_transcript_turns(monkeypatch, *, scanned=True, orchestrator=0, subagent=0):
+    def _fake(root=None, *, since=None, until=None, repo=None, cwd_prefix=None):
+        return {"scanned": scanned, "repl_main_thread": orchestrator, "subagent": subagent}
+    monkeypatch.setattr(factory_log, "count_transcript_turns", _fake, raising=False)
+
+
+def test_coverage_all_layers_captured_is_complete(monkeypatch):
+    _stub_count_transcript_turns(monkeypatch)
+    records = [_cc(source="repl_main_thread", cost=1.0), _cc(source="subagent", cost=1.0),
+               _consult(cost=0.25)]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    cov = ticket_cost.coverage(s, records, since=0, until=1000)
+    assert cov["status"] == "complete"
+    assert cov["captured_layers"] == 3
+    assert cov["total_layers"] == 3
+    for layer in cov["layers"].values():
+        assert layer["status"] in ("captured", "captured-partial")
+
+
+def test_coverage_consults_only_names_the_missing_claude_layers(monkeypatch):
+    """The #381 shape: only the consult layer flowed. Coverage must name the
+    other two as UNCAPTURED with a turn-count denominator and a fix command —
+    and the rendered table must never show $0.00 for them."""
+    _stub_count_transcript_turns(monkeypatch, orchestrator=312, subagent=1204)
+    records = [_consult(cost=0.35)]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    cov = ticket_cost.coverage(s, records, since=0, until=1000)
+    assert cov["layers"]["orchestrator"]["status"] == "uncaptured"
+    assert cov["layers"]["subagents"]["status"] == "uncaptured"
+    assert "312" in cov["layers"]["orchestrator"]["basis"]
+    assert cov["layers"]["orchestrator"]["fix"]
+    assert cov["status"] == "consults-only"
+    md = ticket_cost.render_coverage_markdown(cov)
+    assert "UNCAPTURED" in md
+    assert "$0.00" not in md
+    assert "312" in md
+    assert "1204" in md or "1,204" in md
+
+
+def test_coverage_partial_prints_both_denominators(monkeypatch):
+    _stub_count_transcript_turns(monkeypatch)
+    priced = [_consult(cost=0.1, provider=f"p{i}") for i in range(3)]
+    unpriced = [{"event": factory_log.CONSULT, "provider": f"u{i}", "repo": REPO,
+                 "ticket": TICKET, "tokens_in": 100, "tokens_out": 50}
+                for i in range(9)]
+    records = priced + unpriced
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    cov = ticket_cost.coverage(s, records, since=0, until=1000)
+    assert cov["layers"]["consults"]["status"] == "captured-partial"
+    assert "9" in cov["layers"]["consults"]["basis"]
+    assert "12" in cov["layers"]["consults"]["basis"]
+
+
+def test_coverage_unknown_when_no_transcript_root(monkeypatch):
+    _stub_count_transcript_turns(monkeypatch, scanned=False)
+    records = [_consult(cost=0.25)]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    cov = ticket_cost.coverage(s, records, since=0, until=1000)
+    assert cov["layers"]["orchestrator"]["status"] == "unknown"
+    assert cov["layers"]["subagents"]["status"] == "unknown"
+    md = ticket_cost.render_coverage_markdown(cov)
+    assert "$0.00" not in md
+
+
+def test_coverage_with_no_window_never_scans_and_is_unknown(monkeypatch):
+    """`since is None` -> skip the scan entirely (an unbounded corpus scan at
+    PR time is not worth its cost) -- unknown is the honest answer, never
+    captured, never a fabricated evidence count."""
+    scanned = {"called": False}
+
+    def _fail_if_called(*a, **k):
+        scanned["called"] = True
+        return {"scanned": True, "repl_main_thread": 0, "subagent": 0}
+
+    monkeypatch.setattr(factory_log, "count_transcript_turns", _fail_if_called, raising=False)
+    records = [_consult(cost=0.25)]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    cov = ticket_cost.coverage(s, records)  # no since/until at all
+    assert cov["layers"]["orchestrator"]["status"] == "unknown"
+    assert scanned["called"] is False
+
+
+def test_coverage_untagged_consults_in_window_are_evidence(monkeypatch):
+    """The exact #381 fingerprint: zero TAGGED consults for this ticket, but
+    untagged same-repo consult spend sits in the build window -- that is
+    evidence the review quorum ran untagged, not evidence nothing happened."""
+    _stub_count_transcript_turns(monkeypatch, orchestrator=5, subagent=5)
+    untagged_consults = [{"event": factory_log.CONSULT, "provider": "codex", "repo": REPO,
+                          "tokens_in": 100, "tokens_out": 50, "cost_usd": 0.1, "ts": 50}
+                         for _ in range(3)]
+    records = [_cc(source="repl_main_thread", cost=1.0),
+               _cc(source="subagent", cost=1.0)] + untagged_consults
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET)
+    assert s["status"] == "metered"
+    assert s["layers"]["consults"]["calls"] == 0  # sanity: the tagged slice really is empty
+    cov = ticket_cost.coverage(s, records, since=0, until=1000)
+    assert cov["layers"]["consults"]["status"] == "uncaptured"
+    assert "3" in cov["layers"]["consults"]["basis"]
+    assert cov["layers"]["consults"]["fix"]
+
+
+def test_unmetered_markdown_keeps_its_wording_and_gains_coverage(monkeypatch):
+    _stub_count_transcript_turns(monkeypatch, orchestrator=10, subagent=20)
+    s = ticket_cost.summarize_ticket([], REPO, TICKET)
+    cov = ticket_cost.coverage(s, [], since=0, until=1000)
+    md = ticket_cost.render_actual_markdown(s, cov=cov)
+    # The §5.1 honesty properties must survive unchanged.
+    assert "Unmetered" in md
+    assert "not a $0 build" in md
+    assert "**$" not in md
+    # ...and now also carry the coverage table.
+    assert "UNCAPTURED" in md.upper()
+
+
+def test_exit_code_on_gap_is_opt_in(monkeypatch, tmp_path):
+    """Default stays exit 0 (report-only, docs/gate-rollout.md); --exit-code-on-gap
+    is the opt-in escalation and only it may return 3."""
+    monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
+    monkeypatch.setattr(factory_log, "count_transcript_turns",
+                        lambda *a, **k: {"scanned": False}, raising=False)
+
+    monkeypatch.setattr("sys.argv", ["ticket_cost.py", "actual", "--repo", REPO,
+                                     "--ticket", TICKET, "--format", "text"])
+    assert ticket_cost.main() == 0
+
+    monkeypatch.setattr("sys.argv", ["ticket_cost.py", "actual", "--repo", REPO,
+                                     "--ticket", TICKET, "--format", "text",
+                                     "--exit-code-on-gap"])
+    assert ticket_cost.main() == 3

--- a/tests/test_ticket_cost.py
+++ b/tests/test_ticket_cost.py
@@ -240,6 +240,23 @@ def test_transcript_ingest_cwd_prefix_is_worktree_precise(tmp_path, monkeypatch)
     assert "ticket" not in recs["r2"]              # sibling worktree: not this ticket
 
 
+def test_transcript_ingest_cwd_prefix_does_not_cross_bill_a_lexical_sibling(tmp_path, monkeypatch):
+    """A bare `str.startswith` would match `.../t420` against prefix `.../t42`
+    — a sibling worktree, not a child of it. Reviewer finding (#345 fix-up):
+    cwd_prefix must be exact-or-true-child, never a lexical prefix match."""
+    log = tmp_path / "log.jsonl"
+    monkeypatch.setenv("CW_FACTORY_LOG", str(log))
+    root = tmp_path / "projects"
+    (root / "p").mkdir(parents=True)
+    wt = "/repos/app/.claude/worktrees/t42"
+    (root / "p" / "s.jsonl").write_text(
+        _turn("r1", cwd=wt) + "\n" + _turn("r2", cwd="/repos/app/.claude/worktrees/t420") + "\n")
+    factory_log.ingest_claude_transcripts(root, repo=REPO, ticket=TICKET, cwd_prefix=wt)
+    recs = {r["request_id"]: r for r in factory_log.read_log()}
+    assert recs["r1"]["ticket"] == TICKET
+    assert "ticket" not in recs["r2"]              # lexical sibling t420: not this ticket
+
+
 def test_transcript_ingest_ticket_without_guard_is_rejected(tmp_path, monkeypatch):
     monkeypatch.setenv("CW_FACTORY_LOG", str(tmp_path / "log.jsonl"))
     with pytest.raises(ValueError):
@@ -279,6 +296,18 @@ def test_window_slice_and_tag_never_double_count():
     s = ticket_cost.summarize_ticket(records, REPO, TICKET, cwd_prefix=_WT, since=0, until=200)
     assert s["records"] == 1
     assert s["total_cost_usd"] == pytest.approx(2.0)
+
+
+def test_window_slicing_does_not_cross_bill_a_lexical_sibling_worktree():
+    """Same #345 fix-up as the ingest-tagging case: prefix `.../t42` must not
+    match cwd `.../t420` — a `startswith` on the raw strings would."""
+    records = [
+        _cc(ticket=None, repo=None, cwd=_WT, ts=100, cost=1.0),               # true match
+        _cc(ticket=None, repo=None, cwd=_WT + "0", ts=100, cost=50.0),        # t420: lexical sibling
+    ]
+    s = ticket_cost.summarize_ticket(records, REPO, TICKET, cwd_prefix=_WT, since=0, until=200)
+    assert s["records"] == 1
+    assert s["total_cost_usd"] == pytest.approx(1.0)
 
 
 # ---- coverage: the capture denominator (chief-wiggum#345 AC4) ---------------


### PR DESCRIPTION
## Summary

Per-ticket costing was consult-only in practice (~$3-6/ticket visible while the dominant Claude-layer spend went unrecorded). Root causes fixed: (1) the transcript ingest globbed */*.jsonl and never saw subagent transcripts at <session>/subagents/** — the subagent layer was structurally invisible (this branch's own build: $89 of $195 nominal); (2) run_review.py never passed the ticket to its consult calls, so review-phase spend landed untagged; (3) ticket_cost's markdown silently skipped zero-call layers, inviting a consult-only slice to read as the total; (4) nothing provisioned or verified capture. Now: /setup gets a telemetry profile with honest probes (transcript-route-first; the OTEL snippet is printed, never written to dotfiles), ingest discovers subagent transcripts recursively with request-id dedup unchanged, --ticket threads through the review pipeline, catch-up ingest steps land in /implement, /implement-wave and /reflect (bounded by --until-ts against self-consumption), read-time window slicing (--cwd-prefix/--since-ts, exact-or-child path semantics) makes attribution safe under concurrent sessions, ticket_cost prints a coverage denominator with four honest statuses (captured / captured-partial / uncaptured / unknown — unknown never masquerades as captured), and draft_pr --require-cost rejects stub cost sections.

Closes #345

## Architecture

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#003f5c', 'primaryTextColor': '#fff', 'primaryBorderColor': '#2f4b7c', 'secondaryColor': '#665191', 'tertiaryColor': '#a05195', 'lineColor': '#2f4b7c', 'textColor': '#333'}}}%%
graph TD
    classDef existing fill:#003f5c,stroke:#2f4b7c,color:#fff
    classDef modified fill:#665191,stroke:#a05195,color:#fff
    classDef new fill:#d45087,stroke:#f95d6a,color:#fff
    classDef entry fill:#ff7c43,stroke:#ffa600,color:#fff

    setup["/setup — telemetry profile"]:::entry
    implement["/implement Step 1 + 11"]:::entry
    wave["/implement-wave + /reflect<br/>catch-up ingest steps"]:::entry

    transcripts[("~/.claude/projects/**<br/>incl. subagents/*.jsonl")]:::existing
    ledger[("~/.chief-wiggum/<br/>factory-log.jsonl")]:::existing

    checkdeps["check_deps.py<br/>check_capture() probe"]:::new
    installdeps["install_deps.py<br/>--tool telemetry-capture"]:::new
    flog["factory_log.py<br/>rglob subagent discovery,<br/>--until-ts, cwd recording,<br/>count_transcript_turns()"]:::modified
    tcost["ticket_cost.py<br/>read-time window slicing,<br/>coverage() 4-status denominator"]:::modified
    rreview["run_review.py --ticket<br/>→ every consult tagged"]:::modified
    draftpr["draft_pr.py --require-cost<br/>rejects stub sections"]:::modified

    setup --> checkdeps
    setup --> installdeps
    installdeps -->|bounded catch-up| flog
    implement --> flog
    wave --> flog
    flog -->|dedup by request id| ledger
    transcripts --> flog
    rreview -->|ticket-tagged consults| ledger
    ledger --> tcost
    transcripts -->|independent evidence| tcost
    tcost -->|table + coverage line| draftpr
```

## Changes

- factory_log.py: rglob subagent-transcript discovery (+ workflows/ nesting), per-turn since/until window bounds (mtime only as a cheap file pre-filter), cwd/agent_type recorded on claude_code events, count_transcript_turns() independent-evidence scanner, cwd_matches_prefix() exact-or-child matching (kills sibling-path cross-billing)
- ticket_cost.py: read-time window slicing (--cwd-prefix/--since-ts/--until-ts), coverage() four-status denominator rendered in markdown/text/json, zero-call layers named as uncaptured instead of silently skipped, --exit-code-on-gap
- run_review.py: --ticket flag (TicketContext.number fallback) threaded into every consult_provider call — review-phase consults now attribute (dogfooded: this PR's own review consults landed tagged, $3.85)
- check_deps.py: telemetry profile with check_capture()/check_telemetry_env() probes — honest statuses, degrade-to-inapplicable on non-Claude harnesses; install_deps.py: --tool telemetry-capture provisioning (dir + bounded 7-day catch-up ingest; prints OTEL snippet, never edits ~/.claude/settings.json or shell rc)
- draft_pr.py: --require-cost fails loudly on missing/stub cost sections (validates genuine ticket_cost output shape); REQUIRED_SECTIONS unchanged
- Workflow prose: /implement Step 1 catch-up ingest bounded by --until-ts + Step 11 read-time slicing; /implement-wave wave-level ingest + worktree-precise --cwd-prefix mandate; /reflect Step 1b 30-day catch-up; /setup telemetry section
- Docs: ticket-cost.md + factory-telemetry.md updated (layers, coverage semantics, nominal-vs-billed framing), harness-adapters.md note

## Test Evidence

**Verification: all green**
- ✓ `make test` — exit 0
- ✓ `make lint` — exit 0

## Review

Multi-AI review passed: codex (ok), gemini-vertex (ok), claude-interactive (failed)

## Implementation Cost

| Layer | Calls | Tokens in | Cache | Tokens out | Cost |
|---|---|---|---|---|---|
| Orchestrator | 221 | 10.0k | 71.7M | 189.0k | $101.58 |
| Subagents | 1284 | 26.2k | 292.8M | 124.8k | $89.22 * |
| Consults (codex, gemini-vertex) | 2 | 707.2k | 0 | 12.0k | $3.85 |
| **Total** | | | | | **$194.66** |

**Coverage — 3 of 3 layers captured.**

| Layer | Status | Basis |
|---|---|---|
| Orchestrator | captured | 221 calls captured |
| Sub-agents | captured (partial) | 1284 calls, 68 unpriced |
| Consults | captured | 2 calls captured |

<sub>Nominal model spend (tokens × `config/model_pricing.json`, cache-aware for Claude Code layers). Human time and CI excluded. **Partial**: 68 of 1507 calls had no priced model — the total understates.</sub>

<sub>**Attribution caveat** (measured, not hidden): a concurrent background session ("close dogeared-coach issues", 727+ turns, ~$99 nominal) shares this checkout as its cwd and falls inside the same time+cwd window — the orchestrator/subagent rows above include it. This ticket's own slice is ~$86–95. This is the exact shared-cwd precision limit this PR documents; wave workers avoid it via worktree-precise `--cwd-prefix` (see `implement-wave.md`).</sub>

## Review Checklist

- [ ] Tests pass locally
- [ ] No new warnings or lint errors
- [ ] Multi-AI review feedback addressed
- [ ] No secrets or credentials committed

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
