### PR TITLE
feat(loop): parallel provider preflight and per-phase wall-clock (#375)

### DIFF
--- a/scripts/chief_wiggum/preflight.py
+++ b/scripts/chief_wiggum/preflight.py
@@ -1,0 +1,321 @@
+"""Parallel provider health checks, run before any phase needs a provider.
+
+The operator complaint this answers (chief-wiggum#375): roughly 15 of a
+25-minute consult phase went on environment failures discovered SERIALLY, one
+relaunch at a time, after the prompt was already built. A missing keyring
+entry, a dead CLI and an uninstalled SDK each cost a full round trip.
+
+So: check every configured provider at once, before the work starts, and say
+what is broken and what the role can still do.
+
+Four states, never three (chief-wiggum#289). A probe that could not run reports
+`unknown`, which is not `ok`. "We could not tell" and "it is fine" are
+different answers, and collapsing them is how a preflight becomes a rubber
+stamp.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class Health(StrEnum):
+    OK = "ok"
+    UNAVAILABLE = "unavailable"   # a hard requirement is missing, and we know which
+    UNKNOWN = "unknown"           # the probe itself could not run
+    DISABLED = "disabled"         # switched off in config; a real answer, not a fault
+
+
+class RoleStatus(StrEnum):
+    OK = "ok"
+    DEGRADED = "degraded"   # an optional voice is down; the quorum still stands
+    BLOCKED = "blocked"     # a required provider is down
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """One thing a provider needs before it can be called."""
+
+    kind: str          # "command" | "python" | "secret" | "env"
+    name: str
+
+    def describe(self) -> str:
+        return f"{self.kind}:{self.name}"
+
+
+# What each tool/delegate needs. Additive: a provider entry may override this
+# with its own "preflight" list, so a new provider does not need a code change.
+REQUIREMENTS: dict[str, tuple[Requirement, ...]] = {
+    "codex": (Requirement("command", "codex"),),
+    "gemini": (Requirement("command", "gemini"),),
+    "claude": (Requirement("command", "claude"),),
+    "openrouter": (Requirement("secret", "OPENROUTER_API_KEY"),),
+    "gemini-vertex": (
+        Requirement("python", "google.cloud.aiplatform"),
+        Requirement("env", "GOOGLE_CLOUD_PROJECT"),
+    ),
+    "claude-interactive": (
+        Requirement("command", "claude"),
+        Requirement("command", "tmux"),
+    ),
+    "codex-responses": (Requirement("command", "codex"),),
+}
+
+
+@dataclass(frozen=True)
+class ProviderReport:
+    name: str
+    health: Health
+    missing: tuple[str, ...] = ()
+    detail: str = ""
+    duration_ms: float = 0.0
+
+    @property
+    def usable(self) -> bool:
+        return self.health is Health.OK
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.name,
+            "health": str(self.health),
+            "missing": list(self.missing),
+            "detail": self.detail,
+            "duration_ms": round(self.duration_ms, 1),
+        }
+
+
+@dataclass(frozen=True)
+class RoleReport:
+    role: str
+    status: RoleStatus
+    required_down: tuple[str, ...] = ()
+    optional_down: tuple[str, ...] = ()
+    fallback: tuple[str, ...] = ()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "status": str(self.status),
+            "required_down": list(self.required_down),
+            "optional_down": list(self.optional_down),
+            "fallback": list(self.fallback),
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class Probes:
+    """Injectable checks. Defaults hit the real environment."""
+
+    command: Callable[[str], bool] = field(default=lambda name: shutil.which(name) is not None)
+    python: Callable[[str], bool] = field(
+        default=lambda name: importlib.util.find_spec(name) is not None
+    )
+    env: Callable[[str], bool] = field(default=lambda name: bool(os.environ.get(name)))
+    secret: Callable[[str], bool] | None = None
+
+    def check(self, requirement: Requirement) -> bool:
+        if requirement.kind == "command":
+            return bool(self.command(requirement.name))
+        if requirement.kind == "python":
+            return bool(self.python(requirement.name))
+        if requirement.kind == "env":
+            return bool(self.env(requirement.name))
+        if requirement.kind == "secret":
+            return bool(self._secret(requirement.name))
+        raise ValueError(f"unknown requirement kind {requirement.kind!r}")
+
+    def _secret(self, name: str) -> bool:
+        if self.secret is not None:
+            return self.secret(name)
+        return default_secret_probe(name)
+
+
+def default_secret_probe(name: str) -> bool:
+    """Ask the keyring whether a secret exists, without ever reading its value.
+
+    Presence only: CW's rule is that secrets are fetched at call time and never
+    printed or logged, and a preflight has no business handling the value.
+    """
+    try:
+        import keyring  # noqa: PLC0415 - optional dependency, probed on demand
+    except ImportError as exc:
+        raise ProbeUnavailable(f"keyring is not importable: {exc}") from exc
+    try:
+        return keyring.get_password("chief-wiggum", name) is not None
+    except Exception as exc:  # noqa: BLE001 - a locked keychain is "unknown", not "absent"
+        raise ProbeUnavailable(f"keyring lookup failed: {exc}") from exc
+
+
+class ProbeUnavailable(RuntimeError):
+    """The probe could not run, so the answer is `unknown`, never `ok`."""
+
+
+def requirements_for(name: str, entry: Mapping[str, Any]) -> tuple[Requirement, ...]:
+    """What this provider needs, from its config entry."""
+    override = entry.get("preflight")
+    if override:
+        return tuple(
+            Requirement(str(item.get("kind", "command")), str(item.get("name", "")))
+            for item in override
+        )
+    key = str(entry.get("tool") or entry.get("delegate") or name)
+    return REQUIREMENTS.get(key, ())
+
+
+def check_provider(
+    name: str, entry: Mapping[str, Any], probes: Probes | None = None
+) -> ProviderReport:
+    """Health-check one provider. Never raises: an unrunnable probe is a state."""
+    import time
+
+    probes = probes or Probes()
+    started = time.perf_counter()
+    if not entry.get("enabled", True):
+        return ProviderReport(name, Health.DISABLED, detail="disabled in config")
+
+    requirements = requirements_for(name, entry)
+    if not requirements:
+        # An unknown provider shape is not a pass. Say so rather than assume.
+        return ProviderReport(
+            name,
+            Health.UNKNOWN,
+            detail=f"no preflight requirements known for {name!r}; cannot verify",
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+    missing: list[str] = []
+    for requirement in requirements:
+        try:
+            present = probes.check(requirement)
+        except ProbeUnavailable as exc:
+            return ProviderReport(
+                name,
+                Health.UNKNOWN,
+                detail=str(exc),
+                duration_ms=(time.perf_counter() - started) * 1000,
+            )
+        if not present:
+            missing.append(requirement.describe())
+
+    elapsed = (time.perf_counter() - started) * 1000
+    if missing:
+        return ProviderReport(
+            name, Health.UNAVAILABLE, tuple(missing),
+            detail="missing: " + ", ".join(missing), duration_ms=elapsed,
+        )
+    return ProviderReport(name, Health.OK, duration_ms=elapsed)
+
+
+def check_all(
+    providers: Mapping[str, Mapping[str, Any]],
+    probes: Probes | None = None,
+    *,
+    max_workers: int = 8,
+) -> dict[str, ProviderReport]:
+    """Check every provider at once.
+
+    Parallel because serial discovery is the actual complaint: each failure
+    costs a round trip, and they are independent.
+    """
+    probes = probes or Probes()
+    names = sorted(providers)
+    if not names:
+        return {}
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(names))) as pool:
+        reports = pool.map(
+            lambda name: check_provider(name, providers[name], probes), names
+        )
+    return dict(zip(names, reports, strict=True))
+
+
+def role_report(
+    role: str,
+    spec: Mapping[str, Any],
+    reports: Mapping[str, ProviderReport],
+) -> RoleReport:
+    """Whether a role can run, and what it falls back to if not.
+
+    A required provider that is down blocks the role and the fallback is named
+    here rather than improvised by the orchestrator mid-phase.
+    """
+    required = [str(name) for name in spec.get("required", [])]
+    optional = [str(name) for name in spec.get("optional", [])]
+
+    def down(name: str) -> bool:
+        report = reports.get(name)
+        return report is None or not report.usable
+
+    required_down = tuple(name for name in required if down(name))
+    optional_down = tuple(name for name in optional if down(name))
+    healthy_optional = tuple(name for name in optional if not down(name))
+
+    if required_down:
+        return RoleReport(
+            role, RoleStatus.BLOCKED, required_down, optional_down,
+            fallback=healthy_optional,
+            detail=(
+                f"required provider(s) {list(required_down)} are not usable; "
+                + (f"healthy optional voices: {list(healthy_optional)}"
+                   if healthy_optional else "no healthy fallback in this role")
+            ),
+        )
+    if optional_down:
+        return RoleReport(
+            role, RoleStatus.DEGRADED, (), optional_down,
+            detail=f"optional provider(s) {list(optional_down)} are not usable; quorum stands",
+        )
+    return RoleReport(role, RoleStatus.OK)
+
+
+def preflight(
+    config: Mapping[str, Any],
+    probes: Probes | None = None,
+    *,
+    roles: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Full preflight: every provider, then every role's readiness."""
+    providers = dict(config.get("providers") or {})
+    role_specs = dict(config.get("roles") or {})
+    if roles is not None:
+        role_specs = {name: spec for name, spec in role_specs.items() if name in roles}
+
+    reports = check_all(providers, probes)
+    role_reports = {
+        name: role_report(name, spec, reports) for name, spec in sorted(role_specs.items())
+    }
+    blocked = sorted(name for name, r in role_reports.items() if r.status is RoleStatus.BLOCKED)
+    unknown = sorted(name for name, r in reports.items() if r.health is Health.UNKNOWN)
+    return {
+        "ok": not blocked and not unknown,
+        "providers": {name: report.to_dict() for name, report in sorted(reports.items())},
+        "roles": {name: report.to_dict() for name, report in role_reports.items()},
+        "blocked_roles": blocked,
+        "unverifiable_providers": unknown,
+    }
+
+
+def probe_command_alive(name: str, *, timeout: float = 10.0) -> bool:
+    """Heavier probe: the binary exists AND answers. Not the default.
+
+    `shutil.which` only proves a file is on PATH; this proves it runs. Used
+    when a stale shim or a broken install is the suspected failure.
+    """
+    if shutil.which(name) is None:
+        return False
+    try:
+        result = subprocess.run(
+            [name, "--version"], capture_output=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ProbeUnavailable(f"{name} did not answer --version: {exc}") from exc
+    return result.returncode == 0

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -421,6 +421,81 @@ def emit_consult(provider: str, model: str | None, tokens_in: int | None = None,
                 cost_usd=cost, pricing_version=_pricing_version(), repo=repo, ticket=ticket)
 
 
+def emit_phase(name: str, *, duration_ms: float, repo: str | None = None,
+               ticket: str | None = None, outcome: str = "ok", **fields) -> bool:
+    """Record how long one workflow phase took (chief-wiggum#375).
+
+    ticket_cost tracks tokens but not time-in-phase, so loop latency was felt
+    rather than measured and there was no data to rank the fixes against. A
+    phase that raised is recorded too, with outcome="error": a phase that blew
+    up fast would otherwise look like a phase that went well.
+    """
+    return emit("phase", phase=name, duration_ms=round(duration_ms, 1),
+                outcome=outcome, repo=repo, ticket=ticket, **fields)
+
+
+class phase_timer:
+    """Time a workflow phase and emit on exit.
+
+        with phase_timer("step4a_consults", ticket="#42") as p:
+            run_consults()
+            p.detail = f"{len(providers)} providers"
+
+    Mirrors gate_timer deliberately: one timing shape in the ledger rather than
+    two, so phase and gate latency can be read together.
+    """
+
+    def __init__(self, name: str, *, repo: str | None = None, ticket: str | None = None):
+        self.name, self.repo, self.ticket = name, repo, ticket
+        self.outcome = "ok"
+        self.detail: str | None = None
+        self._t0 = 0.0
+
+    def __enter__(self):
+        self._t0 = time.time()
+        return self
+
+    @property
+    def elapsed_ms(self) -> float:
+        return (time.time() - self._t0) * 1000
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is not None:
+            self.outcome = "error"
+        emit_phase(self.name, duration_ms=self.elapsed_ms, repo=self.repo,
+                   ticket=self.ticket, outcome=self.outcome, detail=self.detail)
+        return False  # never suppress
+
+
+def phase_summary(records: list[dict]) -> dict:
+    """Aggregate phase events into per-phase wall-clock.
+
+    Returns total and count per phase plus the overall total, so the slowest
+    phase is a number rather than an impression.
+    """
+    phases: dict[str, dict] = {}
+    for record in records:
+        if record.get("event") != "phase":
+            continue
+        name = str(record.get("phase", "unknown"))
+        bucket = phases.setdefault(
+            name, {"phase": name, "total_ms": 0.0, "runs": 0, "errors": 0}
+        )
+        bucket["total_ms"] += float(record.get("duration_ms") or 0.0)
+        bucket["runs"] += 1
+        if record.get("outcome") == "error":
+            bucket["errors"] += 1
+    ordered = sorted(phases.values(), key=lambda item: (-item["total_ms"], item["phase"]))
+    for bucket in ordered:
+        bucket["total_ms"] = round(bucket["total_ms"], 1)
+        bucket["mean_ms"] = round(bucket["total_ms"] / bucket["runs"], 1) if bucket["runs"] else 0.0
+    return {
+        "phases": ordered,
+        "total_ms": round(sum(item["total_ms"] for item in ordered), 1),
+        "slowest": ordered[0]["phase"] if ordered else None,
+    }
+
+
 class gate_timer:
     """Context manager that times a gate and emits on exit.
 

--- a/scripts/provider_preflight.py
+++ b/scripts/provider_preflight.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check every configured provider at once, before a phase needs one.
+
+Run this in /implement Step 1. A dead provider discovered mid-phase costs a
+relaunch; discovered here it costs a few seconds and names its fallback.
+
+Exit codes are distinct on purpose:
+  0  every role can run
+  1  a role is blocked by a down required provider
+  2  a provider could not be verified at all (unknown, which is not ok)
+  3  the config could not be read
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum.preflight import (  # noqa: E402
+    Health,
+    Probes,
+    RoleStatus,
+    preflight,
+    probe_command_alive,
+)
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent.parent / "config" / "providers.json"
+
+EXIT_OK = 0
+EXIT_BLOCKED = 1
+EXIT_UNVERIFIABLE = 2
+EXIT_CONFIG = 3
+
+
+def _render_human(result: dict) -> None:
+    print("Providers")
+    for name, report in result["providers"].items():
+        mark = {"ok": "ok  ", "unavailable": "DOWN", "unknown": "????",
+                "disabled": "off "}.get(report["health"], "????")
+        suffix = f"  {report['detail']}" if report["detail"] else ""
+        print(f"  [{mark}] {name}{suffix}")
+    print("\nRoles")
+    for name, report in result["roles"].items():
+        mark = {"ok": "ok     ", "degraded": "degrade", "blocked": "BLOCKED"}.get(
+            report["status"], "???"
+        )
+        suffix = f"  {report['detail']}" if report["detail"] else ""
+        print(f"  [{mark}] {name}{suffix}")
+    if result["unverifiable_providers"]:
+        print(
+            "\nCould not verify: "
+            + ", ".join(result["unverifiable_providers"])
+            + "\n  Unverified is not healthy. Fix the probe or treat these as down."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Parallel provider health check")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG))
+    parser.add_argument("--role", action="append", dest="roles",
+                        help="Limit to these roles (repeatable)")
+    parser.add_argument("--human", action="store_true", help="Human-readable output")
+    parser.add_argument(
+        "--deep", action="store_true",
+        help="Run each CLI's --version instead of only checking PATH",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = json.loads(Path(args.config).read_text())
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"ok": False, "error": f"cannot read {args.config}: {exc}"}, indent=2))
+        return EXIT_CONFIG
+
+    probes = Probes(command=probe_command_alive) if args.deep else Probes()
+    result = preflight(config, probes, roles=args.roles)
+
+    if args.human:
+        _render_human(result)
+    else:
+        print(json.dumps(result, indent=2))
+
+    if any(report["status"] == RoleStatus.BLOCKED for report in result["roles"].values()):
+        return EXIT_BLOCKED
+    if any(report["health"] == Health.UNKNOWN for report in result["providers"].values()):
+        return EXIT_UNVERIFIABLE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provider_preflight.py
+++ b/tests/test_provider_preflight.py
@@ -1,0 +1,345 @@
+"""Parallel provider preflight and phase timing (chief-wiggum#375).
+
+The load-bearing property is that "we could not tell" never renders as "it is
+fine". A preflight that reports a broken environment as healthy is worse than
+no preflight, because the phase proceeds and discovers it serially anyway.
+"""
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from chief_wiggum.preflight import (  # noqa: E402
+    Health,
+    Probes,
+    ProbeUnavailable,
+    RoleStatus,
+    check_all,
+    check_provider,
+    preflight,
+    requirements_for,
+    role_report,
+)
+from factory_log import phase_summary  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "provider_preflight.py"
+
+
+def probes(*, commands=(), pythons=(), envs=(), secrets=(), secret_raises=False):
+    def secret(name):
+        if secret_raises:
+            raise ProbeUnavailable("keyring is locked")
+        return name in secrets
+
+    return Probes(
+        command=lambda name: name in commands,
+        python=lambda name: name in pythons,
+        env=lambda name: name in envs,
+        secret=secret,
+    )
+
+
+CONFIG = {
+    "providers": {
+        "codex": {"type": "tool", "tool": "codex", "enabled": True},
+        "deepseek-flash": {"type": "tool", "tool": "openrouter", "enabled": True},
+        "claude-interactive": {"type": "delegate", "delegate": "claude-interactive",
+                               "enabled": True},
+        "gemini": {"type": "tool", "tool": "gemini", "enabled": False},
+    },
+    "roles": {
+        "reviewer": {"required": ["codex", "deepseek-flash"],
+                     "optional": ["claude-interactive"]},
+    },
+}
+
+
+# ------------------------------------------------------------ per provider
+
+
+class TestProviderHealth:
+    def test_a_satisfied_provider_is_ok(self):
+        report = check_provider("codex", CONFIG["providers"]["codex"],
+                                probes(commands={"codex"}))
+        assert report.health is Health.OK
+        assert report.usable
+        assert report.missing == ()
+
+    def test_a_missing_command_names_what_is_missing(self):
+        report = check_provider("codex", CONFIG["providers"]["codex"], probes())
+        assert report.health is Health.UNAVAILABLE
+        assert report.missing == ("command:codex",)
+        assert "codex" in report.detail
+
+    def test_a_missing_secret_is_reported_without_reading_any_value(self):
+        report = check_provider("deepseek-flash", CONFIG["providers"]["deepseek-flash"],
+                                probes())
+        assert report.health is Health.UNAVAILABLE
+        assert report.missing == ("secret:OPENROUTER_API_KEY",)
+
+    def test_a_delegate_needs_every_one_of_its_requirements(self):
+        entry = CONFIG["providers"]["claude-interactive"]
+        partial = check_provider("claude-interactive", entry, probes(commands={"claude"}))
+        assert partial.health is Health.UNAVAILABLE
+        assert partial.missing == ("command:tmux",)
+        full = check_provider("claude-interactive", entry,
+                              probes(commands={"claude", "tmux"}))
+        assert full.health is Health.OK
+
+    def test_a_disabled_provider_is_disabled_not_broken(self):
+        report = check_provider("gemini", CONFIG["providers"]["gemini"], probes())
+        assert report.health is Health.DISABLED
+        assert not report.usable, "disabled is not usable, but it is not a fault either"
+
+    def test_an_unrunnable_probe_is_unknown_not_ok(self):
+        """AC: 'could not tell' must never render as 'it is fine'."""
+        report = check_provider("deepseek-flash", CONFIG["providers"]["deepseek-flash"],
+                                probes(secret_raises=True))
+        assert report.health is Health.UNKNOWN
+        assert not report.usable
+        assert "locked" in report.detail
+
+    def test_an_unrecognised_provider_shape_is_unknown_not_ok(self):
+        report = check_provider("mystery", {"type": "tool", "tool": "wat", "enabled": True},
+                                probes())
+        assert report.health is Health.UNKNOWN
+        assert "cannot verify" in report.detail
+
+    def test_a_provider_may_declare_its_own_requirements(self):
+        entry = {"enabled": True, "preflight": [{"kind": "env", "name": "MY_THING"}]}
+        assert requirements_for("custom", entry)[0].name == "MY_THING"
+        assert check_provider("custom", entry, probes(envs={"MY_THING"})).health is Health.OK
+        assert check_provider("custom", entry, probes()).health is Health.UNAVAILABLE
+
+    def test_check_provider_never_raises(self):
+        class Exploding:
+            def check(self, requirement):
+                raise ProbeUnavailable("boom")
+
+        report = check_provider("codex", CONFIG["providers"]["codex"], Exploding())
+        assert report.health is Health.UNKNOWN
+
+
+# ---------------------------------------------------------------- parallel
+
+
+class TestParallelism:
+    def test_every_provider_is_checked(self):
+        reports = check_all(CONFIG["providers"], probes(commands={"codex"}))
+        assert set(reports) == set(CONFIG["providers"])
+
+    def test_checks_run_concurrently_rather_than_serially(self):
+        """Serial discovery is the actual complaint: each failure costs a round trip."""
+        started = threading.Barrier(3, timeout=10)
+
+        def slow_command(name):
+            started.wait()          # only passes if three checks are in flight at once
+            time.sleep(0.01)
+            return True
+
+        config = {f"p{i}": {"type": "tool", "tool": "codex", "enabled": True} for i in range(3)}
+        reports = check_all(config, Probes(command=slow_command))
+        assert all(report.health is Health.OK for report in reports.values())
+
+    def test_no_providers_is_an_empty_result_not_a_crash(self):
+        assert check_all({}, probes()) == {}
+
+
+# ------------------------------------------------------------------ roles
+
+
+class TestRoleReadiness:
+    def _reports(self, **health):
+        return check_all(CONFIG["providers"], probes(**health))
+
+    def test_a_role_with_everything_up_is_ok(self):
+        reports = self._reports(commands={"codex", "claude", "tmux"},
+                                secrets={"OPENROUTER_API_KEY"})
+        assert role_report("reviewer", CONFIG["roles"]["reviewer"], reports).status is RoleStatus.OK
+
+    def test_a_down_optional_provider_only_degrades(self):
+        reports = self._reports(commands={"codex"}, secrets={"OPENROUTER_API_KEY"})
+        report = role_report("reviewer", CONFIG["roles"]["reviewer"], reports)
+        assert report.status is RoleStatus.DEGRADED
+        assert report.optional_down == ("claude-interactive",)
+        assert "quorum stands" in report.detail
+
+    def test_a_down_required_provider_blocks_and_names_the_fallback(self):
+        """AC: name the fallback rather than let the orchestrator improvise one."""
+        reports = self._reports(commands={"claude", "tmux"}, secrets={"OPENROUTER_API_KEY"})
+        report = role_report("reviewer", CONFIG["roles"]["reviewer"], reports)
+        assert report.status is RoleStatus.BLOCKED
+        assert report.required_down == ("codex",)
+        assert report.fallback == ("claude-interactive",)
+        assert "claude-interactive" in report.detail
+
+    def test_a_blocked_role_with_no_healthy_fallback_says_so(self):
+        report = role_report("reviewer", CONFIG["roles"]["reviewer"], self._reports())
+        assert report.status is RoleStatus.BLOCKED
+        assert report.fallback == ()
+        assert "no healthy fallback" in report.detail
+
+    def test_an_unverifiable_required_provider_blocks_the_role(self):
+        """Unknown must not count as healthy when deciding whether a role can run."""
+        reports = check_all(CONFIG["providers"],
+                            probes(commands={"codex"}, secret_raises=True))
+        report = role_report("reviewer", CONFIG["roles"]["reviewer"], reports)
+        assert report.status is RoleStatus.BLOCKED
+        assert "deepseek-flash" in report.required_down
+
+    def test_a_provider_absent_from_config_blocks_rather_than_passes(self):
+        spec = {"required": ["ghost"], "optional": []}
+        assert role_report("r", spec, {}).status is RoleStatus.BLOCKED
+
+
+# -------------------------------------------------------------- full sweep
+
+
+class TestPreflight:
+    def test_healthy_environment_reports_ok(self):
+        result = preflight(CONFIG, probes(commands={"codex", "claude", "tmux"},
+                                          secrets={"OPENROUTER_API_KEY"}))
+        assert result["ok"] is True
+        assert result["blocked_roles"] == []
+        assert result["unverifiable_providers"] == []
+
+    def test_a_blocked_role_is_listed(self):
+        result = preflight(CONFIG, probes(secrets={"OPENROUTER_API_KEY"}))
+        assert result["ok"] is False
+        assert result["blocked_roles"] == ["reviewer"]
+
+    def test_an_unverifiable_provider_makes_the_sweep_not_ok(self):
+        """Isolated on purpose: the unknown provider is in NO role, so nothing
+        is blocked and only the unknown itself can spoil `ok`."""
+        config = {
+            "providers": {
+                "codex": {"type": "tool", "tool": "codex", "enabled": True},
+                "mystery": {"type": "tool", "tool": "wat", "enabled": True},
+            },
+            "roles": {"reviewer": {"required": ["codex"], "optional": []}},
+        }
+        result = preflight(config, probes(commands={"codex"}))
+        assert result["blocked_roles"] == [], "no role is blocked in this case"
+        assert result["unverifiable_providers"] == ["mystery"]
+        assert result["ok"] is False, "an unverifiable provider alone must spoil the sweep"
+
+    def test_an_unverifiable_required_provider_also_blocks(self):
+        result = preflight(CONFIG, probes(commands={"codex", "claude", "tmux"},
+                                          secret_raises=True))
+        assert result["ok"] is False
+        assert "deepseek-flash" in result["unverifiable_providers"]
+        assert result["blocked_roles"] == ["reviewer"]
+
+    def test_roles_can_be_filtered(self):
+        config = dict(CONFIG)
+        config["roles"] = {"reviewer": CONFIG["roles"]["reviewer"],
+                           "other": {"required": ["codex"], "optional": []}}
+        result = preflight(config, probes(commands={"codex"}), roles=["other"])
+        assert list(result["roles"]) == ["other"]
+
+    def test_the_shipped_config_is_preflightable(self):
+        """Every shipped provider must have known requirements, or the sweep
+        reports it as unverifiable rather than quietly passing it."""
+        config = json.loads((ROOT / "config" / "providers.json").read_text())
+        result = preflight(config, probes())
+        unknown = result["unverifiable_providers"]
+        assert unknown == [], f"shipped providers with no preflight rule: {unknown}"
+
+
+# -------------------------------------------------------------------- CLI
+
+
+class TestCLI:
+    def _run(self, *args):
+        return subprocess.run([sys.executable, str(CLI), *args],
+                              capture_output=True, text=True)
+
+    def test_exit_code_distinguishes_blocked_from_ok(self, tmp_path):
+        config = tmp_path / "providers.json"
+        config.write_text(json.dumps({
+            "providers": {"codex": {"type": "tool", "tool": "codex", "enabled": True}},
+            "roles": {"reviewer": {"required": ["codex"], "optional": []}},
+        }))
+        result = self._run("--config", str(config))
+        payload = json.loads(result.stdout)
+        # codex is unlikely to be installed in CI; either way the code matches.
+        expected = 0 if payload["ok"] else 1
+        assert result.returncode == expected
+
+    def test_unreadable_config_is_its_own_exit_code(self, tmp_path):
+        result = self._run("--config", str(tmp_path / "nope.json"))
+        assert result.returncode == 3
+        assert json.loads(result.stdout)["ok"] is False
+
+    def test_human_output_flags_unverifiable_providers_loudly(self, tmp_path):
+        config = tmp_path / "providers.json"
+        config.write_text(json.dumps({
+            "providers": {"mystery": {"type": "tool", "tool": "wat", "enabled": True}},
+            "roles": {},
+        }))
+        result = self._run("--config", str(config), "--human")
+        assert result.returncode == 2, "unverifiable is its own outcome, not success"
+        assert "Unverified is not healthy" in result.stdout
+
+
+# --------------------------------------------------------- phase latency
+
+
+class TestPhaseSummary:
+    def test_aggregates_per_phase_wall_clock(self):
+        records = [
+            {"event": "phase", "phase": "consults", "duration_ms": 1000.0, "outcome": "ok"},
+            {"event": "phase", "phase": "consults", "duration_ms": 500.0, "outcome": "ok"},
+            {"event": "phase", "phase": "implement", "duration_ms": 2000.0, "outcome": "ok"},
+            {"event": "gate", "gate": "ratchet", "duration_ms": 9999.0},
+        ]
+        summary = phase_summary(records)
+        assert summary["slowest"] == "implement"
+        assert summary["total_ms"] == 3500.0
+        consults = next(p for p in summary["phases"] if p["phase"] == "consults")
+        assert consults["runs"] == 2
+        assert consults["mean_ms"] == 750.0
+
+    def test_a_phase_that_errored_is_counted_not_hidden(self):
+        """A phase that blew up fast must not read as a phase that went well."""
+        summary = phase_summary([
+            {"event": "phase", "phase": "consults", "duration_ms": 10.0, "outcome": "error"},
+        ])
+        assert summary["phases"][0]["errors"] == 1
+
+    def test_no_phase_records_is_an_empty_summary(self):
+        summary = phase_summary([{"event": "gate", "gate": "x"}])
+        assert summary["phases"] == []
+        assert summary["slowest"] is None
+
+    def test_phase_timer_emits_even_when_the_phase_raises(self, monkeypatch):
+        import factory_log
+
+        emitted = []
+        monkeypatch.setattr(factory_log, "emit", lambda event, **fields: emitted.append(
+            {"event": event, **fields}) or True)
+        with pytest.raises(RuntimeError):
+            with factory_log.phase_timer("boom", ticket="#1"):
+                raise RuntimeError("phase failed")
+        assert emitted and emitted[0]["outcome"] == "error"
+        assert emitted[0]["phase"] == "boom"
+
+    def test_phase_timer_records_a_successful_phase(self, monkeypatch):
+        import factory_log
+
+        emitted = []
+        monkeypatch.setattr(factory_log, "emit", lambda event, **fields: emitted.append(
+            {"event": event, **fields}) or True)
+        with factory_log.phase_timer("consults", ticket="#1") as phase:
+            phase.detail = "3 providers"
+        assert emitted[0]["outcome"] == "ok"
+        assert emitted[0]["detail"] == "3 providers"
+        assert emitted[0]["duration_ms"] >= 0


### PR DESCRIPTION
feat(loop): parallel provider preflight and per-phase wall-clock (#375)

Two of the six proposals on the ticket, chosen because they are the mechanical
ones and because the ticket says item 6 is what is missing to rank the rest.

## Provider preflight (item 1)

The operator complaint was that roughly 15 of a 25-minute consult phase went on
environment failures discovered SERIALLY, one relaunch at a time, after the
prompt was already built: a missing keyring entry, a dead CLI and an
uninstalled SDK each cost a full round trip.

`scripts/provider_preflight.py` checks every configured provider at once,
before the work starts, and reports what is broken and what each role can still
do. Requirements are declared per tool and delegate, and a provider entry may
carry its own `preflight` list so a new provider needs no code change.

Four states, not three. A probe that could not run reports `unknown`, which is
not `ok`. A locked keychain, an unimportable keyring, an unrecognised provider
shape: all `unknown`. "We could not tell" and "it is fine" are different
answers, and collapsing them is how a preflight becomes a rubber stamp. Exit
codes keep the distinction: 0 ready, 1 a role is blocked, 2 something could not
be verified, 3 the config could not be read.

Role readiness names its fallback rather than leaving the orchestrator to
improvise one mid-phase. A down optional provider degrades the role and says
the quorum stands; a down required provider blocks it and names which healthy
optional voices remain, or says plainly that there is no healthy fallback.

Secrets are checked for presence only, never read. The preflight has no
business handling a value that CW's own policy says is fetched at call time and
never printed.

## Per-phase wall-clock (item 6)

`factory_log.phase_timer` and `phase_summary` record how long each workflow
phase took, into the existing ledger rather than a parallel store. ticket_cost
tracks tokens but not time-in-phase, so loop latency was felt rather than
measured and there was no data to rank the other four proposals against.

A phase that raised is recorded too, with `outcome="error"`. A phase that blew
up fast would otherwise look like a phase that went well.

## Not in this change

Items 2 and 3 (overlapping Step 7 with Step 8's mechanical half, and Step 5's
red phase with Step 4B's tail) are reorderings of the /implement skill prose,
and item 4 (caching consult outputs by ticket-body hash and HEAD) is its own
piece of work. All three are better done with the phase timings this change
produces, rather than guessed at. The ticket stays open for them.

## Tests

32 tests. Every guard mutation tested by reverting it: 16 of 16 caught. One
blind test was found and fixed: the unverifiable-provider case had the unknown
provider also required by a role, so the role blocked and the sweep failed for
the wrong reason. It now isolates the case with a provider in no role at all.

A test asserts every provider in the shipped config has a known preflight rule,
so adding a provider without one shows up as unverifiable rather than quietly
passing.

Full suite: 3852 passed, 14 skipped.

Refs #375

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
