### PR TITLE
fix(consult): tolerate OpenRouter keep-alive lines and give kimi its own budget (#372)

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -120,7 +120,8 @@
       "vendor_family": "moonshot",
       "supports_tools": false,
       "context_window": 128000,
-      "latency_class": "standard"
+      "latency_class": "standard",
+      "timeout_seconds": 900
     },
     "glm": {
       "type": "tool",

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -22,6 +22,7 @@ derived exclusively inside ``factory_log.emit_consult`` from
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import re
@@ -102,7 +103,34 @@ def _env_timeout(name: str) -> int | None:
     return _positive_int(os.environ.get(name))
 
 
-def tool_timeout(tool: str, *, override: int | None = None) -> int:
+@functools.lru_cache(maxsize=1)
+def _model_timeouts() -> dict[str, int]:
+    """model id -> per-model timeout, from config/providers.json.
+
+    chief-wiggum#372: every OpenRouter-backed provider shares the `openrouter`
+    tool's one budget, but they are not equally fast. kimi is a REQUIRED
+    provider of the divergence role and blew the 300s default on long
+    generations, failing the quorum every time it thought hard. A per-model
+    budget lives in config beside the provider it describes, so no model name
+    is hardcoded here.
+    """
+    try:
+        config = json.loads(
+            (Path(__file__).resolve().parent.parent / "config" / "providers.json").read_text()
+        )
+    except (OSError, ValueError):
+        return {}
+    timeouts: dict[str, int] = {}
+    for entry in (config.get("providers") or {}).values():
+        model = entry.get("model")
+        seconds = _positive_int(entry.get("timeout_seconds"))
+        if model and seconds is not None:
+            timeouts[str(model)] = seconds
+    return timeouts
+
+
+def tool_timeout(tool: str, *, override: int | None = None,
+                 model: str | None = None) -> int:
     """Resolve ``tool``'s wall-clock timeout (seconds) through a single override
     chain (chief-wiggum#291), highest precedence first:
 
@@ -113,7 +141,8 @@ def tool_timeout(tool: str, *, override: int | None = None) -> int:
        non-alphanumeric character replaced with ``_`` (e.g. ``gemini-vertex`` ->
        ``CW_CONSULT_TIMEOUT_GEMINI_VERTEX``).
     3. ``CW_CONSULT_TIMEOUT`` — applies to every tool.
-    4. The ``TOOL_TIMEOUTS`` table default (``TIMEOUT`` if the tool is unlisted).
+    4. ``timeout_seconds`` for this ``model`` in config/providers.json (#372).
+    5. The ``TOOL_TIMEOUTS`` table default (``TIMEOUT`` if the tool is unlisted).
 
     Every candidate is validated by ``_positive_int``: a non-numeric or
     non-positive value at ANY source (including ``override``) is ignored and
@@ -134,6 +163,14 @@ def tool_timeout(tool: str, *, override: int | None = None) -> int:
     general = _env_timeout("CW_CONSULT_TIMEOUT")
     if general is not None:
         return general
+    if model:
+        # Validated like every other source: the documented invariant is that a
+        # non-numeric or non-positive value at ANY source falls through rather
+        # than being returned, so a bad knob degrades the timeout and never
+        # crashes a consult mid-workflow.
+        per_model = _positive_int(_model_timeouts().get(str(model)))
+        if per_model is not None:
+            return per_model
     return TOOL_TIMEOUTS.get(tool, TIMEOUT)
 
 # A retry after a TIMEOUT-classified failure gets a REDUCED budget, not a
@@ -956,6 +993,82 @@ def consult_claude(
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 
+class OpenRouterBodyError(ValueError):
+    """The response body could not be decoded. Carries an excerpt for diagnosis."""
+
+
+def _decode_openrouter_body(raw: str) -> dict:
+    """Parse an OpenRouter response body that may not be bare JSON.
+
+    chief-wiggum#372: two runs against a slow model with a Mandarin prompt failed
+    at the IDENTICAL byte offset — a deterministic parsing bug, not a network
+    blip. OpenRouter emits SSE-style keep-alive comment lines (`: OPENROUTER
+    PROCESSING`) to hold the connection open during long generations, and a bare
+    `json.loads` on the whole body chokes on them. A long non-English generation
+    simply takes long enough to collect them.
+
+    Tolerated shapes, in order: bare JSON; JSON preceded or followed by `:`
+    comment lines and blank lines; and an SSE `data:` frame stream, from which
+    the last non-`[DONE]` frame is taken.
+
+    A body that still cannot be parsed raises with an EXCERPT of the raw text
+    rather than a bare offset, because "Expecting value: line 1143 column 1" is
+    not diagnosable on its own.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        raise OpenRouterBodyError("openrouter returned an empty body")
+
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+    else:
+        if isinstance(payload, dict):
+            return payload
+        raise OpenRouterBodyError(
+            f"openrouter returned a {type(payload).__name__}, expected an object: "
+            f"{_body_excerpt(raw)}"
+        )
+
+    data_frames: list[str] = []
+    remainder: list[str] = []
+    for line in stripped.splitlines():
+        candidate = line.strip()
+        if not candidate or candidate.startswith(":"):
+            continue  # SSE comment / keep-alive
+        if candidate.startswith("data:"):
+            frame = candidate[len("data:"):].strip()
+            if frame and frame != "[DONE]":
+                data_frames.append(frame)
+            continue
+        remainder.append(line)
+
+    for candidate in (data_frames[-1] if data_frames else None, "\n".join(remainder)):
+        if not candidate or not candidate.strip():
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+
+    raise OpenRouterBodyError(
+        "openrouter response body is not JSON after stripping SSE keep-alives: "
+        + _body_excerpt(raw)
+    )
+
+
+def _body_excerpt(raw: str, limit: int = 400) -> str:
+    """A bounded, single-line view of a body, for an error message."""
+    collapsed = " ".join(raw.split())
+    if len(collapsed) <= limit:
+        return repr(collapsed)
+    half = limit // 2
+    return repr(collapsed[:half] + " ... " + collapsed[-half:])
+
+
 def _http_json_with_deadline(request: urllib.request.Request, timeout: int) -> dict:
     """POST and decode JSON under a HARD wall-clock deadline.
 
@@ -974,7 +1087,8 @@ def _http_json_with_deadline(request: urllib.request.Request, timeout: int) -> d
     def _call() -> None:
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
-                result["payload"] = json.loads(response.read().decode())
+                body = response.read().decode("utf-8", errors="replace")
+                result["payload"] = _decode_openrouter_body(body)
         except BaseException as exc:  # re-raised on the calling thread below
             result["error"] = exc
 
@@ -1060,7 +1174,7 @@ def consult_openrouter(
             "X-Title": "chief-wiggum",
         },
     )
-    effective_timeout = tool_timeout("openrouter", override=timeout)
+    effective_timeout = tool_timeout("openrouter", override=timeout, model=model)
     try:
         payload = _http_json_with_deadline(request, effective_timeout)
     except urllib.error.HTTPError as exc:

--- a/tests/test_openrouter_body.py
+++ b/tests/test_openrouter_body.py
@@ -1,0 +1,182 @@
+"""OpenRouter response-body decoding and per-model timeouts (chief-wiggum#372).
+
+Two runs against a slow model with a Mandarin prompt failed at the IDENTICAL
+byte offset. Same offset twice is a deterministic parsing bug, not a network
+blip: OpenRouter emits SSE-style keep-alive comment lines to hold the
+connection open during long generations, and a bare `json.loads` over the whole
+body chokes on them. A long non-English generation simply takes long enough to
+collect them.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import consult_ai  # noqa: E402
+from consult_ai import (  # noqa: E402
+    OpenRouterBodyError,
+    _body_excerpt,
+    _decode_openrouter_body,
+    tool_timeout,
+)
+
+PAYLOAD = {"choices": [{"message": {"content": "答案"}}],
+           "usage": {"prompt_tokens": 10, "completion_tokens": 5}}
+BODY = json.dumps(PAYLOAD, ensure_ascii=False)
+KEEPALIVE = ": OPENROUTER PROCESSING\n"
+
+
+def _content(payload):
+    return payload["choices"][0]["message"]["content"]
+
+
+class TestBodyDecoding:
+    def test_a_bare_json_body_still_parses(self):
+        assert _content(_decode_openrouter_body(BODY)) == "答案"
+
+    def test_keepalive_comment_lines_before_the_payload(self):
+        """The #372 shape: a long generation collects keep-alives first."""
+        assert _content(_decode_openrouter_body(KEEPALIVE * 1140 + BODY)) == "答案"
+
+    def test_keepalives_on_both_sides(self):
+        body = KEEPALIVE * 3 + "\n" + BODY + "\n" + KEEPALIVE * 2
+        assert _content(_decode_openrouter_body(body)) == "答案"
+
+    def test_an_sse_frame_stream(self):
+        body = f"data: {BODY}\ndata: [DONE]\n"
+        assert _content(_decode_openrouter_body(body)) == "答案"
+
+    def test_sse_frames_interleaved_with_keepalives(self):
+        body = f": ping\n\ndata: {BODY}\n\ndata: [DONE]"
+        assert _content(_decode_openrouter_body(body)) == "答案"
+
+    def test_the_last_real_frame_wins_over_done(self):
+        first = json.dumps({"choices": [{"message": {"content": "first"}}]})
+        second = json.dumps({"choices": [{"message": {"content": "second"}}]})
+        body = f"data: {first}\ndata: {second}\ndata: [DONE]"
+        assert _content(_decode_openrouter_body(body)) == "second"
+
+    def test_multibyte_content_survives(self):
+        """The failing prompt was Mandarin; a mangled decode would corrupt it."""
+        payload = _decode_openrouter_body(KEEPALIVE + BODY)
+        assert _content(payload) == "答案"
+        assert payload["usage"]["prompt_tokens"] == 10
+
+
+class TestTheHttpPathActuallyUsesIt:
+    """The decoder is only a fix if the request path calls it.
+
+    Testing `_decode_openrouter_body` alone left the call site unguarded: a
+    mutation restoring the original bare `json.loads` there passed every test.
+    That is the actual #372 bug, so it needs a test through the real path.
+    """
+
+    class _FakeResponse:
+        def __init__(self, body: bytes):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _urlopen(self, body: str):
+        encoded = body.encode("utf-8")
+
+        def opener(request, timeout=None):
+            return TestTheHttpPathActuallyUsesIt._FakeResponse(encoded)
+
+        return opener
+
+    def test_a_keepalive_prefixed_response_decodes_through_the_request_path(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            consult_ai.urllib.request, "urlopen", self._urlopen(KEEPALIVE * 1140 + BODY)
+        )
+        payload = consult_ai._http_json_with_deadline(object(), 5)
+        assert _content(payload) == "答案"
+
+    def test_a_bare_json_response_still_decodes_through_the_request_path(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(consult_ai.urllib.request, "urlopen", self._urlopen(BODY))
+        assert _content(consult_ai._http_json_with_deadline(object(), 5)) == "答案"
+
+    def test_an_undecodable_response_raises_with_its_body(self, monkeypatch):
+        monkeypatch.setattr(
+            consult_ai.urllib.request, "urlopen", self._urlopen("<html>bad gateway</html>")
+        )
+        with pytest.raises(OpenRouterBodyError, match="bad gateway"):
+            consult_ai._http_json_with_deadline(object(), 5)
+
+
+class TestBodyFailuresAreDiagnosable:
+    def test_an_empty_body_is_named_not_a_parse_offset(self):
+        with pytest.raises(OpenRouterBodyError, match="empty body"):
+            _decode_openrouter_body("   \n  ")
+
+    def test_an_unparseable_body_carries_an_excerpt(self):
+        """AC: capture the error body. 'Expecting value: line 1143 column 1' is
+        not diagnosable on its own — that is why this bug took two runs to even
+        characterise."""
+        with pytest.raises(OpenRouterBodyError) as excinfo:
+            _decode_openrouter_body("<html>gateway timeout</html>")
+        message = str(excinfo.value)
+        assert "gateway timeout" in message, "the raw body must reach the operator"
+
+    def test_a_json_array_is_refused_by_type(self):
+        with pytest.raises(OpenRouterBodyError, match="expected an object"):
+            _decode_openrouter_body("[1, 2, 3]")
+
+    def test_keepalives_alone_are_refused_rather_than_returning_nothing(self):
+        with pytest.raises(OpenRouterBodyError):
+            _decode_openrouter_body(KEEPALIVE * 50)
+
+    def test_excerpts_are_bounded(self):
+        assert len(_body_excerpt("x" * 10_000)) <= 420
+
+    def test_excerpts_keep_both_ends(self):
+        excerpt = _body_excerpt("HEAD" + "-" * 5000 + "TAIL")
+        assert "HEAD" in excerpt and "TAIL" in excerpt
+
+
+class TestPerModelTimeout:
+    def test_a_slow_model_gets_its_configured_budget(self):
+        """kimi is a REQUIRED divergence provider; the shared 300s failed the
+        quorum every time it thought hard."""
+        assert tool_timeout("openrouter", model="moonshotai/kimi-k3") == 900
+
+    def test_other_models_keep_the_tool_default(self):
+        assert tool_timeout("openrouter", model="deepseek/deepseek-v4-flash") == 300
+
+    def test_an_unknown_model_keeps_the_tool_default(self):
+        assert tool_timeout("openrouter", model="nobody/nothing") == 300
+
+    def test_no_model_keeps_the_tool_default(self):
+        assert tool_timeout("openrouter") == 300
+
+    def test_an_explicit_override_still_wins(self):
+        assert tool_timeout("openrouter", model="moonshotai/kimi-k3", override=60) == 60
+
+    def test_the_env_override_still_beats_config(self, monkeypatch):
+        """Documented precedence must not have shifted: env is the escape hatch."""
+        monkeypatch.setenv("CW_CONSULT_TIMEOUT_OPENROUTER", "42")
+        assert tool_timeout("openrouter", model="moonshotai/kimi-k3") == 42
+
+    def test_a_malformed_config_value_degrades_rather_than_crashing(self, monkeypatch):
+        monkeypatch.setattr(consult_ai, "_model_timeouts", lambda: {"m": "not-a-number"})
+        assert tool_timeout("openrouter", model="m") == 300
+
+    def test_the_shipped_config_declares_the_slow_model(self):
+        config = json.loads((ROOT / "config" / "providers.json").read_text())
+        assert config["providers"]["kimi"]["timeout_seconds"] >= 900


### PR DESCRIPTION
fix(consult): tolerate OpenRouter keep-alive lines and give kimi its own budget (#372)

Two runs against kimi with a Mandarin prompt failed at the IDENTICAL byte
offset. Same offset twice is the tell: a deterministic parsing bug, not a
network blip.

OpenRouter emits SSE-style keep-alive comment lines (`: OPENROUTER PROCESSING`)
to hold the connection open during long generations, and
`json.loads(response.read().decode())` over the whole body chokes on them. The
Mandarin prompt was not special in itself — it simply generated long enough to
collect keep-alives, which is why the English run against the same model
succeeded.

## Parsing

`_decode_openrouter_body` now tolerates bare JSON, JSON surrounded by `:`
comment lines and blanks, and an SSE `data:` frame stream (taking the last
non-`[DONE]` frame). Anything still unparseable raises with a bounded excerpt
of the RAW BODY, because "Expecting value: line 1143 column 1 (char 6281)" is
not diagnosable on its own — that is why this took two runs just to
characterise. The ticket asked for the error body to be captured; it is.

Decoding is now `errors="replace"` so a chunk split inside a multibyte
character degrades one glyph instead of throwing, and a test asserts Mandarin
content survives intact.

## Timeout

kimi is a REQUIRED provider of the divergence role and blew the `openrouter`
tool's shared 300s default, failing the quorum every time it thought hard. Every
OpenRouter-backed provider shared one budget despite not being equally fast.

`timeout_seconds` on a provider entry in config/providers.json now gives one
model its own budget, and kimi gets 900 — the value the ticket records as
working. It sits BELOW the env overrides in the precedence chain, so the
documented order is unchanged and env stays the escape hatch. No model name is
hardcoded in the runner.

## Not in this change

The divergence role's optional-provider cap (kimi got only 150s inside a role
run) is a separate knob from the per-provider timeout, and changing role
mechanics is worth doing deliberately rather than alongside a parse fix.

## Tests

24 tests. Mutation tested by reverting each guard: 11 of 11 caught, after one
blind spot that mattered more than the rest — restoring the original bare
`json.loads` at the CALL SITE passed everything, because the tests only
exercised the decoder directly. A decoder is not a fix if the request path does
not call it, so there are now tests through `_http_json_with_deadline` with a
faked response.

One test also caught a real slip while I wrote it: the per-model timeout was
not validated by `_positive_int` like every other source, violating
`tool_timeout`'s documented invariant that a bad value at ANY source degrades
rather than propagating.

Full suite: 3994 passed, 14 skipped.

Closes #372

Generated-by: chief-wiggum (AI system; see docs/ai-act-posture.md)
