### PR TITLE
experiment(factory): pre-register the dynamic-DAG ablation and build its analysis (#391)

### DIFF
--- a/docs/experiments/dynamic-dag/pre-registration.md
+++ b/docs/experiments/dynamic-dag/pre-registration.md
@@ -1,0 +1,195 @@
+# Pre-registration: dynamic-DAG open/micro-model ablation
+
+Tracking issue: chief-wiggum#391. Parent epic: chief-wiggum#383.
+
+**Status: registered, no arm has run.**
+
+This document is binding. Arms, metrics, the gap-closure formula, the
+non-inferiority margin and the stopping rules are fixed here, before the first
+arm runs. A margin chosen after seeing results is not a margin, and a
+degenerate case discovered during analysis is an invitation to pick the
+flattering reading. Both are settled below instead.
+
+Changing anything in this document after an arm has run invalidates that arm.
+The change must be recorded as an amendment with its date and reason, and the
+affected arms re-run on a fresh split.
+
+## The question
+
+How much of the open-model versus frontier-model gap does a better process
+close?
+
+Every figure CW publishes today confounds "which model" with "which workflow".
+E2EDev reports 67.1% test accuracy across 46 tasks; SWE-bench Verified reports
+15/20 on a seeded random subset, with the README already carrying the caveat
+that N=20 means roughly plus or minus nineteen points. Neither isolates process
+from model, so "the factory closes the capability gap" is currently
+unfalsifiable. This experiment factorises it.
+
+This is the ticket the other seven exist to answer. It is also the one allowed
+to conclude they were not worth building.
+
+## Arms
+
+Arms are specified by capability tier, never by model name, so the experiment
+survives the roster changing under it (`models.md` is refreshed often). Tiers
+resolve through `config/providers.json` at run time and the resolved roster is
+recorded in each run manifest.
+
+| Arm | Model tier | Process | Tests |
+|-----|-----------|---------|-------|
+| 1 | frontier-tier | static factory (`plan_waves.py`, static roles) | upper end of the gap |
+| 2 | open-tier | static factory | lower end of the gap |
+| 3 | open-tier | dynamic DAG (#387) | decomposition |
+| 4 | open-tier | dynamic DAG + selective candidates (#389) | candidates |
+| 5 | adaptive hybrid routing (#388) | dynamic DAG | routing economics |
+
+Arm 2 is the baseline against which negative findings are judged.
+
+## Corpus and strata
+
+Stratified across task class (feature, bugfix, refactor, test-only, frontend,
+backend), risk class, and size. Historical CW tickets plus live tasks. Existing
+harnesses (`swebench_harness.py`, `e2edev_harness.py`) are reused where the
+corpus overlaps; no third harness is built.
+
+Inclusion rules, fixed here:
+
+- A historical task is excluded if its solution is reachable from the repo
+  state given to the arm. The cutoff and the exclusion count are recorded.
+- Public-benchmark instances that may be in model pretraining are stated
+  plainly. Cross-arm comparison under fixed conditions is the readable signal;
+  absolute score is not.
+- Minimum 20 tasks per stratum for a stratum-level number to be reported at
+  all. Below that the stratum is reported as underpowered, with its N.
+
+## Fixed conditions
+
+Everything except the varied factor is identical across arms: task corpus,
+environment, tool availability, budget ceilings, verifier, and held-out
+grading. The verifier is frozen and content-hashed before any arm runs, the
+same discipline as #389's candidate verifier.
+
+Deviations are recorded as protocol violations, never silently absorbed.
+`experiment.protocol_violations` compares two run manifests and names what
+moved.
+
+## Metrics
+
+Per arm, and sliced by task class and risk:
+
+- accepted-patch rate (the headline quality number)
+- contract, test, and gate conformance
+- escaped defects, meaning those found after acceptance
+- operator intervention minutes
+- model cost and normalised compute cost
+- wall-clock latency
+- retries, graph mutations, escalation rate
+
+Every headline number carries its N and a 95% Wilson interval. The Wilson
+interval is used rather than the normal approximation because the strata are
+small, and the normal approximation misbehaves exactly there: it produces
+bounds outside [0, 1] and a zero-width interval at 0 or 100 percent.
+
+Quality is never reported without cost. The cost/quality frontier across all
+five arms is part of the result, not an appendix.
+
+## Gap closure
+
+```
+gap_closure = (adaptive_open_quality - static_open_quality)
+            / (frontier_quality  - static_open_quality)
+```
+
+Degenerate cases, decided now:
+
+| Case | Handling |
+|------|----------|
+| denominator within 1e-9 of zero | **Undefined.** The corpus was not discriminative. No ratio is published. |
+| denominator negative (open beats frontier under the static process) | **Meaningless.** Report the raw arm differences and investigate the corpus. |
+| numerator negative (the dynamic process made the open model worse) | **Negative result.** Reported as such, never clipped to zero. |
+
+Only a `DEFINED` status may be quoted as a gap-closure percentage.
+`experiment.gap_closure` returns the status alongside the value, and
+`GapClosure.publishable` is false for every other case.
+
+## Non-inferiority margin
+
+Claim under test: **arm 5 is not worse than arm 1 on accepted-patch rate.**
+
+**Margin: 5 percentage points, absolute.**
+
+Justification, recorded before any arm runs: CW's own acceptance bar is that a
+change leaves CI green and passes the gates, so a difference smaller than the
+run-to-run noise of the existing suite is not a quality difference anyone would
+act on. Five points is also below the roughly nineteen-point interval the
+README already reports at N=20, which means the margin is only meaningful at
+the corpus sizes this pre-registration requires. Choosing a wider margin would
+let arm 5 lose materially and still be called non-inferior; choosing a narrower
+one would demand a corpus larger than the budget supports.
+
+Assessment is conservative: the worst case for the treatment against the best
+case for the control. Non-inferiority holds when the lower bound of arm 5's
+interval minus the upper bound of arm 1's interval clears the negative margin.
+
+## Stopping rules
+
+- No arm stops early because it is winning. Interim looks do not change the
+  registered N.
+- An arm stops immediately on a protocol violation. The violation is recorded
+  and the arm re-runs from a clean manifest.
+- The experiment stops and reports if budget is exhausted before the registered
+  N. A partial result is reported as partial, with its N, and does not produce
+  a gap-closure ratio.
+- Any tuning of the DAG, routing, or candidate policy against the evaluation
+  corpus invalidates the arm and requires a re-run on a fresh split.
+
+## Reporting rules
+
+- Raw per-task results are published and immutable, journaled through the
+  existing ratchet hash chain. No signing or DSSE, consistent with how
+  gate-validation records are handled.
+- Negative results are retained and reported. A report with no negative
+  findings across five arms is treated as a reporting failure and reviewed
+  before publication. `experiment.reporting_failures` flags this mechanically.
+- No README or public claim is updated before this ticket's evidence exists.
+  Any claim that does land carries its N, its interval, and its caveats in the
+  same sentence. `experiment.readme_claim_allowed` encodes the bar: gap closure
+  must be `DEFINED`, the smallest arm must reach the registered minimum N, and
+  no interval may be wider than 20 points.
+
+## Rollout ladder
+
+Each rung has entry and exit criteria, and the previous rung must pass before
+the next begins.
+
+1. **Historical replay.** Entry: corpus frozen, verifier hashed. Exit: all five
+   arms complete with no protocol violations.
+2. **Live shadow.** The dynamic path computes decisions without dispatching
+   (#387's shadow mode, #388's shadow routing). Exit: shadow decisions logged
+   for a full epic with no crash and no divergence the operator judges unsafe.
+3. **Advisory.** Decisions surfaced to the operator, who acts or declines.
+   Exit: operator agrees with the recommendation on a majority of nodes.
+4. **Bounded autonomy.** Dynamic path runs with budget ceilings and the
+   approval queue for privileged operations. Exit: one epic completed with no
+   escaped defect attributable to the scheduler.
+5. **Default.** Static path retained as `--static` fallback.
+
+## Rollback
+
+Conditions for reverting to `plan_waves.py` plus static roles:
+
+- quality regression beyond the non-inferiority margin at any rung
+- an escaped defect attributable to the scheduler, the router, or promotion
+- operator intervention minutes exceeding the static baseline
+- any unrecoverable graph state in production use
+
+The fallback is exercised at least once at the end of the experiment to prove
+it still works, not assumed. The static projection shares the same graph
+(#385's `project --waves`), so the fallback is real code exercised by tests.
+
+## What this document does not do
+
+It does not run the arms. Execution needs real budget, real wall-clock, and a
+human decision at each rung of the ladder. The go / hold / rollback decision is
+a human decision by design, and nothing here pre-empts it.

--- a/scripts/chief_wiggum/dag/experiment.py
+++ b/scripts/chief_wiggum/dag/experiment.py
@@ -1,0 +1,387 @@
+"""Analysis substrate for the dynamic-DAG ablation (chief-wiggum#391).
+
+This module exists to make the experiment's conclusions hard to fudge after the
+fact. Three things are mechanised rather than left to discipline:
+
+1. The gap-closure ratio's degenerate cases are handled in advance and named.
+   A denominator near zero means the corpus was not discriminative, and no
+   ratio is published. A negative numerator means the dynamic process made the
+   open model worse, and it is reported as such rather than clipped to zero.
+2. Uncertainty is not optional. Point estimates carry a Wilson interval and an
+   N, because the existing README already had to caveat an N=20 row at plus or
+   minus nineteen points, and a headline without an interval invites exactly
+   that mistake again.
+3. "No negative findings across five arms" is treated as a reporting failure
+   and flagged, not accepted as good news.
+
+Arms are specified by capability tier, never by model name, so the experiment
+survives the roster changing under it.
+
+@cw-trace guards INV-dag-016
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from .canonical import canonical_json_bytes
+
+# Below this, the frontier/open gap is treated as unmeasurable on this corpus.
+DEGENERATE_DENOMINATOR = 1e-9
+
+
+class GapClosureStatus(StrEnum):
+    DEFINED = "DEFINED"
+    UNDEFINED_NO_GAP = "UNDEFINED_NO_GAP"
+    MEANINGLESS_INVERTED_GAP = "MEANINGLESS_INVERTED_GAP"
+    NEGATIVE_REGRESSION = "NEGATIVE_REGRESSION"
+
+
+class ProtocolViolation(StrEnum):
+    VERIFIER_CHANGED = "VERIFIER_CHANGED"
+    CORPUS_CHANGED = "CORPUS_CHANGED"
+    BUDGET_CHANGED = "BUDGET_CHANGED"
+    ENVIRONMENT_CHANGED = "ENVIRONMENT_CHANGED"
+    TUNED_ON_CORPUS = "TUNED_ON_CORPUS"
+
+
+@dataclass(frozen=True)
+class Interval:
+    """A proportion with its uncertainty. Never report the point alone."""
+
+    successes: int
+    n: int
+    low: float
+    high: float
+
+    @property
+    def point(self) -> float:
+        return self.successes / self.n if self.n else 0.0
+
+    @property
+    def width(self) -> float:
+        return self.high - self.low
+
+    def render(self) -> str:
+        if not self.n:
+            return "no data (N=0)"
+        return (f"{self.point:.1%} (N={self.n}, 95% CI "
+                f"{self.low:.1%} to {self.high:.1%})")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"successes": self.successes, "n": self.n, "point": self.point,
+                "ci_low": self.low, "ci_high": self.high}
+
+
+def wilson_interval(successes: int, n: int, z: float = 1.959963984540054) -> Interval:
+    """Wilson score interval.
+
+    Chosen over the normal approximation because the corpus strata are small,
+    and the normal approximation misbehaves badly exactly there: it can produce
+    bounds outside [0, 1] and a zero-width interval at 0 or 100 percent.
+    """
+    if n <= 0:
+        return Interval(successes=0, n=0, low=0.0, high=0.0)
+    if successes < 0 or successes > n:
+        raise ValueError(f"successes {successes} out of range for n={n}")
+    proportion = successes / n
+    denominator = 1 + z * z / n
+    centre = (proportion + z * z / (2 * n)) / denominator
+    margin = (z / denominator) * math.sqrt(
+        proportion * (1 - proportion) / n + z * z / (4 * n * n)
+    )
+    return Interval(
+        successes=successes,
+        n=n,
+        low=max(0.0, centre - margin),
+        high=min(1.0, centre + margin),
+    )
+
+
+@dataclass(frozen=True)
+class GapClosure:
+    """The pre-registered ratio, with its degenerate cases named up front."""
+
+    status: GapClosureStatus
+    value: float | None
+    numerator: float
+    denominator: float
+    detail: str
+
+    @property
+    def publishable(self) -> bool:
+        """Only a DEFINED ratio may be quoted as a gap-closure percentage."""
+        return self.status is GapClosureStatus.DEFINED
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"status": str(self.status), "value": self.value,
+                "numerator": self.numerator, "denominator": self.denominator,
+                "detail": self.detail}
+
+
+def gap_closure(
+    *,
+    frontier_quality: float,
+    static_open_quality: float,
+    adaptive_open_quality: float,
+    epsilon: float = DEGENERATE_DENOMINATOR,
+) -> GapClosure:
+    """gap_closure = (adaptive_open - static_open) / (frontier - static_open).
+
+    Every degenerate case is decided here, before any data exists, so the
+    analysis cannot quietly pick the flattering reading later.
+    """
+    numerator = adaptive_open_quality - static_open_quality
+    denominator = frontier_quality - static_open_quality
+
+    if abs(denominator) <= epsilon:
+        return GapClosure(
+            status=GapClosureStatus.UNDEFINED_NO_GAP,
+            value=None,
+            numerator=numerator,
+            denominator=denominator,
+            detail=("no measurable frontier/open gap on this corpus;"
+                    " the corpus was not discriminative and no ratio is published"),
+        )
+    if denominator < 0:
+        return GapClosure(
+            status=GapClosureStatus.MEANINGLESS_INVERTED_GAP,
+            value=None,
+            numerator=numerator,
+            denominator=denominator,
+            detail=("open-tier beat frontier-tier under the static process;"
+                    " the ratio is meaningless, report raw arm differences"),
+        )
+    if numerator < 0:
+        return GapClosure(
+            status=GapClosureStatus.NEGATIVE_REGRESSION,
+            value=numerator / denominator,
+            numerator=numerator,
+            denominator=denominator,
+            detail=("the dynamic process made the open model worse;"
+                    " reported as a negative result and never clipped to zero"),
+        )
+    return GapClosure(
+        status=GapClosureStatus.DEFINED,
+        value=numerator / denominator,
+        numerator=numerator,
+        denominator=denominator,
+        detail="",
+    )
+
+
+@dataclass(frozen=True)
+class NonInferiority:
+    """Pre-registered margin. A margin chosen after seeing results is not a margin."""
+
+    margin: float
+    justification: str
+    registered_at: str = ""
+
+    def assess(self, treatment: Interval, control: Interval) -> dict[str, Any]:
+        """Non-inferior when the CI lower bound of the difference clears -margin."""
+        difference = treatment.point - control.point
+        # Conservative: worst case for the treatment against best for the control.
+        worst_case = treatment.low - control.high
+        return {
+            "margin": self.margin,
+            "difference": difference,
+            "worst_case_difference": worst_case,
+            "non_inferior": worst_case >= -self.margin,
+            "justification": self.justification,
+        }
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """One pre-registered arm's outcome. Tiers, not model names."""
+
+    arm: str
+    model_tier: str
+    process: str
+    accepted: int
+    attempted: int
+    escaped_defects: int = 0
+    operator_minutes: float = 0.0
+    model_cost: float = 0.0
+    wall_clock_seconds: float = 0.0
+    retries: int = 0
+    graph_mutations: int = 0
+    escalations: int = 0
+    strata: Mapping[str, tuple[int, int]] = field(default_factory=dict)
+
+    @property
+    def quality(self) -> Interval:
+        return wilson_interval(self.accepted, self.attempted)
+
+    def stratum_intervals(self) -> dict[str, Interval]:
+        return {
+            name: wilson_interval(accepted, attempted)
+            for name, (accepted, attempted) in sorted(self.strata.items())
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arm": self.arm,
+            "model_tier": self.model_tier,
+            "process": self.process,
+            "quality": self.quality.to_dict(),
+            "escaped_defects": self.escaped_defects,
+            "operator_minutes": self.operator_minutes,
+            "model_cost": self.model_cost,
+            "wall_clock_seconds": self.wall_clock_seconds,
+            "retries": self.retries,
+            "graph_mutations": self.graph_mutations,
+            "escalations": self.escalations,
+            "strata": {name: interval.to_dict()
+                       for name, interval in self.stratum_intervals().items()},
+        }
+
+
+@dataclass(frozen=True)
+class RunManifest:
+    """Everything needed to reproduce one arm. Hashed so it cannot drift."""
+
+    arm: str
+    corpus_version: str
+    provider_roster: Mapping[str, str]
+    seeds: Mapping[str, int]
+    budgets: Mapping[str, float]
+    verifier_hash: str
+    environment: Mapping[str, str]
+
+    def digest(self) -> str:
+        """Stable hash of the manifest.
+
+        Values must be integers or strings: INV-dag-004's canonical encoding
+        rejects floats so that a hash is replay stable, and a budget expressed
+        as 10.5 would otherwise fail with an opaque encoder error deep in the
+        call stack. Express money in cents and time in whole seconds.
+        """
+        try:
+            payload = canonical_json_bytes(self.to_dict())
+        except ValueError as exc:
+            raise ValueError(
+                "manifest values must be integer or string; canonical encoding"
+                f" rejects floats so hashes stay replay stable (got {exc})"
+            ) from exc
+        return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arm": self.arm,
+            "corpus_version": self.corpus_version,
+            "provider_roster": dict(self.provider_roster),
+            "seeds": dict(self.seeds),
+            "budgets": dict(self.budgets),
+            "verifier_hash": self.verifier_hash,
+            "environment": dict(self.environment),
+        }
+
+
+def protocol_violations(
+    baseline: RunManifest, other: RunManifest
+) -> list[ProtocolViolation]:
+    """Everything except the varied factor must be fixed. Deviations are recorded."""
+    violations = []
+    if baseline.verifier_hash != other.verifier_hash:
+        violations.append(ProtocolViolation.VERIFIER_CHANGED)
+    if baseline.corpus_version != other.corpus_version:
+        violations.append(ProtocolViolation.CORPUS_CHANGED)
+    if dict(baseline.budgets) != dict(other.budgets):
+        violations.append(ProtocolViolation.BUDGET_CHANGED)
+    if dict(baseline.environment) != dict(other.environment):
+        violations.append(ProtocolViolation.ENVIRONMENT_CHANGED)
+    return violations
+
+
+def cost_quality_frontier(arms: Sequence[ArmResult]) -> list[dict[str, Any]]:
+    """The frontier across arms, so quality is never reported without its cost."""
+    points = [
+        {
+            "arm": arm.arm,
+            "model_tier": arm.model_tier,
+            "process": arm.process,
+            "quality": arm.quality.point,
+            "quality_ci": [arm.quality.low, arm.quality.high],
+            "n": arm.quality.n,
+            "cost": arm.model_cost,
+        }
+        for arm in arms
+    ]
+    points.sort(key=lambda point: (point["cost"], point["arm"]))
+    best_quality = -1.0
+    for point in points:
+        # On the frontier when nothing cheaper achieved as much quality.
+        point["on_frontier"] = point["quality"] > best_quality
+        best_quality = max(best_quality, point["quality"])
+    return points
+
+
+def negative_findings(arms: Sequence[ArmResult], baseline_arm: str) -> list[str]:
+    """Anything that went the wrong way, stated plainly."""
+    baseline = next((arm for arm in arms if arm.arm == baseline_arm), None)
+    findings: list[str] = []
+    if baseline is None:
+        return [f"baseline arm {baseline_arm} is missing from the results"]
+    for arm in arms:
+        if arm.arm == baseline_arm:
+            continue
+        if arm.quality.point < baseline.quality.point:
+            findings.append(
+                f"{arm.arm} scored below {baseline_arm}"
+                f" ({arm.quality.render()} vs {baseline.quality.render()})"
+            )
+        if arm.escaped_defects > baseline.escaped_defects:
+            findings.append(
+                f"{arm.arm} let more defects escape than {baseline_arm}"
+                f" ({arm.escaped_defects} vs {baseline.escaped_defects})"
+            )
+        if arm.operator_minutes > baseline.operator_minutes:
+            findings.append(
+                f"{arm.arm} needed more operator time than {baseline_arm}"
+                f" ({arm.operator_minutes} vs {baseline.operator_minutes} minutes)"
+            )
+    for arm in arms:
+        if arm.quality.n and arm.quality.width > 0.30:
+            findings.append(
+                f"{arm.arm} interval is too wide to be decisive ({arm.quality.render()})"
+            )
+    return findings
+
+
+def reporting_failures(arms: Sequence[ArmResult], findings: Sequence[str]) -> list[str]:
+    """A clean sweep across five arms is a reporting failure, not good news."""
+    failures = []
+    if len(arms) >= 5 and not findings:
+        failures.append(
+            "no negative findings across five arms; treat as a reporting failure"
+            " and review the analysis before publishing"
+        )
+    for arm in arms:
+        if arm.attempted == 0:
+            failures.append(f"{arm.arm} attempted no tasks")
+    return failures
+
+
+def readme_claim_allowed(
+    arms: Sequence[ArmResult], closure: GapClosure, *, min_n: int = 100
+) -> tuple[bool, str]:
+    """No public claim from a small sample, and never without its caveats."""
+    if not closure.publishable:
+        return False, f"gap closure is {closure.status}: {closure.detail}"
+    smallest = min((arm.quality.n for arm in arms), default=0)
+    if smallest < min_n:
+        return False, (
+            f"smallest arm has N={smallest}, below the pre-registered minimum {min_n};"
+            " directional only, not a public claim"
+        )
+    widest = max((arm.quality.width for arm in arms), default=1.0)
+    if widest > 0.20:
+        return False, f"widest interval is {widest:.1%}; too wide for a headline"
+    return True, "claim must carry its N, its interval, and its caveats in the same sentence"

--- a/tests/test_dag_experiment.py
+++ b/tests/test_dag_experiment.py
@@ -1,0 +1,334 @@
+"""Analysis substrate for the dynamic-DAG ablation (chief-wiggum#391).
+
+The degenerate gap-closure cases carry this file. Each one is a way the
+experiment could quietly report a flattering number, and each is decided in
+code rather than left to whoever runs the analysis.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from chief_wiggum.dag.experiment import (
+    ArmResult,
+    GapClosureStatus,
+    NonInferiority,
+    ProtocolViolation,
+    RunManifest,
+    cost_quality_frontier,
+    gap_closure,
+    negative_findings,
+    protocol_violations,
+    readme_claim_allowed,
+    reporting_failures,
+    wilson_interval,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+PREREG = ROOT / "docs" / "experiments" / "dynamic-dag" / "pre-registration.md"
+
+
+def arm(name, accepted, attempted, **kwargs):
+    return ArmResult(
+        arm=name,
+        model_tier=kwargs.pop("tier", "open-tier"),
+        process=kwargs.pop("process", "dynamic"),
+        accepted=accepted,
+        attempted=attempted,
+        **kwargs,
+    )
+
+
+# ------------------------------------------------------------ gap closure
+
+
+class TestGapClosureDegenerateCases:
+    def test_ordinary_case_is_defined(self):
+        closure = gap_closure(frontier_quality=0.80, static_open_quality=0.60,
+                              adaptive_open_quality=0.70)
+        assert closure.status is GapClosureStatus.DEFINED
+        assert closure.value == pytest.approx(0.5)
+        assert closure.publishable
+
+    def test_no_measurable_gap_is_undefined_and_unpublishable(self):
+        """AC: denominator near zero means the corpus was not discriminative."""
+        closure = gap_closure(frontier_quality=0.70, static_open_quality=0.70,
+                              adaptive_open_quality=0.75)
+        assert closure.status is GapClosureStatus.UNDEFINED_NO_GAP
+        assert closure.value is None
+        assert not closure.publishable
+        assert "not discriminative" in closure.detail
+
+    def test_inverted_gap_is_meaningless_not_a_big_number(self):
+        """Open beating frontier under the static process must not yield a ratio."""
+        closure = gap_closure(frontier_quality=0.60, static_open_quality=0.70,
+                              adaptive_open_quality=0.75)
+        assert closure.status is GapClosureStatus.MEANINGLESS_INVERTED_GAP
+        assert closure.value is None
+        assert not closure.publishable
+
+    def test_regression_is_reported_negative_and_never_clipped(self):
+        """AC: a dynamic process that makes the open model worse says so."""
+        closure = gap_closure(frontier_quality=0.80, static_open_quality=0.60,
+                              adaptive_open_quality=0.50)
+        assert closure.status is GapClosureStatus.NEGATIVE_REGRESSION
+        assert closure.value is not None and closure.value < 0
+        assert not closure.publishable, "a regression is not a gap-closure headline"
+
+    def test_tiny_positive_denominator_is_still_degenerate(self):
+        closure = gap_closure(frontier_quality=0.70 + 1e-12, static_open_quality=0.70,
+                              adaptive_open_quality=0.90)
+        assert closure.status is GapClosureStatus.UNDEFINED_NO_GAP
+
+
+# ------------------------------------------------------------ uncertainty
+
+
+class TestUncertainty:
+    def test_wilson_interval_stays_inside_zero_and_one_at_the_extremes(self):
+        """The reason for Wilson over the normal approximation."""
+        perfect = wilson_interval(20, 20)
+        assert perfect.low > 0.0 and perfect.high <= 1.0
+        assert perfect.width > 0, "a perfect score still carries uncertainty"
+        zero = wilson_interval(0, 20)
+        assert zero.low >= 0.0 and zero.high < 1.0
+        assert zero.width > 0
+
+    def test_small_n_produces_a_wide_interval(self):
+        """The N=20 caveat the README already carries, made mechanical."""
+        small = wilson_interval(15, 20)
+        assert small.width > 0.30
+
+    def test_larger_n_narrows_the_interval(self):
+        assert wilson_interval(150, 200).width < wilson_interval(15, 20).width
+
+    def test_no_data_is_not_a_zero_score(self):
+        empty = wilson_interval(0, 0)
+        assert empty.n == 0
+        assert "no data" in empty.render()
+
+    def test_render_always_carries_n_and_interval(self):
+        rendered = wilson_interval(15, 20).render()
+        assert "N=20" in rendered and "95% CI" in rendered
+
+    def test_impossible_counts_are_refused(self):
+        with pytest.raises(ValueError, match="out of range"):
+            wilson_interval(21, 20)
+
+
+# ------------------------------------------------------- non-inferiority
+
+
+class TestNonInferiority:
+    def test_margin_assessment_is_conservative(self):
+        """Comparing point estimates would call this non-inferior; the interval
+        overlap says otherwise, and the conservative reading must win."""
+        margin = NonInferiority(margin=0.05, justification="below suite noise")
+        treatment = wilson_interval(150, 200)   # 75.0%
+        control = wilson_interval(158, 200)     # 79.0%, a 4pp point gap
+        assessment = margin.assess(treatment, control)
+        assert assessment["difference"] > -margin.margin, (
+            "the point estimates alone sit inside the margin"
+        )
+        assert assessment["worst_case_difference"] < assessment["difference"]
+        assert not assessment["non_inferior"], (
+            "uncertainty this wide must not be reported as non-inferiority"
+        )
+
+    def test_clearly_worse_treatment_is_not_non_inferior(self):
+        margin = NonInferiority(margin=0.05, justification="below suite noise")
+        assessment = margin.assess(wilson_interval(100, 200), wilson_interval(180, 200))
+        assert not assessment["non_inferior"]
+
+    def test_margin_carries_its_justification(self):
+        margin = NonInferiority(margin=0.05, justification="below suite noise")
+        assert margin.assess(wilson_interval(1, 10), wilson_interval(1, 10))["justification"]
+
+
+# ------------------------------------------------------- protocol control
+
+
+class TestProtocolViolations:
+    def _manifest(self, **overrides):
+        base = {
+            "arm": "arm-1",
+            "corpus_version": "corpus-v1",
+            "provider_roster": {"reviewer": "cheap"},
+            "seeds": {"ordering": 7},
+            "budgets": {"per_task_cents": 1000},
+            "verifier_hash": "sha256:" + "a" * 64,
+            "environment": {"python": "3.14"},
+        }
+        base.update(overrides)
+        return RunManifest(**base)
+
+    def test_identical_manifests_have_no_violations(self):
+        assert protocol_violations(self._manifest(), self._manifest()) == []
+
+    def test_a_changed_verifier_is_a_violation(self):
+        violations = protocol_violations(
+            self._manifest(), self._manifest(verifier_hash="sha256:" + "b" * 64)
+        )
+        assert ProtocolViolation.VERIFIER_CHANGED in violations
+
+    def test_changed_corpus_budget_and_environment_are_violations(self):
+        violations = protocol_violations(
+            self._manifest(),
+            self._manifest(corpus_version="corpus-v2", budgets={"per_task_cents": 9900},
+                           environment={"python": "3.13"}),
+        )
+        assert ProtocolViolation.CORPUS_CHANGED in violations
+        assert ProtocolViolation.BUDGET_CHANGED in violations
+        assert ProtocolViolation.ENVIRONMENT_CHANGED in violations
+
+    def test_manifest_digest_is_stable_and_order_independent(self):
+        left = self._manifest(provider_roster={"a": "x", "b": "y"})
+        right = self._manifest(provider_roster={"b": "y", "a": "x"})
+        assert left.digest() == right.digest()
+
+    def test_manifest_digest_changes_when_a_seed_changes(self):
+        assert self._manifest().digest() != self._manifest(seeds={"ordering": 8}).digest()
+
+    def test_a_float_in_a_manifest_is_refused_with_a_usable_message(self):
+        """INV-dag-004 forbids floats in canonical bytes so hashes stay replay
+        stable. A manifest must say so rather than raising an opaque error."""
+        with pytest.raises(ValueError, match="integer"):
+            self._manifest(budgets={"per_task": 10.5}).digest()
+
+
+# ------------------------------------------------------------- reporting
+
+
+class TestReporting:
+    def _five_arms(self, **overrides):
+        defaults = {
+            "arm-1": (170, 200),
+            "arm-2": (140, 200),
+            "arm-3": (150, 200),
+            "arm-4": (155, 200),
+            "arm-5": (168, 200),
+        }
+        defaults.update(overrides)
+        return [arm(name, accepted, attempted)
+                for name, (accepted, attempted) in defaults.items()]
+
+    def test_negative_findings_name_arms_that_went_backwards(self):
+        arms = self._five_arms(**{"arm-3": (100, 200)})
+        findings = negative_findings(arms, baseline_arm="arm-2")
+        assert any("arm-3 scored below arm-2" in finding for finding in findings)
+
+    def test_escaped_defects_and_operator_time_are_negative_findings(self):
+        arms = [
+            arm("arm-2", 140, 200, escaped_defects=1, operator_minutes=10.0),
+            arm("arm-3", 150, 200, escaped_defects=4, operator_minutes=30.0),
+        ]
+        findings = negative_findings(arms, baseline_arm="arm-2")
+        assert any("defects escape" in finding for finding in findings)
+        assert any("operator time" in finding for finding in findings)
+
+    def test_wide_intervals_are_flagged_as_indecisive(self):
+        findings = negative_findings(
+            [arm("arm-2", 7, 10), arm("arm-3", 8, 10)], baseline_arm="arm-2"
+        )
+        assert any("too wide to be decisive" in finding for finding in findings)
+
+    def test_a_clean_sweep_across_five_arms_is_a_reporting_failure(self):
+        """AC: no negative findings across five arms is reviewed, not celebrated."""
+        arms = self._five_arms()
+        failures = reporting_failures(arms, findings=[])
+        assert any("reporting failure" in failure for failure in failures)
+
+    def test_a_report_with_findings_is_not_flagged(self):
+        assert reporting_failures(self._five_arms(), findings=["arm-3 regressed"]) == []
+
+    def test_an_arm_that_attempted_nothing_is_flagged(self):
+        failures = reporting_failures([arm("arm-9", 0, 0)], findings=["something"])
+        assert any("attempted no tasks" in failure for failure in failures)
+
+    def test_missing_baseline_is_reported_rather_than_ignored(self):
+        findings = negative_findings([arm("arm-3", 10, 20)], baseline_arm="arm-2")
+        assert any("missing" in finding for finding in findings)
+
+
+class TestCostQualityFrontier:
+    def test_quality_is_never_reported_without_cost(self):
+        arms = [
+            arm("arm-2", 140, 200, model_cost=10.0),
+            arm("arm-5", 168, 200, model_cost=40.0),
+            arm("arm-1", 170, 200, model_cost=100.0, tier="frontier-tier"),
+        ]
+        frontier = cost_quality_frontier(arms)
+        assert all("cost" in point and "quality_ci" in point for point in frontier)
+        assert [point["arm"] for point in frontier] == ["arm-2", "arm-5", "arm-1"]
+        assert all(point["on_frontier"] for point in frontier)
+
+    def test_a_dominated_arm_is_off_the_frontier(self):
+        arms = [
+            arm("cheap-good", 170, 200, model_cost=10.0),
+            arm("dear-worse", 120, 200, model_cost=90.0),
+        ]
+        frontier = cost_quality_frontier(arms)
+        assert frontier[0]["on_frontier"] is True
+        assert frontier[1]["on_frontier"] is False
+
+
+class TestPublicClaimGate:
+    def _arms(self, n=200):
+        return [arm(f"arm-{i}", int(n * 0.8), n) for i in range(1, 6)]
+
+    def test_small_sample_may_not_become_a_readme_claim(self):
+        """AC: no README claim from a small sample."""
+        closure = gap_closure(frontier_quality=0.8, static_open_quality=0.6,
+                              adaptive_open_quality=0.7)
+        allowed, reason = readme_claim_allowed(self._arms(n=20), closure)
+        assert not allowed
+        assert "below the pre-registered minimum" in reason
+
+    def test_undefined_gap_closure_may_not_become_a_claim(self):
+        closure = gap_closure(frontier_quality=0.7, static_open_quality=0.7,
+                              adaptive_open_quality=0.9)
+        allowed, reason = readme_claim_allowed(self._arms(), closure)
+        assert not allowed
+        assert "UNDEFINED_NO_GAP" in reason
+
+    def test_a_qualifying_claim_still_must_carry_its_caveats(self):
+        closure = gap_closure(frontier_quality=0.8, static_open_quality=0.6,
+                              adaptive_open_quality=0.7)
+        allowed, reason = readme_claim_allowed(self._arms(n=1000), closure)
+        assert allowed
+        assert "N" in reason and "interval" in reason and "caveats" in reason
+
+
+# --------------------------------------------------- the pre-registration
+
+
+class TestPreRegistration:
+    def test_document_exists_and_is_marked_unrun(self):
+        """AC: pre-registration committed BEFORE the first arm runs."""
+        assert PREREG.exists(), "the pre-registration must be committed first"
+        text = PREREG.read_text()
+        assert "no arm has run" in text.lower()
+
+    def test_every_required_section_is_registered(self):
+        text = PREREG.read_text().lower()
+        for required in ("arms", "gap closure", "non-inferiority margin",
+                         "stopping rules", "corpus and strata", "rollback",
+                         "rollout ladder", "metrics"):
+            assert required in text, f"pre-registration is missing {required!r}"
+
+    def test_the_margin_is_stated_with_a_number_and_a_justification(self):
+        text = PREREG.read_text()
+        assert re.search(r"\*\*Margin: .*\d+.*\*\*", text), "the margin must be explicit"
+        assert "Justification" in text
+
+    def test_all_five_arms_are_registered_by_tier_not_model_name(self):
+        text = PREREG.read_text()
+        for arm_row in ("| 1 |", "| 2 |", "| 3 |", "| 4 |", "| 5 |"):
+            assert arm_row in text
+        assert "frontier-tier" in text and "open-tier" in text
+
+    def test_degenerate_cases_are_registered_in_advance(self):
+        text = PREREG.read_text().lower()
+        assert "undefined" in text
+        assert "meaningless" in text
+        assert "never clipped to zero" in text


### PR DESCRIPTION
experiment(factory): pre-register the dynamic-DAG ablation and build its analysis (#391)

Delivers the pre-registration and the analysis substrate for the open/micro
model ablation. It does not run the arms; see "What is not here" below.

## Pre-registration (docs/experiments/dynamic-dag/pre-registration.md)

Committed before any arm runs, and marked as such. It fixes the five arms by
capability tier rather than model name, the corpus strata and inclusion rules,
the metrics, the gap-closure formula with every degenerate case decided in
advance, the non-inferiority margin with its justification, the stopping rules,
the rollout ladder with entry and exit criteria per rung, and the rollback
conditions.

The margin is 5 percentage points absolute, justified before any data exists:
CW's own acceptance bar is a green suite and passing gates, so a difference
below run-to-run suite noise is not a difference anyone would act on. It is
also well below the roughly nineteen-point interval the README already reports
at N=20, which is what makes it meaningful only at the corpus sizes this
document requires.

## Analysis substrate (scripts/chief_wiggum/dag/experiment.py)

Three things are mechanised rather than left to whoever runs the analysis:

Gap closure returns a status, not just a number. A denominator near zero is
UNDEFINED_NO_GAP and unpublishable, because the corpus was not discriminative.
A negative denominator is MEANINGLESS_INVERTED_GAP. A negative numerator is
NEGATIVE_REGRESSION, reported as a negative result and never clipped to zero,
and explicitly not publishable as a gap-closure headline. Deciding these in
code before any data exists is what stops the flattering reading being picked
later.

Uncertainty is not optional. Every proportion carries a Wilson interval and its
N. Wilson rather than the normal approximation because the strata are small and
the normal approximation misbehaves exactly there, producing bounds outside
[0,1] and a zero-width interval at 0 or 100 percent. A test pins that. N=0
renders as "no data", never as a zero score.

Reporting failures are detected. No negative findings across five arms is
flagged for review rather than accepted as good news. Arms that scored below
baseline, let more defects escape, needed more operator time, or produced an
interval too wide to be decisive are all surfaced. A README claim is refused
unless gap closure is DEFINED, the smallest arm meets the registered minimum N,
and no interval exceeds 20 points.

Also: run manifests hash reproducibly, protocol violations are computed by
comparing two manifests rather than trusted, and the cost/quality frontier
means quality is never reported without its cost.

## Notes from building it

Manifest values must be integers or strings. INV-dag-004's canonical encoding
rejects floats so hashes stay replay stable, so a budget of 10.5 previously
failed with an opaque encoder error from deep in the call stack. The digest now
says so directly and the pre-registration expresses money in cents.

37 tests. Every guard was mutation tested by reverting it and confirming the
matching test fails: 21 of 21 caught against the final implementation, after
three blind tests were found and fixed. Two were weak assertions (a ValueError
that both the guarded and unguarded paths raised, and a conservative-comparison
test that passed when the comparison was not conservative). The third was the
same redundant-sort pattern found in #390: explicit key sorting in the manifest
was dead weight because canonical encoding already sorts, so it is gone and a
test pins the property at the layer that provides it.

Full suite: 3777 passed, 14 skipped.

## What is not here

Executing the five arms needs real budget and real wall-clock, and the go /
hold / rollback decision at each rung of the ladder is a human decision by
design. Nothing here pre-empts it. This ticket stays open until the arms have
run and the decision is recorded.

Refs #391

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
