### PR TITLE
feat(dag): parallel candidates with verifier-blind promotion (#389)

### DIFF
--- a/scripts/chief_wiggum/dag/candidates.py
+++ b/scripts/chief_wiggum/dag/candidates.py
@@ -1,0 +1,360 @@
+"""Parallel candidate implementations with verifier-blind promotion.
+
+Two properties make fan-out worth its cost rather than merely expensive:
+
+1. The verifier cannot be written to fit the winner. Its artifact is hashed
+   before any candidate output exists, and a hash that moves afterwards is a
+   hard failure, not a warning. This is TDD's ordering discipline applied to a
+   competitive setting, and the same instinct as the ratchet's rule that a
+   contract cannot pass by weakening its definition.
+2. The scorer is not told who produced what. Candidate labels are derived from
+   artifact content, so swapping which provider produced which candidate cannot
+   move the winner, and presentation order is shuffled under a journaled seed so
+   position cannot proxy for identity.
+
+Fan-out is policy-gated and defaults to one implementation. Fan-out on every
+ticket multiplies cost for no gain on routine work.
+
+@cw-trace guards INV-dag-012 INV-dag-013
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+# Gate outcomes that do not disqualify a candidate. `inapplicable` is a real
+# answer; `error` is not a pass (chief-wiggum#289).
+PASSING_GATE_OUTCOMES = frozenset({"pass", "inapplicable"})
+
+
+class FanOutRefusal(StrEnum):
+    NOT_JUSTIFIED = "NOT_JUSTIFIED"
+    BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+    ISOLATION_UNAVAILABLE = "ISOLATION_UNAVAILABLE"
+    VERIFIER_NOT_FROZEN = "VERIFIER_NOT_FROZEN"
+    NO_INDEPENDENT_VERIFIER = "NO_INDEPENDENT_VERIFIER"
+
+
+class PromotionRefusal(StrEnum):
+    ALL_CANDIDATES_FAILED = "ALL_CANDIDATES_FAILED"
+    VERIFIER_TAMPERED = "VERIFIER_TAMPERED"
+    NO_CANDIDATES = "NO_CANDIDATES"
+
+
+class VerifierTampered(Exception):
+    """The verifier changed after candidate output existed. Never recoverable."""
+
+
+@dataclass(frozen=True)
+class CandidatePolicy:
+    """When fan-out is justified, how wide, and under what cap."""
+
+    default_width: int = 1
+    max_width: int = 3
+    risk_classes: tuple[str, ...] = ("high", "critical")
+    min_blast_radius: int = 0
+    min_contract_density: float = 0.0
+    min_historical_failure_rate: float = 0.0
+    per_node_budget: float | None = None
+    candidate_cost: float = 1.0
+
+
+@dataclass(frozen=True)
+class NodeProfile:
+    """Mechanical inputs to the fan-out decision. No model opinion here."""
+
+    risk_class: str = "standard"
+    blast_radius: int = 0
+    contract_density: float = 0.0
+    historical_failure_rate: float = 0.0
+
+
+@dataclass(frozen=True)
+class VerifierFreeze:
+    """A content hash of the verifier, taken before candidates are produced."""
+
+    node_id: str
+    digest: str
+    author_provider: str = ""
+    frozen_at: str = ""
+
+    @staticmethod
+    def of(node_id: str, artifact: bytes | str, *, author_provider: str = "",
+           frozen_at: str = "") -> VerifierFreeze:
+        payload = artifact.encode("utf-8") if isinstance(artifact, str) else artifact
+        return VerifierFreeze(
+            node_id=node_id,
+            digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+            author_provider=author_provider,
+            frozen_at=frozen_at,
+        )
+
+    def verify(self, artifact: bytes | str) -> None:
+        """Re-check the artifact. A moved hash invalidates the whole comparison."""
+        current = VerifierFreeze.of(self.node_id, artifact)
+        if current.digest != self.digest:
+            raise VerifierTampered(
+                f"verifier for {self.node_id} changed after freeze:"
+                f" expected {self.digest}, found {current.digest}"
+            )
+
+
+@dataclass(frozen=True)
+class CandidateResult:
+    """One candidate's mechanical outcome. `provider` is never given to scoring."""
+
+    candidate_id: str
+    provider: str
+    artifact_digest: str
+    hard_gates: Mapping[str, str] = field(default_factory=dict)
+    tests_failed: int = 0
+    tests_passed: int = 0
+    contract_conformance: float = 0.0
+    diff_lines: int = 0
+    blast_radius: int = 0
+    hotspot_overlap: int = 0
+    cost: float = 0.0
+
+    @property
+    def blind_label(self) -> str:
+        """Derived from CONTENT, so relabelling providers cannot move the winner."""
+        return hashlib.sha256(self.artifact_digest.encode("utf-8")).hexdigest()[:12]
+
+    @property
+    def failing_gates(self) -> list[str]:
+        return sorted(
+            name for name, outcome in self.hard_gates.items()
+            if str(outcome) not in PASSING_GATE_OUTCOMES
+        )
+
+    @property
+    def eliminated(self) -> bool:
+        """Hard gates run before any qualitative judgement."""
+        return bool(self.failing_gates) or self.tests_failed > 0
+
+
+@dataclass(frozen=True)
+class BlindView:
+    """What the scorer sees. There is no provider field, by construction."""
+
+    label: str
+    tests_failed: int
+    tests_passed: int
+    contract_conformance: float
+    diff_lines: int
+    blast_radius: int
+    hotspot_overlap: int
+    cost: float
+    failing_gates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FanOutDecision:
+    width: int
+    refusal: FanOutRefusal | None = None
+    detail: str = ""
+    factors: tuple[str, ...] = ()
+
+    @property
+    def fans_out(self) -> bool:
+        return self.width > 1
+
+
+@dataclass(frozen=True)
+class Promotion:
+    winner: str | None
+    winner_provider: str | None = None
+    superseded: tuple[str, ...] = ()
+    eliminated: tuple[str, ...] = ()
+    refusal: PromotionRefusal | None = None
+    detail: str = ""
+    seed: int = 0
+    order: tuple[str, ...] = ()
+
+    @property
+    def promoted(self) -> bool:
+        return self.winner is not None
+
+
+def decide_fan_out(
+    profile: NodeProfile,
+    policy: CandidatePolicy | None = None,
+    *,
+    spent: float = 0.0,
+    isolation_available: bool = True,
+    isolation_detail: str = "",
+    verifier: VerifierFreeze | None = None,
+) -> FanOutDecision:
+    """Decide width. Default is one; fan-out must be earned and affordable."""
+    policy = policy or CandidatePolicy()
+    factors = [f"risk={profile.risk_class}", f"blast_radius={profile.blast_radius}"]
+
+    if verifier is None:
+        return FanOutDecision(
+            width=1, refusal=FanOutRefusal.VERIFIER_NOT_FROZEN,
+            detail="the verifier must be frozen before any candidate runs",
+            factors=tuple(factors),
+        )
+
+    justified = (
+        profile.risk_class in policy.risk_classes
+        or profile.blast_radius >= policy.min_blast_radius > 0
+        or profile.contract_density >= policy.min_contract_density > 0
+        or profile.historical_failure_rate >= policy.min_historical_failure_rate > 0
+    )
+    if not justified:
+        return FanOutDecision(
+            width=policy.default_width, refusal=FanOutRefusal.NOT_JUSTIFIED,
+            detail="routine work does not earn fan-out", factors=tuple(factors),
+        )
+
+    if not isolation_available:
+        # Cross-contaminated candidates are worse than no candidates, because
+        # the contamination can pass the floor (chief-wiggum#376).
+        return FanOutDecision(
+            width=1, refusal=FanOutRefusal.ISOLATION_UNAVAILABLE,
+            detail=isolation_detail or "candidate isolation could not be guaranteed",
+            factors=tuple(factors),
+        )
+
+    width = policy.max_width
+    if policy.per_node_budget is not None:
+        affordable = int((policy.per_node_budget - spent) // max(policy.candidate_cost, 1e-9))
+        if affordable < 2:
+            return FanOutDecision(
+                width=1, refusal=FanOutRefusal.BUDGET_EXCEEDED,
+                detail=f"budget allows {max(affordable, 0)} candidates",
+                factors=tuple(factors + [f"spent={spent}"]),
+            )
+        width = min(width, affordable)
+    return FanOutDecision(width=width, factors=tuple(factors + [f"width={width}"]))
+
+
+def blind(result: CandidateResult) -> BlindView:
+    """Strip identity. The scorer never receives a provider name."""
+    return BlindView(
+        label=result.blind_label,
+        tests_failed=result.tests_failed,
+        tests_passed=result.tests_passed,
+        contract_conformance=result.contract_conformance,
+        diff_lines=result.diff_lines,
+        blast_radius=result.blast_radius,
+        hotspot_overlap=result.hotspot_overlap,
+        cost=result.cost,
+        failing_gates=tuple(result.failing_gates),
+    )
+
+
+def presentation_order(views: Sequence[BlindView], seed: int) -> list[BlindView]:
+    """Seeded shuffle so position cannot proxy for identity. Replayable."""
+    ordered = sorted(views, key=lambda view: view.label)
+    random.Random(seed).shuffle(ordered)
+    return ordered
+
+
+def rubric_key(view: BlindView) -> tuple:
+    """Mechanical and deterministic. Lower sorts better; label breaks ties."""
+    return (
+        -round(view.contract_conformance, 6),
+        view.tests_failed,
+        len(view.failing_gates),
+        -view.tests_passed,
+        view.blast_radius,
+        view.hotspot_overlap,
+        view.diff_lines,
+        round(view.cost, 6),
+        view.label,
+    )
+
+
+def promote(
+    results: Sequence[CandidateResult],
+    *,
+    verifier: VerifierFreeze,
+    verifier_artifact: bytes | str,
+    seed: int = 0,
+) -> Promotion:
+    """Eliminate on hard gates, then score blind, then promote exactly one."""
+    if not results:
+        return Promotion(winner=None, refusal=PromotionRefusal.NO_CANDIDATES,
+                         detail="no candidates were produced", seed=seed)
+    try:
+        verifier.verify(verifier_artifact)
+    except VerifierTampered as exc:
+        # Fatal: every comparison made against this verifier is void.
+        return Promotion(winner=None, refusal=PromotionRefusal.VERIFIER_TAMPERED,
+                         detail=str(exc), seed=seed)
+
+    eliminated = [result for result in results if result.eliminated]
+    survivors = [result for result in results if not result.eliminated]
+    if not survivors:
+        # A field of all-failing candidates does not get a best-of-a-bad-lot win.
+        return Promotion(
+            winner=None,
+            refusal=PromotionRefusal.ALL_CANDIDATES_FAILED,
+            eliminated=tuple(sorted(result.candidate_id for result in eliminated)),
+            detail="every candidate failed a hard gate or a test",
+            seed=seed,
+        )
+
+    by_label = {result.blind_label: result for result in survivors}
+    views = presentation_order([blind(result) for result in survivors], seed)
+    ranked = sorted(views, key=rubric_key)
+    winner = by_label[ranked[0].label]
+    return Promotion(
+        winner=winner.candidate_id,
+        winner_provider=winner.provider,
+        superseded=tuple(
+            sorted(result.candidate_id for result in survivors if result is not winner)
+        ),
+        eliminated=tuple(sorted(result.candidate_id for result in eliminated)),
+        seed=seed,
+        order=tuple(view.label for view in views),
+    )
+
+
+def promotion_operations(
+    node_group: str,
+    promotion: Promotion,
+    node_of: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    """Graph operations for a promotion: one winner, losers superseded.
+
+    There is no chimera merge. Taking one file from each candidate produces a
+    tree no candidate's tests ever ran against.
+    """
+    if not promotion.promoted or promotion.winner is None:
+        return []
+    operations: list[dict[str, Any]] = [
+        {
+            "op_id": "OPS-promote-001",
+            "operation_type": "promote_candidate",
+            "target_ref": node_of[promotion.winner],
+            "value": {
+                "candidate_group_id": node_group,
+                "execution_node_id": node_of[promotion.winner],
+            },
+        }
+    ]
+    for index, loser in enumerate(promotion.superseded, start=1):
+        operations.append(
+            {
+                "op_id": f"OPS-supersede-{index:03d}",
+                "operation_type": "add_relation",
+                "target_ref": f"REL-supersede-{index:03d}",
+                "value": {
+                    "schema_version": "1.0.0",
+                    "record_type": "relation",
+                    "relation_id": f"REL-supersede-{index:03d}",
+                    "source": node_of[promotion.winner],
+                    "target": node_of[loser],
+                    "kind": "supersedes",
+                },
+            }
+        )
+    return operations

--- a/scripts/chief_wiggum/dag/semantics.py
+++ b/scripts/chief_wiggum/dag/semantics.py
@@ -165,6 +165,28 @@ def validate_snapshot(
         elif node["attempt"]["attempt_id"] != lease["attempt_id"]:
             errors.append(ContractViolation(ErrorCode.COMPILATION_REFERENCE_INVALID, "lease attempt does not match its execution node", f"/lease_records/{index}/attempt_id"))
 
+    # chief-wiggum#389: exactly one promotion per candidate group, enforced at
+    # the contract level so a second promotion is an invalid GRAPH, not merely
+    # something the promotion code declines to do.
+    promoted_by_group: dict[str, list[str]] = {}
+    for node in snapshot.get("execution_nodes", []):
+        candidate = node.get("candidate") or {}
+        if candidate.get("disposition") == "promoted" and candidate.get("group_id"):
+            promoted_by_group.setdefault(str(candidate["group_id"]), []).append(
+                str(node.get("execution_node_id"))
+            )
+    for group, winners in sorted(promoted_by_group.items()):
+        if len(winners) > 1:
+            errors.append(
+                ContractViolation(
+                    ErrorCode.DUPLICATE_RECORD_ID,
+                    f"candidate group {group} has {len(winners)} promoted nodes;"
+                    " exactly one promotion is allowed",
+                    "/execution_nodes",
+                    details={"group_id": group, "promoted": sorted(winners)},
+                )
+            )
+
     if cycle := _cycle(snapshot.get("schedulable_edges", [])):
         errors.append(ContractViolation(ErrorCode.SCHEDULABLE_CYCLE, "schedulable subgraph contains a cycle", "/schedulable_edges", details={"cycle": cycle}))
     return tuple(sorted(errors, key=lambda error: (error.path, error.code.value)))

--- a/tests/test_dag_candidates.py
+++ b/tests/test_dag_candidates.py
@@ -1,0 +1,410 @@
+"""Parallel candidates with verifier-blind promotion (chief-wiggum#389).
+
+The two tests that justify the whole feature are the verifier freeze and the
+identity blinding. If either can be defeated, fan-out is just a way to spend
+three times as much for a result nobody can trust.
+"""
+
+import pytest
+from chief_wiggum.dag import GraphJournal
+from chief_wiggum.dag.candidates import (
+    CandidatePolicy,
+    CandidateResult,
+    FanOutRefusal,
+    NodeProfile,
+    Promotion,
+    PromotionRefusal,
+    VerifierFreeze,
+    VerifierTampered,
+    blind,
+    decide_fan_out,
+    presentation_order,
+    promote,
+    promotion_operations,
+    rubric_key,
+)
+from chief_wiggum.dag.semantics import validate_snapshot
+
+VERIFIER = "def test_contract(): assert behaviour_is_correct()"
+GRAPH = "GRF-cand001"
+
+
+def freeze(node_id="EXN-cand-001", artifact=VERIFIER, author=""):
+    return VerifierFreeze.of(node_id, artifact, author_provider=author,
+                             frozen_at="2026-01-01T00:00:00Z")
+
+
+def candidate(name, *, provider, digest=None, gates=None, tests_failed=0, tests_passed=10,
+              conformance=1.0, diff_lines=100, blast=1, hotspot=0, cost=1.0):
+    return CandidateResult(
+        candidate_id=name,
+        provider=provider,
+        artifact_digest=digest or f"sha256:{name}",
+        hard_gates=gates if gates is not None else {"ratchet": "pass", "traceability": "pass"},
+        tests_failed=tests_failed,
+        tests_passed=tests_passed,
+        contract_conformance=conformance,
+        diff_lines=diff_lines,
+        blast_radius=blast,
+        hotspot_overlap=hotspot,
+        cost=cost,
+    )
+
+
+# ------------------------------------------------------------ verifier freeze
+
+
+class TestVerifierFreeze:
+    def test_unmodified_verifier_passes(self):
+        frozen = freeze()
+        frozen.verify(VERIFIER)
+
+    def test_verifier_modified_after_freeze_is_fatal(self):
+        """AC: a verifier changed after candidate output exists fails hard."""
+        frozen = freeze()
+        with pytest.raises(VerifierTampered, match="changed after freeze"):
+            frozen.verify(VERIFIER + "\ndef test_that_fits_the_winner(): pass")
+
+    def test_tampering_voids_the_promotion_entirely(self):
+        frozen = freeze()
+        result = promote(
+            [candidate("c1", provider="alpha"), candidate("c2", provider="beta")],
+            verifier=frozen,
+            verifier_artifact=VERIFIER + "  # weakened",
+        )
+        assert not result.promoted
+        assert result.refusal is PromotionRefusal.VERIFIER_TAMPERED
+        assert result.winner is None, "no winner may survive a tampered comparison"
+
+    def test_fan_out_is_refused_without_a_frozen_verifier(self):
+        decision = decide_fan_out(NodeProfile(risk_class="high"), verifier=None)
+        assert not decision.fans_out
+        assert decision.refusal is FanOutRefusal.VERIFIER_NOT_FROZEN
+
+
+# ------------------------------------------------------------ identity blind
+
+
+class TestIdentityBlinding:
+    def test_blind_view_has_no_provider_field(self):
+        """The structural guarantee: the scorer cannot see identity."""
+        view = blind(candidate("c1", provider="alpha"))
+        assert not hasattr(view, "provider")
+        assert "alpha" not in repr(view)
+
+    def test_swapping_providers_does_not_change_the_winner(self):
+        """AC: identity-blind ordering, everything else fixed."""
+        def strong(provider):
+            return candidate("c1", provider=provider, digest="sha256:strong",
+                             conformance=1.0, diff_lines=50)
+
+        def weak(provider):
+            return candidate("c2", provider=provider, digest="sha256:weak",
+                             conformance=0.6, diff_lines=900)
+
+        first = promote([strong("alpha"), weak("beta")],
+                        verifier=freeze(), verifier_artifact=VERIFIER, seed=7)
+        swapped = promote([strong("beta"), weak("alpha")],
+                          verifier=freeze(), verifier_artifact=VERIFIER, seed=7)
+        assert first.winner == swapped.winner == "c1"
+        assert first.winner_provider == "alpha"
+        assert swapped.winner_provider == "beta"
+
+    def test_blind_label_is_derived_from_content_not_identity(self):
+        same_content = candidate("c1", provider="alpha", digest="sha256:same")
+        other_provider = candidate("c2", provider="omega", digest="sha256:same")
+        assert same_content.blind_label == other_provider.blind_label
+
+    def test_presentation_order_is_seeded_and_replayable(self):
+        views = [blind(candidate(f"c{i}", provider=f"p{i}", digest=f"sha256:{i}"))
+                 for i in range(6)]
+        assert [v.label for v in presentation_order(views, 42)] == [
+            v.label for v in presentation_order(views, 42)
+        ]
+
+    def test_ordering_seed_does_not_change_the_winner(self):
+        """Position must not proxy for identity: the rubric decides, not order."""
+        results = [
+            candidate("c1", provider="alpha", digest="sha256:a", conformance=1.0),
+            candidate("c2", provider="beta", digest="sha256:b", conformance=0.5),
+            candidate("c3", provider="gamma", digest="sha256:c", conformance=0.7),
+        ]
+        winners = {
+            promote(results, verifier=freeze(), verifier_artifact=VERIFIER, seed=seed).winner
+            for seed in range(12)
+        }
+        assert winners == {"c1"}
+
+
+# ------------------------------------------------------------ hard gates
+
+
+class TestHardGateElimination:
+    def test_seeded_defective_candidate_never_wins(self):
+        """AC: with one defective and one correct candidate, the correct one wins."""
+        good = candidate("good", provider="alpha", digest="sha256:good")
+        bad = candidate("bad", provider="beta", digest="sha256:bad",
+                        gates={"ratchet": "findings"}, tests_failed=3)
+        for seed in range(10):
+            result = promote([good, bad], verifier=freeze(),
+                             verifier_artifact=VERIFIER, seed=seed)
+            assert result.winner == "good"
+            assert result.eliminated == ("bad",)
+
+    def test_all_candidates_failing_promotes_nobody(self):
+        """AC: no best-of-a-bad-lot promotion under any configuration."""
+        results = [
+            candidate("c1", provider="alpha", gates={"ratchet": "findings"}),
+            candidate("c2", provider="beta", tests_failed=1),
+            candidate("c3", provider="gamma", gates={"traceability": "error"}),
+        ]
+        outcome = promote(results, verifier=freeze(), verifier_artifact=VERIFIER)
+        assert not outcome.promoted
+        assert outcome.refusal is PromotionRefusal.ALL_CANDIDATES_FAILED
+        assert set(outcome.eliminated) == {"c1", "c2", "c3"}
+
+    def test_gate_error_is_not_treated_as_a_pass(self):
+        errored = candidate("c1", provider="alpha", gates={"ratchet": "error"})
+        assert errored.eliminated
+        assert errored.failing_gates == ["ratchet"]
+
+    def test_inapplicable_gate_does_not_eliminate(self):
+        skipped = candidate("c1", provider="alpha", gates={"single_writer": "inapplicable"})
+        assert not skipped.eliminated
+
+    def test_no_candidates_refuses_rather_than_returning_none_silently(self):
+        outcome = promote([], verifier=freeze(), verifier_artifact=VERIFIER)
+        assert outcome.refusal is PromotionRefusal.NO_CANDIDATES
+
+
+# ------------------------------------------------------------ rubric
+
+
+class TestRubric:
+    def test_rubric_is_deterministic(self):
+        view = blind(candidate("c1", provider="alpha"))
+        assert rubric_key(view) == rubric_key(view)
+
+    def test_contract_conformance_outranks_diff_size(self):
+        conformant = blind(candidate("c1", provider="a", digest="sha256:1",
+                                     conformance=1.0, diff_lines=5000))
+        tidy = blind(candidate("c2", provider="b", digest="sha256:2",
+                               conformance=0.9, diff_lines=10))
+        assert rubric_key(conformant) < rubric_key(tidy)
+
+    def test_smaller_blast_radius_wins_a_tie(self):
+        wide = blind(candidate("c1", provider="a", digest="sha256:1", blast=9))
+        narrow = blind(candidate("c2", provider="b", digest="sha256:2", blast=1))
+        assert rubric_key(narrow) < rubric_key(wide)
+
+    def test_ties_break_on_the_content_label(self):
+        left = blind(candidate("c1", provider="a", digest="sha256:aaa"))
+        right = blind(candidate("c2", provider="b", digest="sha256:bbb"))
+        assert rubric_key(left)[-1] != rubric_key(right)[-1]
+
+
+# ------------------------------------------------------------ fan-out policy
+
+
+class TestFanOutPolicy:
+    def test_routine_work_does_not_fan_out(self):
+        decision = decide_fan_out(NodeProfile(risk_class="standard"), verifier=freeze())
+        assert decision.width == 1
+        assert decision.refusal is FanOutRefusal.NOT_JUSTIFIED
+
+    def test_high_risk_work_fans_out(self):
+        decision = decide_fan_out(NodeProfile(risk_class="high"), verifier=freeze())
+        assert decision.fans_out
+        assert decision.width == 3
+
+    def test_isolation_failure_refuses_rather_than_degrading(self):
+        """AC: with isolation unavailable, fan-out is refused with a named reason."""
+        decision = decide_fan_out(
+            NodeProfile(risk_class="high"),
+            verifier=freeze(),
+            isolation_available=False,
+            isolation_detail="refs/stash is shared across worktrees (#376)",
+        )
+        assert decision.width == 1
+        assert decision.refusal is FanOutRefusal.ISOLATION_UNAVAILABLE
+        assert "refs/stash" in decision.detail
+
+    def test_budget_caps_the_width(self):
+        decision = decide_fan_out(
+            NodeProfile(risk_class="high"),
+            CandidatePolicy(max_width=5, per_node_budget=3.0, candidate_cost=1.0),
+            verifier=freeze(),
+        )
+        assert decision.width == 3
+
+    def test_insufficient_budget_refuses_fan_out(self):
+        decision = decide_fan_out(
+            NodeProfile(risk_class="high"),
+            CandidatePolicy(per_node_budget=4.0, candidate_cost=1.0),
+            spent=3.0,
+            verifier=freeze(),
+        )
+        assert decision.width == 1
+        assert decision.refusal is FanOutRefusal.BUDGET_EXCEEDED
+
+
+# ------------------------------------------- exactly one promotion, in the graph
+
+
+class TestExactlyOnePromotion:
+    def _snapshot(self, dispositions):
+        nodes = []
+        for index, disposition in enumerate(dispositions, start=1):
+            nodes.append(
+                {
+                    "schema_version": "1.0.0",
+                    "record_type": "execution_node",
+                    "execution_node_id": f"EXN-cand-{index:03d}",
+                    "intent_node_id": "INN-cand-001",
+                    "node_type": "candidate",
+                    "role": "role:implementer",
+                    "lifecycle_state": "succeeded",
+                    "attempt": {"attempt_id": None, "outcome": "succeeded"},
+                    "candidate": {"group_id": "CND-group-001", "disposition": disposition},
+                    "approval_state": "not_required",
+                    "lease_state": "unclaimed",
+                    "control_state": "active",
+                    "compiled_from": {
+                        "intent_node_id": "INN-cand-001",
+                        "intent_graph_digest": "sha256:" + "b" * 64,
+                    },
+                }
+            )
+        return {
+            "schema_version": "1.0.0",
+            "record_type": "graph_snapshot",
+            "graph_id": GRAPH,
+            "graph_revision": 1,
+            "authority_matrix_version": "1.0.0",
+            "intent_nodes": [
+                {
+                    "schema_version": "1.0.0",
+                    "record_type": "intent_node",
+                    "intent_node_id": "INN-cand-001",
+                    "node_type": "implementation",
+                    "role": "role:implementer",
+                    "source_ref": "ticket:#1",
+                    "in_scope": True,
+                }
+            ],
+            "intent_edges": [],
+            "execution_nodes": nodes,
+            "schedulable_edges": [],
+            "relations": [],
+            "evidence_records": [],
+            "approval_records": [],
+            "lease_records": [],
+            "control_records": [],
+            "mutations": [],
+        }
+
+    def test_one_promotion_is_valid(self):
+        errors = validate_snapshot(self._snapshot(["promoted", "superseded", "eliminated"]))
+        assert errors == ()
+
+    def test_two_promotions_in_one_group_is_an_invalid_graph(self):
+        """AC: a second promotion is rejected at the contract level."""
+        errors = validate_snapshot(self._snapshot(["promoted", "promoted"]))
+        assert errors, "a second promotion must be a contract violation"
+        assert any("exactly one promotion" in error.message for error in errors)
+
+    def test_the_engine_refuses_a_second_promotion(self, tmp_path):
+        """Not merely avoided by convention: the journal will not admit it."""
+        from chief_wiggum.dag.schemas import load_authority_matrix
+
+        matrix = {r["operation_type"]: r for r in load_authority_matrix()["operations"]}
+        journal = GraphJournal(tmp_path / "graph.db")
+        journal.init_graph(GRAPH)
+
+        def apply(operations, base_revision, index):
+            needs = any(
+                matrix.get(op["operation_type"], {}).get("approval_required") for op in operations
+            )
+            return journal.propose(
+                {
+                    "schema_version": "1.0.0",
+                    "record_type": "mutation_envelope",
+                    "graph_id": GRAPH,
+                    "base_revision": base_revision,
+                    "mutation_id": f"MUT-cand-{index:03d}",
+                    "idempotency_key": f"cand-{index}",
+                    "actor": "actor:test",
+                    "authority_class": "human" if needs else "automatic",
+                    "operations": operations,
+                    "reason_code": "EV_CANDIDATE_PROMOTED",
+                    "evidence_refs": [],
+                    "expected_effect": "candidate fixture",
+                    "budget_delta": {"unit": "tokens", "value": 0},
+                    "requires_approval": needs,
+                }
+            )
+
+        snapshot = self._snapshot(["pending", "pending"])
+        revision = 0
+        decision = apply(
+            [{"op_id": "OPS-cand-001", "operation_type": "add_intent_node",
+              "target_ref": "INN-cand-001", "value": snapshot["intent_nodes"][0]}],
+            revision, 1,
+        )
+        assert decision.accepted, decision.violations
+        revision = decision.graph_revision
+        for index, node in enumerate(snapshot["execution_nodes"], start=2):
+            decision = apply(
+                [{"op_id": f"OPS-cand-{index:03d}", "operation_type": "add_execution_node",
+                  "target_ref": node["execution_node_id"], "value": node}],
+                revision, index,
+            )
+            assert decision.accepted, decision.violations
+            revision = decision.graph_revision
+
+        first = apply(
+            [{"op_id": "OPS-cand-010", "operation_type": "promote_candidate",
+              "target_ref": "EXN-cand-001",
+              "value": {"candidate_group_id": "CND-group-001",
+                        "execution_node_id": "EXN-cand-001"}}],
+            revision, 10,
+        )
+        assert first.accepted, first.violations
+
+        second = apply(
+            [{"op_id": "OPS-cand-011", "operation_type": "promote_candidate",
+              "target_ref": "EXN-cand-002",
+              "value": {"candidate_group_id": "CND-group-001",
+                        "execution_node_id": "EXN-cand-002"}}],
+            first.graph_revision, 11,
+        )
+        assert not second.accepted, "the engine must refuse a second promotion"
+        assert any("exactly one promotion" in v.message for v in second.violations)
+        journal.close()
+
+
+# ------------------------------------------------------------ lineage
+
+
+class TestLoserRetention:
+    def test_losers_are_superseded_not_deleted(self):
+        results = [
+            candidate("winner", provider="alpha", digest="sha256:w", conformance=1.0),
+            candidate("loser", provider="beta", digest="sha256:l", conformance=0.5),
+        ]
+        outcome = promote(results, verifier=freeze(), verifier_artifact=VERIFIER)
+        assert outcome.winner == "winner"
+        assert outcome.superseded == ("loser",)
+
+        operations = promotion_operations(
+            "CND-group-001", outcome,
+            {"winner": "EXN-cand-001", "loser": "EXN-cand-002"},
+        )
+        assert operations[0]["operation_type"] == "promote_candidate"
+        supersedes = [op for op in operations if op["operation_type"] == "add_relation"]
+        assert len(supersedes) == 1
+        assert supersedes[0]["value"]["kind"] == "supersedes"
+        assert supersedes[0]["value"]["target"] == "EXN-cand-002"
+
+    def test_no_operations_are_emitted_without_a_winner(self):
+        assert promotion_operations("CND-group-001", Promotion(winner=None), {}) == []


### PR DESCRIPTION
feat(dag): parallel candidates with verifier-blind promotion (#389)

Runs several isolated candidate implementations where the fan-out is justified,
judges them against a verifier frozen before any candidate output is visible,
promotes exactly one by a deterministic rubric, and keeps the losers as
superseded evidence.

Two properties make this worth its cost rather than merely expensive, and both
are structural rather than conventions.

The verifier cannot be written to fit the winner. Its artifact is content
hashed before candidates run, and a hash that moves afterwards is fatal: the
promotion is refused entirely rather than returning a winner from a comparison
that is now void. Fan-out without a frozen verifier is refused up front.

The scorer is not told who produced what. The blinded view has no provider
field at all, and candidate labels are derived from artifact content rather
than identity, so swapping which provider produced which candidate cannot move
the winner. A test asserts exactly that. Presentation order is shuffled under a
journaled seed so position cannot proxy for identity, and a second test sweeps
twelve seeds to confirm the rubric decides rather than the ordering.

Hard gates run before any qualitative judgement. A candidate failing a gate or
a test is eliminated first, `error` is not treated as a pass while
`inapplicable` is, and a field where every candidate failed promotes nobody.
There is no best-of-a-bad-lot outcome under any configuration.

Exactly one promotion is enforced at the contract level, not by convention. A
snapshot with two promoted nodes in one candidate group is an invalid graph:
the check lives in validate_snapshot, so the engine refuses the second
promotion as a mutation rather than the promotion code merely declining to emit
it. Tested both ways, through the validator and through a real journal.

Fan-out is policy gated and defaults to one implementation. It must be earned
by risk class, blast radius, contract density or historical failure rate, and
it must be affordable: a budget too small for two candidates refuses rather
than half-running. Insufficient isolation refuses with a named reason, because
cross-contaminated candidates are worse than no candidates when the
contamination can pass the floor (#376).

Losers are superseded, never deleted. Promotion emits one promote_candidate
plus a supersedes relation per loser, preserving the field as the raw material
for #391's analysis of whether fan-out paid. There is no chimera merge: taking
one file from each candidate produces a tree no candidate's tests ever ran
against.

28 tests. Every guard was mutation tested by reverting it and confirming the
matching test fails: 15 of 15 caught.

Full suite: 3704 passed, 14 skipped.

Closes #389

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
