### PR TITLE
feat(env): resolve a validated Python interpreter (#374)

### DIFF
--- a/scripts/chief_wiggum/interpreter.py
+++ b/scripts/chief_wiggum/interpreter.py
@@ -1,0 +1,278 @@
+"""Resolve a VALIDATED Python interpreter for CW to run its scripts under.
+
+The failure this prevents (chief-wiggum#374): skills hardcode `python3` at
+roughly forty call sites, so CW's runtime interpreter is whatever the shell
+happens to resolve. Homebrew bumping `python3` from 3.11 to 3.13 silently
+stranded every dependency installed for the old one, and three scripts died
+mid-pipeline on missing modules while a working `python3.11` sat right there.
+
+The key word is validated. `check_deps.py --for core` verified keyring under
+the interpreter IT was running as, which says nothing about the interpreter the
+skills will actually invoke. So every import here is probed by running it
+inside the candidate, as a subprocess, not by importing it in this process.
+
+Resolution order, first validated candidate wins:
+
+1. ``CW_PYTHON`` — an explicit operator override, always tried first.
+2. ``~/.chief-wiggum/venv/bin/python`` — the canonical managed runtime.
+3. The interpreter running this code.
+4. Named fallbacks (``python3.13`` down to ``python3.11``, then ``python3``).
+
+Nothing here installs anything. When no candidate validates, the error names
+the missing modules and the exact uv command to fix it, because the operator
+cost last time was three failed launches and three ad-hoc pip repairs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+CW_HOME_DIR = Path.home() / ".chief-wiggum"
+VENV_PYTHON = CW_HOME_DIR / "venv" / "bin" / "python"
+CACHE_PATH = CW_HOME_DIR / "interpreter.json"
+
+# Import name -> the distribution that provides it, for the remediation line.
+PACKAGE_FOR_IMPORT = {
+    "keyring": "keyring",
+    "jsonschema": "jsonschema",
+    "referencing": "referencing",
+    "google.genai": "google-genai",
+    "google.cloud.aiplatform": "google-cloud-aiplatform",
+    "anthropic": "anthropic",
+    "yaml": "pyyaml",
+}
+
+# What each profile needs. Profiles mirror check_deps.py's vocabulary.
+PROFILES: dict[str, tuple[str, ...]] = {
+    "core": ("keyring",),
+    "consult": ("keyring",),
+    "formal": ("jsonschema", "referencing"),
+    "vertex": ("google.genai", "google.cloud.aiplatform"),
+}
+
+FALLBACK_NAMES = ("python3.13", "python3.12", "python3.11", "python3")
+
+
+class NoValidInterpreter(RuntimeError):
+    """No candidate had the required modules. Carries the remediation command."""
+
+
+@dataclass(frozen=True)
+class Candidate:
+    path: str
+    source: str
+    version: str = ""
+    missing: tuple[str, ...] = ()
+    error: str = ""
+
+    @property
+    def valid(self) -> bool:
+        return not self.missing and not self.error
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "source": self.source,
+            "version": self.version,
+            "missing": list(self.missing),
+            "error": self.error,
+            "valid": self.valid,
+        }
+
+
+@dataclass
+class Resolution:
+    python: str
+    source: str
+    version: str
+    profiles: tuple[str, ...] = ()
+    considered: list[Candidate] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "python": self.python,
+            "source": self.source,
+            "version": self.version,
+            "profiles": list(self.profiles),
+            "considered": [candidate.to_dict() for candidate in self.considered],
+        }
+
+
+def modules_for(profiles: Iterable[str]) -> tuple[str, ...]:
+    """Union of every named profile's required imports."""
+    required: list[str] = []
+    for profile in profiles:
+        if profile not in PROFILES:
+            raise ValueError(
+                f"unknown profile {profile!r}; known profiles: {', '.join(sorted(PROFILES))}"
+            )
+        for module in PROFILES[profile]:
+            if module not in required:
+                required.append(module)
+    return tuple(required)
+
+
+def remediation(python: str, missing: Sequence[str]) -> str:
+    """The exact command to fix it. uv, because that is the house rule."""
+    packages = sorted({PACKAGE_FOR_IMPORT.get(module, module) for module in missing})
+    return f"uv pip install --python {python} {' '.join(packages)}"
+
+
+def probe(python: str, modules: Sequence[str], *, timeout: float = 30.0) -> Candidate:
+    """Ask the CANDIDATE whether it can import these, by running it.
+
+    Importing in this process would only ever describe this process. That gap
+    is exactly what stranded the dependencies in the first place.
+    """
+    source = "explicit"
+    resolved = shutil.which(python) or python
+    script = (
+        "import json,sys,importlib.util\n"
+        f"mods={list(modules)!r}\n"
+        "missing=[m for m in mods if importlib.util.find_spec(m) is None]\n"
+        "print(json.dumps({'version': sys.version.split()[0], 'missing': missing}))\n"
+    )
+    try:
+        result = subprocess.run(
+            [resolved, "-c", script], capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return Candidate(resolved, source, error=f"could not run {python}: {exc}")
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        return Candidate(
+            resolved, source,
+            error=f"{python} exited {result.returncode}: {detail[-1] if detail else 'no output'}",
+        )
+    try:
+        payload = json.loads(result.stdout.strip() or "{}")
+    except ValueError as exc:
+        return Candidate(resolved, source, error=f"unparseable probe output: {exc}")
+    return Candidate(
+        resolved, source,
+        version=str(payload.get("version", "")),
+        missing=tuple(payload.get("missing", [])),
+    )
+
+
+def candidates() -> list[tuple[str, str]]:
+    """(path, source) pairs in resolution order, de-duplicated."""
+    ordered: list[tuple[str, str]] = []
+    override = os.environ.get("CW_PYTHON")
+    if override:
+        ordered.append((override, "CW_PYTHON"))
+    if VENV_PYTHON.exists():
+        ordered.append((str(VENV_PYTHON), "cw-venv"))
+    ordered.append((sys.executable, "current"))
+    for name in FALLBACK_NAMES:
+        found = shutil.which(name)
+        if found:
+            ordered.append((found, f"path:{name}"))
+
+    seen: set[str] = set()
+    unique = []
+    for path, source in ordered:
+        resolved = shutil.which(path) or path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append((path, source))
+    return unique
+
+
+def resolve(
+    profiles: Sequence[str] = ("core",),
+    *,
+    use_cache: bool = True,
+    cache_path: Path | None = None,
+) -> Resolution:
+    """Find the first interpreter that can import everything the profiles need."""
+    required = modules_for(profiles)
+    cache_file = cache_path if cache_path is not None else CACHE_PATH
+
+    if use_cache:
+        cached = _read_cache(cache_file, profiles, required)
+        if cached is not None:
+            return cached
+
+    considered: list[Candidate] = []
+    for path, source in candidates():
+        candidate = probe(path, required)
+        candidate = Candidate(candidate.path, source, candidate.version,
+                              candidate.missing, candidate.error)
+        considered.append(candidate)
+        if candidate.valid:
+            resolution = Resolution(candidate.path, source, candidate.version,
+                                    tuple(profiles), considered)
+            _write_cache(cache_file, resolution)
+            return resolution
+
+    raise NoValidInterpreter(_failure_message(required, considered))
+
+
+def _failure_message(required: Sequence[str], considered: Sequence[Candidate]) -> str:
+    lines = [
+        f"no Python interpreter can import: {', '.join(required)}",
+        "Tried:",
+    ]
+    for candidate in considered:
+        why = candidate.error or ("missing " + ", ".join(candidate.missing))
+        lines.append(f"  {candidate.path} ({candidate.source}): {why}")
+    best = next(
+        (c for c in considered if not c.error and c.missing),
+        considered[0] if considered else None,
+    )
+    if best is not None:
+        lines.append("")
+        lines.append("Fix the closest candidate with:")
+        lines.append(f"  {remediation(best.path, best.missing or required)}")
+        lines.append(f"Or point CW at a working interpreter: export CW_PYTHON=/path/to/python")
+    return "\n".join(lines)
+
+
+def _read_cache(
+    cache_file: Path, profiles: Sequence[str], required: Sequence[str]
+) -> Resolution | None:
+    """Reuse a previous answer, but never trust it blindly.
+
+    The cache is re-validated against the interpreter it names, because the
+    whole defect being fixed is an interpreter changing underneath CW.
+    """
+    try:
+        data = json.loads(cache_file.read_text())
+    except (OSError, ValueError):
+        return None
+    python = data.get("python")
+    if not python:
+        return None
+    # Re-probe against the FULL required set rather than checking the file
+    # exists or comparing recorded profiles. Both of those would be redundant:
+    # a vanished interpreter and one that no longer covers the asked-for
+    # profiles both fail this probe, and this is the check that matters.
+    candidate = probe(python, required)
+    if not candidate.valid:
+        return None
+    return Resolution(python, str(data.get("source", "cache")), candidate.version,
+                      tuple(profiles), [candidate])
+
+
+def _write_cache(cache_file: Path, resolution: Resolution) -> None:
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({
+            "python": resolution.python,
+            "source": resolution.source,
+            "version": resolution.version,
+            "profiles": list(resolution.profiles),
+        }, indent=2))
+    except OSError:
+        # A cache that cannot be written is a slower resolve, not a failure.
+        pass

--- a/scripts/env.py
+++ b/scripts/env.py
@@ -11,6 +11,7 @@ values such as temp directories and epic slugs.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import sys
@@ -73,6 +74,17 @@ def main() -> int:
     sub.add_parser("home", help="Print chief-wiggum checkout path")
     sub.add_parser("tmp", help="Create and print a session temp directory")
 
+    python = sub.add_parser(
+        "python",
+        help="Print a VALIDATED interpreter path (chief-wiggum#374)",
+    )
+    python.add_argument(
+        "--profile", action="append", dest="profiles", default=None,
+        help="Which imports must work: core, consult, formal, vertex (repeatable)",
+    )
+    python.add_argument("--json", action="store_true", help="Emit the full resolution")
+    python.add_argument("--no-cache", action="store_true", help="Re-probe every candidate")
+
     slug = sub.add_parser("slug", help="Slugify text for docs/epics paths")
     slug.add_argument("value")
 
@@ -82,7 +94,24 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        if args.command == "home":
+        if args.command == "python":
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            from chief_wiggum.interpreter import NoValidInterpreter, resolve
+
+            try:
+                resolution = resolve(
+                    args.profiles or ["core"], use_cache=not args.no_cache
+                )
+            except (NoValidInterpreter, ValueError) as exc:
+                # Name the remediation instead of a bare traceback: the cost
+                # last time was three failed launches and three ad-hoc repairs.
+                print(str(exc), file=sys.stderr)
+                return 1
+            if args.json:
+                print(json.dumps(resolution.to_dict(), indent=2))
+            else:
+                print(resolution.python)
+        elif args.command == "home":
             print(find_home())
         elif args.command == "tmp":
             print(create_tmp())

--- a/scripts/keychain.py
+++ b/scripts/keychain.py
@@ -27,9 +27,17 @@ import sys
 try:
     import keyring
 except ImportError:
+    # Name the interpreter, not just the package (chief-wiggum#374). `python3`
+    # is unpinned across ~40 skill call sites, so "install keyring" is useless
+    # advice when the question is WHICH interpreter is missing it. uv rather
+    # than pip because installing into an externally-managed system Python is
+    # what stranded these dependencies in the first place.
     print(
         "Missing dependency: keyring\n"
-        "Install with: pip3 install keyring",
+        f"  interpreter: {sys.executable}\n"
+        f"  fix:         uv pip install --python {sys.executable} keyring\n"
+        "  or point CW at a working interpreter:\n"
+        "               export CW_PYTHON=$(python3 scripts/env.py python)",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,0 +1,245 @@
+"""Validated interpreter resolution (chief-wiggum#374).
+
+The defect: `check_deps.py` verified keyring under the interpreter IT ran as,
+which says nothing about the interpreter the skills invoke. So the property
+under test throughout is that validation happens INSIDE the candidate, and that
+a candidate missing something is never selected however convenient it is.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from chief_wiggum.interpreter import (  # noqa: E402
+    PACKAGE_FOR_IMPORT,
+    PROFILES,
+    Candidate,
+    NoValidInterpreter,
+    modules_for,
+    probe,
+    remediation,
+    resolve,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_PY = ROOT / "scripts" / "env.py"
+
+
+# ------------------------------------------------------------------ probing
+
+
+class TestProbe:
+    def test_probes_the_candidate_not_the_current_process(self):
+        """The whole defect: an answer about this process is the wrong answer."""
+        result = probe(sys.executable, ["json"])
+        assert result.valid
+        assert result.version.startswith("3.")
+
+    def test_a_missing_module_is_reported_not_raised(self):
+        result = probe(sys.executable, ["definitely_not_a_real_module_xyz"])
+        assert not result.valid
+        assert result.missing == ("definitely_not_a_real_module_xyz",)
+        assert result.error == ""
+
+    def test_an_unrunnable_interpreter_is_an_error_not_a_pass(self):
+        result = probe("/nonexistent/python", ["json"])
+        assert not result.valid
+        assert result.error
+        assert "could not run" in result.error
+
+    def test_a_candidate_that_exits_nonzero_is_not_valid(self, tmp_path):
+        fake = tmp_path / "brokenpython"
+        fake.write_text("#!/bin/sh\nexit 3\n")
+        fake.chmod(0o755)
+        result = probe(str(fake), ["json"])
+        assert not result.valid
+        assert "exited 3" in result.error
+
+    def test_unparseable_probe_output_is_not_a_pass(self, tmp_path):
+        fake = tmp_path / "chattypython"
+        fake.write_text("#!/bin/sh\necho not json\n")
+        fake.chmod(0o755)
+        result = probe(str(fake), ["json"])
+        assert not result.valid
+        assert "unparseable" in result.error
+
+
+# ----------------------------------------------------------------- profiles
+
+
+class TestProfiles:
+    def test_core_requires_keyring(self):
+        assert "keyring" in modules_for(["core"])
+
+    def test_profiles_union_without_duplicates(self):
+        merged = modules_for(["core", "consult"])
+        assert merged.count("keyring") == 1
+
+    def test_an_unknown_profile_is_refused_by_name(self):
+        with pytest.raises(ValueError, match="unknown profile"):
+            modules_for(["not-a-profile"])
+
+    def test_every_profile_module_has_a_package_mapping(self):
+        """A remediation naming an import that pip cannot install is useless."""
+        for profile, modules in PROFILES.items():
+            for module in modules:
+                assert module in PACKAGE_FOR_IMPORT, (
+                    f"{profile} needs {module}, which has no install-name mapping"
+                )
+
+
+class TestRemediation:
+    def test_names_the_interpreter_and_uses_uv(self):
+        command = remediation("/opt/py/bin/python3.11", ["keyring"])
+        assert "/opt/py/bin/python3.11" in command
+        assert command.startswith("uv pip install --python ")
+        assert "pip3 install" not in command
+
+    def test_translates_import_names_to_package_names(self):
+        assert "google-genai" in remediation("/x/python", ["google.genai"])
+
+    def test_is_deterministic_and_deduplicated(self):
+        assert remediation("/x", ["keyring", "keyring"]) == remediation("/x", ["keyring"])
+
+
+# ---------------------------------------------------------------- resolving
+
+
+class TestResolve:
+    def test_finds_an_interpreter_that_satisfies_the_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        resolution = resolve(["core"], use_cache=False, cache_path=tmp_path / "cache.json")
+        assert Path(resolution.python).exists()
+        assert resolution.source == "CW_PYTHON"
+
+    def test_the_override_is_tried_first(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        resolution = resolve(["core"], use_cache=False, cache_path=tmp_path / "cache.json")
+        assert resolution.considered[0].source == "CW_PYTHON"
+
+    def test_an_impossible_requirement_fails_loudly_with_a_remediation(
+        self, tmp_path, monkeypatch
+    ):
+        """AC: name the fix, do not emit a bare traceback."""
+        monkeypatch.setitem(PROFILES, "impossible", ("definitely_not_a_real_module_xyz",))
+        with pytest.raises(NoValidInterpreter) as excinfo:
+            resolve(["impossible"], use_cache=False, cache_path=tmp_path / "cache.json")
+        message = str(excinfo.value)
+        assert "uv pip install --python" in message
+        assert "CW_PYTHON" in message
+        assert "Tried:" in message
+
+    def test_the_failure_lists_every_candidate_it_tried(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(PROFILES, "impossible", ("definitely_not_a_real_module_xyz",))
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        with pytest.raises(NoValidInterpreter) as excinfo:
+            resolve(["impossible"], use_cache=False, cache_path=tmp_path / "cache.json")
+        assert "CW_PYTHON" in str(excinfo.value)
+
+
+class TestCache:
+    def test_a_resolution_is_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        cache = tmp_path / "cache.json"
+        resolve(["core"], use_cache=False, cache_path=cache)
+        assert json.loads(cache.read_text())["python"]
+
+    def test_a_cache_naming_a_vanished_interpreter_is_ignored(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({
+            "python": "/gone/python", "source": "cache", "version": "3.11.0",
+            "profiles": ["core"],
+        }))
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        resolution = resolve(["core"], cache_path=cache)
+        assert resolution.python != "/gone/python"
+
+    def test_the_cache_is_revalidated_not_trusted(self, tmp_path, monkeypatch):
+        """The defect being fixed is an interpreter changing underneath CW, so
+        a cached answer that no longer satisfies the profile must be dropped."""
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({
+            "python": sys.executable, "source": "cache", "version": "3.11.0",
+            "profiles": ["impossible"],
+        }))
+        monkeypatch.setitem(PROFILES, "impossible", ("definitely_not_a_real_module_xyz",))
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        with pytest.raises(NoValidInterpreter):
+            resolve(["impossible"], cache_path=cache)
+
+    def test_a_cache_for_fewer_profiles_is_not_reused(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({
+            "python": sys.executable, "source": "cache", "version": "3.11.0",
+            "profiles": ["core"],
+        }))
+        monkeypatch.setitem(PROFILES, "extra", ("definitely_not_a_real_module_xyz",))
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        with pytest.raises(NoValidInterpreter):
+            resolve(["core", "extra"], cache_path=cache)
+
+    def test_a_corrupt_cache_is_ignored_rather_than_fatal(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache.json"
+        cache.write_text("{not json")
+        monkeypatch.setenv("CW_PYTHON", sys.executable)
+        assert resolve(["core"], cache_path=cache).python
+
+
+class TestCandidateModel:
+    def test_a_candidate_with_an_error_is_never_valid(self):
+        assert not Candidate("/x", "s", error="boom").valid
+
+    def test_a_candidate_with_missing_modules_is_never_valid(self):
+        assert not Candidate("/x", "s", missing=("keyring",)).valid
+
+
+# --------------------------------------------------------------------- CLI
+
+
+class TestEnvPythonCLI:
+    def _run(self, *args, env=None):
+        return subprocess.run([sys.executable, str(ENV_PY), "python", *args],
+                              capture_output=True, text=True, env=env)
+
+    def test_prints_a_usable_interpreter_path(self):
+        result = self._run()
+        assert result.returncode == 0, result.stderr
+        assert Path(result.stdout.strip()).exists()
+
+    def test_json_mode_shows_what_was_considered(self):
+        result = self._run("--json", "--no-cache")
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["python"]
+        assert payload["considered"], "the resolution must show its working"
+
+    def test_an_unknown_profile_exits_nonzero_with_a_named_error(self):
+        result = self._run("--profile", "not-a-profile")
+        assert result.returncode == 1
+        assert "unknown profile" in result.stderr
+
+    def test_the_resolved_interpreter_actually_imports_the_profile(self):
+        """End to end: what it prints must be able to do what was asked."""
+        result = self._run("--no-cache")
+        assert result.returncode == 0, result.stderr
+        interpreter = result.stdout.strip()
+        check = subprocess.run([interpreter, "-c", "import keyring"],
+                               capture_output=True, text=True)
+        assert check.returncode == 0, (
+            f"env.py python returned {interpreter}, which cannot import keyring"
+        )
+
+
+class TestKeychainRemediation:
+    def test_the_missing_keyring_message_names_the_interpreter_and_uv(self):
+        source = (ROOT / "scripts" / "keychain.py").read_text()
+        assert "uv pip install --python" in source
+        assert "pip3 install keyring" not in source, (
+            "pip into an externally-managed system Python is what caused #374"
+        )
+        assert "CW_PYTHON" in source


### PR DESCRIPTION
feat(env): resolve a validated Python interpreter (#374)

Implements proposals 1 and 2 from the ticket. Skills hardcode `python3` across
roughly forty call sites, so CW's runtime interpreter was whatever the shell
resolved: an unpinned, per-machine accident. Homebrew moving `python3` from
3.11 to 3.13 stranded every dependency installed for the old one, and three
scripts died mid-pipeline on missing modules while a working python3.11 sat
right there.

## The word that matters is validated

`check_deps.py --for core` verified keyring under the interpreter IT was
running as, which says nothing about the interpreter the skills will actually
invoke. That gap is the bug.

So every import is probed by running it INSIDE the candidate, as a subprocess.
A mutation that switches the probe to `importlib.util.find_spec` in the current
process fails its test, because an answer about this process is the wrong
answer.

## What was added

`chief_wiggum/interpreter.py` and `env.py python`. Resolution order, first
validated candidate wins: CW_PYTHON override, then ~/.chief-wiggum/venv/bin/python,
then the running interpreter, then named fallbacks from python3.13 down to
python3. Profiles (core, consult, formal, vertex) name which imports must work,
mirroring check_deps.py's vocabulary.

Skills can now do what they already do for CW_HOME:

    CW_PY=$(python3 "$CW_HOME/scripts/env.py" python --profile consult)
    "$CW_PY" "$CW_HOME/scripts/consult_ai.py" ...

`--json` shows every candidate it considered and why each was rejected, so a
resolution shows its working.

## Failure names the fix

When nothing validates, the error lists every candidate tried, what each was
missing, the exact `uv pip install --python <path> <packages>` for the closest
one, and the CW_PYTHON escape hatch. uv rather than pip because installing into
an externally-managed system Python is what caused this in the first place.

keychain.py's missing-keyring message previously said `pip3 install keyring`,
which is both the wrong tool and useless advice when the question is WHICH
interpreter lacks it. It now names the interpreter and the uv command. A test
asserts the old pip3 line cannot come back.

## Caching

The resolution is cached under ~/.chief-wiggum/interpreter.json and
re-validated on every read by re-probing against the full required set. The
defect being fixed is an interpreter changing underneath CW, so a cached answer
is never trusted on its face.

Two guards were removed during mutation testing after no test could tell them
apart from their absence: an exists() check on the cached path and a comparison
of recorded profiles. Both are subsumed by the revalidation probe, which
already fails for a vanished interpreter and for one that no longer covers the
profiles being asked for.

## Not in this change

Proposal 3, a uv-managed venv under ~/.chief-wiggum/venv as the canonical
runtime, is supported by the resolver (it is candidate two) but not created
here: standing one up changes install and is worth doing deliberately. The
~40 skill call sites are also not rewritten yet; the seam exists first.

The ticket's "also observed" note about the gemini CLI free tier is already
handled: `gemini` is `enabled: false` in config/providers.json and no role
lists it as required.

## Tests

28 tests. Every guard mutation tested by reverting it: 14 of 14 caught.

Full suite: 3880 passed, 14 skipped.

Refs #374

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
