### PR TITLE
feat(dag): implement the transactional graph journal and engine (#385)

### DIFF
--- a/scripts/chief_wiggum/dag/__init__.py
+++ b/scripts/chief_wiggum/dag/__init__.py
@@ -3,6 +3,7 @@
 from .canonical import canonical_json_bytes, validate_canonical_bytes
 from .compatibility import ProjectionResult, dependency_block_to_intent_graph, project_legacy_waves
 from .errors import ContractViolation, ErrorCode
+from .journal import Decision, GraphJournal, JournalError
 from .schemas import SCHEMA_VERSION, load_authority_matrix, schema_catalog, validate_record
 from .semantics import (
     LEGAL_TRANSITIONS,
@@ -15,6 +16,9 @@ from .semantics import (
 __all__ = [
     "ContractViolation",
     "ErrorCode",
+    "Decision",
+    "GraphJournal",
+    "JournalError",
     "LEGAL_TRANSITIONS",
     "ProjectionResult",
     "SCHEMA_VERSION",

--- a/scripts/chief_wiggum/dag/__init__.py
+++ b/scripts/chief_wiggum/dag/__init__.py
@@ -3,7 +3,7 @@
 from .canonical import canonical_json_bytes, validate_canonical_bytes
 from .compatibility import ProjectionResult, dependency_block_to_intent_graph, project_legacy_waves
 from .errors import ContractViolation, ErrorCode
-from .journal import Decision, GraphJournal, JournalError
+from .journal import Decision, GraphJournal, JournalError, Snapshot
 from .schemas import SCHEMA_VERSION, load_authority_matrix, schema_catalog, validate_record
 from .semantics import (
     LEGAL_TRANSITIONS,
@@ -22,6 +22,7 @@ __all__ = [
     "LEGAL_TRANSITIONS",
     "ProjectionResult",
     "SCHEMA_VERSION",
+    "Snapshot",
     "TERMINAL_STATES",
     "canonical_json_bytes",
     "dependency_block_to_intent_graph",

--- a/scripts/chief_wiggum/dag/journal.py
+++ b/scripts/chief_wiggum/dag/journal.py
@@ -1,0 +1,318 @@
+"""Transactional GraphJournal — sole sanctioned writer of graph_revision.
+
+@cw-trace guards INV-dag-001 INV-dag-002 INV-dag-003 INV-dag-004
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .canonical import canonical_json_bytes
+from .errors import ContractViolation, ErrorCode
+from .schemas import validate_record
+from .semantics import validate_mutation
+
+_GENESIS_HASH = "0" * 64
+
+
+class JournalError(Exception):
+    """Raised when the journal cannot be opened, is corrupt, or fails closed."""
+
+
+@dataclass(frozen=True)
+class Decision:
+    accepted: bool
+    journal_seq: int
+    graph_revision: int | None
+    reason: str
+    violations: tuple[ContractViolation, ...] = ()
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    graph_id: str
+    graph_revision: int
+    schedule_hash: str
+    audit_state_hash: str
+    snapshot_data: dict[str, Any] = field(default_factory=dict)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _schedule_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "execution_nodes": snapshot_data.get("execution_nodes", []),
+        "schedulable_edges": snapshot_data.get("schedulable_edges", []),
+        "control_records": snapshot_data.get("control_records", []),
+        "lease_records": snapshot_data.get("lease_records", []),
+    }
+
+
+def _audit_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "intent_nodes": snapshot_data.get("intent_nodes", []),
+        "intent_edges": snapshot_data.get("intent_edges", []),
+        "execution_nodes": snapshot_data.get("execution_nodes", []),
+        "schedulable_edges": snapshot_data.get("schedulable_edges", []),
+        "relations": snapshot_data.get("relations", []),
+        "evidence_records": snapshot_data.get("evidence_records", []),
+        "approval_records": snapshot_data.get("approval_records", []),
+        "lease_records": snapshot_data.get("lease_records", []),
+        "control_records": snapshot_data.get("control_records", []),
+        "mutations": snapshot_data.get("mutations", []),
+    }
+
+
+def _compute_schedule_hash(snapshot_data: dict[str, Any]) -> str:
+    return _sha256(canonical_json_bytes(_schedule_projection(snapshot_data)))
+
+
+def _compute_audit_state_hash(snapshot_data: dict[str, Any]) -> str:
+    return _sha256(canonical_json_bytes(_audit_projection(snapshot_data)))
+
+
+def _empty_snapshot(graph_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "graph_snapshot",
+        "graph_id": graph_id,
+        "graph_revision": 0,
+        "authority_matrix_version": "1.0.0",
+        "intent_nodes": [],
+        "intent_edges": [],
+        "execution_nodes": [],
+        "schedulable_edges": [],
+        "relations": [],
+        "evidence_records": [],
+        "approval_records": [],
+        "lease_records": [],
+        "control_records": [],
+        "mutations": [],
+    }
+
+
+def _apply_operation(snapshot_data: dict[str, Any], operation: dict[str, Any]) -> None:
+    op_type = operation["operation_type"]
+    collection_map = {
+        "add_intent_node": "intent_nodes",
+        "add_intent_edge": "intent_edges",
+        "add_execution_node": "execution_nodes",
+        "add_schedulable_edge": "schedulable_edges",
+        "add_relation": "relations",
+        "record_evidence": "evidence_records",
+        "transition_node": "transition_node",
+        "acquire_lease": "lease_records",
+        "release_lease": "lease_records",
+        "set_control": "control_records",
+        "promote_candidate": "promote_candidate",
+        "compensate": "compensate",
+    }
+    collection = collection_map.get(op_type)
+    if collection in ("transition_node", "promote_candidate", "compensate"):
+        return
+    if collection is None:
+        raise JournalError(f"unknown operation type {op_type!r}")
+    if op_type.startswith("add_") or op_type == "record_evidence":
+        record = dict(operation["value"])
+        if "schema_version" not in record:
+            record["schema_version"] = "1.0.0"
+        if "record_type" not in record:
+            type_map = {
+                "add_intent_node": "intent_node",
+                "add_intent_edge": "intent_edge",
+                "add_execution_node": "execution_node",
+                "add_schedulable_edge": "schedulable_edge",
+                "add_relation": "relation",
+                "record_evidence": "evidence_record",
+            }
+            record["record_type"] = type_map[op_type]
+        snapshot_data[collection].append(record)
+
+
+class GraphJournal:
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._conn = sqlite3.connect(str(self._path), isolation_level=None)
+        self._cached_state: dict[str, Any] | None = None
+        self._cached_seq: int = -1
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=FULL")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS graph_events (
+                journal_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                graph_id TEXT NOT NULL,
+                previous_record_hash TEXT NOT NULL,
+                event_hash TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        """)
+
+    def _graph_id(self) -> str:
+        row = self._conn.execute("SELECT graph_id FROM graph_events WHERE event_type='init' LIMIT 1").fetchone()
+        return row[0] if row else ""
+
+    def _last_event_hash(self) -> str:
+        row = self._conn.execute("SELECT event_hash FROM graph_events ORDER BY journal_seq DESC LIMIT 1").fetchone()
+        return row[0] if row else _GENESIS_HASH
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def _verify_chain(self) -> None:
+        previous = _GENESIS_HASH
+        for row in self._conn.execute(
+            "SELECT journal_seq, previous_record_hash, event_hash, payload FROM graph_events ORDER BY journal_seq"
+        ):
+            seq, prev_hash, stored_hash, payload_text = row
+            if prev_hash != previous:
+                raise JournalError(f"hash chain broken at journal_seq={seq}: expected previous={previous!r}, got {prev_hash!r}")
+            computed_hash = _sha256(payload_text.encode("utf-8"))
+            if computed_hash != stored_hash:
+                raise JournalError(f"event hash mismatch at journal_seq={seq}")
+            previous = stored_hash
+
+    def replay(self) -> dict[str, Any]:
+        self._verify_chain()
+        current_max = self._conn.execute("SELECT COALESCE(MAX(journal_seq), 0) FROM graph_events").fetchone()[0]
+        if self._cached_state is not None and self._cached_seq == current_max:
+            return dict(self._cached_state)
+        state = None
+        for row in self._conn.execute(
+            "SELECT journal_seq, event_type, payload FROM graph_events WHERE event_type IN ('init', 'mutation_accepted', 'snapshot') ORDER BY journal_seq"
+        ):
+            _, event_type, payload_text = row
+            payload = json.loads(payload_text)
+            if event_type == "init":
+                state = _empty_snapshot(payload["graph_id"])
+            elif event_type == "snapshot":
+                state = payload["snapshot"]
+            elif event_type == "mutation_accepted":
+                if state is None:
+                    raise JournalError(f"accepted mutation at journal_seq without prior init")
+                for operation in payload.get("operations", []):
+                    _apply_operation(state, operation)
+                state["graph_revision"] += 1
+                state["mutations"].append(payload["envelope"])
+        if isinstance(state, dict):
+            self._cached_state = dict(state)
+            self._cached_seq = current_max
+        if state is None:
+            return {"graph_id": "", "graph_revision": 0, "events": []}
+        return state
+
+    def current_revision(self) -> int:
+        row = self._conn.execute("SELECT MAX(journal_seq) FROM graph_events").fetchone()
+        if row[0] is None:
+            return 0
+        return row[0]
+
+    def init_graph(self, graph_id: str) -> None:
+        existing = self._conn.execute("SELECT COUNT(*) FROM graph_events WHERE event_type='init'").fetchone()[0]
+        if existing:
+            raise JournalError("journal already initialised with a different graph")
+        self._commit_event(graph_id, "init", {"graph_id": graph_id})
+
+    def propose(self, envelope: dict[str, Any], *, actor_note: str = "") -> Decision:
+        errors = validate_record(envelope, "mutation_envelope")
+        if errors:
+            return self._reject(envelope, errors, "schema validation failed")
+        graph_id = envelope["graph_id"]
+        known_graph_id = self._graph_id()
+        if not known_graph_id or graph_id != known_graph_id:
+            return self._reject(envelope, (
+                ContractViolation(ErrorCode.GRAPH_ID_MISMATCH, f"envelope graph_id {graph_id!r} does not match journal graph {known_graph_id!r}", "/graph_id"),
+            ), "unknown graph")
+        state = self.replay() if self.current_revision() > 0 else _empty_snapshot(graph_id)
+        history = state.get("mutations", []) if isinstance(state, dict) else []
+        envelope_digest = _sha256(canonical_json_bytes(envelope))
+        for prior in history:
+            if prior.get("idempotency_key") == envelope.get("idempotency_key"):
+                if _sha256(canonical_json_bytes(prior)) == envelope_digest:
+                    return Decision(accepted=True, journal_seq=self.current_revision(), graph_revision=state["graph_revision"], reason="idempotent no-op")
+                return self._reject(envelope, (
+                    ContractViolation(ErrorCode.IDEMPOTENCY_KEY_DIVERGENT, "idempotency key was previously used with a different canonical envelope", "/idempotency_key"),
+                ), "idempotency key collision")
+        validation_errors = validate_mutation(state, envelope, history=history)
+        if validation_errors:
+            return self._reject(envelope, validation_errors, "semantic validation failed")
+        return self._accept(envelope)
+
+    def _reject(self, envelope: dict[str, Any], violations: tuple[ContractViolation, ...], summary: str) -> Decision:
+        graph_id = envelope.get("graph_id", "")
+        payload = {
+            "graph_id": graph_id,
+            "mutation_id": envelope.get("mutation_id"),
+            "idempotency_key": envelope.get("idempotency_key"),
+            "base_revision": envelope.get("base_revision"),
+            "reason": summary,
+            "violations": [v.to_dict() for v in violations],
+            "envelope_digest": _sha256(canonical_json_bytes(envelope)),
+        }
+        self._commit_event(graph_id, "mutation_rejected", payload)
+        known_graph_id = self._graph_id()
+        if not known_graph_id:
+            revision = 0
+        else:
+            revision = self.replay().get("graph_revision", 0)
+        return Decision(accepted=False, journal_seq=self.current_revision(), graph_revision=revision, reason=summary, violations=violations)
+
+    def _accept(self, envelope: dict[str, Any]) -> Decision:
+        graph_id = envelope["graph_id"]
+        state = self.replay() if self.current_revision() > 0 else _empty_snapshot(graph_id)
+        for operation in envelope.get("operations", []):
+            _apply_operation(state, operation)
+        state["graph_revision"] += 1
+        state["mutations"] = state.get("mutations", []) + [envelope]
+        new_schedule = _compute_schedule_hash(state)
+        new_audit = _compute_audit_state_hash(state)
+        payload = {
+            "graph_id": graph_id,
+            "envelope": envelope,
+            "operations": envelope.get("operations", []),
+            "schedule_hash": new_schedule,
+            "audit_state_hash": new_audit,
+        }
+        self._commit_event(graph_id, "mutation_accepted", payload)
+        seq = self.current_revision()
+        return Decision(accepted=True, journal_seq=seq, graph_revision=state["graph_revision"], reason="accepted")
+
+    def hash(self) -> dict[str, str]:
+        state = self.replay()
+        if not isinstance(state, dict) or not state.get("graph_id"):
+            return {"schedule_hash": _GENESIS_HASH, "audit_state_hash": _GENESIS_HASH}
+        return {
+            "schedule_hash": _compute_schedule_hash(state),
+            "audit_state_hash": _compute_audit_state_hash(state),
+        }
+
+    def _commit_event(self, graph_id: str, event_type: str, payload: dict[str, Any]) -> None:
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            last_row = self._conn.execute(
+                "SELECT event_hash FROM graph_events ORDER BY journal_seq DESC LIMIT 1"
+            ).fetchone()
+            previous_hash = last_row[0] if last_row else _GENESIS_HASH
+            payload_bytes = canonical_json_bytes(payload)
+            event_hash = _sha256(payload_bytes)
+            self._conn.execute(
+                "INSERT INTO graph_events (graph_id, previous_record_hash, event_hash, event_type, payload) VALUES (?,?,?,?,?)",
+                (graph_id, previous_hash, event_hash, event_type, payload_bytes.decode()),
+            )
+            self._conn.execute("COMMIT")
+        except sqlite3.Error as exc:
+            self._conn.execute("ROLLBACK")
+            raise JournalError(f"durability failure: {exc}") from exc
+        self._cached_seq = -1

--- a/scripts/chief_wiggum/dag/journal.py
+++ b/scripts/chief_wiggum/dag/journal.py
@@ -1,23 +1,60 @@
 """Transactional GraphJournal — sole sanctioned writer of graph_revision.
 
+The journal is an append-only, hash-chained log of decision records. The graph
+is a deterministic fold over that log; nothing else may mutate graph state.
+
+Concurrency posture: every decision (read current state -> validate -> append)
+runs inside a single ``BEGIN IMMEDIATE`` transaction. Compare-and-swap on
+``base_revision`` is only meaningful if the check and the append are atomic, so
+the write lock spans validation rather than just the insert.
+
 @cw-trace guards INV-dag-001 INV-dag-002 INV-dag-003 INV-dag-004
 """
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import sqlite3
+import time
+from collections.abc import Generator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from .canonical import canonical_json_bytes
 from .errors import ContractViolation, ErrorCode
-from .schemas import validate_record
-from .semantics import validate_mutation
+from .schemas import SCHEMA_VERSION, validate_record
+from .semantics import validate_mutation, validate_snapshot
 
 _GENESIS_HASH = "0" * 64
+_FOLD_EVENTS = ("init", "mutation_accepted", "snapshot")
+
+# Operations that append a schema-bearing record to a snapshot collection.
+_ADD_OPS: dict[str, tuple[str, str]] = {
+    "add_intent_node": ("intent_nodes", "intent_node"),
+    "add_intent_edge": ("intent_edges", "intent_edge"),
+    "add_execution_node": ("execution_nodes", "execution_node"),
+    "add_schedulable_edge": ("schedulable_edges", "schedulable_edge"),
+    "add_relation": ("relations", "relation"),
+    "record_evidence": ("evidence_records", "evidence_record"),
+}
+
+# Operations that drop a record from a collection, keyed by target_ref.
+_REMOVE_OPS: dict[str, tuple[str, str]] = {
+    "remove_intent_node": ("intent_nodes", "intent_node_id"),
+    "remove_intent_edge": ("intent_edges", "edge_id"),
+    "remove_schedulable_edge": ("schedulable_edges", "edge_id"),
+}
+
+# Operations that upsert a keyed record supplied in `value`.
+_UPSERT_OPS: dict[str, tuple[str, str, str]] = {
+    "acquire_lease": ("lease_records", "lease_id", "lease_record"),
+    "set_control": ("control_records", "control_id", "control_record"),
+    "approve_mutation": ("approval_records", "approval_id", "approval_record"),
+}
 
 
 class JournalError(Exception):
@@ -31,12 +68,14 @@ class Decision:
     graph_revision: int | None
     reason: str
     violations: tuple[ContractViolation, ...] = ()
+    idempotent: bool = False
 
 
 @dataclass(frozen=True)
 class Snapshot:
     graph_id: str
     graph_revision: int
+    journal_seq: int
     schedule_hash: str
     audit_state_hash: str
     snapshot_data: dict[str, Any] = field(default_factory=dict)
@@ -46,7 +85,11 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _schedule_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
+def _digest(record: Any) -> str:
+    return _sha256(canonical_json_bytes(record))
+
+
+def _schedule_projection(snapshot_data: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "execution_nodes": snapshot_data.get("execution_nodes", []),
         "schedulable_edges": snapshot_data.get("schedulable_edges", []),
@@ -55,7 +98,7 @@ def _schedule_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _audit_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
+def _audit_projection(snapshot_data: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "intent_nodes": snapshot_data.get("intent_nodes", []),
         "intent_edges": snapshot_data.get("intent_edges", []),
@@ -70,17 +113,17 @@ def _audit_projection(snapshot_data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _compute_schedule_hash(snapshot_data: dict[str, Any]) -> str:
+def _compute_schedule_hash(snapshot_data: Mapping[str, Any]) -> str:
     return _sha256(canonical_json_bytes(_schedule_projection(snapshot_data)))
 
 
-def _compute_audit_state_hash(snapshot_data: dict[str, Any]) -> str:
+def _compute_audit_state_hash(snapshot_data: Mapping[str, Any]) -> str:
     return _sha256(canonical_json_bytes(_audit_projection(snapshot_data)))
 
 
 def _empty_snapshot(graph_id: str) -> dict[str, Any]:
     return {
-        "schema_version": "1.0.0",
+        "schema_version": SCHEMA_VERSION,
         "record_type": "graph_snapshot",
         "graph_id": graph_id,
         "graph_revision": 0,
@@ -98,53 +141,166 @@ def _empty_snapshot(graph_id: str) -> dict[str, Any]:
     }
 
 
-def _apply_operation(snapshot_data: dict[str, Any], operation: dict[str, Any]) -> None:
+def _find(records: Sequence[dict[str, Any]], key: str, value: Any) -> dict[str, Any] | None:
+    return next((record for record in records if record.get(key) == value), None)
+
+
+def _derive_readiness(snapshot_data: dict[str, Any]) -> None:
+    """Materialise the derived `ready` state after a fold step.
+
+    docs/dag-contract.md: `ready` is a derived projection that a proposal may
+    not set, and #385 is the ticket that composes the lifecycle and control
+    machines — so the engine owns this transition and nothing else does.
+
+    Schedulable edges run `source` AFTER `target`, so a node's predecessors are
+    the targets of the edges it sources. Only the admitted<->ready pair is
+    derived; `blocked`, `running` and the terminal states are proposal-owned.
+    """
+    nodes = {node["execution_node_id"]: node for node in snapshot_data["execution_nodes"]}
+    predecessors: dict[str, list[str]] = {node_id: [] for node_id in nodes}
+    for edge in snapshot_data["schedulable_edges"]:
+        source, target = str(edge.get("source")), str(edge.get("target"))
+        if source in predecessors:
+            predecessors[source].append(target)
+    for node_id, node in nodes.items():
+        satisfied = all(
+            (nodes.get(target) or {}).get("lifecycle_state") == "succeeded"
+            for target in predecessors[node_id]
+        )
+        if node.get("lifecycle_state") == "admitted" and satisfied:
+            node["lifecycle_state"] = "ready"
+        elif node.get("lifecycle_state") == "ready" and not satisfied:
+            node["lifecycle_state"] = "admitted"
+
+
+def _record_from(operation: Mapping[str, Any], record_type: str) -> dict[str, Any]:
+    record = dict(operation["value"])
+    record.setdefault("schema_version", SCHEMA_VERSION)
+    record.setdefault("record_type", record_type)
+    return record
+
+
+def _apply_operation(snapshot_data: dict[str, Any], operation: Mapping[str, Any]) -> None:
+    """Apply one operation to the folded graph state, in place.
+
+    Every operation type in the v1 vocabulary is handled. An operation that
+    cannot be applied raises JournalError rather than silently doing nothing —
+    a no-op fold makes graph_revision advance while the projection stands
+    still, which is the failure mode this engine exists to prevent.
+    """
     op_type = operation["operation_type"]
-    collection_map = {
-        "add_intent_node": "intent_nodes",
-        "add_intent_edge": "intent_edges",
-        "add_execution_node": "execution_nodes",
-        "add_schedulable_edge": "schedulable_edges",
-        "add_relation": "relations",
-        "record_evidence": "evidence_records",
-        "transition_node": "transition_node",
-        "acquire_lease": "lease_records",
-        "release_lease": "lease_records",
-        "set_control": "control_records",
-        "promote_candidate": "promote_candidate",
-        "compensate": "compensate",
-    }
-    collection = collection_map.get(op_type)
-    if collection in ("transition_node", "promote_candidate", "compensate"):
+    target = operation.get("target_ref")
+
+    if op_type in _ADD_OPS:
+        collection, record_type = _ADD_OPS[op_type]
+        snapshot_data[collection].append(_record_from(operation, record_type))
         return
-    if collection is None:
-        raise JournalError(f"unknown operation type {op_type!r}")
-    if op_type.startswith("add_") or op_type == "record_evidence":
-        record = dict(operation["value"])
-        if "schema_version" not in record:
-            record["schema_version"] = "1.0.0"
-        if "record_type" not in record:
-            type_map = {
-                "add_intent_node": "intent_node",
-                "add_intent_edge": "intent_edge",
-                "add_execution_node": "execution_node",
-                "add_schedulable_edge": "schedulable_edge",
-                "add_relation": "relation",
-                "record_evidence": "evidence_record",
-            }
-            record["record_type"] = type_map[op_type]
-        snapshot_data[collection].append(record)
+
+    if op_type in _REMOVE_OPS:
+        collection, key = _REMOVE_OPS[op_type]
+        remaining = [record for record in snapshot_data[collection] if record.get(key) != target]
+        if len(remaining) == len(snapshot_data[collection]):
+            raise JournalError(f"{op_type}: no {key} matching {target!r}")
+        snapshot_data[collection] = remaining
+        return
+
+    if op_type in _UPSERT_OPS:
+        collection, key, record_type = _UPSERT_OPS[op_type]
+        record = _record_from(operation, record_type)
+        existing = _find(snapshot_data[collection], key, record.get(key))
+        if existing is not None:
+            existing.clear()
+            existing.update(record)
+        else:
+            snapshot_data[collection].append(record)
+        if op_type == "acquire_lease":
+            node = _find(
+                snapshot_data["execution_nodes"], "execution_node_id", record.get("execution_node_id")
+            )
+            if node is None:
+                raise JournalError(
+                    f"acquire_lease: execution node {record.get('execution_node_id')!r} does not exist"
+                )
+            node["lease_state"] = record["state"]
+        return
+
+    if op_type == "transition_node":
+        node = _find(snapshot_data["execution_nodes"], "execution_node_id", target)
+        if node is None:
+            raise JournalError(f"transition_node: execution node {target!r} does not exist")
+        node["lifecycle_state"] = operation["to_state"]
+        return
+
+    if op_type == "release_lease":
+        lease = _find(snapshot_data["lease_records"], "lease_id", target)
+        if lease is None:
+            lease = _find(snapshot_data["lease_records"], "execution_node_id", target)
+        if lease is None:
+            raise JournalError(f"release_lease: no lease matching {target!r}")
+        lease["state"] = "released"
+        node = _find(
+            snapshot_data["execution_nodes"], "execution_node_id", lease.get("execution_node_id")
+        )
+        if node is not None:
+            node["lease_state"] = "released"
+        return
+
+    if op_type == "promote_candidate":
+        value = operation["value"]
+        node = _find(snapshot_data["execution_nodes"], "execution_node_id", value["execution_node_id"])
+        if node is None:
+            raise JournalError(
+                f"promote_candidate: execution node {value['execution_node_id']!r} does not exist"
+            )
+        node["candidate"] = {"group_id": value["candidate_group_id"], "disposition": "promoted"}
+        return
+
+    if op_type == "compensate":
+        # A compensating event does not rewrite history; its durable effect is
+        # the envelope itself, which the fold appends to `mutations`. Candidate
+        # routing and compensation *policy* are explicit non-goals of #385
+        # (they belong to #386/#387), so there is no further structural change.
+        return
+
+    raise JournalError(f"unknown operation type {op_type!r}")
 
 
 class GraphJournal:
-    def __init__(self, path: Path | str) -> None:
+    """Append-only hash-chained journal with a deterministic graph fold."""
+
+    def __init__(self, path: Path | str, *, timeout: float = 30.0) -> None:
         self._path = Path(path)
-        self._conn = sqlite3.connect(str(self._path), isolation_level=None)
+        try:
+            self._conn = sqlite3.connect(str(self._path), isolation_level=None, timeout=timeout)
+            self._conn.execute(f"PRAGMA busy_timeout={int(timeout * 1000)}")
+            self._conn.execute("PRAGMA synchronous=FULL")
+            # Switching journal mode needs a brief exclusive lock and SQLite does
+            # NOT run the busy handler for it, so two processes opening the same
+            # new journal at once would otherwise leave one with "database is
+            # locked". Retry both setup steps instead of failing the open.
+            self._retry_while_locked(timeout, self._enable_wal)
+            self._retry_while_locked(timeout, self._create_schema)
+        except sqlite3.Error as exc:
+            raise JournalError(f"cannot open journal at {self._path}: {exc}") from exc
+        # Verification is incremental within a process but always starts from
+        # genesis on a fresh connection, so tamper-evidence survives restarts.
+        self._verified_seq = 0
+        self._verified_hash = _GENESIS_HASH
+        self._chain_error: str | None = None
         self._cached_state: dict[str, Any] | None = None
-        self._cached_seq: int = -1
+        self._cached_seq = -1
+        self._idempotency_index: dict[str, dict[str, Any]] = {}
+        self._state_validated = False
+
+    def _enable_wal(self) -> None:
+        mode = self._conn.execute("PRAGMA journal_mode").fetchone()
+        if mode and str(mode[0]).lower() == "wal":
+            return
         self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA synchronous=FULL")
-        self._conn.execute("""
+
+    def _create_schema(self) -> None:
+        self._conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS graph_events (
                 journal_seq INTEGER PRIMARY KEY AUTOINCREMENT,
                 graph_id TEXT NOT NULL,
@@ -154,15 +310,25 @@ class GraphJournal:
                 payload TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
-        """)
+            """
+        )
 
-    def _graph_id(self) -> str:
-        row = self._conn.execute("SELECT graph_id FROM graph_events WHERE event_type='init' LIMIT 1").fetchone()
-        return row[0] if row else ""
-
-    def _last_event_hash(self) -> str:
-        row = self._conn.execute("SELECT event_hash FROM graph_events ORDER BY journal_seq DESC LIMIT 1").fetchone()
-        return row[0] if row else _GENESIS_HASH
+    @staticmethod
+    def _retry_while_locked(timeout: float, action: Any) -> None:
+        deadline = time.monotonic() + timeout
+        delay = 0.005
+        while True:
+            try:
+                action()
+                return
+            except sqlite3.OperationalError as exc:
+                message = str(exc).lower()
+                if "locked" not in message and "busy" not in message:
+                    raise
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(delay)
+                delay = min(delay * 2, 0.25)
 
     @property
     def path(self) -> Path:
@@ -171,148 +337,446 @@ class GraphJournal:
     def close(self) -> None:
         self._conn.close()
 
-    def _verify_chain(self) -> None:
-        previous = _GENESIS_HASH
-        for row in self._conn.execute(
-            "SELECT journal_seq, previous_record_hash, event_hash, payload FROM graph_events ORDER BY journal_seq"
-        ):
-            seq, prev_hash, stored_hash, payload_text = row
-            if prev_hash != previous:
-                raise JournalError(f"hash chain broken at journal_seq={seq}: expected previous={previous!r}, got {prev_hash!r}")
-            computed_hash = _sha256(payload_text.encode("utf-8"))
-            if computed_hash != stored_hash:
-                raise JournalError(f"event hash mismatch at journal_seq={seq}")
-            previous = stored_hash
+    # ---------------------------------------------------------------- chain
 
-    def replay(self) -> dict[str, Any]:
-        self._verify_chain()
-        current_max = self._conn.execute("SELECT COALESCE(MAX(journal_seq), 0) FROM graph_events").fetchone()[0]
-        if self._cached_state is not None and self._cached_seq == current_max:
-            return dict(self._cached_state)
-        state = None
-        for row in self._conn.execute(
-            "SELECT journal_seq, event_type, payload FROM graph_events WHERE event_type IN ('init', 'mutation_accepted', 'snapshot') ORDER BY journal_seq"
-        ):
-            _, event_type, payload_text = row
-            payload = json.loads(payload_text)
+    def _safe_rollback(self) -> None:
+        try:
+            self._conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            # No active transaction (e.g. BEGIN itself failed). Swallowing this
+            # is deliberate: re-raising here would mask the original failure.
+            pass
+
+    @contextmanager
+    def _write_transaction(self) -> Generator[None]:
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.Error as exc:
+            raise JournalError(f"cannot acquire the journal write lock: {exc}") from exc
+        try:
+            yield
+        except BaseException:
+            self._safe_rollback()
+            raise
+        try:
+            self._conn.execute("COMMIT")
+        except sqlite3.Error as exc:
+            self._safe_rollback()
+            raise JournalError(f"durability failure: {exc}") from exc
+
+    def _rows(self, after_seq: int = 0) -> list[tuple[int, str, str, str]]:
+        return list(
+            self._conn.execute(
+                "SELECT journal_seq, previous_record_hash, event_hash, payload"
+                " FROM graph_events WHERE journal_seq > ? ORDER BY journal_seq",
+                (after_seq,),
+            )
+        )
+
+    def _ensure_verified(self) -> None:
+        """Verify the hash chain, re-checking only records not yet verified."""
+        if self._chain_error is not None:
+            raise JournalError(self._chain_error)
+        previous = self._verified_hash
+        for seq, prev_hash, stored_hash, payload_text in self._rows(self._verified_seq):
+            if prev_hash != previous:
+                self._chain_error = (
+                    f"hash chain broken at journal_seq={seq}:"
+                    f" expected previous={previous!r}, got {prev_hash!r}"
+                )
+                raise JournalError(self._chain_error)
+            if _sha256(payload_text.encode("utf-8")) != stored_hash:
+                self._chain_error = f"event hash mismatch at journal_seq={seq}"
+                raise JournalError(self._chain_error)
+            previous = stored_hash
+            self._verified_seq, self._verified_hash = seq, stored_hash
+
+    def verify(self) -> int:
+        """Verify the whole chain from genesis. Returns the verified record count."""
+        self._verified_seq, self._verified_hash, self._chain_error = 0, _GENESIS_HASH, None
+        self._ensure_verified()
+        return self._verified_seq
+
+    def recover(self) -> dict[str, Any]:
+        """Truncate a torn tail, restoring the longest valid prefix.
+
+        A torn write can only ever damage the tail. Corruption with intact
+        records after it is not a crash artefact, and truncating would discard
+        admitted mutations — so that fails closed instead.
+        """
+        rows = self._rows()
+        previous, last_valid, first_bad = _GENESIS_HASH, 0, None
+        for seq, prev_hash, stored_hash, payload_text in rows:
+            if prev_hash != previous or _sha256(payload_text.encode("utf-8")) != stored_hash:
+                first_bad = seq
+                break
+            previous, last_valid = stored_hash, seq
+        if first_bad is None:
+            return {"dropped": 0, "last_valid_seq": last_valid}
+        tail = [row for row in rows if row[0] > first_bad]
+        if any(_sha256(payload.encode("utf-8")) == stored for _, _, stored, payload in tail):
+            raise JournalError(
+                f"mid-journal corruption at journal_seq={first_bad} with valid records after it;"
+                " refusing to truncate because admitted mutations would be lost"
+            )
+        with self._write_transaction():
+            self._conn.execute("DELETE FROM graph_events WHERE journal_seq >= ?", (first_bad,))
+        dropped = sum(1 for row in rows if row[0] >= first_bad)
+        self._verified_seq, self._verified_hash, self._chain_error = 0, _GENESIS_HASH, None
+        self._invalidate()
+        return {"dropped": dropped, "last_valid_seq": last_valid}
+
+    def _invalidate(self) -> None:
+        self._cached_state = None
+        self._cached_seq = -1
+        self._idempotency_index = {}
+        self._state_validated = False
+
+    # ----------------------------------------------------------------- fold
+
+    def last_journal_seq(self) -> int:
+        row = self._conn.execute("SELECT COALESCE(MAX(journal_seq), 0) FROM graph_events").fetchone()
+        return int(row[0])
+
+    def _fold(self, *, from_snapshot: bool = False) -> dict[str, Any]:
+        """Return the internal folded state. Callers must not mutate it."""
+        self._ensure_verified()
+        current_max = self.last_journal_seq()
+        if not from_snapshot and self._cached_state is not None and self._cached_seq == current_max:
+            return self._cached_state
+
+        start_seq = 0
+        if from_snapshot:
+            row = self._conn.execute(
+                "SELECT COALESCE(MAX(journal_seq), 0) FROM graph_events WHERE event_type='snapshot'"
+            ).fetchone()
+            start_seq = int(row[0]) - 1 if row[0] else 0
+
+        state: dict[str, Any] | None = None
+        index: dict[str, dict[str, Any]] = {}
+        placeholders = ",".join("?" for _ in _FOLD_EVENTS)
+        rows = self._conn.execute(
+            "SELECT journal_seq, event_type, payload FROM graph_events"
+            f" WHERE event_type IN ({placeholders}) AND journal_seq > ? ORDER BY journal_seq",
+            (*_FOLD_EVENTS, start_seq),
+        )
+        for seq, event_type, payload_text in rows:
+            try:
+                payload = json.loads(payload_text)
+            except json.JSONDecodeError as exc:
+                raise JournalError(f"unparseable payload at journal_seq={seq}: {exc}") from exc
             if event_type == "init":
                 state = _empty_snapshot(payload["graph_id"])
             elif event_type == "snapshot":
-                state = payload["snapshot"]
+                embedded = payload["snapshot"]
+                if state is None:
+                    state = copy.deepcopy(embedded)
+                elif _digest(embedded) != _digest(state):
+                    # A snapshot never wins a disagreement with its own prefix.
+                    raise JournalError(
+                        f"snapshot at journal_seq={seq} disagrees with a replay of its journal prefix"
+                    )
             elif event_type == "mutation_accepted":
                 if state is None:
-                    raise JournalError(f"accepted mutation at journal_seq without prior init")
-                for operation in payload.get("operations", []):
+                    raise JournalError(f"accepted mutation at journal_seq={seq} without a prior init")
+                envelope = payload["envelope"]
+                for operation in envelope.get("operations", []):
                     _apply_operation(state, operation)
+                _derive_readiness(state)
                 state["graph_revision"] += 1
-                state["mutations"].append(payload["envelope"])
-        if isinstance(state, dict):
-            self._cached_state = dict(state)
-            self._cached_seq = current_max
+                state["mutations"].append(envelope)
+                index[envelope["idempotency_key"]] = {
+                    "digest": _digest(envelope),
+                    "journal_seq": seq,
+                    "graph_revision": state["graph_revision"],
+                }
+
         if state is None:
-            return {"graph_id": "", "graph_revision": 0, "events": []}
+            state = _empty_snapshot("")
+        if not from_snapshot:
+            self._cached_state = state
+            self._cached_seq = current_max
+            self._idempotency_index = index
         return state
 
-    def current_revision(self) -> int:
-        row = self._conn.execute("SELECT MAX(journal_seq) FROM graph_events").fetchone()
-        if row[0] is None:
-            return 0
-        return row[0]
+    def replay(self, *, from_snapshot: bool = False) -> dict[str, Any]:
+        """Reconstruct graph state from the journal.
 
-    def init_graph(self, graph_id: str) -> None:
-        existing = self._conn.execute("SELECT COUNT(*) FROM graph_events WHERE event_type='init'").fetchone()[0]
-        if existing:
-            raise JournalError("journal already initialised with a different graph")
-        self._commit_event(graph_id, "init", {"graph_id": graph_id})
+        Returns a deep copy: the fold's own state is cached, and handing out an
+        aliased view would let any caller silently corrupt it.
+        """
+        return copy.deepcopy(self._fold(from_snapshot=from_snapshot))
 
-    def propose(self, envelope: dict[str, Any], *, actor_note: str = "") -> Decision:
-        errors = validate_record(envelope, "mutation_envelope")
-        if errors:
-            return self._reject(envelope, errors, "schema validation failed")
-        graph_id = envelope["graph_id"]
-        known_graph_id = self._graph_id()
-        if not known_graph_id or graph_id != known_graph_id:
-            return self._reject(envelope, (
-                ContractViolation(ErrorCode.GRAPH_ID_MISMATCH, f"envelope graph_id {graph_id!r} does not match journal graph {known_graph_id!r}", "/graph_id"),
-            ), "unknown graph")
-        state = self.replay() if self.current_revision() > 0 else _empty_snapshot(graph_id)
-        history = state.get("mutations", []) if isinstance(state, dict) else []
-        envelope_digest = _sha256(canonical_json_bytes(envelope))
-        for prior in history:
-            if prior.get("idempotency_key") == envelope.get("idempotency_key"):
-                if _sha256(canonical_json_bytes(prior)) == envelope_digest:
-                    return Decision(accepted=True, journal_seq=self.current_revision(), graph_revision=state["graph_revision"], reason="idempotent no-op")
-                return self._reject(envelope, (
-                    ContractViolation(ErrorCode.IDEMPOTENCY_KEY_DIVERGENT, "idempotency key was previously used with a different canonical envelope", "/idempotency_key"),
-                ), "idempotency key collision")
-        validation_errors = validate_mutation(state, envelope, history=history)
-        if validation_errors:
-            return self._reject(envelope, validation_errors, "semantic validation failed")
-        return self._accept(envelope)
+    def graph_revision(self) -> int:
+        return int(self._fold()["graph_revision"])
 
-    def _reject(self, envelope: dict[str, Any], violations: tuple[ContractViolation, ...], summary: str) -> Decision:
-        graph_id = envelope.get("graph_id", "")
-        payload = {
-            "graph_id": graph_id,
-            "mutation_id": envelope.get("mutation_id"),
-            "idempotency_key": envelope.get("idempotency_key"),
-            "base_revision": envelope.get("base_revision"),
-            "reason": summary,
-            "violations": [v.to_dict() for v in violations],
-            "envelope_digest": _sha256(canonical_json_bytes(envelope)),
-        }
-        self._commit_event(graph_id, "mutation_rejected", payload)
-        known_graph_id = self._graph_id()
-        if not known_graph_id:
-            revision = 0
-        else:
-            revision = self.replay().get("graph_revision", 0)
-        return Decision(accepted=False, journal_seq=self.current_revision(), graph_revision=revision, reason=summary, violations=violations)
-
-    def _accept(self, envelope: dict[str, Any]) -> Decision:
-        graph_id = envelope["graph_id"]
-        state = self.replay() if self.current_revision() > 0 else _empty_snapshot(graph_id)
-        for operation in envelope.get("operations", []):
-            _apply_operation(state, operation)
-        state["graph_revision"] += 1
-        state["mutations"] = state.get("mutations", []) + [envelope]
-        new_schedule = _compute_schedule_hash(state)
-        new_audit = _compute_audit_state_hash(state)
-        payload = {
-            "graph_id": graph_id,
-            "envelope": envelope,
-            "operations": envelope.get("operations", []),
-            "schedule_hash": new_schedule,
-            "audit_state_hash": new_audit,
-        }
-        self._commit_event(graph_id, "mutation_accepted", payload)
-        seq = self.current_revision()
-        return Decision(accepted=True, journal_seq=seq, graph_revision=state["graph_revision"], reason="accepted")
-
-    def hash(self) -> dict[str, str]:
-        state = self.replay()
-        if not isinstance(state, dict) or not state.get("graph_id"):
+    def hash(self, *, from_snapshot: bool = False) -> dict[str, str]:
+        state = self._fold(from_snapshot=from_snapshot)
+        if not state.get("graph_id"):
             return {"schedule_hash": _GENESIS_HASH, "audit_state_hash": _GENESIS_HASH}
         return {
             "schedule_hash": _compute_schedule_hash(state),
             "audit_state_hash": _compute_audit_state_hash(state),
         }
 
-    def _commit_event(self, graph_id: str, event_type: str, payload: dict[str, Any]) -> None:
-        try:
-            self._conn.execute("BEGIN IMMEDIATE")
-            last_row = self._conn.execute(
-                "SELECT event_hash FROM graph_events ORDER BY journal_seq DESC LIMIT 1"
-            ).fetchone()
-            previous_hash = last_row[0] if last_row else _GENESIS_HASH
-            payload_bytes = canonical_json_bytes(payload)
-            event_hash = _sha256(payload_bytes)
-            self._conn.execute(
-                "INSERT INTO graph_events (graph_id, previous_record_hash, event_hash, event_type, payload) VALUES (?,?,?,?,?)",
-                (graph_id, previous_hash, event_hash, event_type, payload_bytes.decode()),
+    def ready_set(self) -> list[str]:
+        """Execution nodes the scheduler may claim right now.
+
+        Readiness itself is materialised by the fold (_derive_readiness); this
+        applies the control machine on top of it.
+        """
+        state = self._fold()
+        if any(
+            record.get("state") in ("paused", "pause_requested", "cancelled", "cancel_requested")
+            for record in state["control_records"]
+        ):
+            return []
+        return sorted(
+            node["execution_node_id"]
+            for node in state["execution_nodes"]
+            if node.get("lifecycle_state") == "ready" and node.get("control_state") == "active"
+        )
+
+    # -------------------------------------------------------------- writing
+
+    def _append_event(self, graph_id: str, event_type: str, payload: Mapping[str, Any]) -> int:
+        """Append one record. Must be called inside a write transaction.
+
+        Does NOT drop the cached fold: refolding from genesis after every write
+        makes a run of N proposals cost O(N^2). Callers advance the cache
+        instead — they already hold the post-state they just computed.
+        """
+        last_row = self._conn.execute(
+            "SELECT event_hash FROM graph_events ORDER BY journal_seq DESC LIMIT 1"
+        ).fetchone()
+        previous_hash = last_row[0] if last_row else _GENESIS_HASH
+        payload_bytes = canonical_json_bytes(payload)
+        event_hash = _sha256(payload_bytes)
+        cursor = self._conn.execute(
+            "INSERT INTO graph_events (graph_id, previous_record_hash, event_hash, event_type, payload)"
+            " VALUES (?,?,?,?,?)",
+            (graph_id, previous_hash, event_hash, event_type, payload_bytes.decode()),
+        )
+        if cursor.lastrowid is None:  # pragma: no cover - sqlite always sets it on INSERT
+            raise JournalError("insert did not yield a journal_seq")
+        # Deliberately does NOT mark the new record pre-verified: _ensure_verified
+        # already checks each record exactly once per connection, and trusting a
+        # record because we wrote it would hide tampering that lands afterwards.
+        return int(cursor.lastrowid)
+
+    def _advance_cache(self, seq: int, state: dict[str, Any] | None = None) -> None:
+        """Carry the cached fold forward past a record that just landed."""
+        if self._cached_state is None and state is None:
+            return
+        if state is not None:
+            self._cached_state = state
+        self._cached_seq = seq
+
+    def init_graph(self, graph_id: str) -> None:
+        with self._write_transaction():
+            existing = self._conn.execute(
+                "SELECT COUNT(*) FROM graph_events WHERE event_type='init'"
+            ).fetchone()[0]
+            if existing:
+                raise JournalError("journal already initialised with a different graph")
+            self._append_event(graph_id, "init", {"graph_id": graph_id})
+            self._invalidate()
+
+    def snapshot(self) -> Snapshot:
+        """Write a verifiable checkpoint of the current fold."""
+        with self._write_transaction():
+            state = self._fold()
+            if not state.get("graph_id"):
+                raise JournalError("cannot snapshot an uninitialised journal")
+            data = copy.deepcopy(state)
+            payload = {
+                "graph_id": data["graph_id"],
+                "snapshot": data,
+                "journal_seq": self.last_journal_seq(),
+                "schedule_hash": _compute_schedule_hash(data),
+                "audit_state_hash": _compute_audit_state_hash(data),
+            }
+            seq = self._append_event(data["graph_id"], "snapshot", payload)
+            # A checkpoint restates the fold; it does not change it.
+            self._advance_cache(seq)
+            return Snapshot(
+                graph_id=data["graph_id"],
+                graph_revision=data["graph_revision"],
+                journal_seq=seq,
+                schedule_hash=payload["schedule_hash"],
+                audit_state_hash=payload["audit_state_hash"],
+                snapshot_data=data,
             )
-            self._conn.execute("COMMIT")
-        except sqlite3.Error as exc:
-            self._conn.execute("ROLLBACK")
-            raise JournalError(f"durability failure: {exc}") from exc
-        self._cached_seq = -1
+
+    def propose(self, envelope: Mapping[str, Any], *, actor_note: str = "") -> Decision:
+        """Decide one mutation envelope atomically.
+
+        The whole compare-and-swap — read the current revision, validate the
+        envelope against it, append the decision — happens under one write
+        lock. Splitting it would let two proposers pass the same base_revision
+        check and both commit.
+        """
+        with self._write_transaction():
+            return self._decide(envelope, actor_note=actor_note)
+
+    def reject(
+        self, envelope: Mapping[str, Any], *, reason: str, actor: str = "actor:operator"
+    ) -> Decision:
+        """Record an operator's refusal of an envelope, without applying it.
+
+        Carries no ContractViolation: this is a human decision, not a contract
+        failure, and inventing an error code for it would pollute the #384
+        vocabulary.
+        """
+        with self._write_transaction():
+            return self._journal_rejection(envelope, (), f"operator rejection by {actor}: {reason}")
+
+    def _decide(self, envelope: Mapping[str, Any], *, actor_note: str = "") -> Decision:
+        schema_errors = validate_record(envelope, "mutation_envelope")
+        if schema_errors:
+            return self._journal_rejection(envelope, schema_errors, "schema validation failed")
+
+        state = self._fold()
+        known_graph_id = state.get("graph_id", "")
+        if not known_graph_id:
+            return self._journal_rejection(
+                envelope,
+                (
+                    ContractViolation(
+                        ErrorCode.GRAPH_ID_MISMATCH, "journal has no initialised graph", "/graph_id"
+                    ),
+                ),
+                "unknown graph",
+            )
+        if envelope["graph_id"] != known_graph_id:
+            return self._journal_rejection(
+                envelope,
+                (
+                    ContractViolation(
+                        ErrorCode.GRAPH_ID_MISMATCH,
+                        f"envelope graph_id {envelope['graph_id']!r} does not match"
+                        f" journal graph {known_graph_id!r}",
+                        "/graph_id",
+                    ),
+                ),
+                "unknown graph",
+            )
+
+        prior = self._idempotency_index.get(envelope["idempotency_key"])
+        if prior is not None:
+            if prior["digest"] == _digest(envelope):
+                # Replay of a seen key: return the ORIGINAL decision unchanged.
+                return Decision(
+                    accepted=True,
+                    journal_seq=prior["journal_seq"],
+                    graph_revision=prior["graph_revision"],
+                    reason="idempotent no-op",
+                    idempotent=True,
+                )
+            return self._journal_rejection(
+                envelope,
+                (
+                    ContractViolation(
+                        ErrorCode.IDEMPOTENCY_KEY_DIVERGENT,
+                        "idempotency key was previously used with a different canonical envelope",
+                        "/idempotency_key",
+                    ),
+                ),
+                "idempotency key collision",
+            )
+
+        violations = validate_mutation(
+            state,
+            envelope,
+            history=state["mutations"],
+            snapshot_validated=self._state_validated,
+        )
+        if violations:
+            return self._journal_rejection(envelope, violations, "semantic validation failed")
+        self._state_validated = True
+
+        # Apply to a copy so an envelope is all-or-nothing, then validate the
+        # RESULTING graph. Cycle rejection has to look at the post-state: a
+        # mutation that introduces a cycle leaves the pre-state acyclic.
+        candidate = copy.deepcopy(state)
+        try:
+            for operation in envelope["operations"]:
+                _apply_operation(candidate, operation)
+        except JournalError as exc:
+            return self._journal_rejection(
+                envelope,
+                (ContractViolation(ErrorCode.SCHEMA_INVALID, str(exc), "/operations"),),
+                "operation could not be applied",
+            )
+        _derive_readiness(candidate)
+        candidate["graph_revision"] += 1
+        # Deep copy: this candidate may be installed as the cached fold, and a
+        # caller that mutates its own envelope afterwards must not be able to
+        # change what the journal believes it recorded.
+        candidate["mutations"].append(copy.deepcopy(dict(envelope)))
+
+        # Every record entering here was schema-validated as part of the
+        # envelope, so only the referential/identity/acyclicity checks are new.
+        post_errors = validate_snapshot(candidate, schema=False)
+        if post_errors:
+            return self._journal_rejection(
+                envelope, post_errors, "mutation would produce an invalid graph"
+            )
+
+        payload = {
+            "graph_id": known_graph_id,
+            "envelope": dict(envelope),
+            "schedule_hash": _compute_schedule_hash(candidate),
+            "audit_state_hash": _compute_audit_state_hash(candidate),
+            "actor_note": actor_note,
+        }
+        seq = self._append_event(known_graph_id, "mutation_accepted", payload)
+        # The candidate IS the new fold; installing it keeps propose O(1) in the
+        # length of the journal instead of refolding from genesis.
+        self._advance_cache(seq, candidate)
+        self._idempotency_index[envelope["idempotency_key"]] = {
+            "digest": _digest(envelope),
+            "journal_seq": seq,
+            "graph_revision": candidate["graph_revision"],
+        }
+        return Decision(
+            accepted=True,
+            journal_seq=seq,
+            graph_revision=candidate["graph_revision"],
+            reason="accepted",
+        )
+
+    def _journal_rejection(
+        self,
+        envelope: Mapping[str, Any],
+        violations: Sequence[ContractViolation],
+        summary: str,
+    ) -> Decision:
+        """Journal a rejection. Must be called inside a write transaction."""
+        # Attribute the record to THIS journal's graph, never to an unvalidated
+        # graph_id taken from the envelope.
+        row = self._conn.execute(
+            "SELECT payload FROM graph_events WHERE event_type='init' ORDER BY journal_seq LIMIT 1"
+        ).fetchone()
+        graph_id = json.loads(row[0])["graph_id"] if row else ""
+        revision = self._fold()["graph_revision"] if row else 0
+        payload = {
+            "graph_id": graph_id,
+            "mutation_id": envelope.get("mutation_id"),
+            "idempotency_key": envelope.get("idempotency_key"),
+            "base_revision": envelope.get("base_revision"),
+            "graph_revision": revision,
+            "reason": summary,
+            "violations": [violation.to_dict() for violation in violations],
+            "envelope_digest": _digest(envelope),
+        }
+        seq = self._append_event(graph_id, "mutation_rejected", payload)
+        # A rejection changes no graph state, so the cached fold still stands.
+        self._advance_cache(seq)
+        return Decision(
+            accepted=False,
+            journal_seq=seq,
+            graph_revision=revision,
+            reason=summary,
+            violations=tuple(violations),
+        )

--- a/scripts/chief_wiggum/dag/semantics.py
+++ b/scripts/chief_wiggum/dag/semantics.py
@@ -84,10 +84,23 @@ def _duplicates(records: Sequence[Mapping[str, Any]], key: str) -> set[str]:
     return duplicates
 
 
-def validate_snapshot(snapshot: Mapping[str, Any]) -> tuple[ContractViolation, ...]:
-    errors = list(validate_record(snapshot, "graph_snapshot"))
-    if errors:
-        return tuple(errors)
+def validate_snapshot(
+    snapshot: Mapping[str, Any], *, schema: bool = True
+) -> tuple[ContractViolation, ...]:
+    """Validate a graph snapshot.
+
+    `schema=False` skips the whole-snapshot JSON Schema pass and runs only the
+    referential, identity and acyclicity checks. It is for callers that already
+    schema-validated every record on the way in (the journal validates each
+    operation's `value` through the mutation-envelope schema), where
+    re-validating all N records to admit one more is quadratic and redundant.
+    Such a caller must still guarantee the snapshot's own shape.
+    """
+    errors: list[ContractViolation] = []
+    if schema:
+        errors = list(validate_record(snapshot, "graph_snapshot"))
+        if errors:
+            return tuple(errors)
     execution_ids = {node.get("execution_node_id") for node in snapshot.get("execution_nodes", [])}
     intent_ids = {node.get("intent_node_id") for node in snapshot.get("intent_nodes", [])}
     evidence_ids = {record.get("evidence_id") for record in snapshot.get("evidence_records", [])}
@@ -166,10 +179,18 @@ def validate_mutation(
     envelope: Mapping[str, Any],
     *,
     history: Sequence[Mapping[str, Any]] = (),
+    snapshot_validated: bool = False,
 ) -> tuple[ContractViolation, ...]:
-    snapshot_errors = validate_snapshot(snapshot)
-    if snapshot_errors:
-        return snapshot_errors
+    """Validate one envelope against a snapshot.
+
+    `snapshot_validated=True` asserts the caller already validated this exact
+    snapshot, so the pre-state pass is skipped. The journal sets it only for a
+    state its own fold produced and post-validated.
+    """
+    if not snapshot_validated:
+        snapshot_errors = validate_snapshot(snapshot)
+        if snapshot_errors:
+            return snapshot_errors
     errors = list(validate_record(envelope, "mutation_envelope"))
     if errors:
         return tuple(errors)

--- a/scripts/dag_engine.py
+++ b/scripts/dag_engine.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""CLI for the transactional DAG journal and graph engine."""
+"""CLI for the transactional DAG journal and graph engine.
+
+Exit codes are distinct on purpose: 0 success, 1 a decision the engine made
+(rejection / an input it refuses to project), 2 a dependency cycle, 3 an engine
+or storage failure. Collapsing "rejected" and "crashed" into one code is what
+lets a caller read a broken engine as a clean run.
+"""
 
 from __future__ import annotations
 
@@ -7,155 +13,314 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from chief_wiggum.dag import compatibility  # noqa: E402
 from chief_wiggum.dag.journal import GraphJournal, JournalError  # noqa: E402
+
+EXIT_OK = 0
+EXIT_DECISION = 1
+EXIT_CYCLE = 2
+EXIT_ERROR = 3
+
+
+def _fail(message: str) -> int:
+    print(json.dumps({"ok": False, "error": message}, indent=2))
+    return EXIT_ERROR
+
+
+def _open(args: argparse.Namespace) -> GraphJournal:
+    return GraphJournal(args.db)
 
 
 def _init(args: argparse.Namespace) -> int:
-    journal = GraphJournal(args.db)
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
     try:
         journal.init_graph(args.graph_id)
     except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
+        return _fail(str(exc))
     finally:
         journal.close()
-    print(json.dumps({"ok": True, "graph_id": args.graph_id}))
-    return 0
+    print(json.dumps({"ok": True, "graph_id": args.graph_id}, indent=2))
+    return EXIT_OK
 
 
-def _propose(args: argparse.Namespace) -> int:
-    envelope = json.loads(Path(args.envelope).read_bytes())
-    journal = GraphJournal(args.db)
-    try:
-        decision = journal.propose(envelope)
-    except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
-    finally:
-        journal.close()
+def _decision_output(decision: Any) -> dict[str, Any]:
     result = {
         "accepted": decision.accepted,
+        "idempotent": decision.idempotent,
         "journal_seq": decision.journal_seq,
         "graph_revision": decision.graph_revision,
         "reason": decision.reason,
     }
     if not decision.accepted:
-        result["violations"] = [v.to_dict() for v in decision.violations]
-    print(json.dumps(result, indent=2))
-    return 0 if decision.accepted else 1
+        result["violations"] = [violation.to_dict() for violation in decision.violations]
+    return result
+
+
+def _propose(args: argparse.Namespace) -> int:
+    try:
+        envelope = json.loads(Path(args.envelope).read_bytes())
+    except (OSError, ValueError) as exc:
+        return _fail(f"cannot read envelope {args.envelope}: {exc}")
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
+    try:
+        decision = journal.propose(envelope, actor_note=getattr(args, "note", "") or "")
+    except JournalError as exc:
+        return _fail(str(exc))
+    finally:
+        journal.close()
+    print(json.dumps(_decision_output(decision), indent=2))
+    return EXIT_OK if decision.accepted else EXIT_DECISION
+
+
+def _admit(args: argparse.Namespace) -> int:
+    """Propose, and treat a rejection as a hard failure of the caller's intent."""
+    return _propose(args)
+
+
+def _reject(args: argparse.Namespace) -> int:
+    """Record an operator's refusal of an envelope without applying it."""
+    try:
+        envelope = json.loads(Path(args.envelope).read_bytes())
+    except (OSError, ValueError) as exc:
+        return _fail(f"cannot read envelope {args.envelope}: {exc}")
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
+    try:
+        decision = journal.reject(envelope, reason=args.reason, actor=args.actor)
+    except JournalError as exc:
+        return _fail(str(exc))
+    finally:
+        journal.close()
+    print(json.dumps(_decision_output(decision), indent=2))
+    return EXIT_DECISION
 
 
 def _inspect(args: argparse.Namespace) -> int:
-    journal = GraphJournal(args.db)
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
     try:
         state = journal.replay()
         hashes = journal.hash()
+        ready = journal.ready_set()
     except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
+        return _fail(str(exc))
     finally:
         journal.close()
     if args.human:
-        print(f"Graph: {state.get('graph_id', '(uninitialised)')}")
+        print(f"Graph: {state.get('graph_id') or '(uninitialised)'}")
         print(f"Revision: {state.get('graph_revision', 0)}")
         print(f"Schedule hash: {hashes['schedule_hash'][:16]}…")
         print(f"Audit hash: {hashes['audit_state_hash'][:16]}…")
         print(f"Execution nodes: {len(state.get('execution_nodes', []))}")
         print(f"Schedulable edges: {len(state.get('schedulable_edges', []))}")
+        print(f"Ready set: {', '.join(ready) or '(empty)'}")
     else:
-        print(json.dumps(state, indent=2))
-    return 0
+        print(json.dumps({"state": state, "hashes": hashes, "ready_set": ready}, indent=2))
+    return EXIT_OK
 
 
 def _replay(args: argparse.Namespace) -> int:
-    journal = GraphJournal(args.db)
     try:
-        state = journal.replay()
+        journal = _open(args)
     except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
+        return _fail(str(exc))
+    try:
+        state = journal.replay(from_snapshot=args.from_snapshot)
+    except JournalError as exc:
+        return _fail(str(exc))
     finally:
         journal.close()
     print(json.dumps(state, indent=2))
-    return 0
+    return EXIT_OK
 
 
 def _hash(args: argparse.Namespace) -> int:
-    journal = GraphJournal(args.db)
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
     try:
         hashes = journal.hash()
     except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
+        return _fail(str(exc))
     finally:
         journal.close()
-    print(json.dumps(hashes))
-    return 0
+    print(json.dumps(hashes, indent=2))
+    return EXIT_OK
+
+
+def _snapshot(args: argparse.Namespace) -> int:
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
+    try:
+        snapshot = journal.snapshot()
+    except JournalError as exc:
+        return _fail(str(exc))
+    finally:
+        journal.close()
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "graph_id": snapshot.graph_id,
+                "graph_revision": snapshot.graph_revision,
+                "journal_seq": snapshot.journal_seq,
+                "schedule_hash": snapshot.schedule_hash,
+                "audit_state_hash": snapshot.audit_state_hash,
+            },
+            indent=2,
+        )
+    )
+    return EXIT_OK
+
+
+def _verify(args: argparse.Namespace) -> int:
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
+    try:
+        if args.recover:
+            outcome = journal.recover()
+            print(json.dumps({"ok": True, **outcome}, indent=2))
+            return EXIT_OK
+        records = journal.verify()
+    except JournalError as exc:
+        return _fail(str(exc))
+    finally:
+        journal.close()
+    print(json.dumps({"ok": True, "records_verified": records}, indent=2))
+    return EXIT_OK
 
 
 def _project(args: argparse.Namespace) -> int:
-    from chief_wiggum import planning
+    """Emit the legacy six-field wave plan from the journal's intent graph.
 
-    journal = GraphJournal(args.db)
+    Delegates to compatibility.project_legacy_waves so the guards live in one
+    place: an unscanned or malformed intent graph is an error here, never an
+    empty plan that reads as "no work to do".
+    """
+    try:
+        journal = _open(args)
+    except JournalError as exc:
+        return _fail(str(exc))
     try:
         state = journal.replay()
     except JournalError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}))
-        return 1
+        return _fail(str(exc))
     finally:
         journal.close()
 
-    ticket_nodes = [n for n in state.get("intent_nodes", []) if isinstance(n.get("source_ticket"), int) and n.get("in_scope", True)]
-    issues = sorted({n["source_ticket"] for n in ticket_nodes})
-    edges: dict[int, list[int]] = {ticket: [] for ticket in issues}
-    for edge in state.get("intent_edges", []):
-        src, tgt = edge.get("source_ticket"), edge.get("target_ticket")
-        if isinstance(src, int) and isinstance(tgt, int):
-            edges.setdefault(src, []).append(tgt)
+    intent_graph = {
+        "schema_version": state.get("schema_version", "1.0.0"),
+        "record_type": "intent_graph",
+        "graph_id": state.get("graph_id", ""),
+        "source_ref": args.source_ref,
+        "source_digest": "sha256:" + "0" * 64,
+        "scan_status": "observed",
+        "has_dependency_block": True,
+        "source_warnings": [],
+        "nodes": state.get("intent_nodes", []),
+        "edges": state.get("intent_edges", []),
+    }
+    result = compatibility.project_legacy_waves(
+        intent_graph,
+        closed=args.closed or (),
+        gated=args.gated or (),
+    )
+    if result.exit_code == EXIT_CYCLE:
+        print(f"Error: cycle: {result.error}", file=sys.stderr)
+        return EXIT_CYCLE
+    if result.exit_code != EXIT_OK:
+        print(json.dumps({"ok": False, "error": result.error}, indent=2))
+        return EXIT_DECISION
+    print(json.dumps(result.plan, indent=2))
+    return EXIT_OK
 
-    try:
-        plan = planning.plan_waves(issues, edges, closed=[], gated=[])
-    except planning.DependencyCycleError as exc:
-        print(f"Error: cycle: {exc}", file=sys.stderr)
-        return 2
 
-    output = plan.to_dict()
-    print(json.dumps(output, indent=2))
-    return 0
+def _int_list(value: str) -> list[int]:
+    return [int(item) for item in value.split(",") if item.strip()]
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Transactional DAG engine CLI")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    def add_db(p: argparse.ArgumentParser) -> None:
-        p.add_argument("--db", required=True, help="path to the SQLite journal database")
+    def add(name: str, help_text: str, func: Any) -> argparse.ArgumentParser:
+        command = sub.add_parser(name, help=help_text)
+        command.add_argument("--db", required=True, help="path to the SQLite journal database")
+        command.set_defaults(func=func)
+        return command
 
-    init = sub.add_parser("init", help="initialise a new graph")
-    init.add_argument("--db", required=True); init.add_argument("--graph-id", required=True)
-    init.set_defaults(func=_init)
-    propose = sub.add_parser("propose", help="submit a mutation envelope")
-    propose.add_argument("--db", required=True); propose.add_argument("envelope")
-    propose.set_defaults(func=_propose)
-    inspect_p = sub.add_parser("inspect", help="show current graph state")
-    inspect_p.add_argument("--db", required=True); inspect_p.add_argument("--human", action="store_true")
-    inspect_p.set_defaults(func=_inspect)
-    replay = sub.add_parser("replay", help="reconstruct graph from journal")
-    replay.add_argument("--db", required=True); replay.set_defaults(func=_replay)
-    hash_p = sub.add_parser("hash", help="print canonical schedule and audit hashes")
-    hash_p.add_argument("--db", required=True); hash_p.set_defaults(func=_hash)
-    project = sub.add_parser("project", help="emit the legacy six-field wave plan")
-    project.add_argument("--db", required=True); project.set_defaults(func=_project)
+    init = add("init", "initialise a new graph", _init)
+    init.add_argument("--graph-id", required=True)
+
+    propose = add("propose", "submit a mutation envelope", _propose)
+    propose.add_argument("envelope")
+    propose.add_argument("--note", default="")
+
+    admit = add("admit", "submit an envelope expected to be admitted", _admit)
+    admit.add_argument("envelope")
+    admit.add_argument("--note", default="")
+
+    reject = add("reject", "record an operator refusal of an envelope", _reject)
+    reject.add_argument("envelope")
+    reject.add_argument("--reason", required=True)
+    reject.add_argument("--actor", default="actor:operator")
+
+    inspect_command = add("inspect", "show current graph state", _inspect)
+    inspect_command.add_argument("--human", action="store_true")
+
+    replay = add("replay", "reconstruct graph from journal", _replay)
+    replay.add_argument(
+        "--from-snapshot",
+        action="store_true",
+        help="fold forward from the latest snapshot instead of from genesis",
+    )
+
+    add("hash", "print canonical schedule and audit hashes", _hash)
+    add("snapshot", "write a verifiable checkpoint of the current fold", _snapshot)
+
+    verify = add("verify", "verify the hash chain", _verify)
+    verify.add_argument(
+        "--recover",
+        action="store_true",
+        help="truncate a torn tail back to the last valid record",
+    )
+
+    project = add("project", "emit the legacy six-field wave plan", _project)
+    project.add_argument(
+        "--waves",
+        action="store_true",
+        help="emit the wave plan (default, accepted for symmetry with plan_waves.py)",
+    )
+    project.add_argument("--source-ref", default="journal")
+    project.add_argument("--closed", type=_int_list, default=None)
+    project.add_argument("--gated", type=_int_list, default=None)
 
     args = parser.parse_args(argv)
     try:
-        return args.func(args)
+        return int(args.func(args))
+    except JournalError as exc:
+        return _fail(str(exc))
     except (OSError, ValueError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
+        return _fail(str(exc))
 
 
 if __name__ == "__main__":

--- a/scripts/dag_engine.py
+++ b/scripts/dag_engine.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""CLI for the transactional DAG journal and graph engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum.dag.journal import GraphJournal, JournalError  # noqa: E402
+
+
+def _init(args: argparse.Namespace) -> int:
+    journal = GraphJournal(args.db)
+    try:
+        journal.init_graph(args.graph_id)
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+    print(json.dumps({"ok": True, "graph_id": args.graph_id}))
+    return 0
+
+
+def _propose(args: argparse.Namespace) -> int:
+    envelope = json.loads(Path(args.envelope).read_bytes())
+    journal = GraphJournal(args.db)
+    try:
+        decision = journal.propose(envelope)
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+    result = {
+        "accepted": decision.accepted,
+        "journal_seq": decision.journal_seq,
+        "graph_revision": decision.graph_revision,
+        "reason": decision.reason,
+    }
+    if not decision.accepted:
+        result["violations"] = [v.to_dict() for v in decision.violations]
+    print(json.dumps(result, indent=2))
+    return 0 if decision.accepted else 1
+
+
+def _inspect(args: argparse.Namespace) -> int:
+    journal = GraphJournal(args.db)
+    try:
+        state = journal.replay()
+        hashes = journal.hash()
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+    if args.human:
+        print(f"Graph: {state.get('graph_id', '(uninitialised)')}")
+        print(f"Revision: {state.get('graph_revision', 0)}")
+        print(f"Schedule hash: {hashes['schedule_hash'][:16]}…")
+        print(f"Audit hash: {hashes['audit_state_hash'][:16]}…")
+        print(f"Execution nodes: {len(state.get('execution_nodes', []))}")
+        print(f"Schedulable edges: {len(state.get('schedulable_edges', []))}")
+    else:
+        print(json.dumps(state, indent=2))
+    return 0
+
+
+def _replay(args: argparse.Namespace) -> int:
+    journal = GraphJournal(args.db)
+    try:
+        state = journal.replay()
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+    print(json.dumps(state, indent=2))
+    return 0
+
+
+def _hash(args: argparse.Namespace) -> int:
+    journal = GraphJournal(args.db)
+    try:
+        hashes = journal.hash()
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+    print(json.dumps(hashes))
+    return 0
+
+
+def _project(args: argparse.Namespace) -> int:
+    from chief_wiggum import planning
+
+    journal = GraphJournal(args.db)
+    try:
+        state = journal.replay()
+    except JournalError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    finally:
+        journal.close()
+
+    ticket_nodes = [n for n in state.get("intent_nodes", []) if isinstance(n.get("source_ticket"), int) and n.get("in_scope", True)]
+    issues = sorted({n["source_ticket"] for n in ticket_nodes})
+    edges: dict[int, list[int]] = {ticket: [] for ticket in issues}
+    for edge in state.get("intent_edges", []):
+        src, tgt = edge.get("source_ticket"), edge.get("target_ticket")
+        if isinstance(src, int) and isinstance(tgt, int):
+            edges.setdefault(src, []).append(tgt)
+
+    try:
+        plan = planning.plan_waves(issues, edges, closed=[], gated=[])
+    except planning.DependencyCycleError as exc:
+        print(f"Error: cycle: {exc}", file=sys.stderr)
+        return 2
+
+    output = plan.to_dict()
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Transactional DAG engine CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_db(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--db", required=True, help="path to the SQLite journal database")
+
+    init = sub.add_parser("init", help="initialise a new graph")
+    init.add_argument("--db", required=True); init.add_argument("--graph-id", required=True)
+    init.set_defaults(func=_init)
+    propose = sub.add_parser("propose", help="submit a mutation envelope")
+    propose.add_argument("--db", required=True); propose.add_argument("envelope")
+    propose.set_defaults(func=_propose)
+    inspect_p = sub.add_parser("inspect", help="show current graph state")
+    inspect_p.add_argument("--db", required=True); inspect_p.add_argument("--human", action="store_true")
+    inspect_p.set_defaults(func=_inspect)
+    replay = sub.add_parser("replay", help="reconstruct graph from journal")
+    replay.add_argument("--db", required=True); replay.set_defaults(func=_replay)
+    hash_p = sub.add_parser("hash", help="print canonical schedule and audit hashes")
+    hash_p.add_argument("--db", required=True); hash_p.set_defaults(func=_hash)
+    project = sub.add_parser("project", help="emit the legacy six-field wave plan")
+    project.add_argument("--db", required=True); project.set_defaults(func=_project)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_patterns.py
+++ b/tests/test_check_patterns.py
@@ -411,6 +411,15 @@ PATH_LIKE = re.compile(r":\d+|\.(go|ts|tsx|js|py|rb|java)\b")
 
 SCANNED_SUFFIXES = (".json", ".md", ".py", ".sh", ".yaml", ".yml", ".toml")
 
+# Path prefixes every whole-tree scan skips.
+#   docs/quality/ - append-only ratchet journal, never edited even to anonymize.
+#   .claude/worktrees/ - transient worktree checkouts of OTHER branches. They are
+#     untracked working state, not this repo's public surface, and scanning them
+#     makes the guard fail for anyone with a worktree open while reporting an
+#     exposure that does not exist on any branch. (chief-wiggum#396: deleting the
+#     worktrees "fixed" the failure locally but shipped nothing, so it recurred.)
+EXCLUDED_TREES = ("docs/quality/", ".claude/worktrees/")
+
 
 def _scan_for_private_names(root, exclude=(), suffixes=SCANNED_SUFFIXES):
     """Walk `root` for text-ish files and flag any line matching PRIVATE_NAME.
@@ -449,7 +458,7 @@ def test_docs_and_workflow_commands_name_no_private_repos():
     offenders = []
     for tree in ("docs", ".claude/commands", "skills"):
         offenders += _scan_for_private_names(SCRIPTS.parent / tree,
-                                               exclude=("docs/quality/",))
+                                               exclude=EXCLUDED_TREES)
     assert offenders == [], "\n".join(offenders)
 
 
@@ -474,7 +483,7 @@ def test_whole_public_tree_names_no_private_repos():
         root = repo_root / tree
         if not root.exists():
             continue
-        offenders += _scan_for_private_names(root, exclude=("docs/quality/",))
+        offenders += _scan_for_private_names(root, exclude=EXCLUDED_TREES)
     offenders = [o for o in offenders
                  if not o.startswith("tests/test_check_patterns.py")]
     assert offenders == [], (

--- a/tests/test_consult_ai.py
+++ b/tests/test_consult_ai.py
@@ -2150,6 +2150,7 @@ def test_openrouter_raises_on_error_object_in_200_response(monkeypatch):
 
 def test_openrouter_key_is_sent_as_header_not_env(monkeypatch):
     """CLAUDE.md secret policy: fetched at call time, passed to the request, never env."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.setattr(consult_ai, "get_secret", lambda name: "sk-secret")
     captured = {}
 

--- a/tests/test_dag_journal.py
+++ b/tests/test_dag_journal.py
@@ -1,0 +1,338 @@
+import json
+import sys
+import sqlite3
+from pathlib import Path
+
+import pytest
+from chief_wiggum.dag import ErrorCode, GraphJournal, JournalError
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _envelope(**overrides) -> dict:
+    base = {
+        "schema_version": "1.0.0",
+        "record_type": "mutation_envelope",
+        "graph_id": "GRF-test001",
+        "base_revision": 0,
+        "mutation_id": "MUT-test-001",
+        "idempotency_key": "test-key-001",
+        "actor": "actor:test",
+        "authority_class": "automatic",
+        "operations": [
+            {
+                "op_id": "OPS-dag-001",
+                "operation_type": "add_execution_node",
+                "target_ref": "EXN-test-001",
+                "value": {
+                    "schema_version": "1.0.0",
+                    "record_type": "execution_node",
+                    "execution_node_id": "EXN-test-001",
+                    "intent_node_id": "INN-test-001",
+                    "node_type": "implementation",
+                    "role": "role:implementer",
+                    "lifecycle_state": "proposed",
+                    "attempt": {"attempt_id": None, "outcome": "pending"},
+                    "candidate": {"group_id": None, "disposition": "pending"},
+                    "approval_state": "not_required",
+                    "lease_state": "unclaimed",
+                    "control_state": "active",
+                    "compiled_from": {
+                        "intent_node_id": "INN-test-001",
+                        "intent_graph_digest": "sha256:" + "b" * 64,
+                    },
+                },
+            }
+        ],
+        "reason_code": "EV_HUMAN_DECISION",
+        "evidence_refs": [],
+        "expected_effect": "adds one execution node",
+        "budget_delta": {"unit": "tokens", "value": 0},
+        "requires_approval": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _intent_envelope(**overrides) -> dict:
+    """Envelope that adds an intent node — safe on an empty snapshot."""
+    base = {
+        "schema_version": "1.0.0",
+        "record_type": "mutation_envelope",
+        "graph_id": "GRF-test001",
+        "base_revision": 0,
+        "mutation_id": "MUT-dag-001",
+        "idempotency_key": "test-key-001",
+        "actor": "actor:test",
+        "authority_class": "human",
+        "operations": [
+            {
+                "op_id": "OPS-dag-001",
+                "operation_type": "add_intent_node",
+                "target_ref": "INN-dag-001",
+                "value": {
+                    "schema_version": "1.0.0",
+                    "record_type": "intent_node",
+                    "intent_node_id": "INN-dag-001",
+                    "node_type": "implementation",
+                    "role": "role:implementer",
+                    "source_ref": "ticket:#1",
+                    "in_scope": True,
+                },
+            }
+        ],
+        "reason_code": "EV_HUMAN_DECISION",
+        "evidence_refs": [],
+        "expected_effect": "adds one intent node",
+        "budget_delta": {"unit": "tokens", "value": 0},
+        "requires_approval": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _journal(tmp_path: Path) -> GraphJournal:
+    journal = GraphJournal(tmp_path / "test.db")
+    journal.init_graph("GRF-test001")
+    return journal
+
+
+class TestReplay:
+    def test_empty_journal_replays_to_revision_zero(self, tmp_path: Path):
+        journal = GraphJournal(tmp_path / "empty.db")
+        state = journal.replay()
+        assert state.get("graph_revision", 0) == 0
+        journal.close()
+
+    def test_init_then_replay_has_graph_id(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        state = journal.replay()
+        assert state["graph_id"] == "GRF-test001"
+        assert state["graph_revision"] == 0
+        journal.close()
+
+    def test_accepted_mutation_advances_revision(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        decision = journal.propose(_envelope())
+        assert decision.accepted
+        state = journal.replay()
+        assert state["graph_revision"] == 1
+        assert len(state["execution_nodes"]) == 1
+        journal.close()
+
+
+class TestHashChain:
+    def test_genesis_previous_hash_is_64_zeros(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        conn = journal._conn
+        row = conn.execute("SELECT previous_record_hash FROM graph_events ORDER BY journal_seq LIMIT 1").fetchone()
+        assert row[0] == "0" * 64
+        journal.close()
+
+    def test_chain_is_continuous(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        journal.propose(_envelope())
+        journal.propose(_envelope(mutation_id="MUT-test-002", idempotency_key="test-key-002"))
+        rows = journal._conn.execute("SELECT previous_record_hash, event_hash FROM graph_events ORDER BY journal_seq").fetchall()
+        for index in range(1, len(rows)):
+            assert rows[index][0] == rows[index - 1][1]
+        journal.close()
+
+    def test_corrupt_payload_fails_closed(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        journal._conn.execute("UPDATE graph_events SET payload = payload || 'x' WHERE journal_seq = 1")
+        with pytest.raises(JournalError):
+            journal.replay()
+        journal.close()
+
+
+class TestCAS:
+    def test_stale_base_is_rejected(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        envelope = _intent_envelope()
+        journal.propose(envelope)
+        stale = _envelope(mutation_id="MUT-dag-002", idempotency_key="key-stale")
+        decision = journal.propose(stale)
+        assert not decision.accepted
+        assert any(v.code == ErrorCode.BASE_REVISION_MISMATCH for v in decision.violations)
+        journal.close()
+
+
+class TestIdempotency:
+    def test_same_key_same_payload_is_accepted_once(self, tmp_path: Path):
+        journal = _journal(tmp_path)
+        envelope = _intent_envelope()
+        first = journal.propose(envelope)
+        second = journal.propose(dict(envelope))
+        assert first.accepted
+        assert second.accepted
+        state = journal.replay()
+        assert state["graph_revision"] == 1
+        journal.close()
+
+
+class TestCycleRejection:
+    def test_cycle_proposal_reports_path_before_application(self, tmp_path: Path):
+        journal = GraphJournal(tmp_path / "cycle.db")
+        journal.init_graph("GRF-cyc001")
+        envelope_a = _envelope(
+            mutation_id="MUT-cyc-001", idempotency_key="cyc-a",
+            graph_id="GRF-cyc001",
+        )
+        envelope_a["operations"][0]["value"]["execution_node_id"] = "EXN-cyc-001"
+        envelope_a["operations"][0]["value"]["intent_node_id"] = "INN-cyc-001"
+        envelope_a["operations"][0]["target_ref"] = "EXN-cyc-001"
+        envelope_a["operations"] = [
+            {
+                "op_id": "OPS-cyc-001",
+                "operation_type": "add_execution_node",
+                "target_ref": "EXN-cyc-001",
+                "value": {
+                    "schema_version": "1.0.0",
+                    "record_type": "execution_node",
+                    "execution_node_id": "EXN-cyc-001",
+                    "intent_node_id": "INN-cyc-001",
+                    "node_type": "implementation",
+                    "role": "role:implementer",
+                    "lifecycle_state": "proposed",
+                    "attempt": {"attempt_id": None, "outcome": "pending"},
+                    "candidate": {"group_id": None, "disposition": "pending"},
+                    "approval_state": "not_required",
+                    "lease_state": "unclaimed",
+                    "control_state": "active",
+                    "compiled_from": {"intent_node_id": "INN-cyc-001", "intent_graph_digest": "sha256:" + "b" * 64},
+                },
+            }
+        ]
+        journal.propose(envelope_a)
+        state = journal.replay()
+        assert state["graph_revision"] == 1
+        journal.close()
+
+
+class TestCLI:
+    def test_cli_init_and_inspect(self, tmp_path: Path):
+        import subprocess
+
+        db = str(tmp_path / "cli.db")
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "init", "--db", db, "--graph-id", "GRF-cli001"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["ok"]
+
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "hash", "--db", db],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        hashes = json.loads(result.stdout)
+        assert "schedule_hash" in hashes
+        assert "audit_state_hash" in hashes
+
+    def test_cli_replay_matches_direct(self, tmp_path: Path):
+        import subprocess
+
+        db = str(tmp_path / "replay.db")
+        subprocess.run([sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "init", "--db", db, "--graph-id", "GRF-rep001"], capture_output=True)
+        result = subprocess.run([sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "replay", "--db", db], capture_output=True, text=True)
+        assert result.returncode == 0
+        state = json.loads(result.stdout)
+        assert state["graph_id"] == "GRF-rep001"
+
+
+class TestSnapshotEquivalence:
+    def test_replay_produces_same_hashes_twice(self, tmp_path: Path):
+        journal = GraphJournal(tmp_path / "equiv.db")
+        journal.init_graph("GRF-eq0001")
+        envelope = _intent_envelope(graph_id="GRF-eq0001")
+        journal.propose(envelope)
+        hashes_1 = journal.hash()
+
+        journal.close()
+        reopened = GraphJournal(tmp_path / "equiv.db")
+        hashes_2 = reopened.hash()
+        assert hashes_1["schedule_hash"] == hashes_2["schedule_hash"]
+        assert hashes_1["audit_state_hash"] == hashes_2["audit_state_hash"]
+        reopened.close()
+
+
+class TestConcurrentCAS:
+    def test_two_proposals_one_base_only_first_wins(self, tmp_path: Path):
+        journal_a = GraphJournal(tmp_path / "race.db")
+        journal_a.init_graph("GRF-race01")
+        journal_b = GraphJournal(tmp_path / "race.db")
+
+        env_a = _envelope(mutation_id="MUT-dag-003", idempotency_key="race-a", graph_id="GRF-race01")
+        env_b = _envelope(mutation_id="MUT-dag-004", idempotency_key="race-b", graph_id="GRF-race01")
+
+        decision_a = journal_a.propose(env_a)
+        decision_b = journal_b.propose(env_b)
+
+        assert decision_a.accepted
+        assert not decision_b.accepted
+        journal_a.close()
+        journal_b.close()
+
+
+class TestSidecarResolver:
+    def test_sidecar_mode_resolves_meta_outside_target(self, tmp_path: Path):
+        sys.path.insert(0, str(ROOT / "scripts"))
+        from artifacts import Resolver
+
+        target = tmp_path / "target-repo"
+        target.mkdir()
+        try:
+            target_id = Resolver.resolve(target).target_id
+        finally:
+            sys.path.remove(str(ROOT / "scripts"))
+
+        cw_home = tmp_path / "cw-home"
+        cw_home.mkdir()
+        election_dir = cw_home / "meta" / target_id.replace("/", "/")
+        election_dir.mkdir(parents=True)
+        (election_dir / "election.json").write_text(json.dumps({"mode": "sidecar", "backing": "local"}))
+
+        sys.path.insert(0, str(ROOT / "scripts"))
+        resolver = Resolver.resolve(target, cw_home=cw_home)
+        sys.path.remove(str(ROOT / "scripts"))
+        assert resolver.mode == "sidecar"
+        assert str(resolver.meta_root).startswith(str(cw_home))
+        db = resolver.meta_root / "dag" / "journal.db"
+        db.parent.mkdir(parents=True)
+        journal = GraphJournal(db)
+        journal.init_graph("GRF-side01")
+        state = journal.replay()
+        assert state["graph_id"] == "GRF-side01"
+        journal.close()
+
+
+class TestProcessKill:
+    def test_partial_tail_does_not_corrupt_replay(self, tmp_path: Path):
+        import shutil
+
+        db = tmp_path / "kill.db"
+        journal = GraphJournal(db)
+        journal.init_graph("GRF-kill01")
+        envelope = _intent_envelope(graph_id="GRF-kill01")
+        journal.propose(envelope)
+        journal.close()
+
+        copy = tmp_path / "kill-partial.db"
+        shutil.copy2(db, copy)
+        conn = sqlite3.connect(str(copy))
+        raw = conn.execute("SELECT payload FROM graph_events WHERE journal_seq = 1").fetchone()[0]
+        truncated = raw[: len(raw) // 2]
+        conn.execute("UPDATE graph_events SET payload = ? WHERE journal_seq = 1", (truncated,))
+        conn.commit()
+        conn.close()
+
+        recovered = GraphJournal(copy)
+        with pytest.raises(JournalError):
+            recovered.replay()
+        recovered.close()

--- a/tests/test_dag_journal.py
+++ b/tests/test_dag_journal.py
@@ -1,338 +1,1053 @@
+"""Acceptance tests for the transactional graph journal (chief-wiggum#385).
+
+Each class maps to an acceptance criterion on the ticket. Where a criterion
+names a hazard (concurrency, a torn tail, a cycle), the test reproduces the
+hazard rather than a sequential stand-in for it — a test that cannot fail when
+the guard is removed is not evidence the guard works.
+"""
+
 import json
-import sys
 import sqlite3
+import subprocess
+import sys
+import threading
 from pathlib import Path
 
 import pytest
-from chief_wiggum.dag import ErrorCode, GraphJournal, JournalError
-
+from chief_wiggum.dag import ErrorCode, GraphJournal, JournalError, load_authority_matrix
+from chief_wiggum.dag.journal import _apply_operation, _empty_snapshot
 
 ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / "scripts" / "dag_engine.py"
+GRAPH = "GRF-test001"
+
+_MATRIX = {row["operation_type"]: row for row in load_authority_matrix()["operations"]}
+OPERATION_TYPES = sorted(_MATRIX)
 
 
-def _envelope(**overrides) -> dict:
-    base = {
+# --------------------------------------------------------------- builders
+
+
+def envelope(operations, *, base_revision, mutation_id, key, graph_id=GRAPH):
+    """Build a schema-valid envelope with authority fields the matrix accepts."""
+    requires_approval = any(
+        _MATRIX[operation["operation_type"]]["approval_required"] for operation in operations
+    )
+    return {
         "schema_version": "1.0.0",
         "record_type": "mutation_envelope",
-        "graph_id": "GRF-test001",
-        "base_revision": 0,
-        "mutation_id": "MUT-test-001",
-        "idempotency_key": "test-key-001",
+        "graph_id": graph_id,
+        "base_revision": base_revision,
+        "mutation_id": mutation_id,
+        "idempotency_key": key,
         "actor": "actor:test",
-        "authority_class": "automatic",
-        "operations": [
-            {
-                "op_id": "OPS-dag-001",
-                "operation_type": "add_execution_node",
-                "target_ref": "EXN-test-001",
-                "value": {
-                    "schema_version": "1.0.0",
-                    "record_type": "execution_node",
-                    "execution_node_id": "EXN-test-001",
-                    "intent_node_id": "INN-test-001",
-                    "node_type": "implementation",
-                    "role": "role:implementer",
-                    "lifecycle_state": "proposed",
-                    "attempt": {"attempt_id": None, "outcome": "pending"},
-                    "candidate": {"group_id": None, "disposition": "pending"},
-                    "approval_state": "not_required",
-                    "lease_state": "unclaimed",
-                    "control_state": "active",
-                    "compiled_from": {
-                        "intent_node_id": "INN-test-001",
-                        "intent_graph_digest": "sha256:" + "b" * 64,
-                    },
-                },
-            }
-        ],
+        "authority_class": "human" if requires_approval else "automatic",
+        "operations": operations,
         "reason_code": "EV_HUMAN_DECISION",
         "evidence_refs": [],
-        "expected_effect": "adds one execution node",
+        "expected_effect": "test mutation",
         "budget_delta": {"unit": "tokens", "value": 0},
-        "requires_approval": False,
+        "requires_approval": requires_approval,
     }
-    base.update(overrides)
-    return base
 
 
-def _intent_envelope(**overrides) -> dict:
-    """Envelope that adds an intent node — safe on an empty snapshot."""
-    base = {
+def op(op_id, operation_type, target_ref, **extra):
+    return {"op_id": op_id, "operation_type": operation_type, "target_ref": target_ref, **extra}
+
+
+def intent_node(node_id, ticket=None):
+    record = {
         "schema_version": "1.0.0",
-        "record_type": "mutation_envelope",
-        "graph_id": "GRF-test001",
-        "base_revision": 0,
-        "mutation_id": "MUT-dag-001",
-        "idempotency_key": "test-key-001",
-        "actor": "actor:test",
-        "authority_class": "human",
-        "operations": [
-            {
-                "op_id": "OPS-dag-001",
-                "operation_type": "add_intent_node",
-                "target_ref": "INN-dag-001",
-                "value": {
-                    "schema_version": "1.0.0",
-                    "record_type": "intent_node",
-                    "intent_node_id": "INN-dag-001",
-                    "node_type": "implementation",
-                    "role": "role:implementer",
-                    "source_ref": "ticket:#1",
-                    "in_scope": True,
-                },
-            }
-        ],
-        "reason_code": "EV_HUMAN_DECISION",
-        "evidence_refs": [],
-        "expected_effect": "adds one intent node",
-        "budget_delta": {"unit": "tokens", "value": 0},
-        "requires_approval": True,
+        "record_type": "intent_node",
+        "intent_node_id": node_id,
+        "node_type": "implementation",
+        "role": "role:implementer",
+        "source_ref": f"ticket:#{ticket or 1}",
+        "in_scope": True,
     }
-    base.update(overrides)
-    return base
+    if ticket is not None:
+        record["source_ticket"] = ticket
+    return record
 
 
-def _journal(tmp_path: Path) -> GraphJournal:
-    journal = GraphJournal(tmp_path / "test.db")
-    journal.init_graph("GRF-test001")
+def execution_node(node_id, intent_id, *, lifecycle_state="proposed", attempt_id=None):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "execution_node",
+        "execution_node_id": node_id,
+        "intent_node_id": intent_id,
+        "node_type": "implementation",
+        "role": "role:implementer",
+        "lifecycle_state": lifecycle_state,
+        "attempt": {"attempt_id": attempt_id, "outcome": "pending"},
+        "candidate": {"group_id": None, "disposition": "pending"},
+        "approval_state": "not_required",
+        "lease_state": "unclaimed",
+        "control_state": "active",
+        "compiled_from": {"intent_node_id": intent_id, "intent_graph_digest": "sha256:" + "b" * 64},
+    }
+
+
+def evidence_record(evidence_id):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "evidence_record",
+        "evidence_id": evidence_id,
+        "evidence_type": "test_signal",
+        "source_ref": "test",
+        "content_digest": "sha256:" + "c" * 64,
+        "observed_at": "2026-01-01T00:00:00Z",
+        "status": "validated",
+    }
+
+
+def run_concurrently(setups, *, timeout=60):
+    """Release callables together on threads, and never hang the suite.
+
+    A bare threading.Barrier turns an early failure in one thread into a
+    permanent stall in its peer and in the join, which surfaces as a hung test
+    run rather than a red test. Each setup runs before the barrier and returns
+    the callable to race; a setup that raises aborts the barrier so the peer
+    fails fast instead of waiting forever.
+    """
+    barrier = threading.Barrier(len(setups), timeout=timeout)
+    results = {}
+
+    def wrapper(name, setup):
+        try:
+            action = setup()
+        except BaseException as exc:  # noqa: BLE001 - surfaced via results
+            results[name] = exc
+            barrier.abort()
+            return
+        try:
+            barrier.wait()
+            results[name] = action()
+        except BaseException as exc:  # noqa: BLE001 - surfaced via results
+            results[name] = exc
+
+    threads = [
+        threading.Thread(target=wrapper, args=(name, setup), daemon=True)
+        for name, setup in setups.items()
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout)
+        assert not thread.is_alive(), "a racing thread never finished"
+    for name, result in results.items():
+        assert not isinstance(result, BaseException), f"{name} raised {result!r}"
+    return results
+
+
+def journal_at(tmp_path, name="graph.db", graph_id=GRAPH):
+    journal = GraphJournal(tmp_path / name)
+    journal.init_graph(graph_id)
     return journal
 
 
+def seed_pair(journal, *, start_revision=0):
+    """Add two intent nodes, two execution nodes and one evidence record."""
+    revision = start_revision
+    decisions = []
+    for index, (intent_id, exec_id) in enumerate(
+        (("INN-dag-001", "EXN-dag-001"), ("INN-dag-002", "EXN-dag-002")), start=1
+    ):
+        decision = journal.propose(
+            envelope(
+                [op(f"OPS-seed-{index:03d}", "add_intent_node", intent_id, value=intent_node(intent_id, ticket=index))],
+                base_revision=revision,
+                mutation_id=f"MUT-seed-{index:03d}",
+                key=f"seed-intent-{index}",
+            )
+        )
+        assert decision.accepted, decision.violations
+        revision = decision.graph_revision
+        decision = journal.propose(
+            envelope(
+                [
+                    op(
+                        f"OPS-seedx-{index:03d}",
+                        "add_execution_node",
+                        exec_id,
+                        value=execution_node(exec_id, intent_id, attempt_id=f"ATM-dag-{index:03d}"),
+                    )
+                ],
+                base_revision=revision,
+                mutation_id=f"MUT-seedx-{index:03d}",
+                key=f"seed-exec-{index}",
+            )
+        )
+        assert decision.accepted, decision.violations
+        revision = decision.graph_revision
+        decisions.append(decision)
+    decision = journal.propose(
+        envelope(
+            [op("OPS-seedv-001", "record_evidence", "EVD-dag-001", value=evidence_record("EVD-dag-001"))],
+            base_revision=revision,
+            mutation_id="MUT-seedv-001",
+            key="seed-evidence",
+        )
+    )
+    assert decision.accepted, decision.violations
+    return decision.graph_revision
+
+
+# ------------------------------------------------------ AC: deterministic replay
+
+
 class TestReplay:
-    def test_empty_journal_replays_to_revision_zero(self, tmp_path: Path):
+    def test_empty_journal_replays_to_revision_zero(self, tmp_path):
         journal = GraphJournal(tmp_path / "empty.db")
-        state = journal.replay()
-        assert state.get("graph_revision", 0) == 0
+        assert journal.replay()["graph_revision"] == 0
         journal.close()
 
-    def test_init_then_replay_has_graph_id(self, tmp_path: Path):
-        journal = _journal(tmp_path)
+    def test_init_then_replay_has_graph_id(self, tmp_path):
+        journal = journal_at(tmp_path)
         state = journal.replay()
-        assert state["graph_id"] == "GRF-test001"
+        assert state["graph_id"] == GRAPH
         assert state["graph_revision"] == 0
         journal.close()
 
-    def test_accepted_mutation_advances_revision(self, tmp_path: Path):
-        journal = _journal(tmp_path)
-        decision = journal.propose(_envelope())
-        assert decision.accepted
-        state = journal.replay()
-        assert state["graph_revision"] == 1
-        assert len(state["execution_nodes"]) == 1
+    def test_cold_replay_matches_warm_state_after_every_mutation(self, tmp_path):
+        """AC: replay(journal) has an identical hash and ready set to the
+        incrementally-maintained graph, for any sequence of admitted mutations."""
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+
+        sequence = [
+            [op("OPS-p-001", "transition_node", "EXN-dag-001", from_state="proposed", to_state="admitted")],
+            [op("OPS-p-002", "transition_node", "EXN-dag-002", from_state="proposed", to_state="admitted")],
+            [
+                op(
+                    "OPS-p-003",
+                    "add_schedulable_edge",
+                    "SED-dag-001",
+                    value={
+                        "schema_version": "1.0.0",
+                        "record_type": "schedulable_edge",
+                        "edge_id": "SED-dag-001",
+                        "source": "EXN-dag-001",
+                        "target": "EXN-dag-002",
+                        "kind": "depends_on",
+                        "derived_from": ["EVD-dag-001"],
+                    },
+                )
+            ],
+            # EXN-dag-001 sources the edge, so it runs AFTER EXN-dag-002 and
+            # falls back to admitted; EXN-dag-002 stays derived-ready.
+            [op("OPS-p-004", "transition_node", "EXN-dag-002", from_state="ready", to_state="running")],
+            [op("OPS-p-005", "transition_node", "EXN-dag-002", from_state="running", to_state="succeeded")],
+        ]
+        for index, operations in enumerate(sequence, start=1):
+            decision = journal.propose(
+                envelope(
+                    operations,
+                    base_revision=revision,
+                    mutation_id=f"MUT-prop-{index:03d}",
+                    key=f"prop-{index}",
+                )
+            )
+            assert decision.accepted, decision.violations
+            revision = decision.graph_revision
+
+            cold = GraphJournal(tmp_path / "graph.db")
+            assert cold.hash() == journal.hash()
+            assert cold.ready_set() == journal.ready_set()
+            assert cold.replay() == journal.replay()
+            assert cold.graph_revision() == revision
+            cold.close()
+
+        # The dependent node becomes ready only once its predecessor succeeded,
+        # and the engine — not a proposal — is what moved it there.
+        assert journal.ready_set() == ["EXN-dag-001"]
         journal.close()
+
+    def test_caller_mutating_its_envelope_cannot_rewrite_history(self, tmp_path):
+        journal = journal_at(tmp_path)
+        body = envelope(
+            [op("OPS-a-001", "add_intent_node", "INN-alias-001", value=intent_node("INN-alias-001"))],
+            base_revision=0,
+            mutation_id="MUT-al-001",
+            key="alias",
+        )
+        assert journal.propose(body).accepted
+        body["operations"][0]["value"]["intent_node_id"] = "INN-tampered-999"
+        body["expected_effect"] = "rewritten after the fact"
+
+        warm = journal.replay()
+        cold = GraphJournal(tmp_path / "graph.db")
+        assert warm == cold.replay()
+        assert warm["intent_nodes"][0]["intent_node_id"] == "INN-alias-001"
+        cold.close()
+        journal.close()
+
+    def test_replay_result_cannot_corrupt_the_cache(self, tmp_path):
+        journal = journal_at(tmp_path)
+        seed_pair(journal)
+        leaked = journal.replay()
+        leaked["execution_nodes"].append({"execution_node_id": "EXN-bogus-999"})
+        leaked["graph_revision"] = 99
+        assert len(journal.replay()["execution_nodes"]) == 2
+        assert journal.graph_revision() != 99
+        journal.close()
+
+
+# ----------------------------------------------------------- AC: the fold
+
+
+class TestFoldCompleteness:
+    def test_every_vocabulary_operation_is_handled(self):
+        """No operation type may fall through to a silent no-op or an unknown-type
+        crash. This is the guard that the original fold's collection_map lacked."""
+        unhandled = []
+        for operation_type in OPERATION_TYPES:
+            state = _empty_snapshot(GRAPH)
+            try:
+                _apply_operation(state, {"operation_type": operation_type, "target_ref": "X"})
+            except JournalError as exc:
+                if "unknown operation type" in str(exc):
+                    unhandled.append(operation_type)
+            except (KeyError, TypeError):
+                pass  # handled, but needs a well-formed operation to do its work
+        assert unhandled == []
+
+    def test_transition_node_changes_lifecycle_state(self, tmp_path):
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+        decision = journal.propose(
+            envelope(
+                [op("OPS-t-001", "transition_node", "EXN-dag-001", from_state="proposed", to_state="admitted")],
+                base_revision=revision,
+                mutation_id="MUT-tr-001",
+                key="transition-1",
+            )
+        )
+        assert decision.accepted, decision.violations
+        node = next(
+            n for n in journal.replay()["execution_nodes"] if n["execution_node_id"] == "EXN-dag-001"
+        )
+        assert node["lifecycle_state"] == "ready"  # no predecessors, so the fold derives ready
+        journal.close()
+
+    def test_lease_and_control_reach_the_projection(self, tmp_path):
+        """schedule_hash covers control and lease records, so a paused graph must
+        not hash the same as a running one."""
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+        before = journal.hash()["schedule_hash"]
+
+        lease = {
+            "schema_version": "1.0.0",
+            "record_type": "lease_record",
+            "lease_id": "LSE-dag-001",
+            "execution_node_id": "EXN-dag-001",
+            "attempt_id": "ATM-dag-001",
+            "epoch": 0,
+            "state": "active",
+            "fencing_token": "token-1",
+        }
+        decision = journal.propose(
+            envelope(
+                [op("OPS-l-001", "acquire_lease", "LSE-dag-001", value=lease)],
+                base_revision=revision,
+                mutation_id="MUT-ls-001",
+                key="lease-1",
+            )
+        )
+        assert decision.accepted, decision.violations
+        revision = decision.graph_revision
+        state = journal.replay()
+        assert state["lease_records"][0]["state"] == "active"
+        node = next(n for n in state["execution_nodes"] if n["execution_node_id"] == "EXN-dag-001")
+        assert node["lease_state"] == "active"
+        assert journal.hash()["schedule_hash"] != before
+
+        control = {
+            "schema_version": "1.0.0",
+            "record_type": "control_record",
+            "control_id": "CTL-dag-001",
+            "graph_id": GRAPH,
+            "state": "paused",
+            "actor": "actor:test",
+            "reason_code": "EV_HUMAN_DECISION",
+        }
+        paused = journal.propose(
+            envelope(
+                [op("OPS-c-001", "set_control", "CTL-dag-001", value=control)],
+                base_revision=revision,
+                mutation_id="MUT-ct-001",
+                key="control-1",
+            )
+        )
+        assert paused.accepted, paused.violations
+        assert journal.replay()["control_records"][0]["state"] == "paused"
+        assert journal.ready_set() == []
+        journal.close()
+
+    def test_release_lease_marks_the_lease_released(self, tmp_path):
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+        lease = {
+            "schema_version": "1.0.0",
+            "record_type": "lease_record",
+            "lease_id": "LSE-dag-001",
+            "execution_node_id": "EXN-dag-001",
+            "attempt_id": "ATM-dag-001",
+            "epoch": 0,
+            "state": "active",
+            "fencing_token": "token-1",
+        }
+        revision = journal.propose(
+            envelope(
+                [op("OPS-l-002", "acquire_lease", "LSE-dag-001", value=lease)],
+                base_revision=revision,
+                mutation_id="MUT-ls-002",
+                key="lease-2",
+            )
+        ).graph_revision
+        decision = journal.propose(
+            envelope(
+                [op("OPS-l-003", "release_lease", "LSE-dag-001")],
+                base_revision=revision,
+                mutation_id="MUT-ls-003",
+                key="lease-3",
+            )
+        )
+        assert decision.accepted, decision.violations
+        assert journal.replay()["lease_records"][0]["state"] == "released"
+        journal.close()
+
+    def test_remove_intent_node_drops_the_record(self, tmp_path):
+        journal = journal_at(tmp_path)
+        decision = journal.propose(
+            envelope(
+                [op("OPS-r-001", "add_intent_node", "INN-solo-001", value=intent_node("INN-solo-001"))],
+                base_revision=0,
+                mutation_id="MUT-rm-001",
+                key="rm-add",
+            )
+        )
+        assert decision.accepted, decision.violations
+        decision = journal.propose(
+            envelope(
+                [op("OPS-r-002", "remove_intent_node", "INN-solo-001")],
+                base_revision=decision.graph_revision,
+                mutation_id="MUT-rm-002",
+                key="rm-del",
+            )
+        )
+        assert decision.accepted, decision.violations
+        assert journal.replay()["intent_nodes"] == []
+        journal.close()
+
+    def test_dangling_execution_node_is_rejected_before_application(self, tmp_path):
+        """The post-state is validated, so a compilation reference to a
+        non-existent intent node cannot be admitted."""
+        journal = journal_at(tmp_path)
+        decision = journal.propose(
+            envelope(
+                [
+                    op(
+                        "OPS-d-001",
+                        "add_execution_node",
+                        "EXN-ghost-001",
+                        value=execution_node("EXN-ghost-001", "INN-ghost-001"),
+                    )
+                ],
+                base_revision=0,
+                mutation_id="MUT-gh-001",
+                key="ghost",
+            )
+        )
+        assert not decision.accepted
+        assert journal.replay()["execution_nodes"] == []
+        journal.close()
+
+
+# ------------------------------------------------------------ AC: hash chain
 
 
 class TestHashChain:
-    def test_genesis_previous_hash_is_64_zeros(self, tmp_path: Path):
-        journal = _journal(tmp_path)
-        conn = journal._conn
-        row = conn.execute("SELECT previous_record_hash FROM graph_events ORDER BY journal_seq LIMIT 1").fetchone()
+    def test_genesis_previous_hash_is_64_zeros(self, tmp_path):
+        journal = journal_at(tmp_path)
+        row = journal._conn.execute(
+            "SELECT previous_record_hash FROM graph_events ORDER BY journal_seq LIMIT 1"
+        ).fetchone()
         assert row[0] == "0" * 64
         journal.close()
 
-    def test_chain_is_continuous(self, tmp_path: Path):
-        journal = _journal(tmp_path)
-        journal.propose(_envelope())
-        journal.propose(_envelope(mutation_id="MUT-test-002", idempotency_key="test-key-002"))
-        rows = journal._conn.execute("SELECT previous_record_hash, event_hash FROM graph_events ORDER BY journal_seq").fetchall()
+    def test_chain_is_continuous(self, tmp_path):
+        journal = journal_at(tmp_path)
+        seed_pair(journal)
+        rows = journal._conn.execute(
+            "SELECT previous_record_hash, event_hash FROM graph_events ORDER BY journal_seq"
+        ).fetchall()
         for index in range(1, len(rows)):
             assert rows[index][0] == rows[index - 1][1]
         journal.close()
 
-    def test_corrupt_payload_fails_closed(self, tmp_path: Path):
-        journal = _journal(tmp_path)
+    def test_corrupt_payload_fails_closed(self, tmp_path):
+        journal = journal_at(tmp_path)
         journal._conn.execute("UPDATE graph_events SET payload = payload || 'x' WHERE journal_seq = 1")
         with pytest.raises(JournalError):
             journal.replay()
         journal.close()
 
+    def test_verification_stays_failed_once_it_has_failed(self, tmp_path):
+        journal = journal_at(tmp_path)
+        journal._conn.execute("UPDATE graph_events SET payload = payload || 'x' WHERE journal_seq = 1")
+        with pytest.raises(JournalError):
+            journal.replay()
+        with pytest.raises(JournalError):
+            journal.replay()
+        journal.close()
+
+
+# ------------------------------------------------------------------ AC: CAS
+
 
 class TestCAS:
-    def test_stale_base_is_rejected(self, tmp_path: Path):
-        journal = _journal(tmp_path)
-        envelope = _intent_envelope()
-        journal.propose(envelope)
-        stale = _envelope(mutation_id="MUT-dag-002", idempotency_key="key-stale")
-        decision = journal.propose(stale)
-        assert not decision.accepted
-        assert any(v.code == ErrorCode.BASE_REVISION_MISMATCH for v in decision.violations)
+    def test_stale_base_is_rejected_and_journaled(self, tmp_path):
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+        stale = journal.propose(
+            envelope(
+                [op("OPS-s-001", "add_intent_node", "INN-late-001", value=intent_node("INN-late-001"))],
+                base_revision=revision - 1,
+                mutation_id="MUT-st-001",
+                key="stale",
+            )
+        )
+        assert not stale.accepted
+        assert any(v.code == ErrorCode.BASE_REVISION_MISMATCH for v in stale.violations)
+        rejected = journal._conn.execute(
+            "SELECT COUNT(*) FROM graph_events WHERE event_type='mutation_rejected'"
+        ).fetchone()[0]
+        assert rejected == 1
         journal.close()
+
+    @pytest.mark.parametrize("trial", range(15))
+    def test_concurrent_proposers_one_wins_one_is_stale(self, tmp_path, trial):
+        """AC: two proposers against the same base revision — one wins, the other
+        is rejected; no interleaving produces a partially-applied envelope.
+
+        Both threads open their own connection and are released from a barrier
+        together, so the compare-and-swap is genuinely contended. A sequential
+        stand-in for this test passes even with no concurrency control at all.
+        """
+        database = tmp_path / f"race-{trial}.db"
+        setup = GraphJournal(database)
+        setup.init_graph(GRAPH)
+        setup.close()
+
+        def proposer(name, node_id, key):
+            def setup():
+                worker = GraphJournal(database)
+                body = envelope(
+                    [op("OPS-race-001", "add_intent_node", node_id, value=intent_node(node_id))],
+                    base_revision=0,
+                    mutation_id=f"MUT-race{name}-001",
+                    key=key,
+                )
+
+                def act():
+                    try:
+                        return worker.propose(body)
+                    finally:
+                        worker.close()
+
+                return act
+
+            return setup
+
+        results = run_concurrently(
+            {
+                "a": proposer("a", "INN-racea-001", "race-a"),
+                "b": proposer("b", "INN-raceb-001", "race-b"),
+            }
+        )
+        accepted = [name for name, result in results.items() if result.accepted]
+        assert len(accepted) == 1, (
+            f"exactly one proposer must win at base_revision=0, got {len(accepted)}: {results}"
+        )
+        loser = next(result for name, result in results.items() if name not in accepted)
+        assert any(v.code == ErrorCode.BASE_REVISION_MISMATCH for v in loser.violations)
+
+        final = GraphJournal(database)
+        state = final.replay()
+        assert state["graph_revision"] == 1
+        assert len(state["intent_nodes"]) == 1
+        final.close()
+
+    def test_concurrent_init_only_initialises_once(self, tmp_path):
+        database = tmp_path / "init-race.db"
+
+        def initialiser():
+            worker = GraphJournal(database)
+
+            def act():
+                try:
+                    worker.init_graph(GRAPH)
+                    return "ok"
+                except JournalError as exc:
+                    return str(exc)
+                finally:
+                    worker.close()
+
+            return act
+
+        results = run_concurrently({"a": initialiser, "b": initialiser})
+        assert list(results.values()).count("ok") == 1
+        journal = GraphJournal(database)
+        assert (
+            journal._conn.execute(
+                "SELECT COUNT(*) FROM graph_events WHERE event_type='init'"
+            ).fetchone()[0]
+            == 1
+        )
+        journal.close()
+
+
+# ---------------------------------------------------------- AC: idempotency
 
 
 class TestIdempotency:
-    def test_same_key_same_payload_is_accepted_once(self, tmp_path: Path):
-        journal = _journal(tmp_path)
-        envelope = _intent_envelope()
-        first = journal.propose(envelope)
-        second = journal.propose(dict(envelope))
+    def test_same_key_same_payload_returns_the_original_decision(self, tmp_path):
+        journal = journal_at(tmp_path)
+        body = envelope(
+            [op("OPS-i-001", "add_intent_node", "INN-idem-001", value=intent_node("INN-idem-001"))],
+            base_revision=0,
+            mutation_id="MUT-id-001",
+            key="idem-key",
+        )
+        first = journal.propose(body)
         assert first.accepted
-        assert second.accepted
-        state = journal.replay()
-        assert state["graph_revision"] == 1
+
+        # Advance the journal so "the original decision" and "the current head"
+        # are different answers; without this the assertion cannot tell them
+        # apart and a fresh-decision implementation passes.
+        intervening = journal.propose(
+            envelope(
+                [op("OPS-i-009", "add_intent_node", "INN-idem-009", value=intent_node("INN-idem-009"))],
+                base_revision=first.graph_revision,
+                mutation_id="MUT-id-009",
+                key="idem-other",
+            )
+        )
+        assert intervening.accepted, intervening.violations
+        assert intervening.journal_seq != first.journal_seq
+        events_before_replay = journal.last_journal_seq()
+
+        second = journal.propose(dict(body))
+        assert second.accepted and second.idempotent
+        assert (second.journal_seq, second.graph_revision) == (
+            first.journal_seq,
+            first.graph_revision,
+        ), "a repeat must return the ORIGINAL decision, not the current head"
+        assert journal.last_journal_seq() == events_before_replay, "a no-op must not append"
+        assert journal.replay()["graph_revision"] == 2
+        journal.close()
+
+    def test_same_key_different_payload_is_a_hard_error(self, tmp_path):
+        journal = journal_at(tmp_path)
+        first = journal.propose(
+            envelope(
+                [op("OPS-i-002", "add_intent_node", "INN-idem-002", value=intent_node("INN-idem-002"))],
+                base_revision=0,
+                mutation_id="MUT-id-002",
+                key="collide",
+            )
+        )
+        assert first.accepted
+        collision = journal.propose(
+            envelope(
+                [op("OPS-i-003", "add_intent_node", "INN-idem-003", value=intent_node("INN-idem-003"))],
+                base_revision=1,
+                mutation_id="MUT-id-003",
+                key="collide",
+            )
+        )
+        assert not collision.accepted
+        assert any(v.code == ErrorCode.IDEMPOTENCY_KEY_DIVERGENT for v in collision.violations)
+        assert len(journal.replay()["intent_nodes"]) == 1
         journal.close()
 
 
-class TestCycleRejection:
-    def test_cycle_proposal_reports_path_before_application(self, tmp_path: Path):
-        journal = GraphJournal(tmp_path / "cycle.db")
-        journal.init_graph("GRF-cyc001")
-        envelope_a = _envelope(
-            mutation_id="MUT-cyc-001", idempotency_key="cyc-a",
-            graph_id="GRF-cyc001",
+# ------------------------------------------------------------- AC: snapshots
+
+
+class TestSnapshots:
+    def test_snapshot_fast_path_equals_full_replay(self, tmp_path):
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+        snapshot = journal.snapshot()
+
+        decision = journal.propose(
+            envelope(
+                [op("OPS-sn-001", "transition_node", "EXN-dag-001", from_state="proposed", to_state="admitted")],
+                base_revision=revision,
+                mutation_id="MUT-sn-001",
+                key="after-snapshot",
+            )
         )
-        envelope_a["operations"][0]["value"]["execution_node_id"] = "EXN-cyc-001"
-        envelope_a["operations"][0]["value"]["intent_node_id"] = "INN-cyc-001"
-        envelope_a["operations"][0]["target_ref"] = "EXN-cyc-001"
-        envelope_a["operations"] = [
-            {
-                "op_id": "OPS-cyc-001",
-                "operation_type": "add_execution_node",
-                "target_ref": "EXN-cyc-001",
-                "value": {
-                    "schema_version": "1.0.0",
-                    "record_type": "execution_node",
-                    "execution_node_id": "EXN-cyc-001",
-                    "intent_node_id": "INN-cyc-001",
-                    "node_type": "implementation",
-                    "role": "role:implementer",
-                    "lifecycle_state": "proposed",
-                    "attempt": {"attempt_id": None, "outcome": "pending"},
-                    "candidate": {"group_id": None, "disposition": "pending"},
-                    "approval_state": "not_required",
-                    "lease_state": "unclaimed",
-                    "control_state": "active",
-                    "compiled_from": {"intent_node_id": "INN-cyc-001", "intent_graph_digest": "sha256:" + "b" * 64},
-                },
-            }
-        ]
-        journal.propose(envelope_a)
-        state = journal.replay()
-        assert state["graph_revision"] == 1
+        assert decision.accepted, decision.violations
+        assert snapshot.graph_revision == revision
+        # INV-dag-004: identified-record collections are order-insensitive in
+        # canonical form, so equivalence is canonical equality — a snapshot
+        # round-trips through canonical JSON and comes back re-sorted.
+        from chief_wiggum.dag.canonical import canonical_json_bytes
+
+        assert canonical_json_bytes(journal.replay(from_snapshot=True)) == canonical_json_bytes(
+            journal.replay()
+        )
+        assert journal.hash(from_snapshot=True) == journal.hash()
+        assert journal.replay(from_snapshot=True)["graph_revision"] == journal.graph_revision()
         journal.close()
 
+    def test_doctored_snapshot_fails_closed(self, tmp_path):
+        """A snapshot never wins a disagreement with a replay of its prefix."""
+        import hashlib
 
-class TestCLI:
-    def test_cli_init_and_inspect(self, tmp_path: Path):
-        import subprocess
+        from chief_wiggum.dag.canonical import canonical_json_bytes
 
-        db = str(tmp_path / "cli.db")
-        result = subprocess.run(
-            [sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "init", "--db", db, "--graph-id", "GRF-cli001"],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0
-        output = json.loads(result.stdout)
-        assert output["ok"]
-
-        result = subprocess.run(
-            [sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "hash", "--db", db],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0
-        hashes = json.loads(result.stdout)
-        assert "schedule_hash" in hashes
-        assert "audit_state_hash" in hashes
-
-    def test_cli_replay_matches_direct(self, tmp_path: Path):
-        import subprocess
-
-        db = str(tmp_path / "replay.db")
-        subprocess.run([sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "init", "--db", db, "--graph-id", "GRF-rep001"], capture_output=True)
-        result = subprocess.run([sys.executable, str(ROOT / "scripts" / "dag_engine.py"), "replay", "--db", db], capture_output=True, text=True)
-        assert result.returncode == 0
-        state = json.loads(result.stdout)
-        assert state["graph_id"] == "GRF-rep001"
-
-
-class TestSnapshotEquivalence:
-    def test_replay_produces_same_hashes_twice(self, tmp_path: Path):
-        journal = GraphJournal(tmp_path / "equiv.db")
-        journal.init_graph("GRF-eq0001")
-        envelope = _intent_envelope(graph_id="GRF-eq0001")
-        journal.propose(envelope)
-        hashes_1 = journal.hash()
-
+        journal = journal_at(tmp_path)
+        seed_pair(journal)
+        journal.snapshot()
+        seq = journal.last_journal_seq()
         journal.close()
-        reopened = GraphJournal(tmp_path / "equiv.db")
-        hashes_2 = reopened.hash()
-        assert hashes_1["schedule_hash"] == hashes_2["schedule_hash"]
-        assert hashes_1["audit_state_hash"] == hashes_2["audit_state_hash"]
+
+        connection = sqlite3.connect(str(tmp_path / "graph.db"))
+        payload = json.loads(
+            connection.execute(
+                "SELECT payload FROM graph_events WHERE journal_seq = ?", (seq,)
+            ).fetchone()[0]
+        )
+        payload["snapshot"]["graph_revision"] = 99
+        # Re-hash so the chain still verifies: only the fold can catch this.
+        doctored = canonical_json_bytes(payload)
+        connection.execute(
+            "UPDATE graph_events SET payload = ?, event_hash = ? WHERE journal_seq = ?",
+            (doctored.decode(), hashlib.sha256(doctored).hexdigest(), seq),
+        )
+        connection.commit()
+        connection.close()
+
+        reopened = GraphJournal(tmp_path / "graph.db")
+        with pytest.raises(JournalError, match="disagrees"):
+            reopened.replay()
         reopened.close()
 
 
-class TestConcurrentCAS:
-    def test_two_proposals_one_base_only_first_wins(self, tmp_path: Path):
-        journal_a = GraphJournal(tmp_path / "race.db")
-        journal_a.init_graph("GRF-race01")
-        journal_b = GraphJournal(tmp_path / "race.db")
-
-        env_a = _envelope(mutation_id="MUT-dag-003", idempotency_key="race-a", graph_id="GRF-race01")
-        env_b = _envelope(mutation_id="MUT-dag-004", idempotency_key="race-b", graph_id="GRF-race01")
-
-        decision_a = journal_a.propose(env_a)
-        decision_b = journal_b.propose(env_b)
-
-        assert decision_a.accepted
-        assert not decision_b.accepted
-        journal_a.close()
-        journal_b.close()
+# ------------------------------------------------------- AC: crash recovery
 
 
-class TestSidecarResolver:
-    def test_sidecar_mode_resolves_meta_outside_target(self, tmp_path: Path):
+class TestCrashRecovery:
+    def test_torn_tail_at_every_offset_recovers_to_last_valid_state(self, tmp_path):
+        """AC: journal truncated mid-record at every byte offset of a final
+        record → engine recovers to the last valid state; nothing lost."""
+        source = tmp_path / "source.db"
+        journal = journal_at(tmp_path, name="source.db")
+        seed_pair(journal)
+        expected_hash = journal.hash()
+        expected_revision = journal.graph_revision()
+        last_seq = journal.last_journal_seq()
+        raw = journal._conn.execute(
+            "SELECT payload FROM graph_events WHERE journal_seq = ?", (last_seq,)
+        ).fetchone()[0]
+        journal.close()
+
+        offsets = range(0, len(raw), max(1, len(raw) // 40))
+        for offset in offsets:
+            target = tmp_path / f"torn-{offset}.db"
+            target.write_bytes(source.read_bytes())
+            connection = sqlite3.connect(str(target))
+            connection.execute(
+                "UPDATE graph_events SET payload = ? WHERE journal_seq = ?", (raw[:offset], last_seq)
+            )
+            connection.commit()
+            connection.close()
+
+            torn = GraphJournal(target)
+            with pytest.raises(JournalError):
+                torn.replay()  # fails closed before recovery
+            outcome = torn.recover()
+            assert outcome["dropped"] == 1
+            assert outcome["last_valid_seq"] == last_seq - 1
+            state = torn.replay()
+            assert state["graph_revision"] == expected_revision - 1
+            assert torn.hash() != expected_hash
+            torn.close()
+
+    def test_intact_journal_recovers_to_a_no_op(self, tmp_path):
+        journal = journal_at(tmp_path)
+        seed_pair(journal)
+        before = journal.hash()
+        assert journal.recover() == {"dropped": 0, "last_valid_seq": journal.last_journal_seq()}
+        assert journal.hash() == before
+        journal.close()
+
+    def test_mid_journal_corruption_refuses_to_truncate(self, tmp_path):
+        """Corruption with valid records after it is not a torn tail; truncating
+        would discard admitted mutations, so it fails closed instead."""
+        journal = journal_at(tmp_path)
+        seed_pair(journal)
+        journal.close()
+
+        connection = sqlite3.connect(str(tmp_path / "graph.db"))
+        connection.execute("UPDATE graph_events SET payload = 'x' WHERE journal_seq = 2")
+        connection.commit()
+        connection.close()
+
+        reopened = GraphJournal(tmp_path / "graph.db")
+        with pytest.raises(JournalError, match="mid-journal corruption"):
+            reopened.recover()
+        reopened.close()
+
+
+# ------------------------------------------------------- AC: cycle rejection
+
+
+class TestCycleRejection:
+    def test_cycle_is_rejected_before_application_with_the_path(self, tmp_path):
+        journal = journal_at(tmp_path)
+        revision = seed_pair(journal)
+
+        def edge(edge_id, source, target):
+            return {
+                "schema_version": "1.0.0",
+                "record_type": "schedulable_edge",
+                "edge_id": edge_id,
+                "source": source,
+                "target": target,
+                "kind": "depends_on",
+                "derived_from": ["EVD-dag-001"],
+            }
+
+        forward = journal.propose(
+            envelope(
+                [op("OPS-cy-001", "add_schedulable_edge", "SED-dag-001", value=edge("SED-dag-001", "EXN-dag-001", "EXN-dag-002"))],
+                base_revision=revision,
+                mutation_id="MUT-cy-001",
+                key="edge-forward",
+            )
+        )
+        assert forward.accepted, forward.violations
+
+        back = journal.propose(
+            envelope(
+                [op("OPS-cy-002", "add_schedulable_edge", "SED-dag-002", value=edge("SED-dag-002", "EXN-dag-002", "EXN-dag-001"))],
+                base_revision=forward.graph_revision,
+                mutation_id="MUT-cy-002",
+                key="edge-back",
+            )
+        )
+        assert not back.accepted, "a cycle-introducing edge must be rejected"
+        cycle_violations = [v for v in back.violations if v.code == ErrorCode.SCHEDULABLE_CYCLE]
+        assert cycle_violations, back.violations
+        assert cycle_violations[0].details["cycle"], "the offending path must be reported"
+
+        state = journal.replay()
+        assert len(state["schedulable_edges"]) == 1, "the rejected edge must not be applied"
+        assert state["graph_revision"] == forward.graph_revision
+        journal.close()
+
+
+# ---------------------------------------------------- AC: wave projection
+
+
+class TestWaveProjection:
+    def test_project_matches_plan_waves_for_the_same_dependency_graph(self, tmp_path):
+        """AC: project --waves reproduces plan_waves.py's output exactly."""
         sys.path.insert(0, str(ROOT / "scripts"))
-        from artifacts import Resolver
-
-        target = tmp_path / "target-repo"
-        target.mkdir()
         try:
-            target_id = Resolver.resolve(target).target_id
+            from chief_wiggum import planning
         finally:
             sys.path.remove(str(ROOT / "scripts"))
 
-        cw_home = tmp_path / "cw-home"
-        cw_home.mkdir()
-        election_dir = cw_home / "meta" / target_id.replace("/", "/")
-        election_dir.mkdir(parents=True)
-        (election_dir / "election.json").write_text(json.dumps({"mode": "sidecar", "backing": "local"}))
+        journal = journal_at(tmp_path)
+        revision = 0
+        tickets = [1, 2, 3]
+        for ticket in tickets:
+            node_id = f"INN-ticket-{ticket:03d}"
+            decision = journal.propose(
+                envelope(
+                    [op(f"OPS-w-{ticket:03d}", "add_intent_node", node_id, value=intent_node(node_id, ticket=ticket))],
+                    base_revision=revision,
+                    mutation_id=f"MUT-wv-{ticket:03d}",
+                    key=f"wave-node-{ticket}",
+                )
+            )
+            assert decision.accepted, decision.violations
+            revision = decision.graph_revision
 
+        edge_record = {
+            "schema_version": "1.0.0",
+            "record_type": "intent_edge",
+            "edge_id": "IED-ticket-001",
+            "source": "INN-ticket-002",
+            "target": "INN-ticket-001",
+            "source_ticket": 2,
+            "target_ticket": 1,
+            "kind": "depends_on",
+            "actor": "actor:tracker",
+            "reason_code": "EV_DEP_DECLARED",
+        }
+        decision = journal.propose(
+            envelope(
+                [op("OPS-w-900", "add_intent_edge", "IED-ticket-001", value=edge_record)],
+                base_revision=revision,
+                mutation_id="MUT-wv-900",
+                key="wave-edge",
+            )
+        )
+        assert decision.accepted, decision.violations
+        journal.close()
+
+        result = subprocess.run(
+            [sys.executable, str(ENGINE), "project", "--db", str(tmp_path / "graph.db"), "--waves"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        projected = json.loads(result.stdout)
+        expected = planning.plan_waves(tickets, {2: [1], 1: [], 3: []}, closed=[], gated=[]).to_dict()
+        assert projected == expected
+
+    def test_project_errors_rather_than_emitting_an_empty_plan(self, tmp_path):
+        """An intent graph with no ticket-level projection is an error, not a
+        silent empty plan that reads as 'no work to do'."""
+        journal = journal_at(tmp_path)
+        decision = journal.propose(
+            envelope(
+                [op("OPS-w-901", "add_intent_node", "INN-noticket-001", value=intent_node("INN-noticket-001"))],
+                base_revision=0,
+                mutation_id="MUT-wv-901",
+                key="no-ticket",
+            )
+        )
+        assert decision.accepted, decision.violations
+        journal.close()
+
+        result = subprocess.run(
+            [sys.executable, str(ENGINE), "project", "--db", str(tmp_path / "graph.db"), "--waves"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert json.loads(result.stdout)["ok"] is False
+
+
+# ------------------------------------------------------------------ AC: CLI
+
+
+class TestCLI:
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(ENGINE), *args], capture_output=True, text=True
+        )
+
+    def test_init_hash_inspect_and_verify(self, tmp_path):
+        database = str(tmp_path / "cli.db")
+        assert json.loads(self._run("init", "--db", database, "--graph-id", "GRF-cli001").stdout)["ok"]
+
+        hashes = json.loads(self._run("hash", "--db", database).stdout)
+        assert "schedule_hash" in hashes and "audit_state_hash" in hashes
+
+        inspected = self._run("inspect", "--db", database, "--human")
+        assert inspected.returncode == 0
+        assert "GRF-cli001" in inspected.stdout
+
+        verified = json.loads(self._run("verify", "--db", database).stdout)
+        assert verified["ok"] and verified["records_verified"] == 1
+
+    def test_replay_matches_direct(self, tmp_path):
+        database = str(tmp_path / "replay.db")
+        self._run("init", "--db", database, "--graph-id", "GRF-rep001")
+        result = self._run("replay", "--db", database)
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["graph_id"] == "GRF-rep001"
+
+    def test_snapshot_subcommand_writes_a_checkpoint(self, tmp_path):
+        database = str(tmp_path / "snap.db")
+        self._run("init", "--db", database, "--graph-id", "GRF-snp001")
+        result = self._run("snapshot", "--db", database)
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["graph_revision"] == 0
+
+    def test_rejection_and_engine_failure_have_distinct_exit_codes(self, tmp_path):
+        database = str(tmp_path / "codes.db")
+        self._run("init", "--db", database, "--graph-id", "GRF-cod001")
+
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps({"schema_version": "1.0.0", "record_type": "mutation_envelope"}))
+        rejected = self._run("propose", "--db", database, str(bad))
+        assert rejected.returncode == 1
+        assert json.loads(rejected.stdout)["accepted"] is False
+
+        missing = self._run("propose", "--db", database, str(tmp_path / "nope.json"))
+        assert missing.returncode == 3
+        assert json.loads(missing.stdout)["ok"] is False
+
+    def test_operator_reject_is_journaled_without_applying(self, tmp_path):
+        database = str(tmp_path / "opreject.db")
+        self._run("init", "--db", database, "--graph-id", GRAPH)
+        path = tmp_path / "env.json"
+        path.write_text(
+            json.dumps(
+                envelope(
+                    [op("OPS-o-001", "add_intent_node", "INN-op-001", value=intent_node("INN-op-001"))],
+                    base_revision=0,
+                    mutation_id="MUT-op-001",
+                    key="operator",
+                )
+            )
+        )
+        result = self._run("reject", "--db", database, str(path), "--reason", "not now")
+        assert result.returncode == 1
+        assert json.loads(result.stdout)["accepted"] is False
+
+        journal = GraphJournal(tmp_path / "opreject.db")
+        assert journal.replay()["intent_nodes"] == []
+        assert (
+            journal._conn.execute(
+                "SELECT COUNT(*) FROM graph_events WHERE event_type='mutation_rejected'"
+            ).fetchone()[0]
+            == 1
+        )
+        journal.close()
+
+
+# ------------------------------------------------- AC: no hard-coded paths
+
+
+class TestSidecarResolver:
+    def test_sidecar_mode_resolves_meta_outside_target(self, tmp_path):
         sys.path.insert(0, str(ROOT / "scripts"))
-        resolver = Resolver.resolve(target, cw_home=cw_home)
-        sys.path.remove(str(ROOT / "scripts"))
+        try:
+            from artifacts import Resolver
+
+            target = tmp_path / "target-repo"
+            target.mkdir()
+            target_id = Resolver.resolve(target).target_id
+
+            cw_home = tmp_path / "cw-home"
+            election_dir = cw_home / "meta" / target_id
+            election_dir.mkdir(parents=True)
+            (election_dir / "election.json").write_text(
+                json.dumps({"mode": "sidecar", "backing": "local"})
+            )
+
+            resolver = Resolver.resolve(target, cw_home=cw_home)
+        finally:
+            sys.path.remove(str(ROOT / "scripts"))
+
         assert resolver.mode == "sidecar"
         assert str(resolver.meta_root).startswith(str(cw_home))
-        db = resolver.meta_root / "dag" / "journal.db"
-        db.parent.mkdir(parents=True)
-        journal = GraphJournal(db)
+        database = resolver.meta_root / "dag" / "journal.db"
+        database.parent.mkdir(parents=True)
+        journal = GraphJournal(database)
         journal.init_graph("GRF-side01")
-        state = journal.replay()
-        assert state["graph_id"] == "GRF-side01"
+        assert journal.replay()["graph_id"] == "GRF-side01"
+        assert not (target / "docs").exists(), "sidecar mode must not write into the target"
         journal.close()
-
-
-class TestProcessKill:
-    def test_partial_tail_does_not_corrupt_replay(self, tmp_path: Path):
-        import shutil
-
-        db = tmp_path / "kill.db"
-        journal = GraphJournal(db)
-        journal.init_graph("GRF-kill01")
-        envelope = _intent_envelope(graph_id="GRF-kill01")
-        journal.propose(envelope)
-        journal.close()
-
-        copy = tmp_path / "kill-partial.db"
-        shutil.copy2(db, copy)
-        conn = sqlite3.connect(str(copy))
-        raw = conn.execute("SELECT payload FROM graph_events WHERE journal_seq = 1").fetchone()[0]
-        truncated = raw[: len(raw) // 2]
-        conn.execute("UPDATE graph_events SET payload = ? WHERE journal_seq = 1", (truncated,))
-        conn.commit()
-        conn.close()
-
-        recovered = GraphJournal(copy)
-        with pytest.raises(JournalError):
-            recovered.replay()
-        recovered.close()


### PR DESCRIPTION
## Summary

Implements the transactional event-sourced graph engine for #385: a SQLite-backed GraphJournal with deterministic replay, hash-chained events, atomic compare-and-swap on `base_revision`, idempotency by key, snapshots, torn-tail recovery, and a CLI surface.

The first cut of this PR shipped with the two load-bearing behaviours broken and a test suite that could not detect either. This describes the current state.

## What changed

- **`scripts/chief_wiggum/dag/journal.py`** is the sole sanctioned writer of `graph_revision` (INV-dag-001). Each decision runs read, validate and append inside one `BEGIN IMMEDIATE`, so compare-and-swap is atomic. All 16 operation types in the v1 vocabulary apply to the fold. `ready` is materialised by the engine per `docs/dag-contract.md`, which makes it a derived projection a proposal may not set and names #385 as the ticket that composes the machines. Envelopes apply to a copy and the resulting graph is validated, so cycles and dangling references are caught before admission. Adds `snapshot()`, `recover()`, `verify()` and `ready_set()`.
- **`scripts/chief_wiggum/dag/semantics.py`** gains two keyword-only parameters, `validate_snapshot(schema=)` and `validate_mutation(snapshot_validated=)`. Both default to the previous behaviour, so the pure validators keep their contract for other callers.
- **`scripts/dag_engine.py`** covers `init`, `propose`, `admit`, `reject`, `inspect`, `replay`, `hash`, `snapshot`, `verify` and `project --waves`. Projection delegates to `compatibility.project_legacy_waves` rather than reimplementing it without its guards. Exit codes separate a rejection from an engine failure.
- **`tests/test_dag_journal.py`** has 48 tests, each class reproducing the hazard its acceptance criterion names.
- **`tests/test_check_patterns.py`** excludes `.claude/worktrees/` from the private-name scan.

## Defects fixed since the first cut

**Compare-and-swap did not hold under concurrency.** `propose()` read the current revision, validated `base_revision` against it, then opened a separate transaction to append. The write lock covered the insert, not the decision. Two threads released from a barrier produced 200 double-accepts in 200 trials. `init_graph` had the same split.

**Ten of sixteen operation types did not work.** `transition_node`, `acquire_lease`, `release_lease`, `set_control`, `promote_candidate` and `compensate` were accepted and advanced `graph_revision` while changing no state, so a node's `lifecycle_state` could never change and `schedule_hash` could not distinguish a paused graph from a running one. The three `remove_*` types and `approve_mutation` were absent from the map and raised `JournalError` mid-accept.

**Cycles were undetectable.** Validation ran against the pre-state, which is acyclic by construction, so an edge introducing a cycle always passed.

**`ready` was unreachable**, leaving no legal path from `admitted` to `running`. Schedulable edges run `source` after `target`; the first cut had the direction reversed.

**Snapshots and crash recovery did not exist.** There was a reader for a `snapshot` event that nothing ever wrote, and no truncation logic at all.

Also fixed: a repeated idempotency key now returns the original decision rather than one describing the current head; `replay()` returns a deep copy instead of the cached fold; opening a journal retries while locked, because switching journal mode needs a brief exclusive lock that SQLite does not run the busy handler for; the rollback handler no longer raises over the original error; an unparseable payload fails closed; rejections are journaled under this journal's `graph_id` rather than an unvalidated one from the envelope.

## Performance

300 sequential proposals went from 35.3s to 1.13s. Profiling put 96% of the time in jsonschema revalidating the entire snapshot twice per proposal, for records already validated on entry. Chain verification is now incremental per connection and still starts from genesis on a fresh one, so tamper-evidence survives restarts.

Cost is still linear per proposal in graph size, because the contract hashes the whole graph on every accept. Removing that needs an incremental hash, which is a #384 contract change. Tracked separately.

## Test results

Full suite: **3586 passed**, 14 skipped, 0 failed.

Every fix was mutation tested by reverting it and confirming the matching test fails. 8 of 8 were caught. This check is what the first cut lacked: its concurrency test ran sequentially, its cycle test never built a cycle, and its crash test asserted the opposite of the acceptance criterion, so all three passed against code that did not work.

Closes #385

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
