### PR TITLE
fix(render): stamp //go:build ignore on generated guards.go (#380)

### DIFF
--- a/docs/epics/epic-dynamic-evidence-driven-execution-dag/models/guards.go
+++ b/docs/epics/epic-dynamic-evidence-driven-execution-dag/models/guards.go
@@ -1,5 +1,10 @@
+//go:build ignore
+
 // Auto-generated guard clauses from formal contracts.
 // Generated from formal model. Do not edit by hand.
+//
+// This is a generated TEMPLATE, not compilable Go. The build
+// constraint above keeps it out of `go build ./...`.
 
 package handlers
 

--- a/docs/epics/epic-factory-hardening/models/guards.go
+++ b/docs/epics/epic-factory-hardening/models/guards.go
@@ -1,5 +1,10 @@
+//go:build ignore
+
 // Auto-generated guard clauses from formal contracts.
 // Generated from formal model. Do not edit by hand.
+//
+// This is a generated TEMPLATE, not compilable Go. The build
+// constraint above keeps it out of `go build ./...`.
 
 package handlers
 

--- a/docs/formal-methods/examples/generated/guards.go
+++ b/docs/formal-methods/examples/generated/guards.go
@@ -1,5 +1,10 @@
+//go:build ignore
+
 // Auto-generated guard clauses from formal contracts.
 // Generated from formal model. Do not edit by hand.
+//
+// This is a generated TEMPLATE, not compilable Go. The build
+// constraint above keeps it out of `go build ./...`.
 
 package handlers
 

