### PR TITLE
fix(tutorials): grant clipboard permissions on the recording context

### DIFF
--- a/scripts/tutorial_video.py
+++ b/scripts/tutorial_video.py
@@ -471,6 +471,20 @@ def cmd_record(args) -> None:
             context_kwargs["record_video_size"] = viewport
         context = browser.new_context(**context_kwargs)
         context.add_init_script(CURSOR_OVERLAY_JS)
+        # Storyboards may click a "Copy to clipboard" affordance and wait for its
+        # UI to flip to a "Copied" confirmation. Headless Chromium denies
+        # navigator.clipboard.writeText() by default (NotAllowedError), which the
+        # app's own try/catch swallows silently — so without this grant the button
+        # text never changes and any wait_for on the confirmation state hangs until
+        # timeout. Grant write access up front, scoped to the storyboard's own
+        # origin when known.
+        try:
+            if base_url:
+                context.grant_permissions(["clipboard-read", "clipboard-write"], origin=base_url)
+            else:
+                context.grant_permissions(["clipboard-read", "clipboard-write"])
+        except Exception as exc:  # pragma: no cover - browser/channel dependent
+            print(f"  warning: could not grant clipboard permissions: {exc}")
 
         # Setup pre-roll: actions that must happen (sign-in, seeding a route)
         # but should NOT appear in the tutorial. They run on a throwaway page;


### PR DESCRIPTION
Headless Chromium denies `navigator.clipboard.writeText()` by default (NotAllowedError). Target apps typically try/catch the write and swallow the error, so a storyboard that clicks a Copy button and `wait_for`s the "Copied" confirmation hangs until timeout with no signal — the button text simply never flips.

`tutorial_video.py record` now grants `clipboard-read`/`clipboard-write` on the recording context up front, scoped to the storyboard's `base_url` origin when known, with a loud warning (not a crash) if the grant fails on an unsupported channel.

Found live: dogeared-coach's re-recorded build-a-course tutorial gained a copy-the-public-preview-link scene (dogeared#426) whose `Copied` wait_for silently hung.

https://claude.ai/code/session_01PjQdYL6LTw7VmwvVm4bHne