### PR TITLE
feat(dag): live graph explainability, audit views, and operator controls (#390)

### DIFF
--- a/scripts/chief_wiggum/dag/views.py
+++ b/scripts/chief_wiggum/dag/views.py
@@ -1,0 +1,473 @@
+"""Live graph explainability, audit views, and operator controls.
+
+Explanations are DERIVED, never narrated. Every answer is computed from the
+graph and the journal and cites stable IDs (node, edge, evidence, mutation,
+reason code). A model-written summary of a run is not an explanation; it is
+another thing to verify. This is `code_query.py`'s doctrine: a locator, not a
+content store.
+
+Unscanned is not clean. A view that cannot resolve something says so in
+`unresolved` and never renders absence of data as absence of a problem.
+
+Exports are deterministic, so a diff between two exports is a real change and
+not serialisation noise. Redaction is structural and applied on the way out,
+because the views must not become the leak that the keyring policy prevents.
+
+@cw-trace guards INV-dag-014 INV-dag-015
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from .canonical import canonical_json_bytes
+
+TERMINAL = frozenset({"succeeded", "failed", "superseded", "cancelled"})
+
+# Credential-shaped strings. Allowlist-based redaction: anything matching is
+# replaced, rather than trying to enumerate what is safe to print.
+_REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b(sk|pk|rk)-[A-Za-z0-9_\-]{8,}", re.IGNORECASE), "<redacted:key>"),
+    (re.compile(r"\bghp_[A-Za-z0-9]{16,}"), "<redacted:token>"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{8,}"), "<redacted:token>"),
+    (re.compile(r"\bey[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{5,}"),
+     "<redacted:jwt>"),
+    (re.compile(r"\bAKIA[0-9A-Z]{12,}"), "<redacted:aws-key>"),
+    (re.compile(r"(?i)\b(api[_-]?key|secret|password|passwd|token)\s*[=:]\s*\S+"),
+     r"\1=<redacted>"),
+    (re.compile(r"/(?:Users|home)/[^/\s\"']+"), "<redacted:home>"),
+)
+
+
+class Verdict(StrEnum):
+    READY = "ready"
+    RUNNING = "running"
+    BLOCKED = "blocked"
+    TERMINAL = "terminal"
+    PENDING = "pending"
+    UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True)
+class Reason:
+    """One derived fact, carrying handles rather than prose."""
+
+    code: str
+    subject: str
+    refs: tuple[str, ...] = ()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "subject": self.subject, "refs": list(self.refs),
+                "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class Explanation:
+    subject: str
+    verdict: Verdict
+    reasons: tuple[Reason, ...] = ()
+    unresolved: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "verdict": str(self.verdict),
+            "reasons": [reason.to_dict() for reason in self.reasons],
+            "unresolved": list(self.unresolved),
+        }
+
+
+def redact(value: Any) -> Any:
+    """Strip credential-shaped strings and home paths from anything exported."""
+    if isinstance(value, str):
+        redacted = value
+        for pattern, replacement in _REDACTIONS:
+            redacted = pattern.sub(replacement, redacted)
+        return redacted
+    if isinstance(value, Mapping):
+        return {key: redact(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact(item) for item in value]
+    return value
+
+
+def _nodes(state: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    return {node["execution_node_id"]: node for node in state.get("execution_nodes", [])}
+
+
+def _predecessors(state: Mapping[str, Any]) -> dict[str, list[tuple[str, str]]]:
+    """node -> [(predecessor, edge_id)]. source runs AFTER target."""
+    result: dict[str, list[tuple[str, str]]] = {node: [] for node in _nodes(state)}
+    for edge in state.get("schedulable_edges", []):
+        source = str(edge.get("source"))
+        if source in result:
+            result[source].append((str(edge.get("target")), str(edge.get("edge_id"))))
+    return result
+
+
+def node_sets(state: Mapping[str, Any], *, running: Sequence[str] = ()) -> dict[str, Any]:
+    """Ready / running / blocked / terminal, with counts."""
+    nodes = _nodes(state)
+    predecessors = _predecessors(state)
+    running_set = set(running)
+    buckets: dict[str, list[str]] = {"ready": [], "running": [], "blocked": [], "terminal": [],
+                                     "pending": []}
+    for node_id, node in sorted(nodes.items()):
+        lifecycle = str(node.get("lifecycle_state"))
+        if node_id in running_set:
+            buckets["running"].append(node_id)
+        elif lifecycle in TERMINAL:
+            buckets["terminal"].append(node_id)
+        elif lifecycle == "blocked":
+            buckets["blocked"].append(node_id)
+        elif lifecycle == "ready" and node.get("control_state") == "active":
+            buckets["ready"].append(node_id)
+        elif all(
+            str(nodes.get(predecessor, {}).get("lifecycle_state")) == "succeeded"
+            for predecessor, _ in predecessors.get(node_id, ())
+        ):
+            buckets["pending"].append(node_id)
+        else:
+            buckets["blocked"].append(node_id)
+    return {
+        "counts": {name: len(members) for name, members in buckets.items()},
+        **{name: sorted(members) for name, members in buckets.items()},
+    }
+
+
+def conflict_set(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Which ordered_after edges are actively serialising work right now."""
+    nodes = _nodes(state)
+    conflicts = []
+    for edge in state.get("schedulable_edges", []):
+        if str(edge.get("kind")) != "ordered_after":
+            continue
+        target = nodes.get(str(edge.get("target")), {})
+        if str(target.get("lifecycle_state")) not in TERMINAL:
+            conflicts.append(
+                {
+                    "edge_id": str(edge.get("edge_id")),
+                    "waiting": str(edge.get("source")),
+                    "on": str(edge.get("target")),
+                    "derived_from": list(edge.get("derived_from", [])),
+                }
+            )
+    return sorted(conflicts, key=lambda entry: entry["edge_id"])
+
+
+def why(state: Mapping[str, Any], node_id: str, *, running: Sequence[str] = ()) -> Explanation:
+    """Why is this node ready, blocked, or neither? Derived, with handles."""
+    nodes = _nodes(state)
+    node = nodes.get(node_id)
+    if node is None:
+        # Unresolved is a real answer, and never renders as "nothing wrong".
+        return Explanation(
+            subject=node_id,
+            verdict=Verdict.UNRESOLVED,
+            unresolved=(f"{node_id} is not an execution node in this graph",),
+        )
+
+    lifecycle = str(node.get("lifecycle_state"))
+    reasons: list[Reason] = []
+    unresolved: list[str] = []
+
+    for predecessor, edge_id in sorted(_predecessors(state).get(node_id, ())):
+        upstream = nodes.get(predecessor)
+        if upstream is None:
+            unresolved.append(f"edge {edge_id} names {predecessor}, which is not in the graph")
+            continue
+        upstream_state = str(upstream.get("lifecycle_state"))
+        if upstream_state == "succeeded":
+            reasons.append(
+                Reason("DEPENDENCY_SATISFIED", predecessor, (edge_id,), "predecessor succeeded")
+            )
+        else:
+            reasons.append(
+                Reason("DEPENDENCY_PENDING", predecessor, (edge_id,),
+                       f"predecessor is {upstream_state}")
+            )
+
+    for record in state.get("control_records", []):
+        if str(record.get("state")) in ("paused", "pause_requested", "cancelled",
+                                        "cancel_requested"):
+            reasons.append(
+                Reason("GRAPH_CONTROL", str(record.get("control_id")), (),
+                       f"graph control is {record.get('state')}")
+            )
+
+    if node.get("control_state") != "active":
+        reasons.append(
+            Reason("NODE_CONTROL", node_id, (), f"node control is {node.get('control_state')}")
+        )
+
+    if node_id in set(running):
+        verdict = Verdict.RUNNING
+    elif lifecycle in TERMINAL:
+        verdict = Verdict.TERMINAL
+        reasons.append(Reason("TERMINAL_STATE", node_id, (), lifecycle))
+    elif lifecycle == "blocked":
+        verdict = Verdict.BLOCKED
+    elif lifecycle == "ready" and node.get("control_state") == "active":
+        verdict = Verdict.READY
+    elif any(reason.code == "DEPENDENCY_PENDING" for reason in reasons):
+        verdict = Verdict.BLOCKED
+    else:
+        verdict = Verdict.PENDING
+
+    return Explanation(node_id, verdict, tuple(reasons), tuple(unresolved))
+
+
+def why_provider(decisions: Mapping[str, Mapping[str, Any]], node_id: str) -> Explanation:
+    """Why this provider, from #388's recorded routing decision."""
+    decision = decisions.get(node_id)
+    if decision is None:
+        return Explanation(
+            subject=node_id,
+            verdict=Verdict.UNRESOLVED,
+            unresolved=(f"no routing decision was recorded for {node_id}",),
+        )
+    reasons = [
+        Reason("ROUTED_TO", str(decision.get("provider")), (), "chosen provider"),
+        Reason("ALTERNATIVES", node_id, tuple(str(a) for a in decision.get("alternatives", ()))),
+    ]
+    for factor in decision.get("factors", ()):
+        reasons.append(Reason("DECIDING_FACTOR", node_id, (), str(factor)))
+    if decision.get("trigger"):
+        reasons.append(
+            Reason("ESCALATION_TRIGGER", node_id,
+                   tuple(str(e) for e in decision.get("evidence_ids", ())),
+                   str(decision["trigger"]))
+        )
+    return Explanation(node_id, Verdict.READY, tuple(reasons))
+
+
+def why_changed(state: Mapping[str, Any], mutation_id: str) -> Explanation:
+    """Why did the graph change? The mutation, its actor, evidence, budget."""
+    mutation = next(
+        (m for m in state.get("mutations", []) if str(m.get("mutation_id")) == mutation_id), None
+    )
+    if mutation is None:
+        return Explanation(
+            subject=mutation_id,
+            verdict=Verdict.UNRESOLVED,
+            unresolved=(f"{mutation_id} is not an admitted mutation in this graph",),
+        )
+    delta = mutation.get("budget_delta") or {}
+    reasons = [
+        Reason("ACTOR", str(mutation.get("actor")), (), str(mutation.get("authority_class"))),
+        Reason("REASON_CODE", mutation_id, (), str(mutation.get("reason_code"))),
+        Reason("EVIDENCE", mutation_id, tuple(str(e) for e in mutation.get("evidence_refs", ()))),
+        Reason("BUDGET_DELTA", mutation_id, (),
+               f"{delta.get('value', 0)} {delta.get('unit', '')}".strip()),
+        Reason("OPERATIONS", mutation_id,
+               tuple(str(op.get("operation_type")) for op in mutation.get("operations", ()))),
+    ]
+    return Explanation(mutation_id, Verdict.TERMINAL, tuple(reasons))
+
+
+def provenance(state: Mapping[str, Any], node_id: str) -> dict[str, Any]:
+    """From a node, walk back to the evidence that produced its edges and state."""
+    nodes = _nodes(state)
+    if node_id not in nodes:
+        return {"subject": node_id, "unresolved": [f"{node_id} is not in this graph"],
+                "evidence": [], "mutations": []}
+    evidence_ids: set[str] = set()
+    for edge in state.get("schedulable_edges", []):
+        if str(edge.get("source")) == node_id or str(edge.get("target")) == node_id:
+            evidence_ids.update(str(e) for e in edge.get("derived_from", ()))
+    mutations = []
+    for mutation in state.get("mutations", []):
+        touches = any(
+            str(op.get("target_ref")) == node_id for op in mutation.get("operations", ())
+        )
+        if touches:
+            mutations.append(str(mutation.get("mutation_id")))
+            evidence_ids.update(str(e) for e in mutation.get("evidence_refs", ()))
+    known = {str(r.get("evidence_id")) for r in state.get("evidence_records", [])}
+    return {
+        "subject": node_id,
+        "evidence": sorted(evidence_ids & known),
+        "mutations": sorted(mutations),
+        # An evidence id an edge cites but the graph does not hold is a gap that
+        # must be visible, not silently dropped from the walk.
+        "unresolved": sorted(f"evidence {ref} is cited but not recorded"
+                             for ref in evidence_ids - known),
+    }
+
+
+def revision_diff(before: Mapping[str, Any], after: Mapping[str, Any]) -> dict[str, Any]:
+    """Structured operations between two graph revisions."""
+    collections = ("intent_nodes", "intent_edges", "execution_nodes", "schedulable_edges",
+                   "relations", "evidence_records", "approval_records", "lease_records",
+                   "control_records")
+    identity = {
+        "intent_nodes": "intent_node_id", "intent_edges": "edge_id",
+        "execution_nodes": "execution_node_id", "schedulable_edges": "edge_id",
+        "relations": "relation_id", "evidence_records": "evidence_id",
+        "approval_records": "approval_id", "lease_records": "lease_id",
+        "control_records": "control_id",
+    }
+    diff: dict[str, Any] = {
+        "from_revision": before.get("graph_revision", 0),
+        "to_revision": after.get("graph_revision", 0),
+        "added": {}, "removed": {}, "changed": {},
+    }
+    for collection in collections:
+        key = identity[collection]
+        old = {str(r.get(key)): r for r in before.get(collection, [])}
+        new = {str(r.get(key)): r for r in after.get(collection, [])}
+        added = sorted(set(new) - set(old))
+        removed = sorted(set(old) - set(new))
+        changed = sorted(
+            record_id for record_id in set(old) & set(new)
+            if canonical_json_bytes(old[record_id]) != canonical_json_bytes(new[record_id])
+        )
+        if added:
+            diff["added"][collection] = added
+        if removed:
+            diff["removed"][collection] = removed
+        if changed:
+            diff["changed"][collection] = changed
+    before_mutations = {str(m.get("mutation_id")) for m in before.get("mutations", [])}
+    diff["mutations"] = sorted(
+        str(m.get("mutation_id")) for m in after.get("mutations", [])
+        if str(m.get("mutation_id")) not in before_mutations
+    )
+    return diff
+
+
+def export_json(state: Mapping[str, Any], *, running: Sequence[str] = ()) -> bytes:
+    """Deterministic, redacted JSON export. Same revision, same bytes.
+
+    Ordering is not imposed here: INV-dag-004's canonical encoding already
+    sorts identified-record collections, so determinism holds for any input
+    order without this function re-sorting.
+    """
+    payload = {
+        "graph_id": state.get("graph_id", ""),
+        "graph_revision": state.get("graph_revision", 0),
+        "sets": node_sets(state, running=running),
+        "conflicts": conflict_set(state),
+        "nodes": [
+            {
+                "execution_node_id": node.get("execution_node_id"),
+                "lifecycle_state": node.get("lifecycle_state"),
+                "control_state": node.get("control_state"),
+                "lease_state": node.get("lease_state"),
+                "node_type": node.get("node_type"),
+            }
+            for node in state.get("execution_nodes", [])
+        ],
+        "edges": [
+            {
+                "edge_id": edge.get("edge_id"),
+                "source": edge.get("source"),
+                "target": edge.get("target"),
+                "kind": edge.get("kind"),
+            }
+            for edge in state.get("schedulable_edges", [])
+        ],
+    }
+    return canonical_json_bytes(redact(payload))
+
+
+_MERMAID_SHAPE = {
+    "ready": ("([", "])"),
+    "running": ("[[", "]]"),
+    "blocked": ("{{", "}}"),
+    "terminal": ("[", "]"),
+    "pending": ("(", ")"),
+}
+
+
+def export_mermaid(state: Mapping[str, Any], *, running: Sequence[str] = ()) -> str:
+    """Deterministic Mermaid for issue and PR bodies, not a live dashboard."""
+    sets = node_sets(state, running=running)
+    bucket_of = {
+        node_id: bucket
+        for bucket in _MERMAID_SHAPE
+        for node_id in sets.get(bucket, [])
+    }
+    lines = ["graph TD"]
+    for node in sorted(state.get("execution_nodes", []),
+                       key=lambda n: str(n.get("execution_node_id"))):
+        node_id = str(node.get("execution_node_id"))
+        open_shape, close_shape = _MERMAID_SHAPE.get(bucket_of.get(node_id, "pending"),
+                                                     ("(", ")"))
+        label = f"{node_id}<br/>{node.get('lifecycle_state')}"
+        lines.append(f"    {node_id.replace('-', '_')}{open_shape}\"{label}\"{close_shape}")
+    for edge in sorted(state.get("schedulable_edges", []), key=lambda e: str(e.get("edge_id"))):
+        # source runs AFTER target, so the arrow points the way work flows.
+        source = str(edge.get("target")).replace("-", "_")
+        target = str(edge.get("source")).replace("-", "_")
+        arrow = "-.->" if str(edge.get("kind")) == "ordered_after" else "-->"
+        lines.append(f"    {source} {arrow} {target}")
+    return redact("\n".join(lines) + "\n")
+
+
+# ------------------------------------------------------------------ controls
+
+
+CONTROL_STATES = {
+    "pause": "pause_requested",
+    "resume": "active",
+    "cancel": "cancel_requested",
+}
+
+
+def control_envelope(
+    action: str,
+    *,
+    graph_id: str,
+    base_revision: int,
+    operator: str,
+    reason: str,
+    mutation_id: str,
+    idempotency_key: str,
+    control_id: str,
+) -> dict[str, Any]:
+    """An operator control is a journaled human-actor mutation, not a side channel.
+
+    There is no out-of-band control path: pause, resume and cancel all travel
+    the same envelope as any other change, so they replay like any other change.
+    """
+    if action not in CONTROL_STATES:
+        raise ValueError(f"unknown control action {action!r}")
+    if not operator or operator.startswith("actor:model."):
+        raise ValueError("operator controls require a human actor")
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "mutation_envelope",
+        "graph_id": graph_id,
+        "base_revision": base_revision,
+        "mutation_id": mutation_id,
+        "idempotency_key": idempotency_key,
+        "actor": operator,
+        "authority_class": "human",
+        "operations": [
+            {
+                "op_id": "OPS-control-001",
+                "operation_type": "set_control",
+                "target_ref": control_id,
+                "value": {
+                    "schema_version": "1.0.0",
+                    "record_type": "control_record",
+                    "control_id": control_id,
+                    "graph_id": graph_id,
+                    "state": CONTROL_STATES[action],
+                    "actor": operator,
+                    "reason_code": "EV_HUMAN_DECISION",
+                },
+            }
+        ],
+        "reason_code": "EV_HUMAN_DECISION",
+        "evidence_refs": [],
+        "expected_effect": redact(f"operator {action}: {reason}")[:4096] or action,
+        "budget_delta": {"unit": "tokens", "value": 0},
+        "requires_approval": True,
+    }