--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -697,8 +697,20 @@ def generate_guards_python(contracts: dict) -> str:
 def generate_guards_go(contracts: dict) -> str:
     """Generate Go guard clause templates from contract preconditions."""
     lines = [
+        # chief-wiggum#380: this file is a TEMPLATE, not compilable Go —
+        # signatures carry contract argument names and bodies are pseudocode.
+        # Without the constraint, `go build ./...` picks it up on a Go target
+        # and fails with syntax errors, so every re-render silently
+        # reintroduced a build break. The blank line after the constraint is
+        # required: Go only honours a build tag separated from the package
+        # clause by one.
+        "//go:build ignore",
+        "",
         "// Auto-generated guard clauses from formal contracts.",
         "// Generated from formal model. Do not edit by hand.",
+        "//",
+        "// This is a generated TEMPLATE, not compilable Go. The build",
+        "// constraint above keeps it out of `go build ./...`.",
         "",
         "package handlers",
         "",

--- a/tests/test_guards_go_build_constraint.py
+++ b/tests/test_guards_go_build_constraint.py
@@ -1,0 +1,98 @@
+"""Generated Go guard templates must not break `go build` (chief-wiggum#380).
+
+`guards.go` is intentionally pseudocode: signatures carry contract argument
+names and bodies are not valid Go. Without a build constraint, `go build ./...`
+on a Go target picks it up and fails with syntax errors, so every re-render
+silently reintroduced a build break.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import formal_models as fm  # noqa: E402
+
+CONSTRAINT = "//go:build ignore"
+
+
+def _contracts():
+    return {
+        "entities": [
+            {
+                "name": "Order",
+                "operations": [
+                    {
+                        "name": "create order",
+                        "method": "POST",
+                        "path": "/api/v1/orders",
+                        "preconditions": [{"description": "total > 0", "expression": "total > 0"}],
+                        "postconditions": [{"description": "order exists"}],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+class TestGeneratedHeader:
+    def test_the_constraint_is_the_very_first_line(self):
+        """Go only honours a build constraint before anything else."""
+        assert fm.generate_guards_go(_contracts()).splitlines()[0] == CONSTRAINT
+
+    def test_a_blank_line_separates_the_constraint_from_what_follows(self):
+        """Without the blank line Go treats it as an ordinary comment."""
+        assert fm.generate_guards_go(_contracts()).splitlines()[1] == ""
+
+    def test_the_constraint_precedes_the_package_clause(self):
+        lines = fm.generate_guards_go(_contracts()).splitlines()
+        assert lines.index(CONSTRAINT) < lines.index("package handlers")
+
+    def test_the_header_says_it_is_a_template(self):
+        """A reader who ignores the tag should still be told not to compile it."""
+        assert "TEMPLATE" in fm.generate_guards_go(_contracts())
+
+    def test_an_empty_contract_set_still_emits_the_constraint(self):
+        """A render with no operations must still be build-safe."""
+        assert fm.generate_guards_go({"entities": []}).startswith(CONSTRAINT)
+
+    def test_the_generated_body_is_still_produced(self):
+        """The constraint must not have displaced the actual output."""
+        code = fm.generate_guards_go(_contracts())
+        assert "func CreateOrder(" in code
+        assert "// REQUIRES: total > 0" in code
+
+
+class TestCommittedTemplates:
+    def _committed(self):
+        return [
+            path for path in sorted(ROOT.rglob("guards.go"))
+            if ".claude" not in path.relative_to(ROOT).parts
+        ]
+
+    def test_there_are_committed_templates_to_check(self):
+        """Guard against this suite silently policing an empty set."""
+        assert self._committed(), "no committed guards.go found; this test would be vacuous"
+
+    @pytest.mark.parametrize("index", range(3))
+    def test_every_committed_template_carries_the_constraint(self, index):
+        committed = self._committed()
+        if index >= len(committed):
+            pytest.skip("fewer committed templates than parameters")
+        path = committed[index]
+        first = path.read_text().splitlines()[0]
+        assert first == CONSTRAINT, (
+            f"{path.relative_to(ROOT)} would be compiled by `go build ./...`; "
+            "re-render it or restamp the header"
+        )
+
+    def test_a_fresh_render_round_trips_the_committed_header(self):
+        """AC: a fresh render round-trips identically to the committed template."""
+        generated_header = fm.generate_guards_go({"entities": []}).splitlines()[:9]
+        for path in self._committed():
+            assert path.read_text().splitlines()[:9] == generated_header, (
+                f"{path.relative_to(ROOT)} header differs from a fresh render"
+            )


### PR DESCRIPTION
fix(render): stamp //go:build ignore on generated guards.go (#380)

`guards.go` is intentionally pseudocode: signatures carry contract argument
names (`func Run_reviewWithComments(assemble_review_prompt)(w http.ResponseWriter, ...)`)
and bodies are not valid Go. Without a build constraint, `go build ./...` on a
Go target picks it up and fails with syntax errors, so every re-render of the
formal models silently reintroduced a build break.

The renderer now emits the constraint as the first line, followed by the blank
line Go requires to distinguish a build tag from an ordinary comment, and a
header saying plainly that the file is a template. The three committed
templates are restamped so a fresh render round-trips identically to what is
committed, which is the ticket's stated expectation.

## Two corrections to the ticket

The ticket says the committed template already carried the constraint and that
dropping it trips an architecture guard asserting "generated templates cannot
break the build". Neither was true in this repo: no committed `guards.go`
carried `//go:build ignore`, and no such test exists. Nothing was restored —
this adds the constraint for the first time.

The underlying defect is real regardless, and is what matters: the generated Go
does not compile, and nothing stopped it reaching `go build`.

## Tests

11 tests. Beyond the renderer unit test the fix sketch asks for, the suite also
checks every committed `guards.go` still starts with the constraint and that
its header matches a fresh render, so a stale template is caught rather than
discovered by a broken build later. One test asserts the committed set is
non-empty, so the suite cannot quietly police nothing.

Mutation tested by reverting each guard: 4 of 4 caught, including restoring the
original header, which is the proof the tests reproduce the defect. The
"constraint present but not first" and "no blank line after it" mutants matter
because both produce a file that looks tagged and is still compiled.

Full suite: 3902 passed, 14 skipped.

Closes #380

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
