### PR TITLE
feat(harness): add an agentic OpenRouter coding worker behind the shared delegate protocol (#392)

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -103,6 +103,27 @@
       "reads_repo": false,
       "accepts_images": false,
       "needs_inline_diff": true
+    },
+    "openrouter-preview-worker": {
+      "type": "delegate",
+      "delegate": "codex-responses",
+      "execution_adapter": "codex-responses",
+      "model": "stealth/ox-alpha",
+      "base_url": "https://openrouter.ai/api/v1",
+      "enabled": false,
+      "reads_repo": true,
+      "accepts_images": false,
+      "needs_inline_diff": false,
+      "capability_tier": "external-preview-tier",
+      "capabilities": [
+        "responses",
+        "repo-read",
+        "shell-tools",
+        "workspace-write"
+      ],
+      "anonymous_preview": true,
+      "weights_license_evidence": null,
+      "max_input_tokens": 120000
     }
   },
   "roles": {

--- a/docs/experiments/dynamic-dag/probes/2026-08-22-openrouter-codex.json
+++ b/docs/experiments/dynamic-dag/probes/2026-08-22-openrouter-codex.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "observed_on": "2026-08-22",
+  "observation_kind": "read-only-compatibility-probe",
+  "provider_name": "openrouter-preview-worker",
+  "model": "stealth/ox-alpha",
+  "provider_capability_tier": "external-preview-tier",
+  "anonymous_preview": true,
+  "weights_license_evidence": null,
+  "harness": {
+    "name": "codex",
+    "version": "0.149.0"
+  },
+  "execution": {
+    "wire_api": "responses",
+    "sandbox": "read-only",
+    "ephemeral": true,
+    "task_class": "read two repository configuration files with shell tools; no edits",
+    "expected_marker": "OX_TOOL_PROBE_OK",
+    "observed_marker": "OX_TOOL_PROBE_OK",
+    "observed_provider_count": 12,
+    "shell_tool_call_observed": true,
+    "duration_ms": 25700
+  },
+  "usage": {
+    "status": "measured",
+    "input_tokens": 98628,
+    "output_tokens": 90,
+    "reasoning_output_tokens": 0
+  },
+  "model_resolution": {
+    "status": "unavailable",
+    "resolved_model": null,
+    "warning": "Harness had no model metadata and used fallback metadata."
+  },
+  "sanitized_evidence": {
+    "prompt_summary": "Read AGENTS.md and config/providers.json using shell tools; make no edits; return OX_TOOL_PROBE_OK and provider count.",
+    "config_summary": "Codex 0.149.0; OpenRouter Responses; read-only sandbox; ephemeral; ignored user config; configured preview model.",
+    "log_summary": "tool call completed; marker OX_TOOL_PROBE_OK; provider count 12; model metadata fallback warning.",
+    "prompt_sha256": "sha256:2ff2a33ca0232f9174af18c06b93920cb51276e6d4ca3d5de8d8be121c4365cb",
+    "config_sha256": "sha256:69650732bdb1598bd42e9b7ecb037f1ec6bc6e8fc63b43b6f7d6afa2181ed460",
+    "log_sha256": "sha256:53d1173301effcfdf49354454e54de02b5aad3fe0d7d9dffaaba619b4d5da02c"
+  },
+  "admission": {
+    "read_tools": "compatible",
+    "write_enabled": false,
+    "causal_identity_compliant": false,
+    "next_required_stage": "disposable-write-fixture"
+  },
+  "notes": [
+    "The unusually high input-token count requires a hard budget and repeated calibration.",
+    "This observation is compatibility evidence only; no write-enabled model call was made."
+  ]
+}

--- a/scripts/delegates/README.md
+++ b/scripts/delegates/README.md
@@ -12,11 +12,17 @@ Each task lives under a provider-specific root:
 ├── result.md       # final answer written by the worker
 ├── DONE            # success sentinel
 ├── ERROR           # blocked/error sentinel with a concise reason
