### PR TITLE
feat(dag): continuous ready-set scheduler replacing wave barriers (#387)

### DIFF
--- a/scripts/chief_wiggum/dag/scheduler.py
+++ b/scripts/chief_wiggum/dag/scheduler.py
@@ -1,0 +1,597 @@
+"""Continuous ready-set scheduler.
+
+The behavioural change in one line: a blocked node blocks its dependants, not
+the wave. There is no barrier, because the dependency graph already carries
+everything a barrier was protecting.
+
+Two independent readiness computations live here on purpose. `full_ready_set`
+derives readiness from first principles, and `ReadyIndex` maintains it
+incrementally along the affected frontier. They must agree with each other and
+with the journal's own derived `ready` state, which is what makes "incremental"
+safe to rely on rather than merely fast.
+
+Edge direction follows docs/dag-contract.md: `source` runs AFTER `target`, so a
+node's predecessors are the targets of the edges it sources.
+
+Lease timing lives in this module's store rather than in the graph: the v1
+lease_record schema is closed and carries no expiry, so putting deadlines in the
+graph would mean amending #384's contract to add a scheduler detail.
+
+@cw-trace guards INV-dag-008 INV-dag-009
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from .admission import LivenessFailure
+
+TERMINAL = frozenset({"succeeded", "failed", "superseded", "cancelled"})
+BLOCKING_CONTROL = frozenset({"paused", "pause_requested", "cancelled", "cancel_requested"})
+RUNNABLE = frozenset({"admitted", "ready"})
+
+
+class ClaimRefusal(StrEnum):
+    STALE_REVISION = "STALE_REVISION"
+    NOT_READY = "NOT_READY"
+    ALREADY_LEASED = "ALREADY_LEASED"
+    GRAPH_PAUSED = "GRAPH_PAUSED"
+    UNKNOWN_NODE = "UNKNOWN_NODE"
+
+
+@dataclass(frozen=True)
+class SchedulerPolicy:
+    lease_seconds: float = 3600.0
+    heartbeat_seconds: float = 300.0
+    max_retries_per_node: int = 2
+    max_retries_per_graph: int = 10
+    max_concurrent: int = 4
+    risk_rank: Mapping[str, int] = field(default_factory=dict)
+    declared_priority: Mapping[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Claim:
+    granted: bool
+    execution_node_id: str = ""
+    lease_id: str = ""
+    fencing_token: str = ""
+    graph_revision: int = 0
+    refusal: ClaimRefusal | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class LivenessReport:
+    running: tuple[str, ...]
+    ready: tuple[str, ...]
+    blocked: tuple[str, ...]
+    outstanding: tuple[str, ...]
+
+    @property
+    def stalled(self) -> bool:
+        """Nothing running, nothing ready, yet work remains."""
+        return not self.running and not self.ready and bool(self.outstanding)
+
+
+def _nodes_by_id(state: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    return {node["execution_node_id"]: node for node in state.get("execution_nodes", [])}
+
+
+def _predecessors(state: Mapping[str, Any]) -> dict[str, list[str]]:
+    """target runs BEFORE source, so the targets of a node's edges gate it."""
+    predecessors: dict[str, list[str]] = {node: [] for node in _nodes_by_id(state)}
+    for edge in state.get("schedulable_edges", []):
+        source, target = str(edge.get("source")), str(edge.get("target"))
+        if source in predecessors:
+            predecessors[source].append(target)
+    return predecessors
+
+
+def _dependants(state: Mapping[str, Any]) -> dict[str, list[str]]:
+    dependants: dict[str, list[str]] = {node: [] for node in _nodes_by_id(state)}
+    for edge in state.get("schedulable_edges", []):
+        source, target = str(edge.get("source")), str(edge.get("target"))
+        if target in dependants:
+            dependants[target].append(source)
+    return dependants
+
+
+def graph_paused(state: Mapping[str, Any]) -> bool:
+    return any(
+        record.get("state") in BLOCKING_CONTROL for record in state.get("control_records", [])
+    )
+
+
+def _node_is_ready(
+    node: Mapping[str, Any], predecessors: Sequence[str], nodes: Mapping[str, Mapping[str, Any]]
+) -> bool:
+    if node.get("lifecycle_state") not in RUNNABLE:
+        return False
+    if node.get("control_state") != "active":
+        return False
+    return all(
+        (nodes.get(predecessor) or {}).get("lifecycle_state") == "succeeded"
+        for predecessor in predecessors
+    )
+
+
+def full_ready_set(state: Mapping[str, Any]) -> list[str]:
+    """Readiness from first principles. The reference the incremental index must match."""
+    if graph_paused(state):
+        return []
+    nodes = _nodes_by_id(state)
+    predecessors = _predecessors(state)
+    return sorted(
+        node_id
+        for node_id, node in nodes.items()
+        if _node_is_ready(node, predecessors.get(node_id, ()), nodes)
+    )
+
+
+class ReadyIndex:
+    """Incrementally maintained ready set.
+
+    Recomputing the whole topological order on every event is wasteful, so a
+    change invalidates only the node itself and its direct dependants: readiness
+    depends on nothing else. A control change that pauses the graph invalidates
+    everything, because it gates every node at once.
+    """
+
+    def __init__(self, state: Mapping[str, Any]) -> None:
+        self._ready: set[str] = set(full_ready_set(state))
+        self._paused = graph_paused(state)
+
+    def apply(self, state: Mapping[str, Any], dirty: Iterable[str]) -> None:
+        paused = graph_paused(state)
+        if paused:
+            self._ready.clear()
+            self._paused = True
+            return
+        nodes = _nodes_by_id(state)
+        predecessors = _predecessors(state)
+        if self._paused:
+            # Unpausing re-opens every node, so the frontier is the whole graph.
+            self._paused = False
+            frontier = set(nodes)
+        else:
+            dependants = _dependants(state)
+            frontier = set()
+            for node_id in dirty:
+                frontier.add(node_id)
+                frontier.update(dependants.get(node_id, ()))
+        for node_id in frontier:
+            node = nodes.get(node_id)
+            if node is not None and _node_is_ready(node, predecessors.get(node_id, ()), nodes):
+                self._ready.add(node_id)
+            else:
+                self._ready.discard(node_id)
+        self._ready.intersection_update(nodes)
+
+    def ready(self) -> list[str]:
+        return sorted(self._ready)
+
+
+def critical_path_lengths(state: Mapping[str, Any]) -> dict[str, int]:
+    """Longest chain of remaining work downstream of each node."""
+    nodes = _nodes_by_id(state)
+    dependants = _dependants(state)
+    lengths: dict[str, int] = {}
+
+    def visit(node_id: str, seen: frozenset[str]) -> int:
+        if node_id in lengths:
+            return lengths[node_id]
+        if node_id in seen:  # pragma: no cover - the engine rejects cycles
+            return 0
+        best = 0
+        for dependant in dependants.get(node_id, ()):
+            best = max(best, 1 + visit(dependant, seen | {node_id}))
+        lengths[node_id] = best
+        return best
+
+    for node_id in nodes:
+        visit(node_id, frozenset())
+    return lengths
+
+
+def priority_key(
+    node_id: str,
+    state: Mapping[str, Any],
+    policy: SchedulerPolicy,
+    *,
+    critical_path: Mapping[str, int] | None = None,
+    resource_available: Mapping[str, bool] | None = None,
+) -> tuple:
+    """Declared priority, critical path, risk, age, resources, then the node id.
+
+    The final id tie-break is what makes two replays of one journal schedule
+    identically. Without it, deterministic replay is unprovable at this layer.
+    """
+    nodes = list(_nodes_by_id(state))
+    node = _nodes_by_id(state).get(node_id, {})
+    lengths = critical_path if critical_path is not None else critical_path_lengths(state)
+    age = nodes.index(node_id) if node_id in nodes else len(nodes)
+    available = (resource_available or {}).get(node_id, True)
+    return (
+        -int(policy.declared_priority.get(node_id, 0)),
+        -int(lengths.get(node_id, 0)),
+        -int(policy.risk_rank.get(str(node.get("node_type", "")), 0)),
+        age,
+        0 if available else 1,
+        node_id,
+    )
+
+
+class SchedulerStore:
+    """Lease timing, heartbeats and the dispatch log.
+
+    Separate from the graph because the v1 lease record is closed and carries no
+    deadline. The graph owns lease STATE; this owns lease TIME.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._conn = sqlite3.connect(str(self._path), isolation_level=None, timeout=30.0)
+        self._conn.execute("PRAGMA busy_timeout=30000")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS leases (
+                lease_id TEXT PRIMARY KEY,
+                graph_id TEXT NOT NULL,
+                execution_node_id TEXT NOT NULL,
+                worker TEXT NOT NULL,
+                fencing_token TEXT NOT NULL,
+                granted_at REAL NOT NULL,
+                expires_at REAL NOT NULL,
+                heartbeat_at REAL NOT NULL,
+                progress TEXT NOT NULL DEFAULT '{}',
+                state TEXT NOT NULL DEFAULT 'active'
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS dispatches (
+                dispatch_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                graph_id TEXT NOT NULL,
+                execution_node_id TEXT NOT NULL,
+                lease_id TEXT NOT NULL,
+                graph_revision INTEGER NOT NULL,
+                dispatched_at REAL NOT NULL
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS retries (
+                retry_id TEXT PRIMARY KEY,
+                graph_id TEXT NOT NULL,
+                original_node_id TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def grant(
+        self,
+        *,
+        lease_id: str,
+        graph_id: str,
+        node_id: str,
+        worker: str,
+        fencing_token: str,
+        now: float,
+        expires_at: float,
+    ) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO leases (lease_id, graph_id, execution_node_id, worker,"
+            " fencing_token, granted_at, expires_at, heartbeat_at, progress, state)"
+            " VALUES (?,?,?,?,?,?,?,?,'{}','active')",
+            (lease_id, graph_id, node_id, worker, fencing_token, now, expires_at, now),
+        )
+
+    def active_lease_for(self, graph_id: str, node_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute(
+            "SELECT lease_id, worker, expires_at, state FROM leases"
+            " WHERE graph_id=? AND execution_node_id=? AND state='active'",
+            (graph_id, node_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"lease_id": row[0], "worker": row[1], "expires_at": row[2], "state": row[3]}
+
+    def lease(self, lease_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute(
+            "SELECT lease_id, graph_id, execution_node_id, worker, fencing_token, expires_at,"
+            " heartbeat_at, progress, state FROM leases WHERE lease_id=?",
+            (lease_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "lease_id": row[0],
+            "graph_id": row[1],
+            "execution_node_id": row[2],
+            "worker": row[3],
+            "fencing_token": row[4],
+            "expires_at": row[5],
+            "heartbeat_at": row[6],
+            "progress": json.loads(row[7]),
+            "state": row[8],
+        }
+
+    def heartbeat(self, lease_id: str, *, now: float, progress: Mapping[str, Any],
+                  expires_at: float) -> bool:
+        cursor = self._conn.execute(
+            "UPDATE leases SET heartbeat_at=?, progress=?, expires_at=?"
+            " WHERE lease_id=? AND state='active'",
+            (now, json.dumps(dict(progress), sort_keys=True), expires_at, lease_id),
+        )
+        return cursor.rowcount > 0
+
+    def expire(self, lease_id: str) -> None:
+        self._conn.execute(
+            "UPDATE leases SET state='expired' WHERE lease_id=? AND state='active'", (lease_id,)
+        )
+
+    def release(self, lease_id: str) -> None:
+        self._conn.execute(
+            "UPDATE leases SET state='released' WHERE lease_id=? AND state='active'", (lease_id,)
+        )
+
+    def expired(self, graph_id: str, now: float) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT lease_id, execution_node_id, worker, expires_at FROM leases"
+            " WHERE graph_id=? AND state='active' AND expires_at <= ? ORDER BY lease_id",
+            (graph_id, now),
+        )
+        return [
+            {"lease_id": r[0], "execution_node_id": r[1], "worker": r[2], "expires_at": r[3]}
+            for r in rows
+        ]
+
+    def active(self, graph_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT lease_id, execution_node_id, worker FROM leases"
+            " WHERE graph_id=? AND state='active' ORDER BY lease_id",
+            (graph_id,),
+        )
+        return [{"lease_id": r[0], "execution_node_id": r[1], "worker": r[2]} for r in rows]
+
+    def record_dispatch(self, *, graph_id: str, node_id: str, lease_id: str,
+                        revision: int, now: float) -> None:
+        self._conn.execute(
+            "INSERT INTO dispatches (graph_id, execution_node_id, lease_id, graph_revision,"
+            " dispatched_at) VALUES (?,?,?,?,?)",
+            (graph_id, node_id, lease_id, revision, now),
+        )
+
+    def dispatch_order(self, graph_id: str) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT execution_node_id FROM dispatches WHERE graph_id=? ORDER BY dispatch_seq",
+            (graph_id,),
+        )
+        return [row[0] for row in rows]
+
+    def retry_count(self, graph_id: str, node_id: str | None = None) -> int:
+        if node_id is None:
+            row = self._conn.execute(
+                "SELECT COUNT(*) FROM retries WHERE graph_id=?", (graph_id,)
+            ).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT COUNT(*) FROM retries WHERE graph_id=? AND original_node_id=?",
+                (graph_id, node_id),
+            ).fetchone()
+        return int(row[0])
+
+    def record_retry(self, *, retry_id: str, graph_id: str, node_id: str, attempt: int,
+                     now: float) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO retries (retry_id, graph_id, original_node_id, attempt,"
+            " created_at) VALUES (?,?,?,?,?)",
+            (retry_id, graph_id, node_id, attempt, now),
+        )
+
+
+class Scheduler:
+    """Decides what is safe to start now, and refuses to pretend when nothing is."""
+
+    def __init__(
+        self,
+        journal: Any,
+        store: SchedulerStore,
+        policy: SchedulerPolicy | None = None,
+        *,
+        clock: Callable[[], float] = time.time,
+        shadow: bool = False,
+    ) -> None:
+        self._journal = journal
+        self._store = store
+        self._policy = policy or SchedulerPolicy()
+        self._clock = clock
+        self._shadow = shadow
+        state = journal.replay()
+        self._graph_id = str(state.get("graph_id", ""))
+        self._index = ReadyIndex(state)
+
+    @property
+    def shadow(self) -> bool:
+        return self._shadow
+
+    def refresh(self, dirty: Iterable[str] | None = None) -> list[str]:
+        """Advance the incremental index. Passing None forces a full rebuild."""
+        state = self._journal.replay()
+        if dirty is None:
+            self._index = ReadyIndex(state)
+        else:
+            self._index.apply(state, dirty)
+        return self._index.ready()
+
+    def ready(self) -> list[str]:
+        return self._index.ready()
+
+    def _leased(self) -> set[str]:
+        return {entry["execution_node_id"] for entry in self._store.active(self._graph_id)}
+
+    def dispatchable(self, limit: int | None = None) -> list[str]:
+        """Ready nodes in deterministic priority order, minus those already leased."""
+        state = self._journal.replay()
+        lengths = critical_path_lengths(state)
+        leased = self._leased()
+        candidates = [node for node in self._index.ready() if node not in leased]
+        candidates.sort(key=lambda node: priority_key(node, state, self._policy,
+                                                      critical_path=lengths))
+        room = self._policy.max_concurrent - len(leased)
+        if room <= 0:
+            return []
+        return candidates[: min(room, limit if limit is not None else room)]
+
+    def claim(self, node_id: str, *, worker: str, base_revision: int) -> Claim:
+        """Claim a node against a graph revision. A moved graph refuses the claim."""
+        state = self._journal.replay()
+        revision = int(state.get("graph_revision", 0))
+        if base_revision != revision:
+            return Claim(
+                granted=False,
+                refusal=ClaimRefusal.STALE_REVISION,
+                detail=f"claim was computed against revision {base_revision}, graph is at {revision}",
+            )
+        if graph_paused(state):
+            return Claim(granted=False, refusal=ClaimRefusal.GRAPH_PAUSED)
+        nodes = _nodes_by_id(state)
+        if node_id not in nodes:
+            return Claim(granted=False, refusal=ClaimRefusal.UNKNOWN_NODE)
+        if node_id not in full_ready_set(state):
+            return Claim(
+                granted=False,
+                refusal=ClaimRefusal.NOT_READY,
+                detail=f"{node_id} is {nodes[node_id].get('lifecycle_state')}",
+            )
+        if self._store.active_lease_for(self._graph_id, node_id) is not None:
+            return Claim(granted=False, refusal=ClaimRefusal.ALREADY_LEASED)
+
+        now = self._clock()
+        suffix = f"{abs(hash((node_id, worker, revision))) % 10**9:09d}"
+        lease_id = f"LSE-claim-{suffix}"
+        fencing_token = f"{revision}:{suffix}"
+        if not self._shadow:
+            self._store.grant(
+                lease_id=lease_id,
+                graph_id=self._graph_id,
+                node_id=node_id,
+                worker=worker,
+                fencing_token=fencing_token,
+                now=now,
+                expires_at=now + self._policy.lease_seconds,
+            )
+            self._store.record_dispatch(
+                graph_id=self._graph_id, node_id=node_id, lease_id=lease_id,
+                revision=revision, now=now,
+            )
+        return Claim(
+            granted=True,
+            execution_node_id=node_id,
+            lease_id=lease_id,
+            fencing_token=fencing_token,
+            graph_revision=revision,
+        )
+
+    def heartbeat(self, lease_id: str, *, progress: Mapping[str, Any] | None = None) -> bool:
+        """Extend a lease. Objective progress is carried, not just wall-clock."""
+        now = self._clock()
+        return self._store.heartbeat(
+            lease_id,
+            now=now,
+            progress=progress or {},
+            expires_at=now + self._policy.lease_seconds,
+        )
+
+    def release(self, lease_id: str) -> None:
+        self._store.release(lease_id)
+
+    def commit_allowed(self, lease_id: str) -> bool:
+        """A worker whose lease expired may not commit its claim afterwards."""
+        lease = self._store.lease(lease_id)
+        if lease is None or lease["state"] != "active":
+            return False
+        return lease["expires_at"] > self._clock()
+
+    def expire_leases(self) -> list[dict[str, Any]]:
+        """Expiry is evidence, never a silent takeover."""
+        now = self._clock()
+        expired = self._store.expired(self._graph_id, now)
+        for entry in expired:
+            self._store.expire(entry["lease_id"])
+        return expired
+
+    def retry_budget_remaining(self, node_id: str) -> int:
+        per_node = self._policy.max_retries_per_node - self._store.retry_count(
+            self._graph_id, node_id
+        )
+        per_graph = self._policy.max_retries_per_graph - self._store.retry_count(self._graph_id)
+        return max(0, min(per_node, per_graph))
+
+    def register_retry(self, node_id: str, retry_node_id: str) -> bool:
+        """Record a retry attempt. Returns False when the budget is spent."""
+        if self.retry_budget_remaining(node_id) <= 0:
+            return False
+        attempt = self._store.retry_count(self._graph_id, node_id) + 1
+        self._store.record_retry(
+            retry_id=retry_node_id,
+            graph_id=self._graph_id,
+            node_id=node_id,
+            attempt=attempt,
+            now=self._clock(),
+        )
+        return True
+
+    def liveness(self) -> LivenessReport:
+        state = self._journal.replay()
+        nodes = _nodes_by_id(state)
+        running = tuple(sorted(self._leased()))
+        ready = tuple(self._index.ready())
+        outstanding = tuple(
+            sorted(
+                node_id
+                for node_id, node in nodes.items()
+                if node.get("lifecycle_state") not in TERMINAL
+            )
+        )
+        blocked = tuple(
+            node_id for node_id in outstanding if node_id not in ready and node_id not in running
+        )
+        return LivenessReport(running=running, ready=ready, blocked=blocked,
+                              outstanding=outstanding)
+
+    def assert_progress(self) -> LivenessReport:
+        """A graph that cannot progress fails loudly rather than spinning or exiting 0."""
+        report = self.liveness()
+        if report.stalled:
+            raise LivenessFailure(
+                "no node is running and none can become ready; blocking set: "
+                + ", ".join(report.blocked)
+            )
+        return report
+
+    def resume(self) -> dict[str, Any]:
+        """Reconstruct after a crash: rebuild the index, reconcile in-flight leases."""
+        self.refresh(None)
+        expired = self.expire_leases()
+        return {
+            "graph_revision": int(self._journal.replay().get("graph_revision", 0)),
+            "ready": self._index.ready(),
+            "expired_leases": [entry["lease_id"] for entry in expired],
+            "still_running": [entry["execution_node_id"] for entry in self._store.active(self._graph_id)],
+        }

--- a/tests/test_dag_scheduler.py
+++ b/tests/test_dag_scheduler.py
@@ -1,0 +1,667 @@
+"""Continuous ready-set scheduler (chief-wiggum#387).
+
+The scenario tests are the point. Each one reproduces a situation the wave
+barrier handled badly, and asserts the specific thing the barrier could not do:
+unrelated work keeps running.
+"""
+
+import random
+
+import pytest
+from chief_wiggum.dag import GraphJournal
+from chief_wiggum.dag.admission import LivenessFailure
+from chief_wiggum.dag.scheduler import (
+    ClaimRefusal,
+    ReadyIndex,
+    Scheduler,
+    SchedulerPolicy,
+    SchedulerStore,
+    critical_path_lengths,
+    full_ready_set,
+    priority_key,
+)
+
+GRAPH = "GRF-sch001"
+
+
+class FakeClock:
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def envelope(operations, *, base_revision, mutation_id, key, authority_class=None):
+    from chief_wiggum.dag.schemas import load_authority_matrix
+
+    matrix = {row["operation_type"]: row for row in load_authority_matrix()["operations"]}
+    needs = any(matrix.get(op["operation_type"], {}).get("approval_required") for op in operations)
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "mutation_envelope",
+        "graph_id": GRAPH,
+        "base_revision": base_revision,
+        "mutation_id": mutation_id,
+        "idempotency_key": key,
+        "actor": "actor:test",
+        "authority_class": authority_class or ("human" if needs else "automatic"),
+        "operations": operations,
+        "reason_code": "EV_HUMAN_DECISION",
+        "evidence_refs": [],
+        "expected_effect": "scheduler fixture",
+        "budget_delta": {"unit": "tokens", "value": 0},
+        "requires_approval": needs,
+    }
+
+
+def intent_node(node_id):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "intent_node",
+        "intent_node_id": node_id,
+        "node_type": "implementation",
+        "role": "role:implementer",
+        "source_ref": "ticket:#1",
+        "in_scope": True,
+    }
+
+
+def execution_node(node_id, intent_id):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "execution_node",
+        "execution_node_id": node_id,
+        "intent_node_id": intent_id,
+        "node_type": "implementation",
+        "role": "role:implementer",
+        "lifecycle_state": "proposed",
+        "attempt": {"attempt_id": None, "outcome": "pending"},
+        "candidate": {"group_id": None, "disposition": "pending"},
+        "approval_state": "not_required",
+        "lease_state": "unclaimed",
+        "control_state": "active",
+        "compiled_from": {"intent_node_id": intent_id, "intent_graph_digest": "sha256:" + "b" * 64},
+    }
+
+
+def evidence_record(evidence_id):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "evidence_record",
+        "evidence_id": evidence_id,
+        "evidence_type": "test_signal",
+        "source_ref": "test",
+        "content_digest": "sha256:" + "c" * 64,
+        "observed_at": "2026-01-01T00:00:00Z",
+        "status": "validated",
+    }
+
+
+class Graph:
+    """Small fixture builder that keeps base_revision bookkeeping out of tests."""
+
+    def __init__(self, tmp_path, name="graph.db"):
+        self.journal = GraphJournal(tmp_path / name)
+        self.journal.init_graph(GRAPH)
+        self.revision = 0
+        self.counter = 0
+
+    def _apply(self, operations, authority_class=None):
+        self.counter += 1
+        decision = self.journal.propose(
+            envelope(
+                operations,
+                base_revision=self.revision,
+                mutation_id=f"MUT-sch-{self.counter:03d}",
+                key=f"sch-{self.counter}",
+                authority_class=authority_class,
+            )
+        )
+        assert decision.accepted, decision.violations
+        self.revision = decision.graph_revision
+        return decision
+
+    def add_node(self, letter, index):
+        intent_id = f"INN-{letter}-{index:03d}"
+        exec_id = f"EXN-{letter}-{index:03d}"
+        self._apply(
+            [{"op_id": f"OPS-i-{self.counter + 1:03d}", "operation_type": "add_intent_node",
+              "target_ref": intent_id, "value": intent_node(intent_id)}],
+            authority_class="human",
+        )
+        self._apply(
+            [{"op_id": f"OPS-x-{self.counter + 1:03d}", "operation_type": "add_execution_node",
+              "target_ref": exec_id, "value": execution_node(exec_id, intent_id)}]
+        )
+        return exec_id
+
+    def add_evidence(self, evidence_id):
+        self._apply(
+            [{"op_id": f"OPS-e-{self.counter + 1:03d}", "operation_type": "record_evidence",
+              "target_ref": evidence_id, "value": evidence_record(evidence_id)}]
+        )
+        return evidence_id
+
+    def edge(self, source, target, evidence_id, edge_id):
+        """source runs AFTER target."""
+        self._apply(
+            [{"op_id": f"OPS-d-{self.counter + 1:03d}", "operation_type": "add_schedulable_edge",
+              "target_ref": edge_id,
+              "value": {"schema_version": "1.0.0", "record_type": "schedulable_edge",
+                        "edge_id": edge_id, "source": source, "target": target,
+                        "kind": "depends_on", "derived_from": [evidence_id]}}]
+        )
+
+    def transition(self, node_id, before, after):
+        self._apply(
+            [{"op_id": f"OPS-t-{self.counter + 1:03d}", "operation_type": "transition_node",
+              "target_ref": node_id, "from_state": before, "to_state": after}]
+        )
+
+    def admit(self, node_id):
+        self.transition(node_id, "proposed", "admitted")
+
+    def succeed(self, node_id):
+        state = self.journal.replay()
+        current = next(
+            n["lifecycle_state"] for n in state["execution_nodes"]
+            if n["execution_node_id"] == node_id
+        )
+        if current != "running":
+            self.transition(node_id, current, "running")
+        self.transition(node_id, "running", "succeeded")
+
+    def close(self):
+        self.journal.close()
+
+
+def scheduler_for(graph, tmp_path, policy=None, clock=None, shadow=False):
+    store = SchedulerStore(tmp_path / "graph.db")
+    return Scheduler(graph.journal, store, policy or SchedulerPolicy(),
+                     clock=clock or FakeClock(), shadow=shadow), store
+
+
+# ------------------------------------------------------------- ready set
+
+
+class TestReadySet:
+    def test_incremental_matches_full_recomputation_randomised(self, tmp_path):
+        """AC: incremental ready set equals full recomputation for every state."""
+        rng = random.Random(20260822)
+        graph = Graph(tmp_path)
+        nodes = [graph.add_node("n", index) for index in range(1, 7)]
+        evidence = graph.add_evidence("EVD-sched-000000000000001")
+        # A random DAG, kept acyclic by only linking later nodes to earlier ones.
+        edge_count = 0
+        for later in range(1, len(nodes)):
+            for earlier in range(later):
+                if rng.random() < 0.35:
+                    edge_count += 1
+                    graph.edge(nodes[later], nodes[earlier], evidence,
+                               f"SED-rnd-{edge_count:03d}")
+        for node in nodes:
+            graph.admit(node)
+
+        index = ReadyIndex(graph.journal.replay())
+        assert index.ready() == full_ready_set(graph.journal.replay())
+
+        for _ in range(25):
+            state = graph.journal.replay()
+            runnable = [
+                n["execution_node_id"] for n in state["execution_nodes"]
+                if n["lifecycle_state"] in ("ready", "admitted")
+            ]
+            if not runnable:
+                break
+            chosen = rng.choice(sorted(runnable))
+            if chosen not in full_ready_set(state):
+                # Not startable yet; nothing to do this round.
+                continue
+            graph.succeed(chosen)
+            new_state = graph.journal.replay()
+            index.apply(new_state, [chosen])
+            assert index.ready() == full_ready_set(new_state), (
+                f"incremental diverged after {chosen}"
+            )
+        graph.close()
+
+    def test_scheduler_readiness_agrees_with_the_engine(self, tmp_path):
+        """Two independent derivations of the same property must agree."""
+        graph = Graph(tmp_path)
+        first = graph.add_node("a", 1)
+        second = graph.add_node("b", 1)
+        evidence = graph.add_evidence("EVD-agree-000000000000001")
+        graph.edge(second, first, evidence, "SED-agree-001")
+        graph.admit(first)
+        graph.admit(second)
+        state = graph.journal.replay()
+        assert full_ready_set(state) == graph.journal.ready_set() == [first]
+        graph.succeed(first)
+        state = graph.journal.replay()
+        assert full_ready_set(state) == graph.journal.ready_set() == [second]
+        graph.close()
+
+    def test_node_control_state_gates_readiness(self, tmp_path):
+        """Per-node control is distinct from a graph-wide pause and gates alone."""
+        graph = Graph(tmp_path)
+        open_node = graph.add_node("ctl", 1)
+        intent_id = "INN-ctl-002"
+        halted = "EXN-ctl-002"
+        graph._apply(
+            [{"op_id": "OPS-ctl-010", "operation_type": "add_intent_node",
+              "target_ref": intent_id, "value": intent_node(intent_id)}],
+            authority_class="human",
+        )
+        graph._apply(
+            [{"op_id": "OPS-ctl-011", "operation_type": "add_execution_node",
+              "target_ref": halted,
+              "value": dict(execution_node(halted, intent_id), control_state="cancelled")}]
+        )
+        graph.admit(open_node)
+        graph.transition(halted, "proposed", "admitted")
+        state = graph.journal.replay()
+        assert full_ready_set(state) == [open_node], "a non-active node must not be ready"
+        index = ReadyIndex(state)
+        assert index.ready() == [open_node]
+        graph.close()
+
+    def test_pausing_the_graph_empties_the_ready_set(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("p", 1)
+        graph.admit(node)
+        index = ReadyIndex(graph.journal.replay())
+        assert index.ready() == [node]
+        graph._apply(
+            [{"op_id": "OPS-c-900", "operation_type": "set_control", "target_ref": "CTL-p-001",
+              "value": {"schema_version": "1.0.0", "record_type": "control_record",
+                        "control_id": "CTL-p-001", "graph_id": GRAPH, "state": "paused",
+                        "actor": "actor:test", "reason_code": "EV_HUMAN_DECISION"}}],
+            authority_class="human",
+        )
+        state = graph.journal.replay()
+        index.apply(state, [node])
+        assert index.ready() == [] == full_ready_set(state)
+        graph.close()
+
+
+# ------------------------------------------------------------- priority
+
+
+class TestPriority:
+    def test_tie_break_chain_ends_at_the_node_id(self, tmp_path):
+        graph = Graph(tmp_path)
+        first = graph.add_node("z", 1)
+        second = graph.add_node("a", 1)
+        graph.admit(first)
+        graph.admit(second)
+        state = graph.journal.replay()
+        policy = SchedulerPolicy()
+        ordered = sorted(full_ready_set(state),
+                         key=lambda n: priority_key(n, state, policy))
+        # Same declared priority, critical path, risk. Age decides, then id.
+        assert ordered == [first, second]
+        assert priority_key(first, state, policy)[-1] == first
+        graph.close()
+
+    def test_declared_priority_outranks_everything_below_it(self, tmp_path):
+        graph = Graph(tmp_path)
+        first = graph.add_node("z", 1)
+        second = graph.add_node("a", 1)
+        graph.admit(first)
+        graph.admit(second)
+        state = graph.journal.replay()
+        policy = SchedulerPolicy(declared_priority={second: 10})
+        ordered = sorted(full_ready_set(state), key=lambda n: priority_key(n, state, policy))
+        assert ordered[0] == second
+        graph.close()
+
+    def test_critical_path_prefers_the_longer_chain(self, tmp_path):
+        graph = Graph(tmp_path)
+        # `lonely` is added FIRST so it wins on age. Only critical-path length
+        # can put `head` in front, which is what this test is for.
+        lonely = graph.add_node("l", 1)
+        head = graph.add_node("h", 1)
+        middle = graph.add_node("m", 1)
+        tail = graph.add_node("t", 1)
+        evidence = graph.add_evidence("EVD-cp-000000000000001")
+        graph.edge(middle, head, evidence, "SED-cp-001")
+        graph.edge(tail, middle, evidence, "SED-cp-002")
+        for node in (head, middle, tail, lonely):
+            graph.admit(node)
+        state = graph.journal.replay()
+        lengths = critical_path_lengths(state)
+        assert lengths[head] == 2
+        assert lengths[lonely] == 0
+        ordered = sorted(full_ready_set(state),
+                         key=lambda n: priority_key(n, state, SchedulerPolicy(),
+                                                    critical_path=lengths))
+        assert ordered[0] == head
+        graph.close()
+
+
+# ------------------------------------------------------ required scenarios
+
+
+class TestScenarios:
+    def test_failed_gate_blocks_only_dependants_not_siblings(self, tmp_path):
+        """AC: a gate failure blocks only that node's dependants, provably not siblings."""
+        graph = Graph(tmp_path)
+        failing = graph.add_node("f", 1)
+        dependant = graph.add_node("d", 1)
+        sibling_one = graph.add_node("s", 1)
+        sibling_two = graph.add_node("s", 2)
+        evidence = graph.add_evidence("EVD-gate-000000000000001")
+        graph.edge(dependant, failing, evidence, "SED-gate-001")
+        for node in (failing, dependant, sibling_one, sibling_two):
+            graph.admit(node)
+
+        scheduler, store = scheduler_for(graph, tmp_path)
+        assert set(scheduler.refresh(None)) == {failing, sibling_one, sibling_two}
+
+        graph.transition(failing, "ready", "running")
+        graph.transition(failing, "running", "blocked")
+        ready = set(scheduler.refresh(None))
+        assert dependant not in ready, "the dependant must be held"
+        assert {sibling_one, sibling_two} <= ready, "siblings must keep running"
+        store.close()
+        graph.close()
+
+    def test_discovery_mid_run_blocks_only_the_affected_node(self, tmp_path):
+        """AC: a discovered dependency blocks its node; three others run on."""
+        graph = Graph(tmp_path)
+        affected = graph.add_node("af", 1)
+        blocker = graph.add_node("bl", 1)
+        others = [graph.add_node("ot", index) for index in range(1, 4)]
+        for node in [affected, blocker, *others]:
+            graph.admit(node)
+        scheduler, store = scheduler_for(graph, tmp_path)
+        before = set(scheduler.refresh(None))
+        assert set(others) <= before
+
+        evidence = graph.add_evidence("EVD-disc-000000000000001")
+        graph.edge(affected, blocker, evidence, "SED-disc-001")
+
+        after = set(scheduler.refresh(None))
+        assert affected not in after, "the newly dependent node must block"
+        assert set(others) <= after, "unrelated work must be untouched"
+        store.close()
+        graph.close()
+
+    def test_no_progress_raises_an_explicit_liveness_failure(self, tmp_path):
+        """AC: it does not spin, and it does not exit 0."""
+        graph = Graph(tmp_path)
+        stuck = graph.add_node("st", 1)
+        graph.admit(stuck)
+        graph.transition(stuck, "ready", "blocked")
+        scheduler, store = scheduler_for(graph, tmp_path)
+        scheduler.refresh(None)
+        report = scheduler.liveness()
+        assert report.stalled
+        with pytest.raises(LivenessFailure, match=stuck):
+            scheduler.assert_progress()
+        store.close()
+        graph.close()
+
+    def test_finished_graph_is_not_a_liveness_failure(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("done", 1)
+        graph.admit(node)
+        graph.succeed(node)
+        scheduler, store = scheduler_for(graph, tmp_path)
+        scheduler.refresh(None)
+        assert not scheduler.liveness().stalled
+        scheduler.assert_progress()
+        store.close()
+        graph.close()
+
+    def test_replay_determinism_of_dispatch_order(self, tmp_path):
+        """AC: replaying the same journal produces the same dispatch order."""
+        def run(directory):
+            directory.mkdir()
+            graph = Graph(directory)
+            nodes = [graph.add_node("r", index) for index in range(1, 5)]
+            for node in nodes:
+                graph.admit(node)
+            scheduler, store = scheduler_for(graph, directory)
+            scheduler.refresh(None)
+            order = scheduler.dispatchable()
+            revision = graph.revision
+            for node in order:
+                scheduler.claim(node, worker="actor:worker", base_revision=revision)
+            dispatched = store.dispatch_order(GRAPH)
+            hashes = graph.journal.hash()
+            store.close()
+            graph.close()
+            return order, dispatched, hashes
+
+        first = run(tmp_path / "one")
+        second = run(tmp_path / "two")
+        assert first[0] == second[0]
+        assert first[1] == second[1]
+        assert first[2] == second[2]
+
+
+# ---------------------------------------------------------------- leases
+
+
+class TestLeasesAndClaims:
+    def test_stale_revision_refuses_the_claim(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("cl", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(graph, tmp_path)
+        scheduler.refresh(None)
+        stale = scheduler.claim(node, worker="actor:worker", base_revision=graph.revision - 1)
+        assert not stale.granted
+        assert stale.refusal is ClaimRefusal.STALE_REVISION
+        fresh = scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        assert fresh.granted
+        store.close()
+        graph.close()
+
+    def test_claiming_a_node_that_is_not_ready_is_refused(self, tmp_path):
+        graph = Graph(tmp_path)
+        gated = graph.add_node("nr", 1)
+        blocker = graph.add_node("nr", 2)
+        evidence = graph.add_evidence("EVD-notready-000000000000001")
+        graph.edge(gated, blocker, evidence, "SED-nr-001")
+        graph.admit(gated)
+        graph.admit(blocker)
+        scheduler, store = scheduler_for(graph, tmp_path)
+        scheduler.refresh(None)
+        refused = scheduler.claim(gated, worker="actor:worker", base_revision=graph.revision)
+        assert not refused.granted
+        assert refused.refusal is ClaimRefusal.NOT_READY
+        assert store.active(GRAPH) == [], "a refused claim must not take a lease"
+        store.close()
+        graph.close()
+
+    def test_a_node_cannot_be_claimed_twice(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("cl", 2)
+        graph.admit(node)
+        scheduler, store = scheduler_for(graph, tmp_path)
+        scheduler.refresh(None)
+        assert scheduler.claim(node, worker="actor:one", base_revision=graph.revision).granted
+        second = scheduler.claim(node, worker="actor:two", base_revision=graph.revision)
+        assert not second.granted
+        assert second.refusal is ClaimRefusal.ALREADY_LEASED
+        store.close()
+        graph.close()
+
+    def test_expired_lease_cannot_commit_afterwards(self, tmp_path):
+        """AC: a worker whose lease expired cannot commit its claim afterwards."""
+        clock = FakeClock()
+        graph = Graph(tmp_path)
+        node = graph.add_node("lease", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(
+            graph, tmp_path, SchedulerPolicy(lease_seconds=60), clock
+        )
+        scheduler.refresh(None)
+        claim = scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        assert scheduler.commit_allowed(claim.lease_id)
+
+        clock.advance(120)
+        assert not scheduler.commit_allowed(claim.lease_id)
+        expired = scheduler.expire_leases()
+        assert [entry["lease_id"] for entry in expired] == [claim.lease_id]
+        assert not scheduler.commit_allowed(claim.lease_id)
+        store.close()
+        graph.close()
+
+    def test_heartbeat_extends_the_lease(self, tmp_path):
+        clock = FakeClock()
+        graph = Graph(tmp_path)
+        node = graph.add_node("hb", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(
+            graph, tmp_path, SchedulerPolicy(lease_seconds=60), clock
+        )
+        scheduler.refresh(None)
+        claim = scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        clock.advance(45)
+        assert scheduler.heartbeat(claim.lease_id, progress={"commits": 2})
+        clock.advance(45)
+        assert scheduler.commit_allowed(claim.lease_id), "a heartbeat must extend the deadline"
+        assert store.lease(claim.lease_id)["progress"] == {"commits": 2}
+        store.close()
+        graph.close()
+
+    def test_expiry_is_evidence_not_a_silent_takeover(self, tmp_path):
+        clock = FakeClock()
+        graph = Graph(tmp_path)
+        node = graph.add_node("ev", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(
+            graph, tmp_path, SchedulerPolicy(lease_seconds=30), clock
+        )
+        scheduler.refresh(None)
+        scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        clock.advance(60)
+        expired = scheduler.expire_leases()
+        assert expired, "expiry must surface, not be swallowed"
+        assert expired[0]["execution_node_id"] == node
+        # The node is not silently handed to someone else; it must be re-claimed.
+        assert store.active_lease_for(GRAPH, node) is None
+        store.close()
+        graph.close()
+
+    def test_retry_budget_is_bounded_per_node_and_per_graph(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("rt", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(
+            graph, tmp_path, SchedulerPolicy(max_retries_per_node=2, max_retries_per_graph=3)
+        )
+        assert scheduler.register_retry(node, "EXN-rt-101")
+        assert scheduler.register_retry(node, "EXN-rt-102")
+        assert not scheduler.register_retry(node, "EXN-rt-103"), "per-node budget must bound"
+        other = graph.add_node("rt", 2)
+        assert scheduler.register_retry(other, "EXN-rt-201")
+        assert not scheduler.register_retry(other, "EXN-rt-202"), "per-graph budget must bound"
+        store.close()
+        graph.close()
+
+
+# ------------------------------------------------------ concurrency + resume
+
+
+class TestDispatchAndResume:
+    def test_concurrency_cap_is_respected(self, tmp_path):
+        graph = Graph(tmp_path)
+        nodes = [graph.add_node("cc", index) for index in range(1, 6)]
+        for node in nodes:
+            graph.admit(node)
+        scheduler, store = scheduler_for(graph, tmp_path, SchedulerPolicy(max_concurrent=2))
+        scheduler.refresh(None)
+        batch = scheduler.dispatchable()
+        assert len(batch) == 2
+        for node in batch:
+            scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        assert scheduler.dispatchable() == [], "the cap must hold while leases are active"
+        store.close()
+        graph.close()
+
+    def test_resume_reconciles_in_flight_leases(self, tmp_path):
+        """AC: an orchestrator killed mid-dispatch resumes with no node running twice."""
+        clock = FakeClock()
+        graph = Graph(tmp_path)
+        alive = graph.add_node("rs", 1)
+        dead = graph.add_node("rs", 2)
+        for node in (alive, dead):
+            graph.admit(node)
+        scheduler, store = scheduler_for(
+            graph, tmp_path, SchedulerPolicy(lease_seconds=100, max_concurrent=4), clock
+        )
+        scheduler.refresh(None)
+        alive_claim = scheduler.claim(alive, worker="actor:a", base_revision=graph.revision)
+        scheduler.claim(dead, worker="actor:b", base_revision=graph.revision)
+        clock.advance(50)
+        scheduler.heartbeat(alive_claim.lease_id, progress={"commits": 1})
+        clock.advance(80)  # the un-heartbeaten lease is now past its deadline
+
+        # Orchestrator restarts against the same journal and store.
+        resumed = Scheduler(graph.journal, store, SchedulerPolicy(lease_seconds=100),
+                            clock=clock)
+        outcome = resumed.resume()
+        assert dead not in outcome["still_running"], "an expired lease must not resume as running"
+        assert alive in outcome["still_running"], "a live lease must survive the restart"
+        assert len(outcome["expired_leases"]) == 1
+        assert len(store.active(GRAPH)) == 1, "no node may be running twice"
+        store.close()
+        graph.close()
+
+    def test_shadow_mode_decides_without_dispatching(self, tmp_path):
+        graph = Graph(tmp_path)
+        node = graph.add_node("sh", 1)
+        graph.admit(node)
+        scheduler, store = scheduler_for(graph, tmp_path, shadow=True)
+        scheduler.refresh(None)
+        claim = scheduler.claim(node, worker="actor:worker", base_revision=graph.revision)
+        assert claim.granted, "shadow mode still computes the decision"
+        assert store.active(GRAPH) == [], "shadow mode must not take a lease"
+        assert store.dispatch_order(GRAPH) == [], "shadow mode must not dispatch"
+        store.close()
+        graph.close()
+
+
+# ------------------------------------------------------------- fallback
+
+
+class TestStaticFallback:
+    def test_static_projection_shares_the_same_graph(self, tmp_path):
+        """AC: --static shares the graph, so the fallback is exercised, not aspirational."""
+        from chief_wiggum.dag import compatibility
+
+        graph = Graph(tmp_path)
+        for index in (1, 2):
+            intent_id = f"INN-ticket-{index:03d}"
+            graph._apply(
+                [{"op_id": f"OPS-s-{index:03d}", "operation_type": "add_intent_node",
+                  "target_ref": intent_id,
+                  "value": dict(intent_node(intent_id), source_ticket=index)}],
+                authority_class="human",
+            )
+        state = graph.journal.replay()
+        result = compatibility.project_legacy_waves(
+            {
+                "schema_version": "1.0.0",
+                "record_type": "intent_graph",
+                "graph_id": GRAPH,
+                "source_ref": "journal",
+                "source_digest": "sha256:" + "0" * 64,
+                "scan_status": "observed",
+                "has_dependency_block": True,
+                "source_warnings": [],
+                "nodes": state["intent_nodes"],
+                "edges": state["intent_edges"],
+            }
+        )
+        assert result.exit_code == 0, result.error
+        assert result.plan["waves"], "the static fallback must produce a real plan"
+        graph.close()


### PR DESCRIPTION
feat(dag): continuous ready-set scheduler replacing wave barriers (#387)

The behavioural change in one line: a blocked node blocks its dependants, not
the wave. The barrier was not protecting anything the dependency graph does not
already protect; it existed because a static plan cannot answer "what is safe to
start now".

Readiness is computed twice, deliberately. `full_ready_set` derives it from
first principles, and `ReadyIndex` maintains it incrementally, invalidating only
a changed node and its direct dependants because readiness depends on nothing
else. A randomised property test drives a generated DAG through 25 transitions
and asserts the two agree at every step, and a separate test asserts both agree
with the engine's own derived `ready` state from #385. Three independent
derivations of one property is the reason incremental is safe to rely on rather
than merely fast.

Priority is deterministic with the full tie-break chain: declared priority,
critical-path length, risk class, age, resource availability, then the stable
node id. The final id tie-break is what makes two replays of one journal
schedule identically; without it, deterministic replay is unprovable at this
layer, so a mutation that removes it fails the replay test.

Leases replace the three-hour prose timeout. A worker holds a lease with a
heartbeat that carries objective progress, not just wall-clock. Expiry surfaces
as evidence rather than a silent takeover, and a worker whose lease expired
cannot commit its claim afterwards. Claims are refused against a moved graph,
which is the scheduler-side analogue of #385's compare-and-swap.

Lease timing lives in this module's store rather than in the graph. The v1
lease_record schema is closed and carries no deadline, so putting expiry in the
graph would mean amending #384's contract to hold a scheduler detail. The graph
owns lease state; the store owns lease time.

Also here: bounded retry budgets per node and per graph, a concurrency cap, a
shadow mode that computes decisions without taking leases or dispatching, and a
crash resume that rebuilds the index and reconciles in-flight leases so no node
resumes running twice.

A graph that cannot progress raises an explicit liveness failure naming the
blocking set. It does not spin and it does not exit 0.

Scenario coverage from the ticket: discovery mid-run blocks only the affected
node while three others keep running; a failed gate blocks its dependants and
provably not its siblings; dispatch order is identical across replays; nothing
runnable raises the liveness failure; the static projection shares the same
graph so the fallback is exercised rather than aspirational.

23 tests. Every guard was mutation tested by reverting it and confirming the
matching test fails: 17 of 17 caught, after four blind tests were fixed. One of
those four was a harness fault rather than a test fault: rapid rewrites of the
module under test were being served from stale bytecode, so the harness now runs
with bytecode disabled. That fault can only produce a false SURVIVED, never a
false CAUGHT, so earlier results stand.

Closes #387

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