--- a/tests/test_dag_views.py
+++ b/tests/test_dag_views.py
@@ -1,0 +1,393 @@
+"""Explainability views, exports, and operator controls (chief-wiggum#390).
+
+Three properties carry this file: explanations cite stable IDs rather than
+narrating, an unresolvable question says so instead of rendering as clean, and
+exports are byte-identical for the same revision so a diff is a real change.
+"""
+
+import pytest
+from chief_wiggum.dag.views import (
+    Verdict,
+    conflict_set,
+    control_envelope,
+    export_json,
+    export_mermaid,
+    node_sets,
+    provenance,
+    redact,
+    revision_diff,
+    why,
+    why_changed,
+    why_provider,
+)
+
+GRAPH = "GRF-view001"
+
+
+def execution_node(node_id, *, lifecycle="proposed", control="active", lease="unclaimed"):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "execution_node",
+        "execution_node_id": node_id,
+        "intent_node_id": "INN-view-001",
+        "node_type": "implementation",
+        "role": "role:implementer",
+        "lifecycle_state": lifecycle,
+        "attempt": {"attempt_id": None, "outcome": "pending"},
+        "candidate": {"group_id": None, "disposition": "pending"},
+        "approval_state": "not_required",
+        "lease_state": lease,
+        "control_state": control,
+        "compiled_from": {"intent_node_id": "INN-view-001",
+                          "intent_graph_digest": "sha256:" + "b" * 64},
+    }
+
+
+def edge(edge_id, source, target, kind="depends_on", derived_from=("EVD-view-001",)):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "schedulable_edge",
+        "edge_id": edge_id,
+        "source": source,
+        "target": target,
+        "kind": kind,
+        "derived_from": list(derived_from),
+    }
+
+
+def state(nodes=(), edges=(), evidence=(), mutations=(), controls=(), revision=1):
+    return {
+        "schema_version": "1.0.0",
+        "record_type": "graph_snapshot",
+        "graph_id": GRAPH,
+        "graph_revision": revision,
+        "authority_matrix_version": "1.0.0",
+        "intent_nodes": [],
+        "intent_edges": [],
+        "execution_nodes": list(nodes),
+        "schedulable_edges": list(edges),
+        "relations": [],
+        "evidence_records": [{"schema_version": "1.0.0", "record_type": "evidence_record",
+                              "evidence_id": e, "evidence_type": "gate_outcome",
+                              "source_ref": "gate", "content_digest": "sha256:" + "c" * 64,
+                              "observed_at": "2026-01-01T00:00:00Z", "status": "validated"}
+                             for e in evidence],
+        "approval_records": [],
+        "lease_records": [],
+        "control_records": list(controls),
+        "mutations": list(mutations),
+    }
+
+
+# ------------------------------------------------------------------ views
+
+
+class TestNodeSets:
+    def test_buckets_and_counts(self):
+        snapshot = state(
+            nodes=[
+                execution_node("EXN-a-001", lifecycle="ready"),
+                execution_node("EXN-b-001", lifecycle="succeeded"),
+                execution_node("EXN-c-001", lifecycle="blocked"),
+                execution_node("EXN-d-001", lifecycle="ready"),
+            ]
+        )
+        sets = node_sets(snapshot, running=["EXN-d-001"])
+        assert sets["ready"] == ["EXN-a-001"]
+        assert sets["running"] == ["EXN-d-001"]
+        assert sets["blocked"] == ["EXN-c-001"]
+        assert sets["terminal"] == ["EXN-b-001"]
+        assert sets["counts"]["ready"] == 1
+
+    def test_conflict_set_reports_active_serialisation_only(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="ready"),
+                   execution_node("EXN-b-001", lifecycle="running"),
+                   execution_node("EXN-c-001", lifecycle="succeeded")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001", kind="ordered_after"),
+                   edge("SED-2", "EXN-a-001", "EXN-c-001", kind="ordered_after"),
+                   edge("SED-3", "EXN-a-001", "EXN-b-001", kind="depends_on")],
+            evidence=["EVD-view-001"],
+        )
+        conflicts = conflict_set(snapshot)
+        assert [c["edge_id"] for c in conflicts] == ["SED-1"], (
+            "a finished predecessor is not an active conflict, and depends_on is not a conflict"
+        )
+
+
+class TestExplanations:
+    def test_why_ready_names_the_satisfied_dependencies(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="ready"),
+                   execution_node("EXN-b-001", lifecycle="succeeded")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001")],
+            evidence=["EVD-view-001"],
+        )
+        explanation = why(snapshot, "EXN-a-001")
+        assert explanation.verdict is Verdict.READY
+        satisfied = [r for r in explanation.reasons if r.code == "DEPENDENCY_SATISFIED"]
+        assert satisfied[0].subject == "EXN-b-001"
+        assert satisfied[0].refs == ("SED-1",), "the explanation cites the edge, not prose"
+
+    def test_why_blocked_names_the_blocking_edge_and_state(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="admitted"),
+                   execution_node("EXN-b-001", lifecycle="running")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001")],
+            evidence=["EVD-view-001"],
+        )
+        explanation = why(snapshot, "EXN-a-001")
+        assert explanation.verdict is Verdict.BLOCKED
+        pending = [r for r in explanation.reasons if r.code == "DEPENDENCY_PENDING"]
+        assert pending[0].subject == "EXN-b-001"
+        assert "running" in pending[0].detail
+
+    def test_graph_pause_is_named_as_a_reason(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="ready")],
+            controls=[{"schema_version": "1.0.0", "record_type": "control_record",
+                       "control_id": "CTL-1", "graph_id": GRAPH, "state": "paused",
+                       "actor": "actor:human.pat", "reason_code": "EV_HUMAN_DECISION"}],
+        )
+        explanation = why(snapshot, "EXN-a-001")
+        assert any(r.code == "GRAPH_CONTROL" for r in explanation.reasons)
+
+    def test_unknown_node_is_unresolved_not_clean(self):
+        """AC: a view that cannot resolve something says so."""
+        explanation = why(state(), "EXN-ghost-001")
+        assert explanation.verdict is Verdict.UNRESOLVED
+        assert explanation.unresolved
+        assert explanation.reasons == ()
+
+    def test_dangling_edge_endpoint_is_reported_not_dropped(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="admitted")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-missing-001")],
+            evidence=["EVD-view-001"],
+        )
+        explanation = why(snapshot, "EXN-a-001")
+        assert explanation.unresolved, "a missing endpoint must surface"
+        assert "EXN-missing-001" in explanation.unresolved[0]
+
+    def test_why_provider_reports_alternatives_and_trigger(self):
+        decisions = {
+            "EXN-a-001": {
+                "provider": "middle", "alternatives": ["cheap", "middle"],
+                "factors": ["task_type=review", "escalated to depth 1"],
+                "trigger": "FAILING_GATES", "evidence_ids": ["EVD-gate-001"],
+            }
+        }
+        explanation = why_provider(decisions, "EXN-a-001")
+        assert any(r.code == "ROUTED_TO" and r.subject == "middle" for r in explanation.reasons)
+        trigger = [r for r in explanation.reasons if r.code == "ESCALATION_TRIGGER"][0]
+        assert trigger.detail == "FAILING_GATES"
+        assert trigger.refs == ("EVD-gate-001",)
+
+    def test_why_provider_without_a_record_is_unresolved(self):
+        explanation = why_provider({}, "EXN-a-001")
+        assert explanation.verdict is Verdict.UNRESOLVED
+        assert explanation.unresolved
+
+    def test_why_changed_reports_actor_evidence_and_budget(self):
+        mutation = {
+            "mutation_id": "MUT-view-001", "actor": "actor:human.pat",
+            "authority_class": "human", "reason_code": "EV_HUMAN_DECISION",
+            "evidence_refs": ["EVD-view-001"],
+            "budget_delta": {"unit": "tokens", "value": 500},
+            "operations": [{"operation_type": "set_control", "target_ref": "CTL-1"}],
+        }
+        explanation = why_changed(state(mutations=[mutation]), "MUT-view-001")
+        codes = {r.code for r in explanation.reasons}
+        assert {"ACTOR", "REASON_CODE", "EVIDENCE", "BUDGET_DELTA", "OPERATIONS"} <= codes
+        assert [r for r in explanation.reasons if r.code == "ACTOR"][0].subject == "actor:human.pat"
+
+    def test_why_changed_for_an_unknown_mutation_is_unresolved(self):
+        explanation = why_changed(state(), "MUT-ghost-001")
+        assert explanation.verdict is Verdict.UNRESOLVED
+
+
+class TestProvenance:
+    def test_walks_back_to_evidence_and_mutations(self):
+        mutation = {
+            "mutation_id": "MUT-view-001", "actor": "actor:test", "authority_class": "automatic",
+            "reason_code": "EV_GATE_FAILED", "evidence_refs": ["EVD-view-001"],
+            "budget_delta": {"unit": "tokens", "value": 0},
+            "operations": [{"operation_type": "transition_node", "target_ref": "EXN-a-001"}],
+        }
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001"), execution_node("EXN-b-001")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001")],
+            evidence=["EVD-view-001"],
+            mutations=[mutation],
+        )
+        walk = provenance(snapshot, "EXN-a-001")
+        assert walk["evidence"] == ["EVD-view-001"]
+        assert walk["mutations"] == ["MUT-view-001"]
+        assert walk["unresolved"] == []
+
+    def test_cited_but_unrecorded_evidence_is_surfaced(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001"), execution_node("EXN-b-001")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001", derived_from=("EVD-missing-001",))],
+        )
+        walk = provenance(snapshot, "EXN-a-001")
+        assert walk["unresolved"], "a cited-but-absent evidence id must not vanish from the walk"
+
+    def test_unknown_node_is_unresolved(self):
+        walk = provenance(state(), "EXN-ghost-001")
+        assert walk["unresolved"]
+        assert walk["evidence"] == []
+
+
+class TestRevisionDiff:
+    def test_reports_added_removed_and_changed(self):
+        before = state(nodes=[execution_node("EXN-a-001", lifecycle="admitted")], revision=1)
+        after = state(
+            nodes=[execution_node("EXN-a-001", lifecycle="running"),
+                   execution_node("EXN-b-001")],
+            revision=2,
+        )
+        diff = revision_diff(before, after)
+        assert diff["from_revision"] == 1 and diff["to_revision"] == 2
+        assert diff["added"]["execution_nodes"] == ["EXN-b-001"]
+        assert diff["changed"]["execution_nodes"] == ["EXN-a-001"]
+
+    def test_identical_revisions_diff_to_nothing(self):
+        snapshot = state(nodes=[execution_node("EXN-a-001")])
+        diff = revision_diff(snapshot, snapshot)
+        assert diff["added"] == {} and diff["removed"] == {} and diff["changed"] == {}
+
+    def test_new_mutations_are_listed(self):
+        mutation = {"mutation_id": "MUT-view-002", "actor": "actor:test",
+                    "authority_class": "automatic", "reason_code": "EV_GATE_FAILED",
+                    "evidence_refs": [], "budget_delta": {"unit": "tokens", "value": 0},
+                    "operations": []}
+        diff = revision_diff(state(), state(mutations=[mutation]))
+        assert diff["mutations"] == ["MUT-view-002"]
+
+
+class TestDeterministicExport:
+    def test_json_export_is_byte_identical_for_the_same_revision(self):
+        """AC: a diff between two exports is a real change, not serialisation noise."""
+        nodes = [execution_node("EXN-b-001"), execution_node("EXN-a-001", lifecycle="ready")]
+        first = export_json(state(nodes=nodes))
+        shuffled = export_json(state(nodes=list(reversed(nodes))))
+        assert first == shuffled
+
+    def test_mermaid_export_is_deterministic(self):
+        nodes = [execution_node("EXN-b-001"), execution_node("EXN-a-001", lifecycle="ready")]
+        edges = [edge("SED-1", "EXN-a-001", "EXN-b-001")]
+        first = export_mermaid(state(nodes=nodes, edges=edges, evidence=["EVD-view-001"]))
+        again = export_mermaid(
+            state(nodes=list(reversed(nodes)), edges=edges, evidence=["EVD-view-001"])
+        )
+        assert first == again
+        assert first.startswith("graph TD")
+
+    def test_json_determinism_comes_from_canonical_encoding(self):
+        """Determinism must not depend on this module remembering to sort."""
+        from chief_wiggum.dag.canonical import canonical_json_bytes
+
+        payload = {"nodes": [{"execution_node_id": "EXN-b-001"},
+                             {"execution_node_id": "EXN-a-001"}]}
+        reversed_payload = {"nodes": list(reversed(payload["nodes"]))}
+        assert canonical_json_bytes(payload) == canonical_json_bytes(reversed_payload)
+
+    def test_mermaid_redacts_anything_it_renders(self):
+        """Redaction is applied at the output boundary, not per field."""
+        node = execution_node("EXN-a-001")
+        node["lifecycle_state"] = "ghp_abcdefghijklmnopqrstuv"
+        diagram = export_mermaid(state(nodes=[node]))
+        assert "ghp_abcdefghijklmnopqrstuv" not in diagram
+        assert "<redacted:token>" in diagram
+
+    def test_mermaid_arrow_follows_the_direction_work_flows(self):
+        snapshot = state(
+            nodes=[execution_node("EXN-a-001"), execution_node("EXN-b-001")],
+            edges=[edge("SED-1", "EXN-a-001", "EXN-b-001")],
+            evidence=["EVD-view-001"],
+        )
+        diagram = export_mermaid(snapshot)
+        # source runs AFTER target, so b flows into a.
+        assert "EXN_b_001 --> EXN_a_001" in diagram
+
+
+class TestRedaction:
+    @pytest.mark.parametrize(
+        "secret",
+        [
+            "sk-abcdefghijklmnopqrstuvwxyz123456",
+            "ghp_abcdefghijklmnopqrstuvwxyz1234",
+            "xoxb-1234567890-abcdefghijkl",
+            "AKIAIOSFODNN7EXAMPLE",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9WgXcQabcdef",
+            "api_key=hunter2seekrit",
+            "/Users/patwork/secret/place",
+        ],
+    )
+    def test_seeded_secrets_never_reach_an_export(self, secret):
+        """AC: tested with seeded secrets; the views must not become the leak."""
+        node = execution_node("EXN-a-001")
+        node["role"] = f"role:implementer {secret}"
+        snapshot = state(nodes=[node])
+        snapshot["graph_id"] = f"GRF-view001 {secret}"
+        exported = export_json(snapshot).decode()
+        assert secret not in exported, f"{secret} leaked into the export"
+        assert secret not in export_mermaid(snapshot)
+
+    def test_redaction_is_recursive_through_containers(self):
+        payload = {"a": ["sk-abcdefghijklmnopqrstuvwxyz123456"], "b": {"c": "ghp_" + "a" * 20}}
+        cleaned = redact(payload)
+        assert "sk-abcdef" not in str(cleaned)
+        assert "ghp_" not in str(cleaned)
+
+    def test_ordinary_text_survives_redaction(self):
+        assert redact("EXN-a-001 is blocked on EXN-b-001") == "EXN-a-001 is blocked on EXN-b-001"
+
+
+class TestOperatorControls:
+    def test_control_is_a_journaled_human_actor_mutation(self):
+        """AC: every control is audited; there is no out-of-band control path."""
+        envelope = control_envelope(
+            "pause", graph_id=GRAPH, base_revision=3, operator="actor:human.pat",
+            reason="investigating a flaky gate", mutation_id="MUT-ctl-001",
+            idempotency_key="ctl-1", control_id="CTL-ctl-001",
+        )
+        assert envelope["actor"] == "actor:human.pat"
+        assert envelope["authority_class"] == "human"
+        assert envelope["requires_approval"] is True
+        assert envelope["operations"][0]["value"]["state"] == "pause_requested"
+        assert "investigating" in envelope["expected_effect"]
+
+    def test_resume_and_cancel_map_to_control_states(self):
+        for action, expected in (("resume", "active"), ("cancel", "cancel_requested")):
+            envelope = control_envelope(
+                action, graph_id=GRAPH, base_revision=1, operator="actor:human.pat",
+                reason="because", mutation_id="MUT-ctl-002", idempotency_key="ctl-2",
+                control_id="CTL-ctl-002",
+            )
+            assert envelope["operations"][0]["value"]["state"] == expected
+
+    def test_a_model_may_not_issue_an_operator_control(self):
+        with pytest.raises(ValueError, match="human actor"):
+            control_envelope(
+                "cancel", graph_id=GRAPH, base_revision=1, operator="actor:model.opus",
+                reason="I would like to stop", mutation_id="MUT-ctl-003",
+                idempotency_key="ctl-3", control_id="CTL-ctl-003",
+            )
+
+    def test_unknown_action_is_refused(self):
+        with pytest.raises(ValueError, match="unknown control action"):
+            control_envelope(
+                "obliterate", graph_id=GRAPH, base_revision=1, operator="actor:human.pat",
+                reason="", mutation_id="MUT-ctl-004", idempotency_key="ctl-4",
+                control_id="CTL-ctl-004",
+            )
+
+    def test_control_reason_is_redacted(self):
+        envelope = control_envelope(
+            "pause", graph_id=GRAPH, base_revision=1, operator="actor:human.pat",
+            reason="token ghp_abcdefghijklmnopqrstuv leaked", mutation_id="MUT-ctl-005",
+            idempotency_key="ctl-5", control_id="CTL-ctl-005",
+        )
+        assert "ghp_abcdefghijklmnopqrstuv" not in envelope["expected_effect"]