-├── worker.log      # optional provider log
-└── metadata.json   # optional structured metadata
+├── worker.log      # diagnostic JSONL written by the trusted adapter
+└── metadata.json   # schema-valid structured execution metadata
 ```
 
 The orchestrator reads `result.md` only after `DONE` exists. If `ERROR` exists, the orchestrator treats the task as blocked and decides whether to retry with a narrower prompt.
+
+`DONE` and `ERROR` are mutually exclusive terminal commit markers. Trusted
+adapters publish artifacts with same-directory temporary files and place the
+terminal marker last while holding the task's terminal lock. Readers treat
+both markers as a protocol conflict; they never prefer success. Artifact files
+are owner-only and metadata binds the prompt/result/log/config with SHA-256.
 
 Terminal output is diagnostic only. Do not parse terminal UI or stdout as the primary result contract when a provider can write files.
 
@@ -34,3 +40,33 @@ Worker prompts should include:
 ## Verification
 
 Worker results are advisory unless the workflow explicitly defines them as generated artifacts. The orchestrator must independently verify tests, lint, screenshots, file references, and repository state.
+
+## Agentic OpenRouter worker
+
+`openrouter_worker.py` is an execution adapter, not an extension of the
+prompt-only OpenRouter consultation path. It runs Codex's open-source agent
+loop against a configured Responses endpoint in an explicit non-main git
+worktree. Execution providers are disabled by default and are not members of
+workflow roles; a bounded experiment must opt in with `--admit-disabled`.
+
+Create the task first, then run a read-only compatibility probe before any
+write-enabled experiment:
+
+```bash
+python3 scripts/delegates/openrouter_worker.py probe \
+  --provider openrouter-preview-worker \
+  --task-root "$CW_TMP/delegates" --task-id "$TASK_ID" \
+  --worktree "$WORKTREE" --main "$TARGET_REPO" \
+  --admit-disabled --timeout-seconds 120
+```
+
+The prompt must name a harmless repository read and an expected shell-tool
+observation. A successful probe still does not authorize writes: promotion is
+read-only probe → disposable write fixture → bounded shadow ticket → explicit
+routing/experiment admission.
+
+Authentication is fetched by the trusted parent from the system keyring. A
+private helper can consume a random local capability once; it cannot read the
+keyring, the broker disappears after pre-turn authentication, and the adapter
+actively verifies that the helper cannot authenticate again. A failed canary
+rejects the run as `CREDENTIAL_BOUNDARY_UNSAFE`.

--- a/scripts/delegates/openrouter_worker.py
+++ b/scripts/delegates/openrouter_worker.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Agentic OpenRouter coding worker behind the durable delegate protocol.
+
+This module is deliberately separate from ``consult_ai``. Consultation is a
+prompt-only completion; this adapter gives an open-source harness repository
+tools inside an already-isolated worktree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from chief_wiggum import gitops  # noqa: E402
+from keychain import get_secret  # noqa: E402
+from providers import ExecutionProvider, execution_providers_from_config, load_config  # noqa: E402
+
+from delegates import task_protocol  # noqa: E402
+
+ADAPTER_VERSION = 1
+REDACTION_POLICY_VERSION = 1
+SCHEMA = Path(__file__).resolve().parents[2] / "templates" / "delegate-worker-metadata-schema.json"
+REQUIRED_CAPABILITIES = {"responses", "repo-read", "shell-tools", "workspace-write"}
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    status: str
+    reason_code: str | None = None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _git_sha(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True, capture_output=True, check=True
+    ).stdout.strip()
+
+
+def _sanitize_environment(extra: dict[str, str] | None = None) -> dict[str, str]:
+    allowed = {
+        name: os.environ[name]
+        for name in ("PATH", "LANG", "LC_ALL", "TMPDIR")
+        if name in os.environ
+    }
+    for name, value in (extra or {}).items():
+        upper = name.upper()
+        if any(marker in upper for marker in ("KEY", "TOKEN", "SECRET", "CREDENTIAL")):
+            continue
+        allowed[name] = value
+    return allowed
+
+
+def _harness_version(command: str, environment: dict[str, str]) -> str | None:
+    completed = subprocess.run(
+        [command, "--version"],
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=environment,
+    )
+    if completed.returncode != 0:
+        return None
+    version = completed.stdout.strip().splitlines()
+    return version[0][:100] if version else None
+
+
+class _OneShotBroker:
+    """Single-use owner-only Unix socket; it has no keychain capability."""
+
+    def __init__(self, directory: Path, secret: str):
+        self.socket_path = directory / "auth.sock"
+        self.capability = secrets.token_urlsafe(32)
+        self._secret = secret
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(self.socket_path))
+        os.chmod(self.socket_path, 0o600)
+        self._server.listen(1)
+        self._server.settimeout(5)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _serve(self) -> None:
+        try:
+            connection, _ = self._server.accept()
+            with connection:
+                request = connection.recv(4096).decode(errors="replace")
+                if secrets.compare_digest(request, self.capability):
+                    connection.sendall(self._secret.encode())
+        except (OSError, TimeoutError):
+            pass
+        finally:
+            self._secret = ""
+            self._server.close()
+            try:
+                self.socket_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def join(self) -> None:
+        self._thread.join(timeout=6)
+
+
+_AUTH_HELPER = """#!/usr/bin/env python3
+import socket, sys
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+try:
+    sock.settimeout(2)
+    sock.connect(sys.argv[1])
+    sock.sendall(sys.argv[2].encode())
+    value = sock.recv(1024)
+    if not value:
+        raise SystemExit(3)
+    sys.stdout.buffer.write(value)
+except OSError:
+    raise SystemExit(4)
+finally:
+    sock.close()
+"""
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait(timeout=2)
+
+
+def _event_log(stdout: bytes, stderr: bytes, *, secret: str) -> tuple[bytes, list[dict], bool]:
+    events: list[dict] = []
+    records: list[str] = []
+    malformed = False
+    sequence = 0
+    for stream, payload in (("stdout", stdout), ("stderr", stderr)):
+        for raw in payload.decode(errors="replace").splitlines():
+            sequence += 1
+            exposure = bool(secret and secret in raw)
+            sanitized = raw.replace(secret, "[REDACTED]") if secret else raw
+            sanitized = sanitized.replace(str(Path.home()), "$HOME")
+            record: dict = {"seq": sequence, "stream": stream, "observed_at": _utc_now()}
+            if stream == "stdout":
+                try:
+                    parsed = json.loads(sanitized)
+                    if not isinstance(parsed, dict):
+                        raise ValueError("event is not an object")
+                    record["parsed_event"] = parsed
+                    events.append(parsed)
+                except (json.JSONDecodeError, ValueError):
+                    malformed = True
+                    record["raw_if_unparsed"] = sanitized
+            else:
+                record["raw_if_unparsed"] = sanitized
+            record["secret_exposure"] = exposure
+            records.append(json.dumps(record, sort_keys=True))
+    return (("\n".join(records) + ("\n" if records else "")).encode(), events, malformed)
+
+
+def _resolved_model(events: list[dict]) -> str | None:
+    for event in events:
+        for key in ("resolved_model", "model"):
+            value = event.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _usage(events: list[dict], limit: int | None) -> dict:
+    raw = next(
+        (event.get("usage") for event in reversed(events) if isinstance(event.get("usage"), dict)),
+        None,
+    )
+    if raw is None:
+        return {
+            "status": "unavailable",
+            "input_tokens": None,
+            "output_tokens": None,
+            "reasoning_output_tokens": None,
+            "within_limit": None,
+        }
+    input_tokens = raw.get("input_tokens")
+    output_tokens = raw.get("output_tokens")
+    reasoning = raw.get("reasoning_output_tokens")
+    measured = isinstance(input_tokens, int) and isinstance(output_tokens, int)
+    if not measured:
+        input_tokens = None
+        output_tokens = None
+    return {
+        "status": "measured" if measured else "unavailable",
+        "input_tokens": input_tokens if isinstance(input_tokens, int) else None,
+        "output_tokens": output_tokens if isinstance(output_tokens, int) else None,
+        "reasoning_output_tokens": reasoning if isinstance(reasoning, int) else None,
+        "within_limit": (input_tokens <= limit)
+        if isinstance(input_tokens, int) and limit
+        else None,
+    }
+
+
+def _publish_failure(
+    paths: task_protocol.TaskPaths, reason: str, detail: str | None = None, log: bytes | None = None
+) -> WorkerResult:
+    task_protocol.publish_error(paths, reason=reason, detail=detail, log=log)
+    return WorkerResult("error", reason)
+
+
+def run_task(
+    *,
+    paths: task_protocol.TaskPaths,
+    provider: ExecutionProvider,
+    worktree: Path,
+    main_checkout: Path,
+    timeout_seconds: int,
+    harness_command: str = "codex",
+    secret_loader: Callable[[], str | None] = lambda: get_secret("OPENROUTER_API_KEY"),
+    extra_env: dict[str, str] | None = None,
+    sandbox: str = "workspace-write",
+    admit_disabled: bool = False,
+) -> WorkerResult:
+    """Run one configured coding delegate and publish one terminal result."""
+    try:
+        worktree = gitops.assert_worktree(worktree, main_checkout)
+    except (gitops.GitSafetyError, subprocess.SubprocessError):
+        return _publish_failure(paths, "UNSAFE_WORKTREE")
+    if not provider.enabled and not admit_disabled:
+        return _publish_failure(paths, "PROVIDER_DISABLED")
+    if (
+        provider.execution_adapter != "codex-responses"
+        or not provider.model
+        or not provider.base_url
+    ):
+        return _publish_failure(paths, "PROVIDER_CONFIG_INVALID")
+    required_capabilities = REQUIRED_CAPABILITIES - (
+        {"workspace-write"} if sandbox == "read-only" else set()
+    )
+    if sandbox not in {"read-only", "workspace-write"} or not required_capabilities <= set(
+        provider.capabilities
+    ):
+        return _publish_failure(paths, "UNSUPPORTED_CAPABILITY")
+    if timeout_seconds <= 0:
+        return _publish_failure(paths, "PROVIDER_CONFIG_INVALID", "timeout must be positive")
+
+    environment = _sanitize_environment(extra_env)
+    try:
+        harness_version = _harness_version(harness_command, environment)
+    except (OSError, subprocess.SubprocessError):
+        return _publish_failure(paths, "HARNESS_UNAVAILABLE")
+
+    secret = secret_loader()
+    if not secret:
+        return _publish_failure(paths, "CREDENTIAL_UNAVAILABLE")
+    prompt = paths.prompt.read_text()
+    started_at = _utc_now()
+    started = time.monotonic()
+    start_sha = _git_sha(worktree)
+
+    with tempfile.TemporaryDirectory(prefix="cw-openrouter-worker-") as temporary_name:
+        temporary = Path(temporary_name)
+        os.chmod(temporary, 0o700)
+        helper = temporary / "auth-helper"
+        helper.write_text(_AUTH_HELPER)
+        helper.chmod(0o700)
+        last_message = temporary / "last-message.md"
+        codex_home = temporary / "codex-home"
+        codex_home.mkdir(mode=0o700)
+        broker = _OneShotBroker(temporary, secret)
+        broker.start()
+
+        provider_key = "cw_openrouter"
+        auth_args = [str(broker.socket_path), broker.capability]
+        argv = [
+            harness_command,
+            "exec",
+            "--cd",
+            str(worktree),
+            "--sandbox",
+            sandbox,
+            "--ephemeral",
+            "--ignore-user-config",
+            "--json",
+            "--output-last-message",
+            str(last_message),
+            "--model",
+            provider.model,
+            "-c",
+            f'model_provider="{provider_key}"',
+            "-c",
+            f'model_providers.{provider_key}.name="OpenRouter"',
+            "-c",
+            f"model_providers.{provider_key}.base_url={json.dumps(provider.base_url)}",
+            "-c",
+            f'model_providers.{provider_key}.wire_api="responses"',
+            "-c",
+            f"model_providers.{provider_key}.auth.command={json.dumps(str(helper))}",
+            "-c",
+            f"model_providers.{provider_key}.auth.args={json.dumps(auth_args)}",
+            "-c",
+            f"model_providers.{provider_key}.auth.timeout_ms=3000",
+            "-c",
+            f"model_providers.{provider_key}.auth.refresh_interval_ms=0",
+            "-",
+        ]
+        environment["CODEX_HOME"] = str(codex_home)
+        try:
+            process = subprocess.Popen(
+                argv,
+                cwd=worktree,
+                env=environment,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+        except OSError:
+            return _publish_failure(paths, "HARNESS_UNAVAILABLE")
+        try:
+            stdout, stderr = process.communicate(prompt.encode(), timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            _kill_process_group(process)
+            stdout, stderr = process.communicate()
+            log, _, _ = _event_log(stdout, stderr, secret=secret)
+            return _publish_failure(paths, "WORKER_TIMEOUT", log=log)
+        broker.join()
+
+        # Active canary: if auth was never consumed, or remained reusable, this
+        # call succeeds and the write-enabled result is rejected.
+        canary = subprocess.run(
+            [str(helper), *auth_args], capture_output=True, timeout=3, env=_sanitize_environment()
+        )
+        if canary.returncode == 0 or canary.stdout:
+            return _publish_failure(paths, "CREDENTIAL_BOUNDARY_UNSAFE")
+
+        log, events, malformed = _event_log(stdout, stderr, secret=secret)
+        if secret.encode() in stdout or secret.encode() in stderr:
+            return _publish_failure(paths, "SECRET_EXPOSURE_DETECTED", log=log)
+        if process.returncode != 0:
+            return _publish_failure(
+                paths, "HARNESS_EXIT_NONZERO", f"exit {process.returncode}", log
+            )
+        if malformed:
+            return _publish_failure(paths, "MALFORMED_EVENT_STREAM", log=log)
+        if any(event.get("type") == "error" for event in events):
+            return _publish_failure(paths, "HARNESS_REPORTED_ERROR", log=log)
+        if not any(event.get("type") == "turn.completed" for event in events):
+            return _publish_failure(paths, "MALFORMED_EVENT_STREAM", "missing terminal event", log)
+        if not any(
+            event.get("type") == "item.completed"
+            and isinstance(event.get("item"), dict)
+            and event["item"].get("type") == "command_execution"
+            for event in events
+        ):
+            return _publish_failure(paths, "UNSUPPORTED_CAPABILITY", "no tool call observed", log)
+        if not last_message.exists() or not last_message.read_text().strip():
+            return _publish_failure(paths, "MISSING_RESULT", log=log)
+        result = last_message.read_text()
+        if secret in result:
+            return _publish_failure(paths, "SECRET_EXPOSURE_DETECTED", log=log)
+
+        usage = _usage(events, provider.max_input_tokens)
+        if usage["within_limit"] is False:
+            return _publish_failure(paths, "USAGE_LIMIT_EXCEEDED", log=log)
+        resolved = _resolved_model(events)
+        provider_public = {
+            "name": provider.name,
+            "adapter": provider.execution_adapter,
+            "model": provider.model,
+            "base_url": provider.base_url,
+            "tier": provider.capability_tier,
+            "capabilities": provider.capabilities,
+            "max_input_tokens": provider.max_input_tokens,
+        }
+        metadata = {
+            "schema_version": 1,
+            "task_id": paths.task_id,
+            "status": "done",
+            "reason_code": None,
+            "harness": {"name": Path(harness_command).name, "version": harness_version},
+            "execution_adapter": provider.execution_adapter,
+            "provider_name": provider.name,
+            "provider_capability_tier": provider.capability_tier,
+            "requested_model": provider.model,
+            "resolved_model": resolved,
+            "model_resolution_status": "observed" if resolved else "unavailable",
+            "sandbox": sandbox,
+            "tool_behavior": "observed",
+            "worktree_start_sha": start_sha,
+            "worktree_end_sha": _git_sha(worktree),
+            "started_at": started_at,
+            "completed_at": _utc_now(),
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "exit_status": process.returncode,
+            "usage": usage,
+            "prompt_sha256": task_protocol.sha256_digest(prompt.encode()),
+            "provider_config_sha256": task_protocol.sha256_digest(
+                json.dumps(provider_public, sort_keys=True).encode()
+            ),
+            "result_sha256": task_protocol.sha256_digest(result.encode()),
+            "log_sha256": task_protocol.sha256_digest(log),
+            "redaction_policy_version": REDACTION_POLICY_VERSION,
+            "adapter_version": ADAPTER_VERSION,
+        }
+        try:
+            task_protocol.publish_success(
+                paths,
+                result=result,
+                log=log,
+                metadata=metadata,
+                schema=json.loads(SCHEMA.read_text()),
+            )
+        except task_protocol.MetadataValidationError:
+            return _publish_failure(paths, "METADATA_INVALID")
+        return WorkerResult("done")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("run", "probe"):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument("--provider", required=True)
+        command_parser.add_argument("--task-root", type=Path, required=True)
+        command_parser.add_argument("--task-id", required=True)
+        command_parser.add_argument("--worktree", type=Path, required=True)
+        command_parser.add_argument("--main", type=Path, required=True)
+        command_parser.add_argument("--timeout-seconds", type=int, default=900)
+        command_parser.add_argument(
+            "--admit-disabled",
+            action="store_true",
+            help="Explicitly admit a disabled provider for a bounded experiment/probe",
+        )
+    args = parser.parse_args(argv)
+    config = load_config(args.config) if args.config else load_config()
+    providers = execution_providers_from_config(config)
+    if args.provider not in providers:
+        parser.error(f"unknown execution provider: {args.provider}")
+    result = run_task(
+        paths=task_protocol.task_paths(args.task_root, args.task_id),
+        provider=providers[args.provider],
+        worktree=args.worktree,
+        main_checkout=args.main,
+        timeout_seconds=args.timeout_seconds,
+        sandbox="read-only" if args.command == "probe" else "workspace-write",
+        admit_disabled=args.admit_disabled,
+    )
+    return 0 if result.status == "done" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delegates/openrouter_worker.py
+++ b/scripts/delegates/openrouter_worker.py
@@ -57,11 +57,7 @@ def _git_sha(repo: Path) -> str:
 
 
 def _sanitize_environment(extra: dict[str, str] | None = None) -> dict[str, str]:
-    allowed = {
-        name: os.environ[name]
-        for name in ("PATH", "LANG", "LC_ALL", "TMPDIR")
-        if name in os.environ
-    }
+    allowed = {name: os.environ[name] for name in ("PATH", "LANG", "LC_ALL") if name in os.environ}
     for name, value in (extra or {}).items():
         upper = name.upper()
         if any(marker in upper for marker in ("KEY", "TOKEN", "SECRET", "CREDENTIAL")):
@@ -87,15 +83,21 @@ def _harness_version(command: str, environment: dict[str, str]) -> str | None:
 class _OneShotBroker:
     """Single-use owner-only Unix socket; it has no keychain capability."""
 
-    def __init__(self, directory: Path, secret: str):
+    def __init__(self, directory: Path, secret: str, timeout_seconds: int):
         self.socket_path = directory / "auth.sock"
+        self.state_path = directory / ".auth-state"
         self.capability = secrets.token_urlsafe(32)
         self._secret = secret
         self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._server.bind(str(self.socket_path))
         os.chmod(self.socket_path, 0o600)
         self._server.listen(1)
-        self._server.settimeout(5)
+        self._server.settimeout(timeout_seconds)
+        self.consumed = False
+        task_protocol.atomic_write(
+            self.state_path,
+            json.dumps({"socket": str(self.socket_path), "capability": self.capability}).encode(),
+        )
         self._thread = threading.Thread(target=self._serve, daemon=True)
 
     def start(self) -> None:
@@ -108,6 +110,7 @@ class _OneShotBroker:
                 request = connection.recv(4096).decode(errors="replace")
                 if secrets.compare_digest(request, self.capability):
                     connection.sendall(self._secret.encode())
+                    self.consumed = True
         except (OSError, TimeoutError):
             pass
         finally:
@@ -117,18 +120,33 @@ class _OneShotBroker:
                 self.socket_path.unlink()
             except FileNotFoundError:
                 pass
+            try:
+                self.state_path.unlink()
+            except FileNotFoundError:
+                pass
 
     def join(self) -> None:
-        self._thread.join(timeout=6)
+        self._thread.join(timeout=2)
+
+    def close(self) -> None:
+        try:
+            self._server.close()
+        except OSError:
+            pass
+        self.join()
 
 
 _AUTH_HELPER = """#!/usr/bin/env python3
-import socket, sys
+import json, pathlib, socket, sys
+try:
+    state = json.loads(pathlib.Path(__file__).with_name(".auth-state").read_text())
+except (OSError, ValueError):
+    raise SystemExit(2)
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 try:
     sock.settimeout(2)
-    sock.connect(sys.argv[1])
-    sock.sendall(sys.argv[2].encode())
+    sock.connect(state["socket"])
+    sock.sendall(state["capability"].encode())
     value = sock.recv(1024)
     if not value:
         raise SystemExit(3)
@@ -229,8 +247,91 @@ def _usage(events: list[dict], limit: int | None) -> dict:
 def _publish_failure(
     paths: task_protocol.TaskPaths, reason: str, detail: str | None = None, log: bytes | None = None
 ) -> WorkerResult:
+    # @cw-trace ensures CTR-dag-021
     task_protocol.publish_error(paths, reason=reason, detail=detail, log=log)
     return WorkerResult("error", reason)
+
+
+def _publish_failure_with_metadata(
+    paths: task_protocol.TaskPaths,
+    reason: str,
+    metadata: dict,
+    log: bytes,
+    detail: str | None = None,
+) -> WorkerResult:
+    failure_metadata = {**metadata, "status": "error", "reason_code": reason}
+    try:
+        task_protocol.publish_error(
+            paths,
+            reason=reason,
+            detail=detail,
+            log=log,
+            metadata=failure_metadata,
+            schema=json.loads(SCHEMA.read_text()),
+        )
+    except task_protocol.MetadataValidationError:
+        return _publish_failure(paths, "METADATA_INVALID")
+    return WorkerResult("error", reason)
+
+
+def _execution_metadata(
+    *,
+    paths: task_protocol.TaskPaths,
+    provider: ExecutionProvider,
+    harness_command: str,
+    harness_version: str | None,
+    sandbox: str,
+    start_sha: str,
+    end_sha: str,
+    started_at: str,
+    started: float,
+    exit_status: int,
+    prompt: str,
+    result: str | None,
+    log: bytes,
+    events: list[dict],
+    tool_behavior: str,
+) -> dict:
+    resolved = _resolved_model(events)
+    provider_public = {
+        "name": provider.name,
+        "adapter": provider.execution_adapter,
+        "model": provider.model,
+        "base_url": provider.base_url,
+        "tier": provider.capability_tier,
+        "capabilities": provider.capabilities,
+        "max_input_tokens": provider.max_input_tokens,
+    }
+    return {
+        "schema_version": 1,
+        "task_id": paths.task_id,
+        "status": "done",
+        "reason_code": None,
+        "harness": {"name": Path(harness_command).name, "version": harness_version},
+        "execution_adapter": provider.execution_adapter,
+        "provider_name": provider.name,
+        "provider_capability_tier": provider.capability_tier,
+        "requested_model": provider.model,
+        "resolved_model": resolved,
+        "model_resolution_status": "observed" if resolved else "unavailable",
+        "sandbox": sandbox,
+        "tool_behavior": tool_behavior,
+        "worktree_start_sha": start_sha,
+        "worktree_end_sha": end_sha,
+        "started_at": started_at,
+        "completed_at": _utc_now(),
+        "duration_ms": int((time.monotonic() - started) * 1000),
+        "exit_status": exit_status,
+        "usage": _usage(events, provider.max_input_tokens),
+        "prompt_sha256": task_protocol.sha256_digest(prompt.encode()),
+        "provider_config_sha256": task_protocol.sha256_digest(
+            json.dumps(provider_public, sort_keys=True).encode()
+        ),
+        "result_sha256": task_protocol.sha256_digest(result.encode()) if result else None,
+        "log_sha256": task_protocol.sha256_digest(log),
+        "redaction_policy_version": REDACTION_POLICY_VERSION,
+        "adapter_version": ADAPTER_VERSION,
+    }
 
 
 def run_task(
@@ -248,6 +349,7 @@ def run_task(
 ) -> WorkerResult:
     """Run one configured coding delegate and publish one terminal result."""
     try:
+        # @cw-trace guards CTR-dag-020
         worktree = gitops.assert_worktree(worktree, main_checkout)
     except (gitops.GitSafetyError, subprocess.SubprocessError):
         return _publish_failure(paths, "UNSAFE_WORKTREE")
@@ -257,6 +359,7 @@ def run_task(
         provider.execution_adapter != "codex-responses"
         or not provider.model
         or not provider.base_url
+        or provider.max_input_tokens is None
     ):
         return _publish_failure(paths, "PROVIDER_CONFIG_INVALID")
     required_capabilities = REQUIRED_CAPABILITIES - (
@@ -275,28 +378,55 @@ def run_task(
     except (OSError, subprocess.SubprocessError):
         return _publish_failure(paths, "HARNESS_UNAVAILABLE")
 
+    try:
+        prompt = paths.prompt.read_text()
+    except OSError:
+        return _publish_failure(paths, "MISSING_PROMPT")
+    try:
+        start_sha = _git_sha(worktree)
+    except subprocess.SubprocessError:
+        return _publish_failure(paths, "GIT_UNAVAILABLE")
+    for env_name, config_key in (
+        ("GIT_AUTHOR_NAME", "user.name"),
+        ("GIT_AUTHOR_EMAIL", "user.email"),
+        ("GIT_COMMITTER_NAME", "user.name"),
+        ("GIT_COMMITTER_EMAIL", "user.email"),
+    ):
+        value = subprocess.run(
+            ["git", "config", "--get", config_key],
+            cwd=worktree,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        if value:
+            environment[env_name] = value
     secret = secret_loader()
     if not secret:
         return _publish_failure(paths, "CREDENTIAL_UNAVAILABLE")
-    prompt = paths.prompt.read_text()
     started_at = _utc_now()
     started = time.monotonic()
-    start_sha = _git_sha(worktree)
 
-    with tempfile.TemporaryDirectory(prefix="cw-openrouter-worker-") as temporary_name:
+    try:
+        temporary_context = tempfile.TemporaryDirectory(prefix="cw-openrouter-worker-")
+    except OSError:
+        return _publish_failure(paths, "CREDENTIAL_BOUNDARY_UNSAFE")
+    with temporary_context as temporary_name:
         temporary = Path(temporary_name)
-        os.chmod(temporary, 0o700)
-        helper = temporary / "auth-helper"
-        helper.write_text(_AUTH_HELPER)
-        helper.chmod(0o700)
-        last_message = temporary / "last-message.md"
-        codex_home = temporary / "codex-home"
-        codex_home.mkdir(mode=0o700)
-        broker = _OneShotBroker(temporary, secret)
+        try:
+            os.chmod(temporary, 0o700)
+            helper = temporary / "auth-helper"
+            helper.write_text(_AUTH_HELPER)
+            helper.chmod(0o700)
+            last_message = temporary / "last-message.md"
+            codex_home = temporary / "codex-home"
+            codex_home.mkdir(mode=0o700)
+            broker = _OneShotBroker(temporary, secret, timeout_seconds)
+        except OSError:
+            return _publish_failure(paths, "CREDENTIAL_BOUNDARY_UNSAFE")
         broker.start()
 
         provider_key = "cw_openrouter"
-        auth_args = [str(broker.socket_path), broker.capability]
+        auth_args: list[str] = []
         argv = [
             harness_command,
             "exec",
@@ -341,20 +471,28 @@ def run_task(
                 start_new_session=True,
             )
         except OSError:
+            broker.close()
             return _publish_failure(paths, "HARNESS_UNAVAILABLE")
         try:
             stdout, stderr = process.communicate(prompt.encode(), timeout=timeout_seconds)
         except subprocess.TimeoutExpired:
             _kill_process_group(process)
             stdout, stderr = process.communicate()
+            broker.close()
             log, _, _ = _event_log(stdout, stderr, secret=secret)
             return _publish_failure(paths, "WORKER_TIMEOUT", log=log)
-        broker.join()
+        broker.close()
+
+        if not broker.consumed:
+            log, _, _ = _event_log(stdout, stderr, secret=secret)
+            return _publish_failure(
+                paths, "CREDENTIAL_BOUNDARY_UNSAFE", "pre-turn auth was not consumed", log
+            )
 
         # Active canary: if auth was never consumed, or remained reusable, this
         # call succeeds and the write-enabled result is rejected.
         canary = subprocess.run(
-            [str(helper), *auth_args], capture_output=True, timeout=3, env=_sanitize_environment()
+            [str(helper)], capture_output=True, timeout=3, env=_sanitize_environment()
         )
         if canary.returncode == 0 or canary.stdout:
             return _publish_failure(paths, "CREDENTIAL_BOUNDARY_UNSAFE")
@@ -362,73 +500,63 @@ def run_task(
         log, events, malformed = _event_log(stdout, stderr, secret=secret)
         if secret.encode() in stdout or secret.encode() in stderr:
             return _publish_failure(paths, "SECRET_EXPOSURE_DETECTED", log=log)
-        if process.returncode != 0:
-            return _publish_failure(
-                paths, "HARNESS_EXIT_NONZERO", f"exit {process.returncode}", log
-            )
-        if malformed:
-            return _publish_failure(paths, "MALFORMED_EVENT_STREAM", log=log)
-        if any(event.get("type") == "error" for event in events):
-            return _publish_failure(paths, "HARNESS_REPORTED_ERROR", log=log)
-        if not any(event.get("type") == "turn.completed" for event in events):
-            return _publish_failure(paths, "MALFORMED_EVENT_STREAM", "missing terminal event", log)
-        if not any(
+        try:
+            result = last_message.read_text() if last_message.exists() else None
+        except OSError:
+            result = None
+        tool_observed = any(
             event.get("type") == "item.completed"
             and isinstance(event.get("item"), dict)
             and event["item"].get("type") == "command_execution"
             for event in events
-        ):
-            return _publish_failure(paths, "UNSUPPORTED_CAPABILITY", "no tool call observed", log)
-        if not last_message.exists() or not last_message.read_text().strip():
-            return _publish_failure(paths, "MISSING_RESULT", log=log)
-        result = last_message.read_text()
-        if secret in result:
-            return _publish_failure(paths, "SECRET_EXPOSURE_DETECTED", log=log)
-
-        usage = _usage(events, provider.max_input_tokens)
-        if usage["within_limit"] is False:
-            return _publish_failure(paths, "USAGE_LIMIT_EXCEEDED", log=log)
-        resolved = _resolved_model(events)
-        provider_public = {
-            "name": provider.name,
-            "adapter": provider.execution_adapter,
-            "model": provider.model,
-            "base_url": provider.base_url,
-            "tier": provider.capability_tier,
-            "capabilities": provider.capabilities,
-            "max_input_tokens": provider.max_input_tokens,
-        }
-        metadata = {
-            "schema_version": 1,
-            "task_id": paths.task_id,
-            "status": "done",
-            "reason_code": None,
-            "harness": {"name": Path(harness_command).name, "version": harness_version},
-            "execution_adapter": provider.execution_adapter,
-            "provider_name": provider.name,
-            "provider_capability_tier": provider.capability_tier,
-            "requested_model": provider.model,
-            "resolved_model": resolved,
-            "model_resolution_status": "observed" if resolved else "unavailable",
-            "sandbox": sandbox,
-            "tool_behavior": "observed",
-            "worktree_start_sha": start_sha,
-            "worktree_end_sha": _git_sha(worktree),
-            "started_at": started_at,
-            "completed_at": _utc_now(),
-            "duration_ms": int((time.monotonic() - started) * 1000),
-            "exit_status": process.returncode,
-            "usage": usage,
-            "prompt_sha256": task_protocol.sha256_digest(prompt.encode()),
-            "provider_config_sha256": task_protocol.sha256_digest(
-                json.dumps(provider_public, sort_keys=True).encode()
-            ),
-            "result_sha256": task_protocol.sha256_digest(result.encode()),
-            "log_sha256": task_protocol.sha256_digest(log),
-            "redaction_policy_version": REDACTION_POLICY_VERSION,
-            "adapter_version": ADAPTER_VERSION,
-        }
+        )
         try:
+            end_sha = _git_sha(worktree)
+        except subprocess.SubprocessError:
+            return _publish_failure(paths, "GIT_UNAVAILABLE", log=log)
+        metadata = _execution_metadata(
+            paths=paths,
+            provider=provider,
+            harness_command=harness_command,
+            harness_version=harness_version,
+            sandbox=sandbox,
+            start_sha=start_sha,
+            end_sha=end_sha,
+            started_at=started_at,
+            started=started,
+            exit_status=process.returncode,
+            prompt=prompt,
+            result=result,
+            log=log,
+            events=events,
+            tool_behavior="observed" if tool_observed else "not-observed",
+        )
+        if process.returncode != 0:
+            return _publish_failure_with_metadata(
+                paths, "HARNESS_EXIT_NONZERO", metadata, log, f"exit {process.returncode}"
+            )
+        if malformed:
+            return _publish_failure_with_metadata(paths, "MALFORMED_EVENT_STREAM", metadata, log)
+        if any(event.get("type") == "error" for event in events):
+            return _publish_failure_with_metadata(paths, "HARNESS_REPORTED_ERROR", metadata, log)
+        if not any(event.get("type") == "turn.completed" for event in events):
+            return _publish_failure_with_metadata(
+                paths, "MALFORMED_EVENT_STREAM", metadata, log, "missing terminal event"
+            )
+        if not tool_observed:
+            metadata["tool_behavior"] = "unsupported"
+            return _publish_failure_with_metadata(
+                paths, "UNSUPPORTED_CAPABILITY", metadata, log, "no tool call observed"
+            )
+        if not result or not result.strip():
+            return _publish_failure_with_metadata(paths, "MISSING_RESULT", metadata, log)
+        if secret in result:
+            return _publish_failure_with_metadata(paths, "SECRET_EXPOSURE_DETECTED", metadata, log)
+
+        if metadata["usage"]["within_limit"] is False:
+            return _publish_failure_with_metadata(paths, "USAGE_LIMIT_EXCEEDED", metadata, log)
+        try:
+            # @cw-trace ensures CTR-dag-021
             task_protocol.publish_success(
                 paths,
                 result=result,

--- a/scripts/delegates/task_protocol.py
+++ b/scripts/delegates/task_protocol.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, FormatChecker
 
 DEFAULT_TASK_ROOT = Path.home() / ".chief-wiggum" / "delegates"
 
@@ -181,7 +181,10 @@ def publish_success(
     metadata: dict[str, Any],
     schema: dict[str, Any],
 ) -> None:
-    errors = sorted(Draft202012Validator(schema).iter_errors(metadata), key=lambda e: list(e.path))
+    errors = sorted(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(metadata),
+        key=lambda e: list(e.path),
+    )
     if errors:
         raise MetadataValidationError(errors[0].message)
     result_bytes = result.encode()
@@ -205,10 +208,22 @@ def publish_error(
     detail: str | None = None,
     log: bytes | None = None,
     metadata: dict[str, Any] | None = None,
+    schema: dict[str, Any] | None = None,
 ) -> None:
     record = {"reason": reason}
     if detail:
         record["detail"] = detail[:500]
+    if metadata is not None and schema is not None:
+        errors = sorted(
+            Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(metadata),
+            key=lambda error: list(error.path),
+        )
+        if errors:
+            raise MetadataValidationError(errors[0].message)
+        if metadata.get("status") != "error" or metadata.get("reason_code") != reason:
+            raise MetadataValidationError("error metadata status/reason does not match sentinel")
+        if log is not None and metadata.get("log_sha256") != sha256_digest(log):
+            raise MetadataValidationError("log_sha256 does not match log bytes")
     with _terminal_lock(paths):
         if log is not None:
             atomic_write(paths.log, log)

--- a/scripts/delegates/task_protocol.py
+++ b/scripts/delegates/task_protocol.py
@@ -3,12 +3,47 @@
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import tempfile
 import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
 
 DEFAULT_TASK_ROOT = Path.home() / ".chief-wiggum" / "delegates"
+
+
+class TaskProtocolError(RuntimeError):
+    """Base error for durable delegate task publication."""
+
+
+class TerminalStateError(TaskProtocolError):
+    """A terminal result already exists and cannot be replaced."""
+
+
+class ProtocolConflictError(TerminalStateError):
+    """Both mutually-exclusive terminal sentinels exist."""
+
+
+class MetadataValidationError(TaskProtocolError):
+    """Delegate metadata does not conform to its declared schema."""
+
+
+class UnsafeTaskPathError(TaskProtocolError):
+    """A protocol artifact is symlinked or escapes its task directory."""
+
+
+@dataclass(frozen=True)
+class TerminalStatus:
+    state: str
+    reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -30,6 +65,8 @@ def new_task_id() -> str:
 
 
 def task_paths(task_root: Path, task_id: str) -> TaskPaths:
+    if not task_id or task_id in {".", ".."} or Path(task_id).name != task_id:
+        raise UnsafeTaskPathError(f"invalid task id: {task_id!r}")
     task_dir = task_root.expanduser().resolve() / task_id
     return TaskPaths(
         task_id=task_id,
@@ -43,12 +80,144 @@ def task_paths(task_root: Path, task_id: str) -> TaskPaths:
     )
 
 
-def create_task(task_root: Path, task_id: str | None = None, prompt: str | None = None) -> TaskPaths:
+def create_task(
+    task_root: Path, task_id: str | None = None, prompt: str | None = None
+) -> TaskPaths:
     paths = task_paths(task_root, task_id or new_task_id())
     paths.task_dir.mkdir(parents=True, exist_ok=False)
     if prompt is not None:
-        paths.prompt.write_text(prompt)
+        atomic_write(paths.prompt, prompt.encode())
     return paths
+
+
+def sha256_digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_digest(path.read_bytes())
+
+
+def atomic_write(path: Path, data: bytes, *, mode: int = 0o600) -> None:
+    """Write bytes durably using a same-directory temporary replacement."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+def _artifact_paths(paths: TaskPaths) -> tuple[Path, ...]:
+    return (paths.prompt, paths.result, paths.done, paths.error, paths.log, paths.metadata)
+
+
+def _validate_paths(paths: TaskPaths) -> None:
+    task_dir = paths.task_dir.resolve()
+    if paths.task_dir.is_symlink() or not paths.task_dir.is_dir():
+        raise UnsafeTaskPathError(f"unsafe task directory: {paths.task_dir}")
+    for path in _artifact_paths(paths):
+        if path.is_symlink():
+            raise UnsafeTaskPathError(f"symlinked task artifact: {path.name}")
+        if path.parent.resolve() != task_dir:
+            raise UnsafeTaskPathError(f"task artifact escapes directory: {path.name}")
+
+
+def completion_status(paths: TaskPaths) -> TerminalStatus:
+    has_done = paths.done.exists()
+    has_error = paths.error.exists()
+    if has_done and has_error:
+        return TerminalStatus("conflict", "both DONE and ERROR exist")
+    if has_done:
+        return TerminalStatus("done")
+    if has_error:
+        reason = None
+        with contextlib.suppress(OSError, json.JSONDecodeError, TypeError):
+            reason = json.loads(paths.error.read_text()).get("reason")
+        return TerminalStatus("error", reason)
+    return TerminalStatus("pending")
+
+
+@contextlib.contextmanager
+def _terminal_lock(paths: TaskPaths):
+    _validate_paths(paths)
+    lock_path = paths.task_dir / ".terminal.lock"
+    if lock_path.is_symlink():
+        raise UnsafeTaskPathError("symlinked terminal lock")
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeTaskPathError("unsafe terminal lock") from exc
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        status = completion_status(paths)
+        if status.state == "conflict":
+            raise ProtocolConflictError(status.reason or "terminal conflict")
+        if status.state != "pending":
+            raise TerminalStateError(f"task is already terminal: {status.state}")
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def publish_success(
+    paths: TaskPaths,
+    *,
+    result: str,
+    log: bytes,
+    metadata: dict[str, Any],
+    schema: dict[str, Any],
+) -> None:
+    errors = sorted(Draft202012Validator(schema).iter_errors(metadata), key=lambda e: list(e.path))
+    if errors:
+        raise MetadataValidationError(errors[0].message)
+    result_bytes = result.encode()
+    if metadata.get("result_sha256") != sha256_digest(result_bytes):
+        raise MetadataValidationError("result_sha256 does not match result bytes")
+    if metadata.get("log_sha256") != sha256_digest(log):
+        raise MetadataValidationError("log_sha256 does not match log bytes")
+    with _terminal_lock(paths):
+        atomic_write(paths.result, result_bytes)
+        atomic_write(paths.log, log)
+        atomic_write(
+            paths.metadata, (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
+        )
+        atomic_write(paths.done, b"done\n")
+
+
+def publish_error(
+    paths: TaskPaths,
+    *,
+    reason: str,
+    detail: str | None = None,
+    log: bytes | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    record = {"reason": reason}
+    if detail:
+        record["detail"] = detail[:500]
+    with _terminal_lock(paths):
+        if log is not None:
+            atomic_write(paths.log, log)
+        if metadata is not None:
+            atomic_write(
+                paths.metadata,
+                (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode(),
+            )
+        atomic_write(paths.error, (json.dumps(record, sort_keys=True) + "\n").encode())
 
 
 def wait_for_completion(paths: TaskPaths, timeout_seconds: int, poll_seconds: float = 2.0) -> str:
@@ -58,9 +227,10 @@ def wait_for_completion(paths: TaskPaths, timeout_seconds: int, poll_seconds: fl
     """
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
-        if paths.done.exists():
-            return "done"
-        if paths.error.exists():
-            return "error"
+        status = completion_status(paths)
+        if status.state == "conflict":
+            raise ProtocolConflictError(status.reason or "terminal conflict")
+        if status.state in {"done", "error"}:
+            return status.state
         time.sleep(poll_seconds)
     raise TimeoutError(f"no DONE or ERROR after {timeout_seconds}s: {paths.task_dir}")

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -463,9 +463,12 @@ def validate_config(
     *,
     supported_tools: set[str] | None = None,
     supported_delegates: set[str] | None = None,
+    supported_execution_adapters: set[str] | None = None,
 ) -> list[str]:
     errors: list[str] = []
     providers = providers_from_config(config)
+    execution_providers = execution_providers_from_config(config)
+    supported_execution_adapters = supported_execution_adapters or {"codex-responses"}
     for role_name, role in roles_from_config(config).items():
         for provider_name in role.required + role.optional:
             if provider_name not in providers:
@@ -503,14 +506,23 @@ def validate_config(
             supported_delegates is not None
             and provider.type == "delegate"
             and provider.delegate not in supported_delegates
-            and provider.name not in execution_providers_from_config(config)
+            and provider.name not in execution_providers
         ):
             errors.append(
                 f"provider {provider.name} references unsupported delegate {provider.delegate}"
             )
         if provider.type not in {"tool", "delegate"}:
             errors.append(f"provider {provider.name} has unsupported type {provider.type}")
-    for provider in execution_providers_from_config(config).values():
+    for provider in execution_providers.values():
+        if provider.execution_adapter not in supported_execution_adapters:
+            errors.append(
+                f"execution provider {provider.name} references unsupported execution adapter "
+                f"{provider.execution_adapter}"
+            )
+        if provider.delegate != provider.execution_adapter:
+            errors.append(
+                f"execution provider {provider.name} delegate must match execution_adapter"
+            )
         if not provider.model or not provider.base_url:
             errors.append(f"execution provider {provider.name} requires model and base_url")
         required = {"responses", "repo-read", "shell-tools", "workspace-write"}
@@ -519,17 +531,15 @@ def validate_config(
             errors.append(
                 f"execution provider {provider.name} is missing capabilities: {', '.join(missing)}"
             )
-        if (
-            provider.anonymous_preview
-            and not provider.weights_license_evidence
-            and provider.capability_tier != "external-preview-tier"
-        ):
+        # @cw-trace realizes INV-dag-022
+        if not provider.weights_license_evidence and provider.capability_tier == "open-tier":
             errors.append(
-                f"anonymous preview provider {provider.name} without weights/license evidence "
-                "must use external-preview-tier"
+                f"provider {provider.name} cannot use open-tier without weights/license evidence; "
+                "anonymous previews must use external-preview-tier"
             )
-        if provider.max_input_tokens is not None and (
-            isinstance(provider.max_input_tokens, bool)
+        if (
+            provider.max_input_tokens is None
+            or isinstance(provider.max_input_tokens, bool)
             or not isinstance(provider.max_input_tokens, int)
             or provider.max_input_tokens <= 0
         ):

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -114,7 +114,7 @@ def _retry_backoff_seconds(attempt: int, previous_failure_kind: str | None) -> f
     don't all land in lockstep; a ``rate_limit`` classified failure gets a
     multiplied delay on top of that schedule."""
     exponent = max(0, attempt - 2)
-    delay = min(RETRY_BACKOFF_CAP_SECONDS, RETRY_BACKOFF_BASE_SECONDS * (2 ** exponent))
+    delay = min(RETRY_BACKOFF_CAP_SECONDS, RETRY_BACKOFF_BASE_SECONDS * (2**exponent))
     if previous_failure_kind == "rate_limit":
         delay *= RETRY_BACKOFF_RATE_LIMIT_MULTIPLIER
     jitter = delay * 0.2 * random.random()
@@ -198,6 +198,23 @@ class Provider:
     # DOES read files) while still needing the diff inlined, because it has
     # no tool loop to fetch a pointed-to file with.
     needs_inline_diff: bool = True
+
+
+@dataclass(frozen=True)
+class ExecutionProvider:
+    """Typed configuration for a repository-capable delegate adapter."""
+
+    name: str
+    enabled: bool
+    execution_adapter: str
+    delegate: str
+    model: str
+    base_url: str
+    capability_tier: str
+    capabilities: tuple[str, ...]
+    anonymous_preview: bool = False
+    weights_license_evidence: str | None = None
+    max_input_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -331,6 +348,27 @@ def providers_from_config(config: dict[str, Any]) -> dict[str, Provider]:
     return providers
 
 
+def execution_providers_from_config(config: dict[str, Any]) -> dict[str, ExecutionProvider]:
+    providers: dict[str, ExecutionProvider] = {}
+    for name, raw in config.get("providers", {}).items():
+        if not raw.get("execution_adapter"):
+            continue
+        providers[name] = ExecutionProvider(
+            name=name,
+            enabled=bool(raw.get("enabled", False)),
+            execution_adapter=str(raw.get("execution_adapter", "")),
+            delegate=str(raw.get("delegate", "")),
+            model=str(raw.get("model", "")),
+            base_url=str(raw.get("base_url", "")),
+            capability_tier=str(raw.get("capability_tier", "")),
+            capabilities=tuple(str(item) for item in raw.get("capabilities", [])),
+            anonymous_preview=bool(raw.get("anonymous_preview", False)),
+            weights_license_evidence=raw.get("weights_license_evidence"),
+            max_input_tokens=raw.get("max_input_tokens"),
+        )
+    return providers
+
+
 def roles_from_config(config: dict[str, Any]) -> dict[str, Role]:
     roles: dict[str, Role] = {}
     for name, raw in config.get("roles", {}).items():
@@ -453,7 +491,11 @@ def validate_config(
     for provider in providers.values():
         if provider.type == "tool" and not provider.tool:
             errors.append(f"provider {provider.name} has type=tool but no tool")
-        if supported_tools is not None and provider.type == "tool" and provider.tool not in supported_tools:
+        if (
+            supported_tools is not None
+            and provider.type == "tool"
+            and provider.tool not in supported_tools
+        ):
             errors.append(f"provider {provider.name} references unsupported tool {provider.tool}")
         if provider.type == "delegate" and not provider.delegate:
             errors.append(f"provider {provider.name} has type=delegate but no delegate")
@@ -461,12 +503,37 @@ def validate_config(
             supported_delegates is not None
             and provider.type == "delegate"
             and provider.delegate not in supported_delegates
+            and provider.name not in execution_providers_from_config(config)
         ):
             errors.append(
                 f"provider {provider.name} references unsupported delegate {provider.delegate}"
             )
         if provider.type not in {"tool", "delegate"}:
             errors.append(f"provider {provider.name} has unsupported type {provider.type}")
+    for provider in execution_providers_from_config(config).values():
+        if not provider.model or not provider.base_url:
+            errors.append(f"execution provider {provider.name} requires model and base_url")
+        required = {"responses", "repo-read", "shell-tools", "workspace-write"}
+        missing = sorted(required - set(provider.capabilities))
+        if missing:
+            errors.append(
+                f"execution provider {provider.name} is missing capabilities: {', '.join(missing)}"
+            )
+        if (
+            provider.anonymous_preview
+            and not provider.weights_license_evidence
+            and provider.capability_tier != "external-preview-tier"
+        ):
+            errors.append(
+                f"anonymous preview provider {provider.name} without weights/license evidence "
+                "must use external-preview-tier"
+            )
+        if provider.max_input_tokens is not None and (
+            isinstance(provider.max_input_tokens, bool)
+            or not isinstance(provider.max_input_tokens, int)
+            or provider.max_input_tokens <= 0
+        ):
+            errors.append(f"execution provider {provider.name} has invalid max_input_tokens")
     return errors
 
 
@@ -486,9 +553,7 @@ def validate_role_lenses(role: Role, lenses: dict[str, Any]) -> list[str]:
                 "which is not a required or optional provider of that role"
             )
         if lens_name not in lenses:
-            errors.append(
-                f"role {role.name} references unknown lens {lens_name!r}"
-            )
+            errors.append(f"role {role.name} references unknown lens {lens_name!r}")
     return errors
 
 
@@ -677,30 +742,38 @@ def detect_blind_providers(
         checked += 1
         prompt_tokens = prompt_tokens_by_provider.get(result.name)
         if result.tokens_in is None:
-            findings.append(BlindnessFinding(
-                provider=result.name, kind="unmeasured", tokens_in=None,
-                prompt_tokens_estimate=prompt_tokens,
-                message=(
-                    f"{result.name} is declared repo-reading and required by role "
-                    f"{role.name!r}, but its tokens_in could not be measured "
-                    f"(usage_status={result.usage_status!r}). A provider that cannot "
-                    "be measured is not the same as one measured and fine — do not "
-                    "count this voice as confirmed-informed."
-                ),
-            ))
+            findings.append(
+                BlindnessFinding(
+                    provider=result.name,
+                    kind="unmeasured",
+                    tokens_in=None,
+                    prompt_tokens_estimate=prompt_tokens,
+                    message=(
+                        f"{result.name} is declared repo-reading and required by role "
+                        f"{role.name!r}, but its tokens_in could not be measured "
+                        f"(usage_status={result.usage_status!r}). A provider that cannot "
+                        "be measured is not the same as one measured and fine — do not "
+                        "count this voice as confirmed-informed."
+                    ),
+                )
+            )
             continue
         if prompt_tokens is not None and result.tokens_in <= prompt_tokens * margin:
-            findings.append(BlindnessFinding(
-                provider=result.name, kind="blind", tokens_in=result.tokens_in,
-                prompt_tokens_estimate=prompt_tokens,
-                message=(
-                    f"{result.name}'s tokens_in ({result.tokens_in}) is within {margin}x "
-                    f"of its own prompt's estimated size (~{prompt_tokens} tokens) in role "
-                    f"{role.name!r} — it answered from the prompt text alone, not the repo. "
-                    "A provider whose tokens_in is ~the prompt size did not read the repo, "
-                    "by definition (chief-wiggum#319)."
-                ),
-            ))
+            findings.append(
+                BlindnessFinding(
+                    provider=result.name,
+                    kind="blind",
+                    tokens_in=result.tokens_in,
+                    prompt_tokens_estimate=prompt_tokens,
+                    message=(
+                        f"{result.name}'s tokens_in ({result.tokens_in}) is within {margin}x "
+                        f"of its own prompt's estimated size (~{prompt_tokens} tokens) in role "
+                        f"{role.name!r} — it answered from the prompt text alone, not the repo. "
+                        "A provider whose tokens_in is ~the prompt size did not read the repo, "
+                        "by definition (chief-wiggum#319)."
+                    ),
+                )
+            )
     return BlindnessReport(
         role=role.name, requires_repo_read=True, findings=findings, providers_checked=checked
     )
@@ -808,17 +881,19 @@ def detect_image_blind_providers(
         if provider.accepts_images:
             continue
         required = name in role.required
-        findings.append(ImageBlindnessFinding(
-            provider=name,
-            required=required,
-            message=(
-                f"{name} is a {'required' if required else 'optional'} provider "
-                f"of role {role.name!r}, which sends images, but {name} is "
-                "declared unable to accept images (provider.accepts_images="
-                "False) — it critiques a written description of the images, "
-                "never the rendered pixels (chief-wiggum#321)."
-            ),
-        ))
+        findings.append(
+            ImageBlindnessFinding(
+                provider=name,
+                required=required,
+                message=(
+                    f"{name} is a {'required' if required else 'optional'} provider "
+                    f"of role {role.name!r}, which sends images, but {name} is "
+                    "declared unable to accept images (provider.accepts_images="
+                    "False) — it critiques a written description of the images, "
+                    "never the rendered pixels (chief-wiggum#321)."
+                ),
+            )
+        )
     return ImageBlindnessReport(
         role=role.name, sends_images=True, findings=findings, providers_checked=checked
     )
@@ -906,7 +981,9 @@ def _run_one_provider(
             time.sleep(_retry_backoff_seconds(attempt, last_failure_kind))
         try:
             if retry_context_aware:
-                outcome = execute(provider, attempt=attempt, previous_failure_kind=last_failure_kind)
+                outcome = execute(
+                    provider, attempt=attempt, previous_failure_kind=last_failure_kind
+                )
             else:
                 outcome = execute(provider)
         except Exception as exc:  # noqa: BLE001 - any provider failure is retryable
@@ -928,7 +1005,12 @@ def _run_one_provider(
             continue
         ok_path.write_text(text)
         return ProviderResult(
-            provider.name, required, "ok", str(ok_path), attempt, None,
+            provider.name,
+            required,
+            "ok",
+            str(ok_path),
+            attempt,
+            None,
             tokens_in=getattr(usage, "tokens_in", None),
             tokens_out=getattr(usage, "tokens_out", None),
             usage_status=getattr(usage, "usage_status", None),
@@ -1005,7 +1087,9 @@ def run_role_quorum(
     # required and optional, must not run twice and clobber its own file).
     tasks: list[tuple[Provider, bool]] = []
     seen: set[str] = set()
-    for provider, required in [(p, True) for p in plan.required] + [(p, False) for p in plan.optional]:
+    for provider, required in [(p, True) for p in plan.required] + [
+        (p, False) for p in plan.optional
+    ]:
         if provider.name in seen:
             continue
         seen.add(provider.name)
@@ -1019,7 +1103,13 @@ def run_role_quorum(
         future_map = {
             pool.submit(
                 _run_one_provider,
-                provider, required, execute, out, plan.role.name, max_attempts, min_bytes,
+                provider,
+                required,
+                execute,
+                out,
+                plan.role.name,
+                max_attempts,
+                min_bytes,
             ): (provider, required)
             for provider, required in tasks
         }
@@ -1041,10 +1131,16 @@ def run_role_quorum(
                 if fut.done():
                     results.append(fut.result())
                     continue
-                results.append(ProviderResult(
-                    provider.name, required, "failed", None, 0,
-                    f"abandoned: quorum deadline of {quorum_timeout}s exceeded",
-                ))
+                results.append(
+                    ProviderResult(
+                        provider.name,
+                        required,
+                        "failed",
+                        None,
+                        0,
+                        f"abandoned: quorum deadline of {quorum_timeout}s exceeded",
+                    )
+                )
         finally:
             # wait=False: don't block returning on a task that ignored its
             # own timeout — see the TimeoutError branch's comment above.
@@ -1062,7 +1158,8 @@ def run_role_quorum(
         manifest.image_blindness = detect_image_blind_providers(plan.role, providers_by_name)
     except Exception as exc:  # noqa: BLE001 - the check itself must never break the quorum
         manifest.image_blindness = ImageBlindnessReport(
-            role=plan.role.name, sends_images=plan.role.sends_images,
+            role=plan.role.name,
+            sends_images=plan.role.sends_images,
             error=f"image blindness check failed: {exc}",
         )
 
@@ -1078,6 +1175,7 @@ def run_role_quorum(
             # false-flags a legitimately-smaller-prompt provider).
             def _prompt_body_for(name: str) -> str:
                 return prompt[name] if isinstance(prompt, dict) else prompt
+
             prompt_tokens_by_provider = {
                 name: estimate_prompt_tokens(
                     prompt_for_provider(plan.role, name, _prompt_body_for(name), lenses or {})
@@ -1086,12 +1184,16 @@ def run_role_quorum(
                 if not isinstance(prompt, dict) or name in prompt
             }
             manifest.blindness = detect_blind_providers(
-                plan.role, providers_by_name, results, prompt_tokens_by_provider,
+                plan.role,
+                providers_by_name,
+                results,
+                prompt_tokens_by_provider,
                 margin=blindness_margin,
             )
         except Exception as exc:  # noqa: BLE001 - the check itself must never break the quorum
             manifest.blindness = BlindnessReport(
-                role=plan.role.name, requires_repo_read=plan.role.requires_repo_read,
+                role=plan.role.name,
+                requires_repo_read=plan.role.requires_repo_read,
                 error=f"blindness check failed: {exc}",
             )
 

--- a/templates/delegate-worker-metadata-schema.json
+++ b/templates/delegate-worker-metadata-schema.json
@@ -54,7 +54,12 @@
     },
     "prompt_sha256": {"$ref": "#/$defs/digest"},
     "provider_config_sha256": {"$ref": "#/$defs/digest"},
-    "result_sha256": {"$ref": "#/$defs/digest"},
+    "result_sha256": {
+      "oneOf": [
+        {"$ref": "#/$defs/digest"},
+        {"type": "null"}
+      ]
+    },
     "log_sha256": {"$ref": "#/$defs/digest"},
     "redaction_policy_version": {"type": "integer", "minimum": 1},
     "adapter_version": {"type": "integer", "minimum": 1}

--- a/templates/delegate-worker-metadata-schema.json
+++ b/templates/delegate-worker-metadata-schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chief-wiggum.dev/schemas/delegate-worker-metadata-v1.json",
+  "title": "Chief Wiggum delegate worker metadata",
+  "type": "object",
+  "required": [
+    "schema_version", "task_id", "status", "reason_code", "harness",
+    "execution_adapter", "provider_name", "provider_capability_tier",
+    "requested_model", "resolved_model", "model_resolution_status", "sandbox",
+    "tool_behavior", "worktree_start_sha", "worktree_end_sha", "started_at",
+    "completed_at", "duration_ms", "exit_status", "usage", "prompt_sha256",
+    "provider_config_sha256", "result_sha256", "log_sha256",
+    "redaction_policy_version", "adapter_version"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "task_id": {"type": "string", "minLength": 1},
+    "status": {"enum": ["done", "error"]},
+    "reason_code": {"type": ["string", "null"]},
+    "harness": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": ["string", "null"]}
+      },
+      "additionalProperties": false
+    },
+    "execution_adapter": {"type": "string", "minLength": 1},
+    "provider_name": {"type": "string", "minLength": 1},
+    "provider_capability_tier": {"type": "string", "minLength": 1},
+    "requested_model": {"type": "string", "minLength": 1},
+    "resolved_model": {"type": ["string", "null"]},
+    "model_resolution_status": {"enum": ["observed", "unavailable"]},
+    "sandbox": {"enum": ["read-only", "workspace-write"]},
+    "tool_behavior": {"enum": ["observed", "not-observed", "unsupported"]},
+    "worktree_start_sha": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+    "worktree_end_sha": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": "string", "format": "date-time"},
+    "duration_ms": {"type": "integer", "minimum": 0},
+    "exit_status": {"type": ["integer", "null"]},
+    "usage": {
+      "type": "object",
+      "required": ["status", "input_tokens", "output_tokens", "reasoning_output_tokens", "within_limit"],
+      "properties": {
+        "status": {"enum": ["measured", "unavailable"]},
+        "input_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "output_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "reasoning_output_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "within_limit": {"type": ["boolean", "null"]}
+      },
+      "additionalProperties": false
+    },
+    "prompt_sha256": {"$ref": "#/$defs/digest"},
+    "provider_config_sha256": {"$ref": "#/$defs/digest"},
+    "result_sha256": {"$ref": "#/$defs/digest"},
+    "log_sha256": {"$ref": "#/$defs/digest"},
+    "redaction_policy_version": {"type": "integer", "minimum": 1},
+    "adapter_version": {"type": "integer", "minimum": 1}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_delegate_task_protocol.py
+++ b/tests/test_delegate_task_protocol.py
@@ -6,7 +6,6 @@ import threading
 import pytest
 from delegates import task_protocol
 
-
 SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -147,3 +146,8 @@ def test_symlinked_artifact_path_is_rejected(tmp_path):
         )
 
     assert outside.read_text() == "untouched"
+
+
+def test_task_id_cannot_escape_task_root(tmp_path):
+    with pytest.raises(task_protocol.UnsafeTaskPathError):
+        task_protocol.task_paths(tmp_path, "../escape")

--- a/tests/test_delegate_task_protocol.py
+++ b/tests/test_delegate_task_protocol.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+from delegates import task_protocol
+
+
+SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["status", "result_sha256", "log_sha256"],
+    "properties": {
+        "status": {"const": "done"},
+        "result_sha256": {"type": "string"},
+        "log_sha256": {"type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+
+def test_publish_success_hashes_artifacts_and_commits_done_last(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1", "do work")
+    metadata = {
+        "status": "done",
+        "result_sha256": task_protocol.sha256_digest(b"answer\n"),
+        "log_sha256": task_protocol.sha256_digest(b'{"event":"ok"}\n'),
+    }
+
+    task_protocol.publish_success(
+        paths,
+        result="answer\n",
+        log=b'{"event":"ok"}\n',
+        metadata=metadata,
+        schema=SCHEMA,
+    )
+
+    assert task_protocol.completion_status(paths).state == "done"
+    assert json.loads(paths.metadata.read_text()) == metadata
+    assert paths.done.read_text().strip() == "done"
+    assert not paths.error.exists()
+    assert paths.result.stat().st_mode & 0o777 == 0o600
+
+
+def test_invalid_metadata_never_publishes_done(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+
+    with pytest.raises(task_protocol.MetadataValidationError):
+        task_protocol.publish_success(
+            paths, result="answer", log=b"{}\n", metadata={}, schema=SCHEMA
+        )
+
+    assert task_protocol.completion_status(paths).state == "pending"
+
+
+def test_error_is_terminal_and_success_cannot_overwrite_it(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    task_protocol.publish_error(paths, reason="HARNESS_EXIT_NONZERO", detail="exit 3")
+
+    with pytest.raises(task_protocol.TerminalStateError):
+        task_protocol.publish_success(
+            paths,
+            result="answer",
+            log=b"{}\n",
+            metadata={
+                "status": "done",
+                "result_sha256": task_protocol.sha256_digest(b"answer"),
+                "log_sha256": task_protocol.sha256_digest(b"{}\n"),
+            },
+            schema=SCHEMA,
+        )
+
+    assert task_protocol.completion_status(paths).state == "error"
+    assert not paths.done.exists()
+
+
+def test_both_sentinels_are_conflict_never_success(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    paths.done.touch()
+    paths.error.touch()
+
+    assert task_protocol.completion_status(paths).state == "conflict"
+    with pytest.raises(task_protocol.ProtocolConflictError):
+        task_protocol.wait_for_completion(paths, timeout_seconds=1, poll_seconds=0.01)
+
+
+def test_concurrent_publishers_create_exactly_one_terminal_state(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    barrier = threading.Barrier(2)
+    outcomes = []
+
+    def success():
+        barrier.wait()
+        try:
+            task_protocol.publish_success(
+                paths,
+                result="answer",
+                log=b"{}\n",
+                metadata={
+                    "status": "done",
+                    "result_sha256": task_protocol.sha256_digest(b"answer"),
+                    "log_sha256": task_protocol.sha256_digest(b"{}\n"),
+                },
+                schema=SCHEMA,
+            )
+            outcomes.append("success")
+        except task_protocol.TerminalStateError:
+            outcomes.append("lost")
+
+    def error():
+        barrier.wait()
+        try:
+            task_protocol.publish_error(paths, reason="WORKER_TIMEOUT")
+            outcomes.append("error")
+        except task_protocol.TerminalStateError:
+            outcomes.append("lost")
+
+    threads = [threading.Thread(target=success), threading.Thread(target=error)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert outcomes.count("lost") == 1
+    assert task_protocol.completion_status(paths).state in {"done", "error"}
+    assert not (paths.done.exists() and paths.error.exists())
+
+
+def test_symlinked_artifact_path_is_rejected(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    outside = tmp_path / "outside"
+    outside.write_text("untouched")
+    paths.result.symlink_to(outside)
+
+    with pytest.raises(task_protocol.UnsafeTaskPathError):
+        task_protocol.publish_success(
+            paths,
+            result="answer",
+            log=b"{}\n",
+            metadata={
+                "status": "done",
+                "result_sha256": task_protocol.sha256_digest(b"answer"),
+                "log_sha256": task_protocol.sha256_digest(b"{}\n"),
+            },
+            schema=SCHEMA,
+        )
+
+    assert outside.read_text() == "untouched"

--- a/tests/test_delegate_task_protocol.py
+++ b/tests/test_delegate_task_protocol.py
@@ -53,6 +53,23 @@ def test_invalid_metadata_never_publishes_done(tmp_path):
     assert task_protocol.completion_status(paths).state == "pending"
 
 
+def test_mismatched_artifact_digest_never_publishes_done(tmp_path):
+    paths = task_protocol.create_task(tmp_path, "worker-1")
+    metadata = {
+        "status": "done",
+        "result_sha256": "sha256:" + "0" * 64,
+        "log_sha256": task_protocol.sha256_digest(b"{}\n"),
+    }
+
+    with pytest.raises(task_protocol.MetadataValidationError, match="result_sha256"):
+        task_protocol.publish_success(
+            paths, result="answer", log=b"{}\n", metadata=metadata, schema=SCHEMA
+        )
+
+    assert task_protocol.completion_status(paths).state == "pending"
+    assert not paths.result.exists()
+
+
 def test_error_is_terminal_and_success_cannot_overwrite_it(tmp_path):
     paths = task_protocol.create_task(tmp_path, "worker-1")
     task_protocol.publish_error(paths, reason="HARNESS_EXIT_NONZERO", detail="exit 3")

--- a/tests/test_openrouter_worker.py
+++ b/tests/test_openrouter_worker.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from delegates import openrouter_worker, task_protocol
+from providers import ExecutionProvider
+
+
+FAKE_HARNESS = r'''#!/usr/bin/env python3
+import json, os, subprocess, sys, time
+args = sys.argv[1:]
+capture = os.environ["CW_FAKE_CAPTURE"]
+prompt = sys.stdin.read()
+configs = [args[i + 1] for i, arg in enumerate(args) if arg == "-c"]
+def config_value(suffix):
+    value = next(v.split("=", 1)[1] for v in configs if v.split("=", 1)[0].endswith(suffix))
+    return json.loads(value)
+helper = config_value("auth.command")
+helper_args = config_value("auth.args")
+first = subprocess.run([helper, *helper_args], text=True, capture_output=True)
+second = subprocess.run([helper, *helper_args], text=True, capture_output=True)
+last_message = args[args.index("--output-last-message") + 1]
+Path = __import__("pathlib").Path
+Path(capture).write_text(json.dumps({
+    "argv": args, "prompt": prompt,
+    "env_names": sorted(os.environ),
+    "first_ok": first.returncode == 0 and bool(first.stdout.strip()),
+    "second_ok": second.returncode == 0 or bool(second.stdout.strip()),
+}))
+mode = os.environ.get("CW_FAKE_MODE", "success")
+if mode == "timeout":
+    subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    time.sleep(60)
+if mode == "nonzero":
+    print(json.dumps({"type":"turn.completed","usage":{}}))
+    raise SystemExit(7)
+if mode == "malformed":
+    print("not-json")
+    raise SystemExit(0)
+if mode == "reported-error":
+    print(json.dumps({"type":"error","message":"upstream failed"}))
+    raise SystemExit(0)
+if mode != "missing-result":
+    Path(last_message).write_text("worker answer\n")
+print(json.dumps({"type":"item.completed","item":{"type":"agent_message","text":"worker answer"}}))
+print(json.dumps({"type":"item.completed","item":{"type":"command_execution","status":"completed"}}))
+print(json.dumps({"type":"turn.completed","usage":{"input_tokens":11,"output_tokens":5}}))
+'''
+
+
+@pytest.fixture
+def git_paths(tmp_path):
+    main = tmp_path / "main"
+    main.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=main, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=main, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=main, check=True)
+    (main / "README").write_text("x")
+    subprocess.run(["git", "add", "."], cwd=main, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=main, check=True)
+    worktree = tmp_path / "worker"
+    subprocess.run(["git", "worktree", "add", "-q", "-b", "worker", str(worktree)], cwd=main, check=True)
+    return main, worktree
+
+
+@pytest.fixture
+def fake_harness(tmp_path):
+    path = tmp_path / "codex"
+    path.write_text(FAKE_HARNESS)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+@pytest.fixture
+def provider():
+    return ExecutionProvider(
+        name="preview-worker",
+        enabled=True,
+        execution_adapter="codex-responses",
+        delegate="codex-responses",
+        model="vendor/preview-model",
+        base_url="https://openrouter.ai/api/v1",
+        capability_tier="external-preview-tier",
+        capabilities=("responses", "repo-read", "shell-tools", "workspace-write"),
+        max_input_tokens=1000,
+    )
+
+
+def run_worker(tmp_path, git_paths, fake_harness, provider, *, mode="success", secret_loader=None):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "Make a harmless edit")
+    capture = tmp_path / "capture.json"
+    env = {"CW_FAKE_CAPTURE": str(capture), "CW_FAKE_MODE": mode, "SHOULD_BE_SECRET_TOKEN": "drop"}
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=provider,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=1 if mode == "timeout" else 10,
+        harness_command=str(fake_harness),
+        secret_loader=secret_loader or (lambda: "seeded-super-secret"),
+        extra_env=env,
+    )
+    return paths, capture, result
+
+
+def test_success_uses_responses_workspace_write_and_one_shot_auth(
+    tmp_path, git_paths, fake_harness, provider
+):
+    paths, capture_path, result = run_worker(tmp_path, git_paths, fake_harness, provider)
+    capture = json.loads(capture_path.read_text())
+    durable = "\n".join(path.read_text() for path in paths.task_dir.iterdir() if path.is_file())
+
+    assert result.status == "done"
+    assert paths.done.exists() and not paths.error.exists()
+    assert paths.result.read_text() == "worker answer\n"
+    assert "--sandbox" in capture["argv"] and "workspace-write" in capture["argv"]
+    assert "--ephemeral" in capture["argv"] and "--ignore-user-config" in capture["argv"]
+    assert any('wire_api=\"responses\"' in item for item in capture["argv"])
+    assert capture["prompt"] == "Make a harmless edit"
+    assert capture["first_ok"] is True
+    assert capture["second_ok"] is False
+    assert "SHOULD_BE_SECRET_TOKEN" not in capture["env_names"]
+    assert "seeded-super-secret" not in json.dumps(capture)
+    assert "seeded-super-secret" not in durable
+    metadata = json.loads(paths.metadata.read_text())
+    assert metadata["requested_model"] == "vendor/preview-model"
+    assert metadata["resolved_model"] is None
+    assert metadata["usage"]["input_tokens"] == 11
+
+
+def test_main_checkout_refused_before_secret_or_harness(tmp_path, git_paths, fake_harness, provider):
+    main, _ = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
+    called = []
+
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=provider,
+        worktree=main,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(fake_harness),
+        secret_loader=lambda: called.append(True) or "secret",
+    )
+
+    assert result.reason_code == "UNSAFE_WORKTREE"
+    assert called == []
+    assert paths.error.exists() and not paths.done.exists()
+
+
+@pytest.mark.parametrize(
+    ("mode", "reason"),
+    [
+        ("nonzero", "HARNESS_EXIT_NONZERO"),
+        ("malformed", "MALFORMED_EVENT_STREAM"),
+        ("reported-error", "HARNESS_REPORTED_ERROR"),
+        ("missing-result", "MISSING_RESULT"),
+        ("timeout", "WORKER_TIMEOUT"),
+    ],
+)
+def test_failures_publish_stable_exclusive_error(
+    tmp_path, git_paths, fake_harness, provider, mode, reason
+):
+    paths, _, result = run_worker(tmp_path, git_paths, fake_harness, provider, mode=mode)
+
+    assert result.reason_code == reason
+    assert paths.error.exists() and not paths.done.exists()
+    assert json.loads(paths.error.read_text())["reason"] == reason
+
+
+def test_missing_key_fails_closed(tmp_path, git_paths, fake_harness, provider):
+    paths, _, result = run_worker(
+        tmp_path, git_paths, fake_harness, provider, secret_loader=lambda: None
+    )
+    assert result.reason_code == "CREDENTIAL_UNAVAILABLE"
+    assert paths.error.exists() and not paths.done.exists()
+
+
+def test_disabled_provider_is_not_admitted(tmp_path, git_paths, fake_harness, provider):
+    disabled = ExecutionProvider(**{**provider.__dict__, "enabled": False})
+    paths, _, result = run_worker(tmp_path, git_paths, fake_harness, disabled)
+    assert result.reason_code == "PROVIDER_DISABLED"
+    assert paths.error.exists() and not paths.done.exists()

--- a/tests/test_openrouter_worker.py
+++ b/tests/test_openrouter_worker.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 import json
-import os
 import stat
 import subprocess
-from pathlib import Path
 
 import pytest
 from delegates import openrouter_worker, task_protocol
 from providers import ExecutionProvider
 
-
-FAKE_HARNESS = r'''#!/usr/bin/env python3
+FAKE_HARNESS = r"""#!/usr/bin/env python3
 import json, os, subprocess, sys, time
 args = sys.argv[1:]
+if args == ["--version"]:
+    print("codex 0.test")
+    raise SystemExit(0)
 capture = os.environ["CW_FAKE_CAPTURE"]
 prompt = sys.stdin.read()
 configs = [args[i + 1] for i, arg in enumerate(args) if arg == "-c"]
@@ -45,12 +45,20 @@ if mode == "malformed":
 if mode == "reported-error":
     print(json.dumps({"type":"error","message":"upstream failed"}))
     raise SystemExit(0)
+if mode == "secret-echo":
+    print(first.stdout)
+    raise SystemExit(0)
 if mode != "missing-result":
     Path(last_message).write_text("worker answer\n")
 print(json.dumps({"type":"item.completed","item":{"type":"agent_message","text":"worker answer"}}))
-print(json.dumps({"type":"item.completed","item":{"type":"command_execution","status":"completed"}}))
-print(json.dumps({"type":"turn.completed","usage":{"input_tokens":11,"output_tokens":5}}))
-'''
+if mode != "unsupported":
+    print(json.dumps({"type":"item.completed","item":{"type":"command_execution","status":"completed"}}))
+usage = {"input_tokens": 2000 if mode == "high-usage" else 11, "output_tokens": 5}
+terminal = {"type":"turn.completed", "usage": usage}
+if mode == "resolved":
+    terminal["resolved_model"] = "served/model-id"
+print(json.dumps(terminal))
+"""
 
 
 @pytest.fixture
@@ -64,7 +72,9 @@ def git_paths(tmp_path):
     subprocess.run(["git", "add", "."], cwd=main, check=True)
     subprocess.run(["git", "commit", "-qm", "init"], cwd=main, check=True)
     worktree = tmp_path / "worker"
-    subprocess.run(["git", "worktree", "add", "-q", "-b", "worker", str(worktree)], cwd=main, check=True)
+    subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", "worker", str(worktree)], cwd=main, check=True
+    )
     return main, worktree
 
 
@@ -121,7 +131,7 @@ def test_success_uses_responses_workspace_write_and_one_shot_auth(
     assert paths.result.read_text() == "worker answer\n"
     assert "--sandbox" in capture["argv"] and "workspace-write" in capture["argv"]
     assert "--ephemeral" in capture["argv"] and "--ignore-user-config" in capture["argv"]
-    assert any('wire_api=\"responses\"' in item for item in capture["argv"])
+    assert any('wire_api="responses"' in item for item in capture["argv"])
     assert capture["prompt"] == "Make a harmless edit"
     assert capture["first_ok"] is True
     assert capture["second_ok"] is False
@@ -129,12 +139,17 @@ def test_success_uses_responses_workspace_write_and_one_shot_auth(
     assert "seeded-super-secret" not in json.dumps(capture)
     assert "seeded-super-secret" not in durable
     metadata = json.loads(paths.metadata.read_text())
+    schema = json.loads(openrouter_worker.SCHEMA.read_text())
+    __import__("jsonschema").Draft202012Validator(schema).validate(metadata)
     assert metadata["requested_model"] == "vendor/preview-model"
+    assert metadata["harness"]["version"] == "codex 0.test"
     assert metadata["resolved_model"] is None
     assert metadata["usage"]["input_tokens"] == 11
 
 
-def test_main_checkout_refused_before_secret_or_harness(tmp_path, git_paths, fake_harness, provider):
+def test_main_checkout_refused_before_secret_or_harness(
+    tmp_path, git_paths, fake_harness, provider
+):
     main, _ = git_paths
     paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
     called = []
@@ -162,6 +177,9 @@ def test_main_checkout_refused_before_secret_or_harness(tmp_path, git_paths, fak
         ("reported-error", "HARNESS_REPORTED_ERROR"),
         ("missing-result", "MISSING_RESULT"),
         ("timeout", "WORKER_TIMEOUT"),
+        ("unsupported", "UNSUPPORTED_CAPABILITY"),
+        ("secret-echo", "SECRET_EXPOSURE_DETECTED"),
+        ("high-usage", "USAGE_LIMIT_EXCEEDED"),
     ],
 )
 def test_failures_publish_stable_exclusive_error(
@@ -187,3 +205,13 @@ def test_disabled_provider_is_not_admitted(tmp_path, git_paths, fake_harness, pr
     paths, _, result = run_worker(tmp_path, git_paths, fake_harness, disabled)
     assert result.reason_code == "PROVIDER_DISABLED"
     assert paths.error.exists() and not paths.done.exists()
+
+
+def test_resolved_identity_is_recorded_only_when_observed(
+    tmp_path, git_paths, fake_harness, provider
+):
+    paths, _, result = run_worker(tmp_path, git_paths, fake_harness, provider, mode="resolved")
+    metadata = json.loads(paths.metadata.read_text())
+    assert result.status == "done"
+    assert metadata["resolved_model"] == "served/model-id"
+    assert metadata["model_resolution_status"] == "observed"

--- a/tests/test_openrouter_worker.py
+++ b/tests/test_openrouter_worker.py
@@ -28,7 +28,7 @@ last_message = args[args.index("--output-last-message") + 1]
 Path = __import__("pathlib").Path
 Path(capture).write_text(json.dumps({
     "argv": args, "prompt": prompt,
-    "env_names": sorted(os.environ),
+    "environment": dict(os.environ),
     "first_ok": first.returncode == 0 and bool(first.stdout.strip()),
     "second_ok": second.returncode == 0 or bool(second.stdout.strip()),
 }))
@@ -135,7 +135,7 @@ def test_success_uses_responses_workspace_write_and_one_shot_auth(
     assert capture["prompt"] == "Make a harmless edit"
     assert capture["first_ok"] is True
     assert capture["second_ok"] is False
-    assert "SHOULD_BE_SECRET_TOKEN" not in capture["env_names"]
+    assert "SHOULD_BE_SECRET_TOKEN" not in capture["environment"]
     assert "seeded-super-secret" not in json.dumps(capture)
     assert "seeded-super-secret" not in durable
     metadata = json.loads(paths.metadata.read_text())
@@ -154,6 +154,7 @@ def test_main_checkout_refused_before_secret_or_harness(
     paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
     called = []
 
+    # @cw-trace verifies CTR-dag-020
     result = openrouter_worker.run_task(
         paths=paths,
         provider=provider,
@@ -190,6 +191,11 @@ def test_failures_publish_stable_exclusive_error(
     assert result.reason_code == reason
     assert paths.error.exists() and not paths.done.exists()
     assert json.loads(paths.error.read_text())["reason"] == reason
+    if mode == "high-usage":
+        metadata = json.loads(paths.metadata.read_text())
+        assert metadata["status"] == "error"
+        assert metadata["reason_code"] == "USAGE_LIMIT_EXCEEDED"
+        assert metadata["usage"]["input_tokens"] == 2000
 
 
 def test_missing_key_fails_closed(tmp_path, git_paths, fake_harness, provider):
@@ -200,10 +206,137 @@ def test_missing_key_fails_closed(tmp_path, git_paths, fake_harness, provider):
     assert paths.error.exists() and not paths.done.exists()
 
 
+def test_missing_prompt_publishes_stable_error(tmp_path, git_paths, fake_harness, provider):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1")
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=provider,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(fake_harness),
+    )
+
+    assert result.reason_code == "MISSING_PROMPT"
+    assert paths.error.exists() and not paths.done.exists()
+
+
 def test_disabled_provider_is_not_admitted(tmp_path, git_paths, fake_harness, provider):
     disabled = ExecutionProvider(**{**provider.__dict__, "enabled": False})
     paths, _, result = run_worker(tmp_path, git_paths, fake_harness, disabled)
     assert result.reason_code == "PROVIDER_DISABLED"
+    assert paths.error.exists() and not paths.done.exists()
+
+
+def test_provider_without_budget_is_invalid_before_secret(
+    tmp_path, git_paths, fake_harness, provider
+):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
+    unbounded = ExecutionProvider(**{**provider.__dict__, "max_input_tokens": None})
+    called = []
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=unbounded,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(fake_harness),
+        secret_loader=lambda: called.append(True) or "secret",
+    )
+
+    assert result.reason_code == "PROVIDER_CONFIG_INVALID"
+    assert called == []
+
+
+def test_invalid_success_metadata_becomes_stable_error(
+    tmp_path, git_paths, fake_harness, provider, monkeypatch
+):
+    def reject(*args, **kwargs):
+        raise task_protocol.MetadataValidationError("bad metadata")
+
+    monkeypatch.setattr(task_protocol, "publish_success", reject)
+    paths, _, result = run_worker(tmp_path, git_paths, fake_harness, provider)
+
+    assert result.reason_code == "METADATA_INVALID"
+    assert paths.error.exists() and not paths.done.exists()
+
+
+def test_read_only_probe_uses_read_only_sandbox(tmp_path, git_paths, fake_harness, provider):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "Inspect only")
+    capture = tmp_path / "capture.json"
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=provider,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(fake_harness),
+        secret_loader=lambda: "seeded-super-secret",
+        extra_env={"CW_FAKE_CAPTURE": str(capture)},
+        sandbox="read-only",
+    )
+
+    assert result.status == "done"
+    invocation = json.loads(capture.read_text())["argv"]
+    assert invocation[invocation.index("--sandbox") + 1] == "read-only"
+    assert json.loads(paths.metadata.read_text())["sandbox"] == "read-only"
+
+
+def test_harness_unavailable_is_stable_error(tmp_path, git_paths, provider):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=provider,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(tmp_path / "not-installed"),
+    )
+
+    assert result.reason_code == "HARNESS_UNAVAILABLE"
+    assert paths.error.exists() and not paths.done.exists()
+
+
+def test_capability_mismatch_refuses_before_secret(tmp_path, git_paths, fake_harness, provider):
+    main, worktree = git_paths
+    paths = task_protocol.create_task(tmp_path / "tasks", "task-1", "do it")
+    incapable = ExecutionProvider(
+        **{**provider.__dict__, "capabilities": ("responses", "repo-read", "workspace-write")}
+    )
+    called = []
+    result = openrouter_worker.run_task(
+        paths=paths,
+        provider=incapable,
+        worktree=worktree,
+        main_checkout=main,
+        timeout_seconds=10,
+        harness_command=str(fake_harness),
+        secret_loader=lambda: called.append(True) or "secret",
+    )
+
+    assert result.reason_code == "UNSUPPORTED_CAPABILITY"
+    assert called == []
+
+
+def test_reusable_auth_canary_fails_closed(
+    tmp_path, git_paths, fake_harness, provider, monkeypatch
+):
+    original_run = openrouter_worker.subprocess.run
+
+    def canary_leaks(argv, *args, **kwargs):
+        if str(argv[0]).endswith("auth-helper"):
+            return subprocess.CompletedProcess(argv, 0, b"still-secret", b"")
+        return original_run(argv, *args, **kwargs)
+
+    monkeypatch.setattr(openrouter_worker.subprocess, "run", canary_leaks)
+    paths, _, result = run_worker(tmp_path, git_paths, fake_harness, provider)
+
+    # @cw-trace verifies INV-dag-019
+    assert result.reason_code == "CREDENTIAL_BOUNDARY_UNSAFE"
     assert paths.error.exists() and not paths.done.exists()
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -58,6 +58,27 @@ def test_anonymous_preview_without_license_must_be_external_preview_tier():
     assert any("external-preview-tier" in error for error in errors)
 
 
+def test_open_tier_without_license_evidence_is_rejected_when_preview_flag_omitted():
+    config = {
+        "providers": {
+            "unproven": {
+                "type": "delegate",
+                "delegate": "codex-responses",
+                "execution_adapter": "codex-responses",
+                "model": "configured/model",
+                "enabled": False,
+                "base_url": "https://example.invalid/api/v1",
+                "capability_tier": "open-tier",
+                "capabilities": ["responses", "repo-read", "shell-tools", "workspace-write"],
+                "weights_license_evidence": None,
+            }
+        },
+        "roles": {},
+    }
+
+    assert any("cannot use open-tier" in error for error in providers.validate_config(config))
+
+
 def test_role_plan_separates_required_optional_and_disabled():
     config = {
         "providers": {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,6 +14,43 @@ def test_default_provider_config_is_valid():
     assert {"explorer", "implementer", "reviewer", "architecture_critic", "design_critic", "risky_diff_review"} <= set(roles)
 
 
+def test_default_config_has_disabled_external_preview_execution_provider():
+    config = providers.load_config()
+    execution = providers.execution_providers_from_config(config)
+
+    provider = execution["openrouter-preview-worker"]
+    assert not provider.enabled
+    assert provider.execution_adapter == "codex-responses"
+    assert provider.capability_tier == "external-preview-tier"
+    assert all(
+        "openrouter-preview-worker" not in raw.get("required", []) + raw.get("optional", [])
+        for raw in config["roles"].values()
+    )
+
+
+def test_anonymous_preview_without_license_must_be_external_preview_tier():
+    config = {
+        "providers": {
+            "preview": {
+                "type": "delegate",
+                "delegate": "codex-responses",
+                "execution_adapter": "codex-responses",
+                "model": "configured/model",
+                "enabled": False,
+                "base_url": "https://example.invalid/api/v1",
+                "capability_tier": "open-tier",
+                "capabilities": ["responses", "shell-tools"],
+                "anonymous_preview": True,
+                "weights_license_evidence": None,
+            }
+        },
+        "roles": {},
+    }
+
+    errors = providers.validate_config(config)
+    assert any("external-preview-tier" in error for error in errors)
+
+
 def test_role_plan_separates_required_optional_and_disabled():
     config = {
         "providers": {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,7 +11,14 @@ def test_default_provider_config_is_valid():
 
     assert providers.validate_config(config) == []
     roles = providers.roles_from_config(config)
-    assert {"explorer", "implementer", "reviewer", "architecture_critic", "design_critic", "risky_diff_review"} <= set(roles)
+    assert {
+        "explorer",
+        "implementer",
+        "reviewer",
+        "architecture_critic",
+        "design_critic",
+        "risky_diff_review",
+    } <= set(roles)
 
 
 def test_default_config_has_disabled_external_preview_execution_provider():
@@ -99,7 +106,9 @@ def test_validate_config_flags_unknown_role_provider():
         "roles": {"reviewer": {"required": ["codex"], "optional": ["missing"]}},
     }
 
-    assert providers.validate_config(config) == ["role reviewer references unknown provider missing"]
+    assert providers.validate_config(config) == [
+        "role reviewer references unknown provider missing"
+    ]
 
 
 def test_validate_config_can_flag_unknown_backend_names():
@@ -188,7 +197,9 @@ def test_prompt_for_provider_raises_for_unknown_lens():
 def test_validate_lenses_flags_unknown_lens_name():
     config = {
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
-        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"codex": "missing-lens"}}},
+        "roles": {
+            "reviewer": {"required": ["codex"], "optional": [], "lenses": {"codex": "missing-lens"}}
+        },
     }
     errors = providers.validate_lenses(config, {"refute-soundness": {}})
     assert any("unknown lens" in e for e in errors)
@@ -197,7 +208,13 @@ def test_validate_lenses_flags_unknown_lens_name():
 def test_validate_lenses_flags_provider_not_in_role():
     config = {
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
-        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"gemini": "refute-soundness"}}},
+        "roles": {
+            "reviewer": {
+                "required": ["codex"],
+                "optional": [],
+                "lenses": {"gemini": "refute-soundness"},
+            }
+        },
     }
     errors = providers.validate_lenses(config, {"refute-soundness": {}})
     assert any("not a required or optional provider" in e for e in errors)
@@ -206,7 +223,13 @@ def test_validate_lenses_flags_provider_not_in_role():
 def test_validate_lenses_passes_for_well_formed_role():
     config = {
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
-        "roles": {"reviewer": {"required": ["codex"], "optional": [], "lenses": {"codex": "refute-soundness"}}},
+        "roles": {
+            "reviewer": {
+                "required": ["codex"],
+                "optional": [],
+                "lenses": {"codex": "refute-soundness"},
+            }
+        },
     }
     assert providers.validate_lenses(config, {"refute-soundness": {}}) == []
 
@@ -226,7 +249,9 @@ def test_role_loads_optional_timeout_seconds_from_config():
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
         "roles": {
             "reviewer": {
-                "required": ["codex"], "optional": [], "optional_timeout_seconds": 300,
+                "required": ["codex"],
+                "optional": [],
+                "optional_timeout_seconds": 300,
             }
         },
     }
@@ -249,7 +274,9 @@ def test_validate_config_rejects_malformed_optional_timeout_seconds(bad_value):
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
         "roles": {
             "reviewer": {
-                "required": ["codex"], "optional": [], "optional_timeout_seconds": bad_value,
+                "required": ["codex"],
+                "optional": [],
+                "optional_timeout_seconds": bad_value,
             }
         },
     }
@@ -262,7 +289,9 @@ def test_validate_config_accepts_well_formed_optional_timeout_seconds():
         "providers": {"codex": {"type": "tool", "tool": "codex"}},
         "roles": {
             "reviewer": {
-                "required": ["codex"], "optional": [], "optional_timeout_seconds": 300,
+                "required": ["codex"],
+                "optional": [],
+                "optional_timeout_seconds": 300,
             }
         },
     }


### PR DESCRIPTION
Closes #392. Parent epic: #383.

Adds an agentic OpenRouter coding worker behind the shared delegate protocol, so the factory can run a repo-reading, tool-using worker on a provider other than the two CLIs it depends on today.

**The provider ships `"enabled": false`.** Nothing routes to it until someone turns it on.

## Why

The consult quorum is currently pinned to locally installed CLIs. When one goes down the quorum degrades, and there is no seam for a worker that reads the repo and calls tools through a hosted API instead. This PR adds that seam and one guarded provider behind it.

## Shape

```mermaid
flowchart TD
    C[providers.py] -->|resolves capability tier| P["openrouter-preview-worker<br/>enabled: false"]
    P --> W[openrouter_worker.py]
    W --> T[task_protocol.py]
    T --> B{Broker}
    B -->|one-shot state deleted<br/>before the model turn| M[Model turn via responses wire]
    M --> U[usage + timing retained<br/>even on error]
    W --> S[delegate-worker-metadata-schema.json<br/>format + execution-adapter validated]
