### PR TITLE
feat(tutorials): recorder captures visited routes — ground truth for render-closure drift

### DIFF
--- a/scripts/tutorial_video.py
+++ b/scripts/tutorial_video.py
@@ -471,6 +471,20 @@ def cmd_record(args) -> None:
             context_kwargs["record_video_size"] = viewport
         context = browser.new_context(**context_kwargs)
         context.add_init_script(CURSOR_OVERLAY_JS)
+        # Storyboards may click a "Copy to clipboard" affordance and wait for its
+        # UI to flip to a "Copied" confirmation. Headless Chromium denies
+        # navigator.clipboard.writeText() by default (NotAllowedError), which the
+        # app's own try/catch swallows silently — so without this grant the button
+        # text never changes and any wait_for on the confirmation state hangs until
+        # timeout. Grant write access up front, scoped to the storyboard's own
+        # origin when known.
+        try:
+            if base_url:
+                context.grant_permissions(["clipboard-read", "clipboard-write"], origin=base_url)
+            else:
+                context.grant_permissions(["clipboard-read", "clipboard-write"])
+        except Exception as exc:  # pragma: no cover - browser/channel dependent
+            print(f"  warning: could not grant clipboard permissions: {exc}")
 
         # Setup pre-roll: actions that must happen (sign-in, seeding a route)
         # but should NOT appear in the tutorial. They run on a throwaway page;

--- a/scripts/tutorial_video.py
+++ b/scripts/tutorial_video.py
@@ -503,6 +503,28 @@ def cmd_record(args) -> None:
         t0 = time.monotonic()
         page.wait_for_timeout(SCENE_SETTLE * 1000)
 
+        # Route capture for render-closure drift detection: storyboards only
+        # NAME entry URLs — everything reached by clicking is invisible to any
+        # static reading of the storyboard, so the recorder is the one honest
+        # witness of which routes the video actually shows. A framenavigated
+        # listener (not post-action polling) catches redirects that resolve
+        # mid-wait or during a scene's visual hold. Concrete paths (with real
+        # ids) are recorded; consumers match them against route patterns.
+        visited_routes: list[str] = []
+
+        def _note_route(frame) -> None:
+            if frame != page.main_frame:
+                return
+            try:
+                from urllib.parse import urlsplit
+                path = urlsplit(frame.url).path or "/"
+            except Exception:
+                return
+            if path and (not visited_routes or visited_routes[-1] != path):
+                visited_routes.append(path)
+
+        page.on("framenavigated", _note_route)
+
         for scene in board["scenes"]:
             start = time.monotonic() - t0
             print(f"  scene {scene['id']} @ {start:.1f}s")
@@ -537,6 +559,16 @@ def cmd_record(args) -> None:
 
     (out_dir / "markers.json").write_text(json.dumps(markers, indent=2), encoding="utf-8")
     print(f"Markers: {out_dir / 'markers.json'}")
+    # Written NEXT TO THE STORYBOARD (not out_dir): the sidecar is production
+    # metadata about the recording that ships with the tutorial's other inputs,
+    # for drift scanners to resolve which routes the video renders. Ordered,
+    # consecutive-deduped. NEVER on dry-run: a dry run races async navigations
+    # (pace 0.1, holds skipped) and would overwrite a real recording's ground
+    # truth with a truncated, flaky list.
+    if visited_routes and not args.dry_run:
+        sidecar = Path(args.storyboard).resolve().parent / "visited_routes.json"
+        sidecar.write_text(json.dumps(visited_routes, indent=2) + "\n", encoding="utf-8")
+        print(f"Visited routes: {sidecar} ({len(visited_routes)} entries)")
     if args.dry_run:
         print("Dry run OK: every action executed against the live app.")
 


### PR DESCRIPTION
Chief-wiggum half of #365 (companion to dogeared PR #500, which consumes the sidecar).

`tutorial_video.py record` now registers a `framenavigated` listener on the main frame and writes the consecutive-deduped concrete route paths to `visited_routes.json` **next to the storyboard** after a real recording. Design points from the sighted review round (both were FIX-FIRST findings, both addressed):

- **Listener, not post-action polling** — redirects that resolve mid-wait or during a scene's visual hold are captured
- **Never written on dry-run** — a dry run (pace 0.1, holds skipped) races async navigations and would clobber real ground truth with a truncated list

Product-neutral: the recorder knows only the storyboard's directory; what consumes the sidecar (drift scanners, hosting metadata) is the target repo's business.

https://claude.ai/code/session_01PjQdYL6LTw7VmwvVm4bHne