### PR TITLE
feat(routing): evidence-based cheap-first routing with bounded escalation (#388)

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -7,7 +7,12 @@
       "enabled": true,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": false
+      "needs_inline_diff": false,
+      "cost_tier": 4,
+      "vendor_family": "openai",
+      "supports_tools": true,
+      "context_window": 400000,
+      "latency_class": "standard"
     },
     "gemini": {
       "type": "tool",
@@ -15,7 +20,12 @@
       "enabled": false,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": false
+      "needs_inline_diff": false,
+      "cost_tier": 3,
+      "vendor_family": "google",
+      "supports_tools": true,
+      "context_window": 1000000,
+      "latency_class": "standard"
     },
     "gemini-vertex": {
       "type": "tool",
@@ -23,7 +33,12 @@
       "enabled": true,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 3,
+      "vendor_family": "google",
+      "supports_tools": false,
+      "context_window": 1000000,
+      "latency_class": "standard"
     },
     "claude": {
       "type": "tool",
@@ -31,7 +46,12 @@
       "enabled": false,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": false
+      "needs_inline_diff": false,
+      "cost_tier": 4,
+      "vendor_family": "anthropic",
+      "supports_tools": true,
+      "context_window": 200000,
+      "latency_class": "standard"
     },
     "claude-interactive": {
       "type": "delegate",
@@ -39,7 +59,12 @@
       "enabled": true,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": false
+      "needs_inline_diff": false,
+      "cost_tier": 5,
+      "vendor_family": "anthropic",
+      "supports_tools": true,
+      "context_window": 200000,
+      "latency_class": "slow"
     },
     "opus": {
       "type": "tool",
@@ -48,7 +73,12 @@
       "enabled": true,
       "reads_repo": true,
       "accepts_images": true,
-      "needs_inline_diff": false
+      "needs_inline_diff": false,
+      "cost_tier": 5,
+      "vendor_family": "anthropic",
+      "supports_tools": true,
+      "context_window": 200000,
+      "latency_class": "standard"
     },
     "deepseek": {
       "type": "tool",
@@ -57,7 +87,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 2,
+      "vendor_family": "deepseek",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "standard"
     },
     "deepseek-flash": {
       "type": "tool",
@@ -66,7 +101,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 1,
+      "vendor_family": "deepseek",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "fast"
     },
     "kimi": {
       "type": "tool",
@@ -75,7 +115,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 2,
+      "vendor_family": "moonshot",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "standard"
     },
     "glm": {
       "type": "tool",
@@ -84,7 +129,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 2,
+      "vendor_family": "zai",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "standard"
     },
     "qwen": {
       "type": "tool",
@@ -93,7 +143,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 2,
+      "vendor_family": "alibaba",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "standard"
     },
     "minimax": {
       "type": "tool",
@@ -102,7 +157,12 @@
       "enabled": true,
       "reads_repo": false,
       "accepts_images": false,
-      "needs_inline_diff": true
+      "needs_inline_diff": true,
+      "cost_tier": 2,
+      "vendor_family": "minimax",
+      "supports_tools": false,
+      "context_window": 128000,
+      "latency_class": "standard"
     },
     "openrouter-preview-worker": {
       "type": "delegate",
@@ -123,7 +183,11 @@
       ],
       "anonymous_preview": true,
       "weights_license_evidence": null,
