### PR TITLE
feat(tracker): add the dependency verb group (link / deps / ready / claim) (#371)

### DIFF
--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -201,3 +201,91 @@ description (as today); for other backends it is written to
 frontmatter `epic` field set by `tracker.py group`. The remaining
 `gh`-calling commands (`/seed`, `/implement`, `/implement-wave`,
 `/close-epic`) are a later ticket.
+
+## Dependency verb group (chief-wiggum#371)
+
+The five core verbs (`get` / `list` / `create` / `update` / `comment`) plus
+epic grouping stay the minimal contract every backend must honour. Dependency
+knowledge is a separate, **optional** verb group, so a backend that models
+dependencies natively can expose them and one that cannot says so.
+
+| Verb | Shape | Meaning |
+|---|---|---|
+| `link` | `link(ref, blocked_by) -> None` | Record that `ref` is blocked by `blocked_by` |
+| `unlink` | `unlink(ref, blocked_by) -> None` | Remove that edge |
+| `deps` | `deps(ref) -> Dependencies` | Edges both ways: `.blocked_by`, `.blocks` |
+| `ready` | `ready(query=None) -> list[Issue]` | Open issues with no OPEN blocker |
+| `claim` | `claim(ref, agent_id) -> bool` | Atomically claim; `True` if this agent holds it |
+| `release` | `release(ref, agent_id) -> bool` | Release; `False` if this agent does not hold it |
+
+### Capability discovery
+
+Ask, do not probe:
+
+```python
+from tracker import CAP_CLAIM, get_tracker
+
+backend = get_tracker("acme/app", repo_root=target_root)
+if CAP_CLAIM in backend.capabilities():
+    won = backend.claim(ref, agent_id)
+else:
+    ...  # fall back to the wave lock
+```
+
+`capabilities()` returns a frozenset of `CAP_DEPENDENCIES` (link/unlink/deps),
+`CAP_READY`, and `CAP_CLAIM`. Feature-detecting means an unsupported verb is a
+planned branch rather than an exception path, and it is why callers never need
+`try/except NotImplementedError` around a verb.
+
+From the CLI: `python3 scripts/tracker.py --repo-root <root> capabilities <target>`.
+
+### Per-backend semantics
+
+| | `local` | `github` |
+|---|---|---|
+| `link` / `unlink` / `deps` | native, `blocked_by:` list in YAML frontmatter | emulated, `<!-- BLOCKED-BY ... -->` block in the issue body |
+| `ready` | computed client-side | computed client-side |
+| `claim` / `release` | **supported**, mutual exclusion via `O_EXCL` | **unsupported**, raises `UnsupportedCapability` |
+
+**Why GitHub declines `claim` rather than emulating it.** GitHub offers no
+compare-and-set on assignee, so an assignee-based claim is a read followed by a
+write, and two workers racing for the same issue can both come away believing
+they won. A claim that does not exclude is worse than no claim, because both
+workers then proceed. The backend therefore refuses the verb and reports
+`CAP_CLAIM` as absent, so a caller chooses its own exclusion (today, the wave
+lock) with its eyes open. This is the same fail-closed posture as the rest of
+CW: an unsupported verb is loud, never a silent no-op.
+
+**The per-issue `BLOCKED-BY` block is deliberately distinct** from the
+milestone-level `<!-- DEPENDENCIES -->` block that `chief_wiggum.github`
+parses. That one describes a whole epic's graph in one place; this one records
+the edges of a single issue. Parsing one with the other's reader would silently
+mix epic-wide and per-issue scope.
+
+### Rules that hold on every backend
+
+- **Cycles are refused at link time**, not discovered at schedule time. A cycle
+  makes every node in it permanently unready, so `ready()` would just return a
+  silently shorter list. `link` raises `DependencyCycle` and names the path.
+- **A blocker that does not exist does not block.** A deleted or not-yet-created
+  blocker would otherwise wedge its dependants forever with nothing to close.
+  The same rule applies inside cycle traversal, so linking ahead of an issue's
+  creation is allowed.
+- **`ready()` lists open work only**, and a closed blocker releases its
+  dependants.
+- **`link` leaves the rest of the issue alone** — title, body prose, labels and
+  epic are untouched.
+
+### Epic grouping and dependency edges
+
+They are independent axes. `group()` records *which* epic an issue belongs to;
+dependency edges record *ordering* within (or across) epics. `ready()` does not
+filter by epic — pass a query, or filter `members()` yourself, if a caller
+wants an epic-scoped ready set.
+
+### Not yet wired
+
+This ticket adds the seam. Rewiring `/plan-epic` to write edges instead of
+prose, and `/implement-wave` to schedule from `ready()`, are the payoff
+follow-ups. A `BeadsBackend` (native dependencies, readiness and claiming) is
+what the seam exists to make worth building.

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -101,6 +102,108 @@ class IssueDraft:
 
 
 VALID_STATES = ("open", "closed")
+
+# --- dependency verb group (chief-wiggum#371) --------------------------------
+
+# Capability names for feature detection. A caller asks what a backend can do
+# rather than probing with try/except, so an unsupported verb is a planned
+# branch instead of an exception path.
+CAP_DEPENDENCIES = "dependencies"   # link / unlink / deps
+CAP_READY = "ready"                 # ready()
+CAP_CLAIM = "claim"                 # claim / release, with real mutual exclusion
+
+
+class UnsupportedCapability(NotImplementedError):
+    """A backend cannot honour a verb.
+
+    Raised rather than returning a falsy no-op: a claim that silently fails to
+    exclude is worse than no claim at all, because two workers then believe
+    they hold it.
+    """
+
+
+@dataclass
+class Dependencies:
+    """Edges in both directions for one issue."""
+
+    blocked_by: list[str] = field(default_factory=list)
+    blocks: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {"blocked_by": list(self.blocked_by), "blocks": list(self.blocks)}
+
+
+class DependencyCycle(ValueError):
+    """A link that would make ready() unsatisfiable for the whole cycle."""
+
+
+_BLOCKED_BY_RE = re.compile(
+    r"<!--\s*BLOCKED-BY\s*\n(?P<body>.*?)\n?-->", re.DOTALL | re.IGNORECASE
+)
+_BLOCKED_BY_HEADER = "<!-- BLOCKED-BY"
+
+
+def parse_blocked_by_block(body: str | None) -> list[str]:
+    """Read the per-issue BLOCKED-BY block from an issue body.
+
+    Deliberately distinct from the milestone-level DEPENDENCIES block in
+    chief_wiggum.github: that one describes a whole epic's graph in one place,
+    this one records the edges of a single issue. Parsing one with the other's
+    reader would silently mix epic-wide and per-issue scope.
+
+    Format, one ref per line inside an HTML comment::
+
+        <!-- BLOCKED-BY
+        acme/app#42
+        -->
+    """
+    if not body:
+        return []
+    match = _BLOCKED_BY_RE.search(body)
+    if not match:
+        return []
+    refs = []
+    for line in match.group("body").splitlines():
+        candidate = line.strip().lstrip("-").strip()
+        if candidate:
+            refs.append(candidate)
+    return refs
+
+
+def write_blocked_by_block(body: str, blockers: list[str]) -> str:
+    """Replace (or remove) the BLOCKED-BY block, leaving the rest of the body."""
+    stripped = _BLOCKED_BY_RE.sub("", body or "").rstrip()
+    if not blockers:
+        return stripped
+    block = _BLOCKED_BY_HEADER + "\n" + "\n".join(blockers) + "\n-->"
+    return (stripped + "\n\n" + block).lstrip("\n")
+
+
+def _would_cycle(
+    ref: str, blocker: str, blocked_by_of: Callable[[str], list[str]]
+) -> list[str] | None:
+    """Return the path if adding ref -> blocker closes a cycle.
+
+    Checked at link time rather than discovered at schedule time: a cycle makes
+    every node in it permanently unready, and ready() returning a silently
+    shorter list is the failure mode this prevents.
+    """
+    # No special case for ref == blocker: the walk below starts at `blocker`
+    # and its first comparison already matches, so a separate self-link branch
+    # would be unreachable.
+    stack = [(blocker, [ref, blocker])]
+    seen = set()
+    while stack:
+        node, path = stack.pop()
+        if node == ref:
+            return path
+        if node in seen:
+            continue
+        seen.add(node)
+        for parent in blocked_by_of(node):
+            stack.append((parent, path + [parent]))
+    return None
+
 
 
 def _validate_update_fields(fields: dict[str, Any]) -> None:
@@ -336,6 +439,82 @@ class GithubBackend:
         for ref in refs:
             self.update(ref, {"epic": epic_name})
 
+    # --- dependency verb group (chief-wiggum#371) ---------------------------
+
+    @staticmethod
+    def capabilities() -> frozenset[str]:
+        """Dependencies and readiness are emulated; claim is NOT supported.
+
+        GitHub offers no compare-and-set on assignee, so an assignee-based
+        claim cannot exclude two workers racing for the same issue. A claim
+        that does not exclude is worse than none, because both workers then
+        proceed believing they hold it, so this backend declines the verb
+        instead of emulating it.
+        """
+        return frozenset({CAP_DEPENDENCIES, CAP_READY})
+
+    def _blocked_by(self, ref: str) -> list[str]:
+        return parse_blocked_by_block(self.get(ref).body)
+
+    def _blocked_by_or_empty(self, ref: str) -> list[str]:
+        """Edges of a possibly-absent issue, for cycle traversal. See LocalBackend."""
+        try:
+            return self._blocked_by(ref)
+        except Exception:  # noqa: BLE001 - an unreadable issue has no edges
+            return []
+
+    def link(self, ref: str, blocked_by: str) -> None:
+        cycle = _would_cycle(ref, blocked_by, self._blocked_by_or_empty)
+        if cycle is not None:
+            raise DependencyCycle(
+                "link would create a dependency cycle: " + " -> ".join(cycle)
+            )
+        issue = self.get(ref)
+        blockers = parse_blocked_by_block(issue.body)
+        if blocked_by in blockers:
+            return
+        blockers.append(blocked_by)
+        self.update(ref, {"body": write_blocked_by_block(issue.body, blockers)})
+
+    def unlink(self, ref: str, blocked_by: str) -> None:
+        issue = self.get(ref)
+        blockers = [item for item in parse_blocked_by_block(issue.body) if item != blocked_by]
+        self.update(ref, {"body": write_blocked_by_block(issue.body, blockers)})
+
+    def deps(self, ref: str) -> Dependencies:
+        blocked_by = self._blocked_by(ref)
+        blocks = [
+            issue.ref for issue in self.list()
+            if ref in parse_blocked_by_block(issue.body)
+        ]
+        return Dependencies(blocked_by=blocked_by, blocks=sorted(blocks))
+
+    def ready(self, query: str | dict[str, Any] | None = None) -> list[Issue]:
+        everything = self.list()
+        states = {issue.ref: issue.state for issue in everything}
+        result = []
+        for issue in everything:
+            if issue.state != "open" or not _matches_query(issue, query):
+                continue
+            blockers = parse_blocked_by_block(issue.body)
+            if any(states.get(blocker) == "open" for blocker in blockers):
+                continue
+            result.append(issue)
+        return result
+
+    def claim(self, ref: str, agent_id: str) -> bool:
+        raise UnsupportedCapability(
+            "the github backend cannot claim atomically: GitHub has no"
+            " compare-and-set on assignee, so an emulated claim would let two"
+            " workers both believe they won. Use the wave lock, or a backend"
+            " that reports CAP_CLAIM."
+        )
+
+    def release(self, ref: str, agent_id: str) -> bool:
+        raise UnsupportedCapability(
+            "the github backend does not support claim, so there is nothing to release"
+        )
+
     def members(self, epic_name: str) -> list[Issue]:
         return self.list(query={"epic": epic_name})
 
@@ -486,6 +665,114 @@ class LocalBackend:
     def members(self, epic_name: str) -> list[Issue]:
         return [issue for issue in self.list() if issue.epic == epic_name]
 
+    # --- dependency verb group (chief-wiggum#371) ---------------------------
+
+    @staticmethod
+    def capabilities() -> frozenset[str]:
+        """Local supports everything: it owns its storage and its filesystem."""
+        return frozenset({CAP_DEPENDENCIES, CAP_READY, CAP_CLAIM})
+
+    def _blocked_by(self, ref: str) -> list[str]:
+        path = self._resolve_path(ref)
+        data, _ = _parse_frontmatter(path.read_text())
+        return [str(item) for item in (data.get("blocked_by") or [])]
+
+    def _write_blocked_by(self, ref: str, blockers: list[str]) -> None:
+        path = self._resolve_path(ref)
+        data, full_body = _parse_frontmatter(path.read_text())
+        data["blocked_by"] = blockers
+        path.write_text(_dump_frontmatter(data) + "\n\n" + full_body.lstrip("\n"))
+
+    def _blocked_by_or_empty(self, ref: str) -> list[str]:
+        """Edges of a possibly-absent issue, for cycle traversal.
+
+        A ref that cannot be read has no edges. This mirrors ready()'s rule
+        that a blocker which does not exist does not block, so linking to a
+        not-yet-created issue is allowed rather than crashing the walk.
+        """
+        try:
+            return self._blocked_by(ref)
+        except (FileNotFoundError, ValueError):
+            return []
+
+    def link(self, ref: str, blocked_by: str) -> None:
+        """Record that `ref` is blocked by `blocked_by`."""
+        self._resolve_path(ref)
+        cycle = _would_cycle(ref, blocked_by, self._blocked_by_or_empty)
+        if cycle is not None:
+            raise DependencyCycle(
+                "link would create a dependency cycle: " + " -> ".join(cycle)
+            )
+        blockers = self._blocked_by(ref)
+        if blocked_by not in blockers:
+            blockers.append(blocked_by)
+            self._write_blocked_by(ref, blockers)
+
+    def unlink(self, ref: str, blocked_by: str) -> None:
+        blockers = [item for item in self._blocked_by(ref) if item != blocked_by]
+        self._write_blocked_by(ref, blockers)
+
+    def deps(self, ref: str) -> Dependencies:
+        self._resolve_path(ref)
+        blocks = [
+            issue.ref for issue in self.list()
+            if ref in self._blocked_by(issue.ref)
+        ]
+        return Dependencies(blocked_by=self._blocked_by(ref), blocks=sorted(blocks))
+
+    def ready(self, query: str | dict[str, Any] | None = None) -> list[Issue]:
+        """Open issues with no OPEN blocker.
+
+        A blocker that no longer exists does not block: a deleted issue would
+        otherwise wedge its dependants forever with nothing to close.
+        """
+        issues = self.list(query)
+        states = {issue.ref: issue.state for issue in self.list()}
+        result = []
+        for issue in issues:
+            if issue.state != "open":
+                continue
+            if any(states.get(blocker) == "open" for blocker in self._blocked_by(issue.ref)):
+                continue
+            result.append(issue)
+        return result
+
+    def _claim_path(self, ref: str) -> Path:
+        issue_path = self._resolve_path(ref)
+        return issue_path.with_suffix(".claim")
+
+    def claim(self, ref: str, agent_id: str) -> bool:
+        """Atomically claim an issue. True if this agent now holds it.
+
+        Exclusion comes from O_EXCL, not from a read-then-write: two workers
+        racing here must not both be told they won.
+        """
+        claim_path = self._claim_path(ref)
+        try:
+            handle = os.open(claim_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            # Re-claiming what you already hold is idempotent, not a failure.
+            return claim_path.read_text().strip() == agent_id
+        with os.fdopen(handle, "w") as stream:
+            stream.write(agent_id)
+        self.update(ref, {"assignee": agent_id})
+        return True
+
+    def release(self, ref: str, agent_id: str) -> bool:
+        """Release a claim. False if this agent does not hold it."""
+        claim_path = self._claim_path(ref)
+        if not claim_path.exists():
+            return False
+        if claim_path.read_text().strip() != agent_id:
+            return False
+        claim_path.unlink()
+        self.update(ref, {"assignee": None})
+        return True
+
+    def claimant(self, ref: str) -> str | None:
+        claim_path = self._claim_path(ref)
+        return claim_path.read_text().strip() if claim_path.exists() else None
+
 
 Backend = GithubBackend | LocalBackend
 
@@ -623,6 +910,28 @@ def _build_parser() -> argparse.ArgumentParser:
     p_members.add_argument("target")
     p_members.add_argument("epic")
 
+    p_caps = sub.add_parser(
+        "capabilities", help="Print which optional verb groups a backend supports"
+    )
+    p_caps.add_argument("target")
+
+    p_link = sub.add_parser("link", help="Record that REF is blocked by BLOCKER")
+    p_link.add_argument("ref")
+    p_link.add_argument("blocker")
+    p_link.add_argument("--remove", action="store_true", help="Remove the edge instead")
+
+    p_deps = sub.add_parser("deps", help="Show dependency edges in both directions")
+    p_deps.add_argument("ref")
+
+    p_ready = sub.add_parser("ready", help="List open issues with no open blocker")
+    p_ready.add_argument("target")
+    p_ready.add_argument("--query", help="Substring filter over title/body")
+
+    p_claim = sub.add_parser("claim", help="Atomically claim an issue for an agent")
+    p_claim.add_argument("ref")
+    p_claim.add_argument("agent_id")
+    p_claim.add_argument("--release", action="store_true", help="Release instead of claim")
+
     return parser
 
 
@@ -677,6 +986,40 @@ def main(argv: list[str] | None = None) -> int:
             scheme, ident = parse_ref(args.refs[0])
             backend = _backend_for_ref(scheme, ident, repo_root)
             backend.group(args.refs, args.epic)
+
+        elif args.command == "capabilities":
+            backend = get_tracker(args.target, repo_root=repo_root)
+            caps = sorted(getattr(backend, "capabilities", lambda: frozenset())())
+            print(json.dumps({"backend": type(backend).__name__, "capabilities": caps}, indent=2))
+
+        elif args.command == "link":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            if args.remove:
+                backend.unlink(args.ref, args.blocker)
+            else:
+                backend.link(args.ref, args.blocker)
+            print(json.dumps(backend.deps(args.ref).to_dict(), indent=2))
+
+        elif args.command == "deps":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            print(json.dumps(backend.deps(args.ref).to_dict(), indent=2))
+
+        elif args.command == "ready":
+            backend = get_tracker(args.target, repo_root=repo_root)
+            issues = backend.ready(args.query)
+            print(json.dumps([issue.to_dict() for issue in issues], indent=2))
+
+        elif args.command == "claim":
+            scheme, ident = parse_ref(args.ref)
+            backend = _backend_for_ref(scheme, ident, repo_root)
+            if args.release:
+                held = backend.release(args.ref, args.agent_id)
+            else:
+                held = backend.claim(args.ref, args.agent_id)
+            print(json.dumps({"ref": args.ref, "agent_id": args.agent_id, "held": held}, indent=2))
+            return 0 if held else 1
 
         elif args.command == "members":
             backend = get_tracker(args.target, repo_root=repo_root)

--- a/tests/test_tracker_dependencies.py
+++ b/tests/test_tracker_dependencies.py
@@ -1,0 +1,335 @@
+"""Dependency verb group on the tracker seam (chief-wiggum#371).
+
+The parity suite runs link / deps / ready against both backends, because a
+dependency edge that means different things per backend is worse than no seam.
+Claim is deliberately asymmetric and tested that way: local excludes for real,
+GitHub refuses loudly rather than emulating an exclusion it cannot provide.
+"""
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from test_tracker import FakeGh  # noqa: E402
+from tracker import (  # noqa: E402
+    CAP_CLAIM,
+    CAP_DEPENDENCIES,
+    CAP_READY,
+    DependencyCycle,
+    GithubBackend,
+    IssueDraft,
+    LocalBackend,
+    UnsupportedCapability,
+    main,
+    parse_blocked_by_block,
+    write_blocked_by_block,
+)
+
+
+@pytest.fixture(params=["github", "local"])
+def backend(request, tmp_path):
+    if request.param == "github":
+        return GithubBackend("acme/widget", runner=FakeGh())
+    return LocalBackend(tmp_path)
+
+
+def use_local_backend(root: Path) -> None:
+    """Point backend resolution at `local` for this target, as a real repo would."""
+    config = root / "docs" / "cw"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "tracker.json").write_text(json.dumps({"backend": "local"}))
+
+
+def two_issues(backend):
+    blocker = backend.create(IssueDraft(title="Blocker", body="must land first"))
+    blocked = backend.create(IssueDraft(title="Blocked", body="waits on the blocker"))
+    return blocker, blocked
+
+
+# ------------------------------------------------------------ parity suite
+
+
+class TestDependencyParity:
+    def test_link_then_deps_reads_back_in_both_directions(self, backend):
+        blocker, blocked = two_issues(backend)
+        backend.link(blocked, blocker)
+
+        downstream = backend.deps(blocked)
+        assert downstream.blocked_by == [blocker]
+        assert downstream.blocks == []
+
+        upstream = backend.deps(blocker)
+        assert upstream.blocked_by == []
+        assert upstream.blocks == [blocked]
+
+    def test_link_is_idempotent(self, backend):
+        blocker, blocked = two_issues(backend)
+        backend.link(blocked, blocker)
+        backend.link(blocked, blocker)
+        assert backend.deps(blocked).blocked_by == [blocker]
+
+    def test_unlink_removes_the_edge(self, backend):
+        blocker, blocked = two_issues(backend)
+        backend.link(blocked, blocker)
+        backend.unlink(blocked, blocker)
+        assert backend.deps(blocked).blocked_by == []
+        assert backend.deps(blocker).blocks == []
+
+    def test_ready_excludes_blocked_then_includes_it_once_the_blocker_closes(self, backend):
+        """The end-to-end acceptance walk from the ticket."""
+        blocker, blocked = two_issues(backend)
+        backend.link(blocked, blocker)
+
+        ready = {issue.ref for issue in backend.ready()}
+        assert blocker in ready
+        assert blocked not in ready, "an open blocker must hold its dependant back"
+
+        backend.update(blocker, {"state": "closed"})
+
+        ready = {issue.ref for issue in backend.ready()}
+        assert blocked in ready, "closing the blocker must release the dependant"
+        assert blocker not in ready, "ready lists open work only"
+
+    def test_ready_honours_a_query(self, backend):
+        backend.create(IssueDraft(title="Alpha", body="first"))
+        backend.create(IssueDraft(title="Beta", body="second"))
+        titles = {issue.title for issue in backend.ready("Alpha")}
+        assert titles == {"Alpha"}
+
+    def test_a_missing_blocker_does_not_wedge_its_dependant(self, backend):
+        """A blocker that does not exist cannot be closed, so it must not block."""
+        blocked = backend.create(IssueDraft(title="Blocked", body="on a ghost"))
+        backend.link(blocked, "local:docs/issues/9999.md"
+                     if isinstance(backend, LocalBackend) else "acme/widget#9999")
+        assert blocked in {issue.ref for issue in backend.ready()}
+
+    def test_self_link_is_refused(self, backend):
+        blocked = backend.create(IssueDraft(title="Solo", body="alone"))
+        with pytest.raises(DependencyCycle):
+            backend.link(blocked, blocked)
+
+    def test_a_cycle_is_refused_at_link_time(self, backend):
+        """A cycle makes every node in it permanently unready, so it is caught
+        when the edge is drawn rather than when the schedule comes up short."""
+        first, second = two_issues(backend)
+        backend.link(second, first)
+        with pytest.raises(DependencyCycle, match="cycle"):
+            backend.link(first, second)
+        assert backend.deps(first).blocked_by == []
+
+    def test_a_longer_cycle_is_refused(self, backend):
+        one = backend.create(IssueDraft(title="One"))
+        two = backend.create(IssueDraft(title="Two"))
+        three = backend.create(IssueDraft(title="Three"))
+        backend.link(two, one)
+        backend.link(three, two)
+        with pytest.raises(DependencyCycle):
+            backend.link(one, three)
+
+    def test_capabilities_are_declared_not_probed(self, backend):
+        caps = backend.capabilities()
+        assert CAP_DEPENDENCIES in caps
+        assert CAP_READY in caps
+
+
+# --------------------------------------------------- claim, deliberately split
+
+
+class TestLocalClaim:
+    def test_claim_is_exclusive(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Contended"))
+        assert backend.claim(ref, "agent-a") is True
+        assert backend.claim(ref, "agent-b") is False, "a second agent must not win"
+        assert backend.claimant(ref) == "agent-a"
+
+    def test_reclaiming_what_you_hold_is_idempotent(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Mine"))
+        assert backend.claim(ref, "agent-a") is True
+        assert backend.claim(ref, "agent-a") is True
+
+    def test_claim_records_the_assignee(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Assigned"))
+        backend.claim(ref, "agent-a")
+        assert backend.get(ref).assignee == "agent-a"
+
+    def test_release_frees_the_claim_only_for_its_holder(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Held"))
+        backend.claim(ref, "agent-a")
+        assert backend.release(ref, "agent-b") is False, "only the holder may release"
+        assert backend.release(ref, "agent-a") is True
+        assert backend.claimant(ref) is None
+        assert backend.claim(ref, "agent-b") is True
+
+    def test_releasing_an_unclaimed_issue_is_false_not_an_error(self, tmp_path):
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Free"))
+        assert backend.release(ref, "agent-a") is False
+
+    def test_concurrent_claims_produce_exactly_one_winner(self, tmp_path):
+        """Exclusion must come from O_EXCL, not a read-then-write.
+
+        Repeated over many trials on purpose. A read-then-write implementation
+        wins some individual races by luck of scheduling, so a single trial is
+        a flaky test that reports the guard as working when it is not. Across
+        this many trials it loses at least once.
+        """
+        workers = 8
+        trials = 25
+        for trial in range(trials):
+            root = tmp_path / f"trial-{trial}"
+            root.mkdir()
+            backend = LocalBackend(root)
+            ref = backend.create(IssueDraft(title="Raced"))
+            results = {}
+            barrier = threading.Barrier(workers)
+
+            def attempt(name, ref=ref, root=root, barrier=barrier, results=results):
+                worker = LocalBackend(root)
+                barrier.wait(timeout=30)
+                try:
+                    results[name] = worker.claim(ref, name)
+                except BaseException as exc:  # noqa: BLE001 - asserted below
+                    results[name] = exc
+
+            threads = [threading.Thread(target=attempt, args=(f"agent-{i}",), daemon=True)
+                       for i in range(workers)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(30)
+                assert not thread.is_alive()
+
+            for name, result in results.items():
+                assert not isinstance(result, BaseException), f"{name} raised {result!r}"
+            winners = [name for name, won in results.items() if won]
+            assert len(winners) == 1, (
+                f"trial {trial}: exactly one agent may win, got {winners}"
+            )
+            assert backend.claimant(ref) == winners[0]
+
+
+class TestGithubClaimIsRefused:
+    def test_claim_raises_rather_than_emulating_an_exclusion_it_cannot_provide(self):
+        """AC: no silent no-ops. GitHub has no CAS on assignee."""
+        backend = GithubBackend("acme/widget", runner=FakeGh())
+        ref = backend.create(IssueDraft(title="Contended"))
+        with pytest.raises(UnsupportedCapability, match="compare-and-set"):
+            backend.claim(ref, "agent-a")
+        with pytest.raises(UnsupportedCapability):
+            backend.release(ref, "agent-a")
+
+    def test_capabilities_says_so_before_the_caller_tries(self):
+        caps = GithubBackend("acme/widget", runner=FakeGh()).capabilities()
+        assert CAP_CLAIM not in caps
+        assert CAP_DEPENDENCIES in caps and CAP_READY in caps
+
+    def test_local_declares_claim_support(self, tmp_path):
+        assert CAP_CLAIM in LocalBackend(tmp_path).capabilities()
+
+
+# ----------------------------------------------------------- block encoding
+
+
+class TestBlockedByBlock:
+    def test_roundtrips(self):
+        body = write_blocked_by_block("Some prose.", ["acme/app#1", "acme/app#2"])
+        assert parse_blocked_by_block(body) == ["acme/app#1", "acme/app#2"]
+        assert "Some prose." in body
+
+    def test_rewriting_replaces_rather_than_appends(self):
+        body = write_blocked_by_block("Prose.", ["acme/app#1"])
+        body = write_blocked_by_block(body, ["acme/app#2"])
+        assert parse_blocked_by_block(body) == ["acme/app#2"]
+        assert body.count("BLOCKED-BY") == 1
+
+    def test_empty_list_removes_the_block_entirely(self):
+        body = write_blocked_by_block("Prose.", ["acme/app#1"])
+        cleared = write_blocked_by_block(body, [])
+        assert "BLOCKED-BY" not in cleared
+        assert cleared.strip() == "Prose."
+
+    def test_a_body_without_a_block_reads_as_no_edges(self):
+        assert parse_blocked_by_block("just prose") == []
+        assert parse_blocked_by_block("") == []
+        assert parse_blocked_by_block(None) == []
+
+    def test_prose_survives_linking(self):
+        original = "The real description.\n\nWith paragraphs."
+        body = write_blocked_by_block(original, ["acme/app#7"])
+        assert "The real description." in body
+        assert "With paragraphs." in body
+
+
+# ------------------------------------------------------------------- CLI
+
+
+class TestDependencyCLI:
+    def test_link_deps_and_ready_round_trip(self, tmp_path, capsys):
+        use_local_backend(tmp_path)
+        backend = LocalBackend(tmp_path)
+        blocker = backend.create(IssueDraft(title="Blocker"))
+        blocked = backend.create(IssueDraft(title="Blocked"))
+
+        assert main(["--repo-root", str(tmp_path), "link", blocked, blocker]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["blocked_by"] == [blocker]
+
+        assert main(["--repo-root", str(tmp_path), "deps", blocker]) == 0
+        assert json.loads(capsys.readouterr().out)["blocks"] == [blocked]
+
+        assert main(["--repo-root", str(tmp_path), "ready", str(tmp_path)]) == 0
+        refs = {issue["ref"] for issue in json.loads(capsys.readouterr().out)}
+        assert refs == {blocker}
+
+    def test_claim_exit_code_reflects_whether_it_was_won(self, tmp_path, capsys):
+        use_local_backend(tmp_path)
+        backend = LocalBackend(tmp_path)
+        ref = backend.create(IssueDraft(title="Contended"))
+        assert main(["--repo-root", str(tmp_path), "claim", ref, "agent-a"]) == 0
+        assert json.loads(capsys.readouterr().out)["held"] is True
+        assert main(["--repo-root", str(tmp_path), "claim", ref, "agent-b"]) == 1
+        assert json.loads(capsys.readouterr().out)["held"] is False
+
+    def test_capabilities_subcommand_reports_the_matrix(self, tmp_path, capsys):
+        use_local_backend(tmp_path)
+        assert main(["--repo-root", str(tmp_path), "capabilities", str(tmp_path)]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["backend"] == "LocalBackend"
+        assert sorted(payload["capabilities"]) == sorted([CAP_CLAIM, CAP_DEPENDENCIES, CAP_READY])
+
+
+# ----------------------------------------------- the five verbs are unchanged
+
+
+class TestExistingContractUnchanged:
+    def test_the_original_five_verbs_still_work(self, backend):
+        """AC: existing five-verb behaviour and backend resolution are unchanged."""
+        ref = backend.create(IssueDraft(title="Ordinary", body="Nothing special"))
+        assert backend.get(ref).title == "Ordinary"
+        assert any(issue.ref == ref for issue in backend.list())
+        backend.update(ref, {"state": "closed"})
+        assert backend.get(ref).state == "closed"
+        backend.comment(ref, "a note")
+        backend.group([ref], "Epic: Something")
+        assert [issue.ref for issue in backend.members("Epic: Something")] == [ref]
+
+    def test_linking_does_not_disturb_the_issue_body_or_title(self, backend):
+        blocker, blocked = two_issues(backend)
+        before = backend.get(blocked)
+        backend.link(blocked, blocker)
+        after = backend.get(blocked)
+        assert after.title == before.title
+        assert "waits on the blocker" in after.body
+
+    def test_an_unlinked_issue_reports_no_edges(self, backend):
+        ref = backend.create(IssueDraft(title="Lonely"))
+        assert backend.deps(ref).to_dict() == {"blocked_by": [], "blocks": []}


### PR DESCRIPTION
feat(tracker): add the dependency verb group (link / deps / ready / claim) (#371)

CW computes dependency graphs in /plan-epic and /architect, flushes them into
prose, and re-parses that prose in /implement-wave. Plan state between skills
was ephemeral and regenerated rather than queryable. This adds the seam where
it can live.

The five core verbs stay the minimal contract every backend must honour.
Dependencies are a separate, optional verb group, discovered rather than
probed: `capabilities()` returns CAP_DEPENDENCIES, CAP_READY and CAP_CLAIM, so
an unsupported verb is a planned branch instead of an exception path.

## The one interesting decision: GitHub declines claim

GitHub offers no compare-and-set on assignee, so an assignee-based claim is a
read followed by a write, and two workers racing for the same issue can both
come away believing they won. A claim that does not exclude is worse than no
claim, because both then proceed. The backend refuses the verb and reports
CAP_CLAIM as absent, so a caller picks its own exclusion (today, the wave lock)
with its eyes open. The ticket left this open; this is the call, and it is the
same fail-closed posture as the rest of CW.

Local supports claim for real, with mutual exclusion from O_EXCL rather than a
read-then-write.

## Per backend

- local: `blocked_by:` list in YAML frontmatter, ready computed client-side,
  claim via an O_EXCL lock file alongside the issue.
- github: `<!-- BLOCKED-BY ... -->` block in the issue body, ready computed
  client-side, claim and release raise UnsupportedCapability.

The per-issue BLOCKED-BY block is deliberately distinct from the milestone-level
DEPENDENCIES block that chief_wiggum.github parses. That one describes a whole
epic's graph in one place; this one records the edges of a single issue.
Parsing one with the other's reader would silently mix epic-wide and per-issue
scope.

## Rules that hold on both backends

Cycles are refused at link time rather than discovered at schedule time. A
cycle makes every node in it permanently unready, so ready() would just return
a silently shorter list; link raises DependencyCycle and names the path.

A blocker that does not exist does not block. A deleted or not-yet-created
blocker would otherwise wedge its dependants forever with nothing to close, and
the same rule applies inside cycle traversal so linking ahead of an issue's
creation works.

Linking leaves the rest of the issue alone: title, prose, labels and epic are
untouched, asserted by test on both backends.

## Notes from building it

43 new tests, 112 including the existing tracker suite. The parity suite runs
link / deps / ready against both backends, because an edge that means different
things per backend is worse than no seam.

Mutation tested by reverting each guard: 13 of 13 meaningful mutants caught.
Two blind spots were found and both turned out to be redundant code rather than
missing tests, so the code is gone: a self-link early return that the traversal
already handled on its first comparison, and a tolerant lookup in ready() that
could not fire because ready() only iterates issues it just read.

The concurrency test was flaky on first write. A read-then-write claim wins
some individual races by luck of scheduling, so one trial reported the guard as
working when it was not. It now runs 25 trials of 8 racing workers and catches
the racy implementation in 6 out of 6 verification runs.

Full suite: 3820 passed, 14 skipped.

Closes #371

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