### PR DESCRIPTION
feat(dag): live graph explainability, audit views, and operator controls (#390)

Makes a running graph legible and controllable. Without this the epic would
ship a system that is more capable and less inspectable than the wave barriers
it replaces, which is a bad trade at any capability level.

Explanations are derived, never narrated. Every answer is computed from the
graph and cites stable IDs: which edge is blocking, which node it waits on,
which evidence produced it, which mutation changed it, which actor issued that
mutation and what it cost. This follows code_query.py's doctrine of a locator
rather than a content store, and a mutation that strips the edge handles from an
explanation fails its test, because prose without handles is not an explanation.

Unscanned is not clean. An unknown node, an unrecorded routing decision, an
unknown mutation, an edge endpoint that is not in the graph, and an evidence id
cited but never recorded all surface in an explicit `unresolved` list. None of
them render as an absence of problems. Four separate mutations that quietly
convert one of those into a clean answer are each caught.

Views: ready / running / blocked / terminal sets with counts, the active
resource-conflict set (only edges still serialising work, so a finished
predecessor is not reported as a conflict), why-ready, why-blocked,
why-this-provider from #388's recorded decision, why-the-graph-changed, a
structured revision diff, and provenance that walks a node back to its evidence
and mutations.

Exports are deterministic and redacted. Determinism is not this module
remembering to sort: INV-dag-004's canonical encoding already orders
identified-record collections, so the export holds for any input order. An
explicit sort here was removed once mutation testing showed no test could
distinguish it, and a test now pins the property at the layer that actually
provides it.

Redaction is structural and applied at the output boundary rather than per
field, so nothing rendered can bypass it. Seeded secrets covering API keys,
GitHub and Slack tokens, JWTs, AWS keys, key-value credential pairs and home
paths are asserted never to reach a JSON or Mermaid export. That boundary
placement was also a mutation-testing finding: per-label redaction left the
diagram reachable.

Controls are journaled human-actor mutations. Pause, resume and cancel travel
the same envelope as any other change, carry the operator's identity and
reason, and replay like anything else. There is no out-of-band control path, a
model actor is refused, an unknown action is refused, and the operator's stated
reason is redacted before it is stored.

36 tests. Every guard was mutation tested by reverting it and confirming the
matching test fails: 16 of 16 caught against the final implementation, after
two blind spots were found and fixed rather than accepted.

Full suite: 3740 passed, 14 skipped.

Closes #390

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