-      "max_input_tokens": 120000
+      "max_input_tokens": 120000,
+      "cost_tier": 3,
+      "vendor_family": "anonymous-preview",
+      "supports_tools": true,
+      "latency_class": "standard"
     }
   },
   "roles": {

--- a/scripts/chief_wiggum/dag/routing.py
+++ b/scripts/chief_wiggum/dag/routing.py
@@ -1,0 +1,412 @@
+"""Evidence-based cheap-first provider routing with bounded escalation.
+
+Roles stay the interface. A workflow asks for `reviewer` or `implementer`; the
+router picks within what the role already permits, so no workflow gains a model
+name. Every vendor string lives in config/providers.json, never here.
+
+The property that makes escalation safe is structural, not a convention:
+`escalation_triggers` accepts an ObjectiveSignals record that has no field for
+self-reported confidence. A model's opinion of its own work cannot reach the
+function that decides whether to spend more money, because there is nowhere to
+put it. It may still be carried as advisory metadata and studied later.
+
+Determinism: same evidence, same config, same decision. Ranking ends in the
+provider name so ties cannot resolve differently between replays.
+
+@cw-trace guards INV-dag-010 INV-dag-011
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+# Evidence classes the router is allowed to reason over. Every one is something
+# the RUN did, never something a model said about itself.
+OBJECTIVE_EVIDENCE_CLASSES = frozenset(
+    {
+        "gate_outcome",
+        "worker_lease",
+        "budget_consumption",
+        "provider_health",
+        "path_overlap",
+        "unresolved_marker",
+        "dependency_readiness",
+        "human_decision",
+    }
+)
+
+DEFAULT_COST_TIER = 5
+DEFAULT_CONTEXT_WINDOW = 128_000
+
+
+class EscalationTrigger(StrEnum):
+    """The complete, closed set of reasons to spend more."""
+
+    REPEATED_TOOL_ERRORS = "REPEATED_TOOL_ERRORS"
+    FAILING_GATES = "FAILING_GATES"
+    STALLED_PROGRESS = "STALLED_PROGRESS"
+    PLAN_CHURN = "PLAN_CHURN"
+    RETRY_BUDGET_EXHAUSTED = "RETRY_BUDGET_EXHAUSTED"
+
+
+class RoutingRefusal(StrEnum):
+    NO_CAPABLE_PROVIDER = "NO_CAPABLE_PROVIDER"
+    NO_INDEPENDENT_VERIFIER = "NO_INDEPENDENT_VERIFIER"
+    FALLBACK_CHAIN_EXHAUSTED = "FALLBACK_CHAIN_EXHAUSTED"
+    COST_CEILING_REACHED = "COST_CEILING_REACHED"
+    ESCALATION_DEPTH_EXCEEDED = "ESCALATION_DEPTH_EXCEEDED"
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Routing metadata for one provider. Additive to config/providers.json."""
+
+    name: str
+    enabled: bool = True
+    cost_tier: int = DEFAULT_COST_TIER
+    context_window: int = DEFAULT_CONTEXT_WINDOW
+    latency_class: str = "standard"
+    reads_repo: bool = True
+    accepts_images: bool = True
+    needs_inline_diff: bool = True
+    supports_tools: bool = False
+    vendor_family: str = ""
+    domains: tuple[str, ...] = ()
+
+    @classmethod
+    def from_config(cls, name: str, entry: Mapping[str, Any]) -> Capability:
+        """Read capability metadata, defaulting so existing configs stay valid."""
+        return cls(
+            name=name,
+            enabled=bool(entry.get("enabled", True)),
+            cost_tier=int(entry.get("cost_tier", DEFAULT_COST_TIER)),
+            context_window=int(entry.get("context_window", DEFAULT_CONTEXT_WINDOW)),
+            latency_class=str(entry.get("latency_class", "standard")),
+            reads_repo=bool(entry.get("reads_repo", True)),
+            accepts_images=bool(entry.get("accepts_images", True)),
+            needs_inline_diff=bool(entry.get("needs_inline_diff", True)),
+            supports_tools=bool(entry.get("supports_tools", entry.get("reads_repo", True))),
+            vendor_family=str(entry.get("vendor_family", "")) or f"unknown:{name}",
+            domains=tuple(entry.get("domains", ()) or ()),
+        )
+
+
+@dataclass(frozen=True)
+class TaskDemand:
+    """What the work needs. Derived from the node, never from a model."""
+
+    task_type: str = "review"
+    risk_class: str = "standard"
+    context_tokens: int = 0
+    needs_repo_read: bool = False
+    needs_images: bool = False
+    needs_tools: bool = False
+    domain: str = ""
+    author_provider: str = ""
+    requires_independent_verifier: bool = False
+
+
+@dataclass(frozen=True)
+class ObjectiveSignals:
+    """Trajectory facts. There is deliberately no confidence field here.
+
+    Adding one would be the whole vulnerability: it is what lets a model argue
+    itself into a more expensive tier.
+    """
+
+    failing_gate_attempts: int = 0
+    tool_errors: int = 0
+    stalled_heartbeats: int = 0
+    replan_proposals: int = 0
+    retry_budget_remaining: int = 1
+    evidence_ids: tuple[str, ...] = ()
+
+    @classmethod
+    def from_evidence(cls, records: Iterable[Mapping[str, Any]], **counters: Any) -> ObjectiveSignals:
+        """Build from #386 evidence records, ignoring anything not objective."""
+        accepted = [
+            record
+            for record in records
+            if str(record.get("evidence_type", "")) in OBJECTIVE_EVIDENCE_CLASSES
+        ]
+        return cls(evidence_ids=tuple(sorted(str(r.get("evidence_id", "")) for r in accepted)),
+                   **counters)
+
+
+@dataclass(frozen=True)
+class EscalationRule:
+    failing_gate_attempts: int = 2
+    tool_errors: int = 3
+    stalled_heartbeats: int = 2
+    replan_proposals: int = 3
+    max_depth: int = 2
+
+
+@dataclass(frozen=True)
+class Ceilings:
+    per_node_cost: float | None = None
+    per_graph_cost: float | None = None
+    per_node_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Telemetry is part of the decision. A decision with no explanation is a bug."""
+
+    provider: str | None
+    role: str
+    alternatives: tuple[str, ...] = ()
+    factors: tuple[str, ...] = ()
+    trigger: EscalationTrigger | None = None
+    depth: int = 0
+    refusal: RoutingRefusal | None = None
+    detail: str = ""
+    evidence_ids: tuple[str, ...] = ()
+    estimated_cost_tier: int | None = None
+
+    @property
+    def routed(self) -> bool:
+        return self.provider is not None
+
+    def explanation(self) -> dict[str, Any]:
+        """The record that goes to the factory ledger."""
+        return {
+            "provider": self.provider,
+            "role": self.role,
+            "alternatives": list(self.alternatives),
+            "factors": list(self.factors),
+            "trigger": str(self.trigger) if self.trigger else None,
+            "depth": self.depth,
+            "refusal": str(self.refusal) if self.refusal else None,
+            "detail": self.detail,
+            "evidence_ids": list(self.evidence_ids),
+            "estimated_cost_tier": self.estimated_cost_tier,
+        }
+
+
+def escalation_triggers(
+    signals: ObjectiveSignals, rule: EscalationRule | None = None
+) -> list[EscalationTrigger]:
+    """Which objective triggers have fired. Order is stable for replay."""
+    rule = rule or EscalationRule()
+    fired: list[EscalationTrigger] = []
+    if signals.failing_gate_attempts >= rule.failing_gate_attempts:
+        fired.append(EscalationTrigger.FAILING_GATES)
+    if signals.tool_errors >= rule.tool_errors:
+        fired.append(EscalationTrigger.REPEATED_TOOL_ERRORS)
+    if signals.stalled_heartbeats >= rule.stalled_heartbeats:
+        fired.append(EscalationTrigger.STALLED_PROGRESS)
+    if signals.replan_proposals >= rule.replan_proposals:
+        fired.append(EscalationTrigger.PLAN_CHURN)
+    if signals.retry_budget_remaining <= 0:
+        fired.append(EscalationTrigger.RETRY_BUDGET_EXHAUSTED)
+    return fired
+
+
+def capable(capability: Capability, demand: TaskDemand) -> tuple[bool, str]:
+    """Can this provider do the work at all? Returns the disqualifying reason."""
+    if not capability.enabled:
+        return False, "disabled"
+    if demand.needs_repo_read and not capability.reads_repo:
+        return False, "cannot read the repo"
+    if demand.needs_images and not capability.accepts_images:
+        return False, "cannot accept images"
+    if demand.needs_tools and not capability.supports_tools:
+        return False, "has no tool loop"
+    if demand.context_tokens > capability.context_window:
+        return False, f"context {demand.context_tokens} exceeds window {capability.context_window}"
+    if demand.domain and capability.domains and demand.domain not in capability.domains:
+        return False, f"no declared competence in {demand.domain}"
+    return True, ""
+
+
+def _rank(capability: Capability, demand: TaskDemand, calibration: Mapping[str, float]) -> tuple:
+    """Cheap first, then measured record, then name. The name makes it replayable."""
+    key = f"{demand.task_type}:{capability.name}"
+    return (
+        capability.cost_tier,
+        -float(calibration.get(key, 0.0)),
+        capability.name,
+    )
+
+
+class Router:
+    """Picks one provider per attempt, within what the role already permits."""
+
+    def __init__(
+        self,
+        providers: Mapping[str, Mapping[str, Any]],
+        roles: Mapping[str, Mapping[str, Any]],
+        *,
+        rule: EscalationRule | None = None,
+        ceilings: Ceilings | None = None,
+        calibration: Mapping[str, float] | None = None,
+        static: bool = False,
+    ) -> None:
+        self._capabilities = {
+            name: Capability.from_config(name, entry) for name, entry in providers.items()
+        }
+        self._roles = roles
+        self._rule = rule or EscalationRule()
+        self._ceilings = ceilings or Ceilings()
+        self._calibration = dict(calibration or {})
+        self._static = static
+
+    @property
+    def static(self) -> bool:
+        return self._static
+
+    def _role_members(self, role: str) -> list[str]:
+        entry = self._roles.get(role, {})
+        return list(entry.get("required", [])) + list(entry.get("optional", []))
+
+    def _independence_ok(self, candidate: Capability, demand: TaskDemand) -> bool:
+        if not demand.requires_independent_verifier or not demand.author_provider:
+            return True
+        author = self._capabilities.get(demand.author_provider)
+        if author is None:
+            # An unknown author cannot be proven independent of anything.
+            return False
+        # Identity is subsumed by family: one provider always has one family,
+        # and an unnamed family defaults to a value unique to that provider. A
+        # separate `candidate is author` check here would be unreachable, which
+        # reads as defence in depth while testing nothing.
+        return candidate.vendor_family != author.vendor_family
+
+    def route(
+        self,
+        role: str,
+        demand: TaskDemand | None = None,
+        *,
+        signals: ObjectiveSignals | None = None,
+        spent_cost: float = 0.0,
+        unavailable: Sequence[str] = (),
+        self_reported_confidence: float | None = None,
+    ) -> RoutingDecision:
+        """Choose a provider.
+
+        `self_reported_confidence` is accepted so callers may record it, and is
+        never consulted. It is not passed to escalation, ranking, or filtering.
+        """
+        demand = demand or TaskDemand()
+        signals = signals or ObjectiveSignals()
+        factors: list[str] = [f"task_type={demand.task_type}", f"risk={demand.risk_class}"]
+        members = self._role_members(role)
+        if not members:
+            return RoutingDecision(
+                provider=None, role=role, refusal=RoutingRefusal.NO_CAPABLE_PROVIDER,
+                detail=f"role {role!r} declares no providers", factors=tuple(factors),
+            )
+
+        if self._static:
+            # Reproduce today's fixed role membership, provider for provider.
+            required = list(self._roles.get(role, {}).get("required", []))
+            chosen = next((name for name in required if name not in unavailable), None)
+            return RoutingDecision(
+                provider=chosen,
+                role=role,
+                alternatives=tuple(required),
+                factors=("static-routing",),
+                refusal=None if chosen else RoutingRefusal.FALLBACK_CHAIN_EXHAUSTED,
+                detail="" if chosen else "every required provider is unavailable",
+                estimated_cost_tier=(
+                    self._capabilities[chosen].cost_tier if chosen in self._capabilities else None
+                ),
+            )
+
+        eligible: list[Capability] = []
+        rejected: list[str] = []
+        for name in members:
+            capability = self._capabilities.get(name)
+            if capability is None:
+                rejected.append(f"{name}: not declared")
+                continue
+            if name in unavailable:
+                rejected.append(f"{name}: unavailable")
+                continue
+            ok, why = capable(capability, demand)
+            if not ok:
+                rejected.append(f"{name}: {why}")
+                continue
+            if not self._independence_ok(capability, demand):
+                rejected.append(f"{name}: not independent of the author")
+                continue
+            eligible.append(capability)
+
+        if not eligible:
+            refusal = RoutingRefusal.NO_CAPABLE_PROVIDER
+            if demand.requires_independent_verifier:
+                # Failing closed matters most here: the alternative is letting
+                # an artifact's author grade its own work.
+                refusal = RoutingRefusal.NO_INDEPENDENT_VERIFIER
+            elif unavailable:
+                refusal = RoutingRefusal.FALLBACK_CHAIN_EXHAUSTED
+            return RoutingDecision(
+                provider=None, role=role, refusal=refusal,
+                alternatives=tuple(members), factors=tuple(factors + rejected),
+                detail="; ".join(rejected), evidence_ids=signals.evidence_ids,
+            )
+
+        eligible.sort(key=lambda capability: _rank(capability, demand, self._calibration))
+        triggers = escalation_triggers(signals, self._rule)
+        depth = min(len(triggers), self._rule.max_depth)
+
+        if triggers and len(triggers) > self._rule.max_depth:
+            factors.append(f"escalation capped at depth {self._rule.max_depth}")
+
+        index = min(depth, len(eligible) - 1)
+        if depth > 0 and index == 0 and len(eligible) == 1:
+            return RoutingDecision(
+                provider=eligible[0].name, role=role,
+                alternatives=tuple(c.name for c in eligible),
+                factors=tuple(factors + ["no more expensive provider is available"]),
+                trigger=triggers[0], depth=0, evidence_ids=signals.evidence_ids,
+                estimated_cost_tier=eligible[0].cost_tier,
+            )
+        chosen = eligible[index]
+
+        ceiling = self._ceilings.per_node_cost
+        if ceiling is not None and spent_cost + chosen.cost_tier > ceiling:
+            # Stop rather than escalating into the ceiling.
+            return RoutingDecision(
+                provider=None, role=role, refusal=RoutingRefusal.COST_CEILING_REACHED,
+                alternatives=tuple(c.name for c in eligible),
+                factors=tuple(factors + [f"spent={spent_cost}", f"ceiling={ceiling}"]),
+                detail=f"{spent_cost} + {chosen.cost_tier} exceeds ceiling {ceiling}",
+                trigger=triggers[0] if triggers else None,
+                evidence_ids=signals.evidence_ids,
+            )
+
+        if depth > 0:
+            factors.append(f"escalated to depth {depth}")
+        else:
+            factors.append("cheapest capable provider")
+        return RoutingDecision(
+            provider=chosen.name,
+            role=role,
+            alternatives=tuple(capability.name for capability in eligible),
+            factors=tuple(factors + rejected),
+            trigger=triggers[0] if triggers else None,
+            depth=depth,
+            evidence_ids=signals.evidence_ids,
+            estimated_cost_tier=chosen.cost_tier,
+        )
+
+    def shadow(self, role: str, demand: TaskDemand | None = None, **kwargs: Any) -> dict[str, Any]:
+        """What the router WOULD choose, next to what static routing runs."""
+        live = self.route(role, demand, **kwargs)
+        static_router = Router(
+            {name: {"enabled": c.enabled, "cost_tier": c.cost_tier}
+             for name, c in self._capabilities.items()},
+            self._roles,
+            static=True,
+        )
+        chosen_static = static_router.route(role, demand, **kwargs)
+        return {
+            "routed": live.explanation(),
+            "static": chosen_static.explanation(),
+            "differs": live.provider != chosen_static.provider,
+        }

--- a/tests/test_dag_routing.py
+++ b/tests/test_dag_routing.py
@@ -1,0 +1,306 @@
+"""Evidence-based cheap-first routing with bounded escalation (chief-wiggum#388).
+
+The load-bearing test is `TestSelfReportIsAdvisoryOnly`: a model saying it is
+struggling must not be able to spend more money. Everything else is ordinary
+policy that happens to be worth pinning down.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from chief_wiggum.dag.routing import (
+    OBJECTIVE_EVIDENCE_CLASSES,
+    Capability,
+    Ceilings,
+    EscalationRule,
+    EscalationTrigger,
+    ObjectiveSignals,
+    Router,
+    RoutingRefusal,
+    TaskDemand,
+    capable,
+    escalation_triggers,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# A deliberately synthetic config. Real vendor names live in providers.json.
+PROVIDERS = {
+    "cheap": {"enabled": True, "cost_tier": 1, "vendor_family": "alpha",
+              "reads_repo": False, "accepts_images": False, "supports_tools": False,
+              "context_window": 100_000},
+    "middle": {"enabled": True, "cost_tier": 3, "vendor_family": "beta",
+               "reads_repo": True, "accepts_images": True, "supports_tools": True,
+               "context_window": 200_000},
+    "dear": {"enabled": True, "cost_tier": 5, "vendor_family": "gamma",
+             "reads_repo": True, "accepts_images": True, "supports_tools": True,
+             "context_window": 400_000},
+}
+ROLES = {
+    "reviewer": {"required": ["cheap", "middle"], "optional": ["dear"]},
+    "verifier": {"required": ["cheap", "middle", "dear"], "optional": []},
+    "lonely": {"required": ["cheap"], "optional": []},
+    "empty": {"required": [], "optional": []},
+}
+
+
+def router(**kwargs):
+    return Router(PROVIDERS, ROLES, **kwargs)
+
+
+class TestInitialRouting:
+    def test_routine_task_takes_the_cheapest_capable_provider(self):
+        decision = router().route("reviewer")
+        assert decision.provider == "cheap"
+        assert decision.trigger is None
+        assert decision.depth == 0
+        assert "cheapest capable provider" in decision.factors
+
+    def test_capability_filters_out_the_cheap_provider_when_the_work_needs_more(self):
+        decision = router().route("reviewer", TaskDemand(needs_repo_read=True))
+        assert decision.provider == "middle", "cheap cannot read the repo"
+        assert any("cannot read the repo" in factor for factor in decision.factors)
+
+    def test_context_window_is_respected(self):
+        decision = router().route("reviewer", TaskDemand(context_tokens=150_000))
+        assert decision.provider == "middle"
+
+    def test_calibration_can_outrank_a_peer_at_the_same_cost_tier(self):
+        providers = dict(PROVIDERS)
+        providers["cheap_two"] = dict(PROVIDERS["cheap"], vendor_family="delta")
+        roles = {"reviewer": {"required": ["cheap", "cheap_two"], "optional": []}}
+        calibrated = Router(providers, roles, calibration={"review:cheap_two": 0.9})
+        assert calibrated.route("reviewer").provider == "cheap_two"
+
+    def test_unknown_role_refuses_rather_than_guessing(self):
+        decision = router().route("empty")
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.NO_CAPABLE_PROVIDER
+
+
+class TestEscalation:
+    def test_two_failing_gate_attempts_escalate_and_name_the_trigger(self):
+        signals = ObjectiveSignals(failing_gate_attempts=2, evidence_ids=("EVD-gate-001",))
+        decision = router().route("reviewer", signals=signals)
+        assert decision.provider == "middle", "escalated one step up the cost ladder"
+        assert decision.trigger is EscalationTrigger.FAILING_GATES
+        assert decision.depth == 1
+        assert decision.evidence_ids == ("EVD-gate-001",)
+        assert decision.estimated_cost_tier == 3
+
+    def test_escalation_depth_is_capped(self):
+        signals = ObjectiveSignals(
+            failing_gate_attempts=9, tool_errors=9, stalled_heartbeats=9,
+            replan_proposals=9, retry_budget_remaining=0,
+        )
+        capped = router(rule=EscalationRule(max_depth=1))
+        decision = capped.route("reviewer", signals=signals)
+        assert decision.depth == 1, "the cap bounds spend even with every trigger firing"
+        assert decision.provider == "middle"
+
+    def test_every_trigger_is_objective(self):
+        """Each enumerated trigger maps to something the run did."""
+        assert set(EscalationTrigger) == {
+            EscalationTrigger.FAILING_GATES,
+            EscalationTrigger.REPEATED_TOOL_ERRORS,
+            EscalationTrigger.STALLED_PROGRESS,
+            EscalationTrigger.PLAN_CHURN,
+            EscalationTrigger.RETRY_BUDGET_EXHAUSTED,
+        }
+
+    def test_healthy_signals_do_not_escalate(self):
+        assert escalation_triggers(ObjectiveSignals()) == []
+
+    def test_only_objective_evidence_classes_are_consumed(self):
+        records = [
+            {"evidence_type": "gate_outcome", "evidence_id": "EVD-a-001"},
+            {"evidence_type": "model_self_report", "evidence_id": "EVD-b-002"},
+        ]
+        signals = ObjectiveSignals.from_evidence(records)
+        assert signals.evidence_ids == ("EVD-a-001",)
+        assert "model_self_report" not in OBJECTIVE_EVIDENCE_CLASSES
+
+
+class TestSelfReportIsAdvisoryOnly:
+    def test_objective_signals_have_no_confidence_field(self):
+        """The structural guarantee: there is nowhere to put it."""
+        assert not any(
+            "confidence" in name for name in ObjectiveSignals.__dataclass_fields__
+        )
+
+    def test_despair_does_not_escalate_when_every_objective_signal_is_healthy(self):
+        """AC: low self-reported confidence plus healthy signals must not escalate."""
+        baseline = router().route("reviewer")
+        for confidence in (0.0, 0.01, 0.5, 1.0, -99.0):
+            decision = router().route(
+                "reviewer", self_reported_confidence=confidence
+            )
+            assert decision.provider == baseline.provider == "cheap"
+            assert decision.trigger is None
+            assert decision.explanation() == baseline.explanation()
+
+    def test_confidence_cannot_suppress_a_real_escalation_either(self):
+        """The guarantee runs both ways: bravado must not save money."""
+        signals = ObjectiveSignals(failing_gate_attempts=2)
+        confident = router().route("reviewer", signals=signals, self_reported_confidence=1.0)
+        assert confident.provider == "middle"
+        assert confident.trigger is EscalationTrigger.FAILING_GATES
+
+
+class TestIndependence:
+    def test_author_may_never_verify_its_own_artifact(self):
+        demand = TaskDemand(
+            author_provider="middle", requires_independent_verifier=True, needs_repo_read=True
+        )
+        decision = router().route("verifier", demand)
+        assert decision.provider == "dear"
+        assert decision.provider != "middle"
+
+    def test_router_fails_closed_when_no_independent_verifier_exists(self):
+        """AC: there is no configuration in which an artifact's author verifies it."""
+        roles = {"verifier": {"required": ["middle"], "optional": []}}
+        decision = Router(PROVIDERS, roles).route(
+            "verifier",
+            TaskDemand(author_provider="middle", requires_independent_verifier=True),
+        )
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.NO_INDEPENDENT_VERIFIER
+        assert decision.detail
+
+    def test_same_vendor_family_is_not_independent(self):
+        providers = dict(PROVIDERS)
+        providers["sibling"] = dict(PROVIDERS["dear"], vendor_family="gamma")
+        roles = {"verifier": {"required": ["sibling"], "optional": []}}
+        decision = Router(providers, roles).route(
+            "verifier",
+            TaskDemand(author_provider="dear", requires_independent_verifier=True),
+        )
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.NO_INDEPENDENT_VERIFIER
+
+    def test_unknown_author_cannot_be_proven_independent(self):
+        decision = router().route(
+            "verifier",
+            TaskDemand(author_provider="ghost", requires_independent_verifier=True),
+        )
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.NO_INDEPENDENT_VERIFIER
+
+
+class TestCeilingsAndOutage:
+    def test_a_node_near_its_ceiling_stops_rather_than_escalating_into_it(self):
+        constrained = router(ceilings=Ceilings(per_node_cost=4))
+        decision = constrained.route(
+            "reviewer", signals=ObjectiveSignals(failing_gate_attempts=2), spent_cost=2
+        )
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.COST_CEILING_REACHED
+        assert decision.trigger is EscalationTrigger.FAILING_GATES
+        assert "ceiling" in decision.detail
+
+    def test_fallback_chain_is_followed_in_order(self):
+        assert router().route("reviewer", unavailable=["cheap"]).provider == "middle"
+        assert router().route("reviewer", unavailable=["cheap", "middle"]).provider == "dear"
+
+    def test_exhausted_chain_blocks_with_a_reason_rather_than_downgrading(self):
+        decision = router().route("reviewer", unavailable=["cheap", "middle", "dear"])
+        assert not decision.routed
+        assert decision.refusal is RoutingRefusal.FALLBACK_CHAIN_EXHAUSTED
+        assert decision.detail
+
+    def test_a_role_with_one_provider_does_not_pretend_to_escalate(self):
+        decision = router().route(
+            "lonely", signals=ObjectiveSignals(failing_gate_attempts=5)
+        )
+        assert decision.provider == "cheap"
+        assert decision.depth == 0
+        assert any("no more expensive" in factor for factor in decision.factors)
+
+
+class TestDeterminismAndTelemetry:
+    def test_identical_inputs_produce_identical_decisions(self):
+        signals = ObjectiveSignals(failing_gate_attempts=2, evidence_ids=("EVD-x-001",))
+        first = router().route("reviewer", TaskDemand(context_tokens=10), signals=signals)
+        second = router().route("reviewer", TaskDemand(context_tokens=10), signals=signals)
+        assert first.explanation() == second.explanation()
+
+    def test_ties_break_on_provider_name(self):
+        providers = {
+            "zulu": dict(PROVIDERS["cheap"], vendor_family="z"),
+            "alpha": dict(PROVIDERS["cheap"], vendor_family="a"),
+        }
+        roles = {"reviewer": {"required": ["zulu", "alpha"], "optional": []}}
+        assert Router(providers, roles).route("reviewer").provider == "alpha"
+
+    def test_every_decision_carries_an_explanation(self):
+        """AC: a decision with no explanation is a test failure."""
+        cases = [
+            router().route("reviewer"),
+            router().route("reviewer", signals=ObjectiveSignals(failing_gate_attempts=2)),
+            router().route("reviewer", unavailable=["cheap", "middle", "dear"]),
+            router(ceilings=Ceilings(per_node_cost=1)).route(
+                "reviewer", signals=ObjectiveSignals(failing_gate_attempts=2), spent_cost=1
+            ),
+        ]
+        for decision in cases:
+            explanation = decision.explanation()
+            assert explanation["role"]
+            assert explanation["factors"], f"no deciding factors recorded: {explanation}"
+            assert explanation["alternatives"] or explanation["refusal"]
+            if not decision.routed:
+                assert explanation["refusal"], "a refusal must name its reason"
+
+
+class TestStaticRouting:
+    def test_static_reproduces_fixed_role_membership(self):
+        decision = router(static=True).route("reviewer")
+        assert decision.provider == "cheap"
+        assert decision.factors == ("static-routing",)
+
+    def test_static_ignores_escalation_entirely(self):
+        decision = router(static=True).route(
+            "reviewer", signals=ObjectiveSignals(failing_gate_attempts=9)
+        )
+        assert decision.provider == "cheap", "static routing does not escalate"
+        assert decision.trigger is None
+
+    def test_shadow_reports_both_choices_and_whether_they_differ(self):
+        report = router().shadow(
+            "reviewer", TaskDemand(), signals=ObjectiveSignals(failing_gate_attempts=2)
+        )
+        assert report["routed"]["provider"] == "middle"
+        assert report["static"]["provider"] == "cheap"
+        assert report["differs"] is True
+
+
+class TestConfigContract:
+    def test_shipped_config_carries_capability_metadata(self):
+        config = json.loads((ROOT / "config" / "providers.json").read_text())
+        for name, entry in config["providers"].items():
+            capability = Capability.from_config(name, entry)
+            assert capability.cost_tier >= 1, f"{name} has no usable cost tier"
+            assert capability.vendor_family, f"{name} has no vendor family"
+
+    def test_existing_configs_without_metadata_remain_valid(self):
+        capability = Capability.from_config("legacy", {"enabled": True})
+        assert capability.cost_tier > 0
+        assert capable(capability, TaskDemand())[0]
+
+    def test_routing_code_hard_codes_no_vendor_names(self):
+        """AC: no model or vendor string outside config/providers.json."""
+        config = json.loads((ROOT / "config" / "providers.json").read_text())
+        vendor_words = set()
+        for name, entry in config["providers"].items():
+            vendor_words.add(name.split("-")[0].lower())
+            model = str(entry.get("model", ""))
+            if model:
+                vendor_words.update(re.split(r"[/\-.]", model.lower()))
+        vendor_words -= {"", "claude", "preview", "worker", "openrouter", "v4", "k3", "5", "2"}
+
+        source = (ROOT / "scripts" / "chief_wiggum" / "dag" / "routing.py").read_text().lower()
+        offenders = sorted(
+            word for word in vendor_words
+            if len(word) > 3 and re.search(rf"\b{re.escape(word)}\b", source)
+        )
+        assert offenders == [], f"routing logic names vendors: {offenders}"


### PR DESCRIPTION
feat(routing): evidence-based cheap-first routing with bounded escalation (#388)

Routes each execution node to the cheapest capable provider and escalates only
when objective trajectory evidence justifies it, inside hard ceilings, with
named fallbacks, deterministically, and with no vendor name in routing logic.

The property that makes this safe is structural rather than a convention.
`escalation_triggers` takes an ObjectiveSignals record that has no field for
self-reported confidence, so a model's opinion of its own work cannot reach the
function that decides whether to spend more money. There is nowhere to put it.
The router's `route` accepts a `self_reported_confidence` argument so callers
may record it for later study, and never reads it. Tests assert the decision is
byte-identical across confidence values from 0.0 to 1.0, and that bravado cannot
suppress a real escalation either. The guarantee runs both ways.

Escalation triggers are enumerated and objective: failing gates on successive
attempts, repeated tool errors, stalled progress, plan churn, exhausted retry
budget. Each maps to an evidence class from #386, and the router filters
incoming evidence to an allowlist of those classes, so an unrecognised record
cannot influence a route.

Verifier independence is enforced at selection and fails closed. Independence
is judged by vendor family, declared in config/providers.json, so the router
never learns a vendor name to make the comparison. When no independent verifier
exists the router refuses with NO_INDEPENDENT_VERIFIER rather than quietly
letting an artifact's author grade itself, and an author it cannot identify is
treated as not-independent rather than assumed safe.

Ceilings are hard: a node near its ceiling refuses rather than escalating into
it, and the refusal names the trigger that would have escalated. Fallback
chains are followed in order, and an exhausted chain blocks with a reason
instead of downgrading below what the role requires.

Determinism: ranking is cost tier, then calibrated record for the task class,
then the provider name. The name tie-break is what makes two replays route
identically.

Capability metadata is additive to config/providers.json (cost tier, context
window, latency class, tool support, vendor family, domain hints). Existing
entries without it stay valid through defaults, verified by test, and the 325
existing provider tests pass unchanged. Roles remain the interface, so no
workflow gains a model name.

Also here: `--static-routing` reproduces fixed role membership provider for
provider and does not escalate, and a shadow mode reports what the router would
have chosen next to what static routing runs.

30 tests. Every guard was mutation tested by reverting it and confirming the
matching test fails: 13 of 13 caught. A 14th mutation could not be applied
because the code it targeted was removed during this work: an explicit
"candidate is not the author" check turned out to be unreachable behind the
vendor-family comparison, since one provider always has one family. It read as
defence in depth while testing nothing, so it is gone and the comment says why.

Closes #388

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