```

Guards that came out of review, all with tests:

- The broker capability is not passed in argv.
- One-shot state is deleted before the model turn, so a crash cannot replay it.
- Usage and timing are retained on the error path, not just the success path.
- Schema formats and execution adapters are validated rather than assumed.
- Broker expiry is bound to the run.
- Tests assert environment *values*, not just that variable names are present.
- Any open-tier claim requires weights and licence evidence. This provider does not have it, so it is declared `external-preview-tier` with `anonymous_preview: true` and `weights_license_evidence: null` rather than being labelled open.

## Evidence

`docs/experiments/dynamic-dag/probes/2026-08-22-openrouter-codex.json` is a measured read-only compatibility probe, not an assertion: shell tool call observed, expected marker returned, 12 providers read, 98628 input tokens, 25.7s, against codex 0.149.0 on the responses wire.

## Verification

Full suite on this branch, rebased onto main after #393 landed: **3423 passed, 14 skipped**. Lint clean, including `check_portability.py` and `check_cw_standards.py --gate`. 623 lines of new tests across `test_openrouter_worker.py`, `test_delegate_task_protocol.py`, and `test_providers.py`.

## Review provenance

The review quorum for this ticket was degraded and should be read as such. Codex was retried and stayed quota-blocked; Gemini and Kimi failed. Two independent reviews completed, from DeepSeek and from Claude, and their findings are what the hardening commit addresses. Recording this rather than presenting it as a full quorum.

## Caveat worth a second opinion

`stealth/ox-alpha` is an unreleased anonymous preview model. Prompts routed through it are generally retained by whoever operates it. That is fine for chief-wiggum's own repo and is a deliberate consideration before pointing it at a client repo. The disabled-by-default flag is doing real work here.
