### PR TITLE
feat(experiment): freeze the corpus, journal the results, refuse the ratio (#391)

### DIFF
--- a/docs/experiments/dynamic-dag/running-the-arms.md
+++ b/docs/experiments/dynamic-dag/running-the-arms.md
@@ -1,0 +1,249 @@
+# Running the arms
+
+Operator runbook for the dynamic-DAG ablation (chief-wiggum#391).
+
+The pre-registration (`pre-registration.md`) is the binding document and it
+does not change. This file is the machinery underneath it: what to run, in
+what order, and which step refuses to continue.
+
+Everything here is `scripts/dag_experiment.py`. Nothing here spends model
+budget. The harness freezes, pins, records, and analyses. Executing the arms
+themselves, and the go / hold / rollback decision at each rung of the ladder,
+stays a human decision by design.
+
+## Order of operations
+
+```
+freeze-corpus  ->  hash-verifier  ->  manifest (x5)  ->  [run the arm]
+                                          |
+                                   check-protocol
+                                          |
+                                       record (x5)  ->  report
+```
+
+`check-protocol` deliberately sits before `report`. The pre-registration stops
+an arm on a protocol violation and re-runs it from a clean manifest, and that
+decision has to be reachable without anyone having looked at a score yet.
+
+## 1. Freeze the corpus
+
+```bash
+python3 scripts/dag_experiment.py freeze-corpus \
+  --candidates corpus/candidates.json \
+  --repo ~/.chief-wiggum/repos/owner/repo \
+  --out corpus/corpus.json
+```
+
+A candidate record:
+
+```json
+{
+  "task_id": "cw-352",
+  "source": "cw-history",
+  "task_class": "bugfix",
+  "risk": "low",
+  "size": "small",
+  "base_commit": "b6a4e...",
+  "base_date": "2026-05-01",
+  "solution_commit": "179181c...",
+  "solution_date": "2026-08-23",
+  "public_benchmark": false
+}
+```
+
+`task_class`, `risk` and `size` must come from the pre-registered
+vocabularies (`corpus.TASK_CLASSES`, `RISK_CLASSES`, `SIZE_CLASSES`).
+Anything else excludes the task rather than inventing a stratum. A typo would
+otherwise produce a stratum of one, and a stratum of one gets reported as a
+stratum.
+
+### Contamination
+
+A task is excluded when its solution is reachable from the repo state the arm
+is given. `--repo` is what makes that question answerable: the harness asks git
+whether `solution_commit` is an ancestor of `base_commit`.
+
+**Without `--repo`, reachability is `UNKNOWN`, not clean.** The task then falls
+back to its dates, and a task whose dates cannot settle it is excluded as
+`UNVERIFIABLE_BASE`. That direction is deliberate. An unverifiable task
+admitted is a silently contaminated corpus, and contamination does not show up
+as an anomaly in the results. It just raises every arm that can read the
+answer, which looks exactly like a real difference.
+
+Exclusion reasons, all counted and published with their denominator:
+
+| Reason | Meaning |
+|---|---|
+| `SOLUTION_IN_BASE` | git says the solution is an ancestor of the base |
+| `SOLUTION_PREDATES_BASE` | git could not say; the dates put the solution first |
+| `UNVERIFIABLE_BASE` | neither git nor the dates could settle it |
+| `DUPLICATE_ID` | the same task id appeared twice |
+| `INVALID_STRATUM` | a class, risk or size outside the registered vocabulary |
+
+Public-benchmark instances are **annotated, not excluded**. They are listed
+under `pretraining_risk` so the reader knows the absolute score may be
+inflated; the readable signal is the cross-arm difference under fixed
+conditions.
+
+### Underpowered strata
+
+The pre-registration sets a floor of 20 tasks per stratum for a stratum-level
+number to be quoted at all. Strata below it are labelled `UNDERPOWERED` with
+their N and still counted in the corpus, never dropped.
+
+`--gate` turns the floor into a blocking check (exit 1). Without it the command
+reports and exits 0, per `docs/gate-rollout.md`.
+
+## 2. Hash the verifier
+
+```bash
+python3 scripts/dag_experiment.py hash-verifier \
+  --path tests/verify_patch.py --path tests/conftest.py \
+  --command "pytest tests/" \
+  --out corpus/verifier.json
+```
+
+Frozen before any arm runs, identical across arms. A path that does not exist
+raises: "the verifier file was missing so we hashed the rest" is how two arms
+end up sharing a hash while running different verifiers.
+
+## 3. Pin each arm's conditions
+
+```bash
+python3 scripts/dag_experiment.py manifest \
+  --arm arm-3 \
+  --corpus corpus/corpus.json --verifier corpus/verifier.json \
+  --roster implementer=open-tier-a --roster reviewer=open-tier-b \
+  --seed task_order=7 \
+  --budget usd_cents=50000 --budget wall_seconds=7200 \
+  --env python=3.11 --env os=darwin-25.1 \
+  --out runs/manifest-arm-3.json
+```
+
+The registered arms are `arm-1` through `arm-5`; the tier and process for each
+come from `report.ARM_SPECS`, copied from the pre-registration, so an arm
+cannot be relabelled at run time.
+
+Budgets and seeds are whole integers. Manifests are hashed, and the canonical
+encoding rejects floats so hashes stay replay stable, so express money in cents
+and time in whole seconds.
+
+## 4. Run the arm
+
+This is the part that costs money and wall-clock, and the part this repo does
+not automate. Produce one outcome record per corpus task:
+
+```json
+{"task_id": "cw-352", "accepted": true, "gate_conformant": true,
+ "escaped_defect": false, "operator_seconds": 240,
+ "model_cost_cents": 812, "wall_clock_seconds": 1830,
+ "retries": 1, "graph_mutations": 4, "escalations": 0}
+```
+
+`accepted` has no default. A record without it is refused rather than read as
+a rejection.
+
+## 5. Check protocol before looking at anything
+
+```bash
+python3 scripts/dag_experiment.py check-protocol --gate \
+  --manifest runs/manifest-arm-1.json ... --manifest runs/manifest-arm-5.json
+```
+
+Compares every arm against `arm-1` and names what moved: verifier, corpus,
+budgets, environment. Any finding means those arms re-run from a clean
+manifest.
+
+## 6. Record the raw results
+
+```bash
+python3 scripts/dag_experiment.py record \
+  --arm arm-3 \
+  --corpus corpus/corpus.json \
+  --manifest runs/manifest-arm-3.json \
+  --outcomes runs/outcomes-arm-3.json \
+  --journal docs/quality/ratchet-journal.jsonl \
+  --out runs/run-arm-3.json
+```
+
+This is what makes the raw results immutable in the sense the repo can
+actually enforce. The per-task records live in `runs/run-arm-3.json`; their
+digest, the manifest digest, the corpus version and the verifier hash go into
+the ratchet hash chain as an `experiment-record` event. Edit any one of them
+afterwards and the digest recorded at the time no longer matches.
+
+The event is never `merged`, so it does not touch the ratchet's pass-set
+high-water mark. Appending onto a broken chain fails closed, and the reader
+(`chief_wiggum.experiment_journal.experiment_records`) reads only the verified
+prefix. A record past a torn tail is not evidence of anything.
+
+The append lives in `scripts/chief_wiggum/experiment_journal.py` rather than in
+`ratchet.py`. The ratchet gate's `--scanner-version` is the hash of
+`ratchet.py` and its finding-affecting dependencies (INV-fh-005), so editing
+that file to add an unrelated event type would stale the ratchet gate's
+validation record and demand a re-run of its seeded-defect trials, paid for a
+change that touches none of the gate's finding logic.
+
+Coverage is reported here, not inferred:
+
+- **missing**: a corpus task with no outcome. Not scored as a rejection; an
+  arm that died halfway must read as incomplete, not merely bad.
+- **unknown**: an outcome for a task outside the corpus. Not counted as an
+  attempt.
+- **duplicates**: the same task twice. First record wins, second is counted.
+
+## 7. Report, or refuse to
+
+```bash
+python3 scripts/dag_experiment.py report \
+  --corpus corpus/corpus.json \
+  --run runs/run-arm-1.json ... --run runs/run-arm-5.json \
+  --out-json results/report.json --out-md results/report.md
+```
+
+The report refuses to produce a gap-closure ratio at all when the registered
+stopping rules say it should not exist:
+
+| Suppression | Cause |
+|---|---|
+| `PROTOCOL_VIOLATION` | arms ran under different conditions |
+| `PARTIAL_RUN` | some arm did not attempt the whole corpus |
+| `MISSING_ARM` | arm 1, arm 2 or arm 5 is absent |
+
+Suppression is kept distinct from a degenerate ratio on purpose. "We never ran
+enough tasks" must not read like "the corpus was not discriminative". Only
+one of those is a finding about the corpus.
+
+When nothing is suppressed, gap closure is reported for **arms 3, 4 and 5
+against the same denominator**. Arm 5 is the headline because the registered
+non-inferiority claim is about arm 5; showing all three is what stops the
+flattering one being quietly promoted.
+
+Also in the report: per-arm accepted-patch rate and gate conformance with N and
+95% Wilson intervals, the cost/quality frontier, the negative findings, the
+reporting failures (a clean sweep across five arms is one), and the public-claim
+gate. `--gate` exits 1 when there are reporting failures.
+
+## Rollback
+
+The registered fallback is `plan_waves.py` plus static roles. It shares #385's
+graph, so the thing to exercise is the static projection:
+
+```bash
+python3 scripts/dag_engine.py project --waves --db <journal.db>
+```
+
+`tests/test_dag_experiment_harness.py::test_static_fallback_still_projects_a_wave_plan`
+exercises it on every run. If that projection stops working there is nothing
+to roll back to, and the rollback criteria in the pre-registration become
+unenforceable.
+
+## What is still a human decision
+
+- running arms 1 to 5 (real budget, real wall-clock)
+- the go / hold / rollback call at each rung of the ladder
+- publishing anything, which the public-claim gate can only refuse, never grant
+
+Amending the arms, the metrics, the formula or the margin after an arm has run
+invalidates that arm. Record the amendment with its date and reason and re-run
+on a fresh split.

--- a/docs/experiments/dynamic-dag/running-the-arms.md
+++ b/docs/experiments/dynamic-dag/running-the-arms.md
@@ -80,10 +80,21 @@ Exclusion reasons, all counted and published with their denominator:
 | `DUPLICATE_ID` | the same task id appeared twice |
 | `INVALID_STRATUM` | a class, risk or size outside the registered vocabulary |
 
-Public-benchmark instances are **annotated, not excluded**. They are listed
-under `pretraining_risk` so the reader knows the absolute score may be
-inflated; the readable signal is the cross-arm difference under fixed
-conditions.
+There are two different contamination vectors here and they are handled
+differently. Conflating them is easy, so state them separately:
+
+- **Pretraining contamination** (the task may be memorised from a public
+  benchmark) is **annotated, not excluded**. Such tasks are listed under
+  `pretraining_risk` so the reader knows the absolute score may be inflated;
+  the readable signal is the cross-arm difference under fixed conditions.
+- **Reachability contamination** (the arm can read the solution out of the
+  repo state it was handed) is **excluded**, and that applies to public
+  benchmark instances too. `public_benchmark` only exempts a task from the
+  `UNVERIFIABLE_BASE` rule when no solution is recorded at all, because a
+  benchmark instance takes its repo state from the benchmark harness rather
+  than from a `base_commit`. A benchmark task that does carry a
+  `solution_commit` reachable from its base is still excluded: annotating it
+  would leave an answer key inside the corpus.
 
 ### Underpowered strata
 

--- a/scripts/chief_wiggum/dag/corpus.py
+++ b/scripts/chief_wiggum/dag/corpus.py
@@ -1,0 +1,460 @@
+"""Corpus freeze, contamination controls, and verifier hashing (chief-wiggum#391).
+
+Rung 1 of the pre-registered ladder cannot start until two things are true:
+the corpus is frozen and the verifier is content-hashed. Both are recorded in
+every run manifest, and `experiment.protocol_violations` reads them to prove
+that nothing except the varied factor moved between arms.
+
+Three decisions are mechanised here rather than left to whoever runs the arms:
+
+1. **Contamination is decided per task, with a reason, and counted.** The
+   pre-registration requires the exclusion count to be recorded. A task whose
+   solution is reachable from the repo state the arm is given is not
+   a task, it is a lookup. Reachability is asked of git, and a question git cannot
+   answer excludes the task as `UNVERIFIABLE_BASE` rather than admitting it.
+   That direction matters: an unverifiable task admitted is a silently
+   contaminated corpus, and contamination inflates every arm that can read it.
+2. **Strata are validated against a fixed vocabulary.** A typo in a task
+   class would otherwise create a stratum of one, and a stratum of one is
+   reported as a stratum. Unknown values exclude the task and are counted.
+3. **Underpowered strata are reported, never dropped.** The pre-registration
+   sets a 20-task floor for a stratum-level number to be quoted at all. Below
+   it the stratum still exists and still contributes to the arm total; it is
+   labelled underpowered with its N so the reader can see what was thin.
+
+Pretraining risk is an annotation, not an exclusion. The pre-registration is
+explicit that public-benchmark instances which may sit in a model's
+pretraining are stated plainly, and that cross-arm comparison under fixed
+conditions, not absolute score, is the readable signal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from .canonical import canonical_json_bytes
+
+# Pre-registered vocabularies. Anything outside them is an excluded task, not
+# a new stratum.
+TASK_CLASSES = ("feature", "bugfix", "refactor", "test-only", "frontend", "backend")
+RISK_CLASSES = ("low", "medium", "high")
+SIZE_CLASSES = ("small", "medium", "large")
+
+# "Minimum 20 tasks per stratum for a stratum-level number to be reported at
+# all" - pre-registration, Corpus and strata.
+MIN_STRATUM_N = 20
+
+
+class ExclusionReason(StrEnum):
+    """Why a candidate task is not in the frozen corpus."""
+
+    SOLUTION_IN_BASE = "SOLUTION_IN_BASE"
+    SOLUTION_PREDATES_BASE = "SOLUTION_PREDATES_BASE"
+    UNVERIFIABLE_BASE = "UNVERIFIABLE_BASE"
+    DUPLICATE_ID = "DUPLICATE_ID"
+    INVALID_STRATUM = "INVALID_STRATUM"
+
+
+class Reachability(StrEnum):
+    """The three answers to "can the arm read the solution from its base?"."""
+
+    REACHABLE = "reachable"
+    UNREACHABLE = "unreachable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class TaskRecord:
+    """One candidate task, with everything the freeze needs to judge it."""
+
+    task_id: str
+    source: str
+    task_class: str
+    risk: str
+    size: str
+    base_commit: str = ""
+    base_date: str = ""
+    solution_commit: str = ""
+    solution_date: str = ""
+    public_benchmark: bool = False
+
+    @property
+    def stratum(self) -> str:
+        return f"{self.task_class}/{self.risk}/{self.size}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "source": self.source,
+            "task_class": self.task_class,
+            "risk": self.risk,
+            "size": self.size,
+            "base_commit": self.base_commit,
+            "base_date": self.base_date,
+            "solution_commit": self.solution_commit,
+            "solution_date": self.solution_date,
+            "public_benchmark": self.public_benchmark,
+            "stratum": self.stratum,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> TaskRecord:
+        missing = [key for key in ("task_id", "source", "task_class", "risk", "size")
+                   if not str(raw.get(key, "")).strip()]
+        if missing:
+            raise ValueError(
+                f"task record is missing required fields: {', '.join(missing)}"
+            )
+        return cls(
+            task_id=str(raw["task_id"]),
+            source=str(raw["source"]),
+            task_class=str(raw["task_class"]),
+            risk=str(raw["risk"]),
+            size=str(raw["size"]),
+            base_commit=str(raw.get("base_commit", "")),
+            base_date=str(raw.get("base_date", "")),
+            solution_commit=str(raw.get("solution_commit", "")),
+            solution_date=str(raw.get("solution_date", "")),
+            public_benchmark=bool(raw.get("public_benchmark", False)),
+        )
+
+
+@dataclass(frozen=True)
+class Exclusion:
+    """A task kept out of the corpus, with the reason it was kept out.
+
+    Exclusions are retained rather than discarded: the pre-registration
+    requires the exclusion count to be published, and a count with no reasons
+    behind it cannot be audited.
+    """
+
+    task_id: str
+    reason: ExclusionReason
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"task_id": self.task_id, "reason": str(self.reason),
+                "detail": self.detail}
+
+
+def _dates_ordered(solution_date: str, base_date: str) -> bool | None:
+    """True when the solution is dated at or before the base state.
+
+    Returns None when either date is absent or unparseable, so the caller can
+    tell "the solution predates the base" from "nobody knows". Comparison is
+    lexicographic on ISO-8601 strings, which is why the format is checked
+    rather than assumed: `2026-8-1` sorts before `2026-10-1` as text and after
+    it in reality.
+    """
+    if not solution_date or not base_date:
+        return None
+    for value in (solution_date, base_date):
+        parts = value.split("T")[0].split("-")
+        if len(parts) != 3 or not all(part.isdigit() for part in parts):
+            return None
+        if len(parts[0]) != 4 or len(parts[1]) != 2 or len(parts[2]) != 2:
+            return None
+    return solution_date <= base_date
+
+
+def git_reachability(repo: str | Path) -> Callable[[str, str], Reachability]:
+    """Ask git whether `solution_commit` is an ancestor of `base_commit`.
+
+    A commit git does not have, a directory that is not a repository, or a git
+    that fails for any other reason all answer UNKNOWN. UNKNOWN excludes the
+    task upstream - the failure mode this avoids is the one where a broken
+    subprocess call reads as "not contaminated" and quietly admits everything.
+    """
+
+    root = Path(repo)
+
+    def check(solution_commit: str, base_commit: str) -> Reachability:
+        if not solution_commit or not base_commit:
+            return Reachability.UNKNOWN
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(root), "merge-base", "--is-ancestor",
+                 solution_commit, base_commit],
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return Reachability.UNKNOWN
+        if completed.returncode == 0:
+            return Reachability.REACHABLE
+        if completed.returncode == 1:
+            return Reachability.UNREACHABLE
+        # Any other code is git refusing the question (unknown revision, not a
+        # repository), never a clean "no".
+        return Reachability.UNKNOWN
+
+    return check
+
+
+def _unasked(_solution: str, _base: str) -> Reachability:
+    """The default oracle: nobody was asked, so nothing is known.
+
+    UNKNOWN, never UNREACHABLE. An oracle that answers "not contaminated"
+    because no repository was supplied is the fail-open version of this
+    check - it would silently admit every task whose solution nobody looked
+    for. UNKNOWN sends the task to the date fallback, and if the dates cannot
+    settle it either, it is excluded as unverifiable.
+    """
+    return Reachability.UNKNOWN
+
+
+@dataclass(frozen=True)
+class FrozenCorpus:
+    """An immutable, hashed corpus. Its digest is the manifest's corpus_version."""
+
+    included: tuple[TaskRecord, ...]
+    exclusions: tuple[Exclusion, ...]
+    min_stratum_n: int = MIN_STRATUM_N
+    notes: str = ""
+
+    @property
+    def strata(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for task in self.included:
+            counts[task.stratum] = counts.get(task.stratum, 0) + 1
+        return dict(sorted(counts.items()))
+
+    @property
+    def underpowered(self) -> tuple[str, ...]:
+        """Strata below the pre-registered floor. Reported, never dropped."""
+        return tuple(name for name, count in self.strata.items()
+                     if count < self.min_stratum_n)
+
+    @property
+    def pretraining_risk(self) -> tuple[str, ...]:
+        """Included tasks that may sit in pretraining. Stated, not excluded."""
+        return tuple(sorted(task.task_id for task in self.included
+                            if task.public_benchmark))
+
+    @property
+    def exclusion_counts(self) -> dict[str, int]:
+        counts = {str(reason): 0 for reason in ExclusionReason}
+        for exclusion in self.exclusions:
+            counts[str(exclusion.reason)] += 1
+        return counts
+
+    @property
+    def considered(self) -> int:
+        """The denominator. An exclusion count without one says nothing."""
+        return len(self.included) + len(self.exclusions)
+
+    def digest(self) -> str:
+        """Content hash of the frozen corpus.
+
+        The task list is sorted by id before hashing. That sort is NOT
+        redundant here: `canonical_json_bytes` only auto-sorts collections of
+        records carrying a DAG identity key, and a task record carries none -
+        so without it the same corpus fed in a different order would hash
+        differently and read as a CORPUS_CHANGED protocol violation.
+        """
+        payload = {
+            "included": [task.to_dict() for task in
+                         sorted(self.included, key=lambda task: task.task_id)],
+            "min_stratum_n": self.min_stratum_n,
+        }
+        return "sha256:" + hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "corpus_version": self.digest(),
+            "notes": self.notes,
+            "min_stratum_n": self.min_stratum_n,
+            "considered": self.considered,
+            "included_n": len(self.included),
+            "excluded_n": len(self.exclusions),
+            "exclusion_counts": self.exclusion_counts,
+            "strata": self.strata,
+            "underpowered_strata": list(self.underpowered),
+            "pretraining_risk": list(self.pretraining_risk),
+            "included": [task.to_dict() for task in
+                         sorted(self.included, key=lambda task: task.task_id)],
+            "exclusions": [exclusion.to_dict() for exclusion in
+                           sorted(self.exclusions, key=lambda item: item.task_id)],
+        }
+
+    def render(self) -> str:
+        """Human summary. Every count carries its denominator."""
+        lines = [
+            f"corpus {self.digest()}",
+            f"  considered: {self.considered}",
+            f"  included:   {len(self.included)}/{self.considered}",
+            f"  excluded:   {len(self.exclusions)}/{self.considered}",
+        ]
+        for reason, count in sorted(self.exclusion_counts.items()):
+            if count:
+                lines.append(f"    {reason}: {count}")
+        lines.append(f"  strata: {len(self.strata)} (floor N={self.min_stratum_n})")
+        for name, count in self.strata.items():
+            flag = "  UNDERPOWERED" if count < self.min_stratum_n else ""
+            lines.append(f"    {name}: {count}{flag}")
+        risky = self.pretraining_risk
+        lines.append(
+            f"  pretraining risk: {len(risky)}/{len(self.included)} included tasks"
+            " are public-benchmark instances that may be in pretraining;"
+            " read cross-arm differences, not absolute scores"
+        )
+        return "\n".join(lines)
+
+
+def freeze_corpus(
+    candidates: Iterable[TaskRecord],
+    *,
+    reachable: Callable[[str, str], Reachability] | None = None,
+    min_stratum_n: int = MIN_STRATUM_N,
+    notes: str = "",
+) -> FrozenCorpus:
+    """Apply the pre-registered inclusion rules and freeze what survives.
+
+    The rules run in a fixed order so the same candidate list always produces
+    the same corpus: identity, then stratum vocabulary, then contamination.
+    """
+    oracle = reachable or _unasked
+    included: list[TaskRecord] = []
+    exclusions: list[Exclusion] = []
+    seen: set[str] = set()
+
+    for task in candidates:
+        if task.task_id in seen:
+            exclusions.append(Exclusion(
+                task.task_id, ExclusionReason.DUPLICATE_ID,
+                "task id appears more than once in the candidate list",
+            ))
+            continue
+        seen.add(task.task_id)
+
+        bad = [f"{name}={value!r}" for name, value, allowed in (
+            ("task_class", task.task_class, TASK_CLASSES),
+            ("risk", task.risk, RISK_CLASSES),
+            ("size", task.size, SIZE_CLASSES),
+        ) if value not in allowed]
+        if bad:
+            exclusions.append(Exclusion(
+                task.task_id, ExclusionReason.INVALID_STRATUM,
+                "outside the pre-registered vocabulary: " + ", ".join(bad),
+            ))
+            continue
+
+        verdict = _contamination(task, oracle)
+        if verdict is not None:
+            exclusions.append(verdict)
+            continue
+        included.append(task)
+
+    return FrozenCorpus(
+        included=tuple(included),
+        exclusions=tuple(exclusions),
+        min_stratum_n=min_stratum_n,
+        notes=notes,
+    )
+
+
+def _contamination(
+    task: TaskRecord, oracle: Callable[[str, str], Reachability]
+) -> Exclusion | None:
+    """None when the task is clean; an Exclusion when it is not, or cannot be judged."""
+    # A task with no solution to leak - a live task, or one whose fix does not
+    # exist yet - cannot be contaminated by reachability.
+    if not task.solution_commit and not task.solution_date:
+        if task.public_benchmark:
+            return None
+        if not task.base_commit:
+            return Exclusion(
+                task.task_id, ExclusionReason.UNVERIFIABLE_BASE,
+                "no base commit recorded, so the repo state given to the arm"
+                " cannot be established",
+            )
+        return None
+
+    if not task.base_commit and not task.base_date:
+        return Exclusion(
+            task.task_id, ExclusionReason.UNVERIFIABLE_BASE,
+            "no base commit or base date, so reachability cannot be decided",
+        )
+
+    verdict = oracle(task.solution_commit, task.base_commit)
+    if verdict is Reachability.REACHABLE:
+        return Exclusion(
+            task.task_id, ExclusionReason.SOLUTION_IN_BASE,
+            f"solution {task.solution_commit[:12]} is an ancestor of base"
+            f" {task.base_commit[:12]}; the arm can read the answer",
+        )
+    if verdict is Reachability.UNREACHABLE:
+        return None
+
+    # The oracle could not answer. Fall back to dates, and if those cannot
+    # answer either, exclude - an unverifiable task admitted is a corpus
+    # nobody can defend.
+    ordered = _dates_ordered(task.solution_date, task.base_date)
+    if ordered is True:
+        return Exclusion(
+            task.task_id, ExclusionReason.SOLUTION_PREDATES_BASE,
+            f"solution dated {task.solution_date} at or before base"
+            f" {task.base_date}, and reachability could not be decided",
+        )
+    if ordered is False:
+        return None
+    return Exclusion(
+        task.task_id, ExclusionReason.UNVERIFIABLE_BASE,
+        "reachability could not be decided and the dates do not settle it;"
+        " excluded rather than admitted, because an unverifiable task admitted"
+        " is a silently contaminated corpus",
+    )
+
+
+@dataclass(frozen=True)
+class VerifierFingerprint:
+    """The frozen verifier. Hashed before any arm runs, identical across arms."""
+
+    files: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    command: str = ""
+
+    def digest(self) -> str:
+        payload = {
+            "command": self.command,
+            "files": [{"path": path, "sha256": sha} for path, sha in self.files],
+        }
+        return "sha256:" + hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verifier_hash": self.digest(),
+            "command": self.command,
+            "files": [{"path": path, "sha256": sha} for path, sha in self.files],
+        }
+
+
+def fingerprint_verifier(
+    paths: Sequence[str | Path], *, root: str | Path = ".", command: str = ""
+) -> VerifierFingerprint:
+    """Content-hash the verifier's files.
+
+    A path that does not exist raises rather than being skipped. "The verifier
+    file was missing so we hashed the rest" is how two arms end up sharing a
+    hash while running different verifiers, which is the exact thing the hash
+    exists to make impossible.
+    """
+    base = Path(root)
+    entries: list[tuple[str, str]] = []
+    for candidate in paths:
+        target = Path(candidate)
+        absolute = target if target.is_absolute() else base / target
+        if not absolute.is_file():
+            raise FileNotFoundError(
+                f"verifier file not found: {absolute}. The verifier is frozen"
+                " before any arm runs; a missing file is a stop, not a skip."
+            )
+        digest = hashlib.sha256(absolute.read_bytes()).hexdigest()
+        relative = str(target).replace("\\", "/")
+        entries.append((relative, digest))
+    entries.sort()
+    return VerifierFingerprint(files=tuple(entries), command=command)

--- a/scripts/chief_wiggum/dag/corpus.py
+++ b/scripts/chief_wiggum/dag/corpus.py
@@ -34,6 +34,7 @@ import hashlib
 import subprocess
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -111,12 +112,16 @@ class TaskRecord:
             raise ValueError(
                 f"task record is missing required fields: {', '.join(missing)}"
             )
+        # Stored stripped, not merely validated stripped. Identity is compared
+        # as a plain string, so `"cw-352"` and `"cw-352 "` would be two
+        # different tasks: the duplicate check would pass them both and the
+        # same task would be scored twice, inflating its stratum.
         return cls(
-            task_id=str(raw["task_id"]),
-            source=str(raw["source"]),
-            task_class=str(raw["task_class"]),
-            risk=str(raw["risk"]),
-            size=str(raw["size"]),
+            task_id=str(raw["task_id"]).strip(),
+            source=str(raw["source"]).strip(),
+            task_class=str(raw["task_class"]).strip(),
+            risk=str(raw["risk"]).strip(),
+            size=str(raw["size"]).strip(),
             base_commit=str(raw.get("base_commit", "")),
             base_date=str(raw.get("base_date", "")),
             solution_commit=str(raw.get("solution_commit", "")),
@@ -154,13 +159,35 @@ def _dates_ordered(solution_date: str, base_date: str) -> bool | None:
     """
     if not solution_date or not base_date:
         return None
+
+    # Parsed as instants, never compared as text. Lexicographic order looks
+    # equivalent and is not: the time portion may carry a UTC offset, which
+    # sorting ignores. A solution stamped 2026-08-01T00:00:00+02:00 is
+    # 2026-07-31 22:00 UTC, genuinely earlier than a base of
+    # 2026-07-31T23:00:00Z, yet it sorts later as text - so the contaminated
+    # task read as clean and was admitted. Comparing calendar days does not
+    # fix it either, because the offset moves the day.
+    stamps = []
     for value in (solution_date, base_date):
-        parts = value.split("T")[0].split("-")
-        if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        try:
+            stamps.append(datetime.fromisoformat(value))
+        except ValueError:
             return None
-        if len(parts[0]) != 4 or len(parts[1]) != 2 or len(parts[2]) != 2:
-            return None
-    return solution_date <= base_date
+
+    solution_at, base_at = stamps
+    if (solution_at.tzinfo is None) != (base_at.tzinfo is None):
+        # One instant, one wall-clock date. Assuming a zone for the naive one
+        # would be inventing the fact that decides contamination, so this is
+        # unorderable and the caller excludes the task as unverifiable.
+        return None
+    if solution_at == base_at:
+        return True
+    if solution_at.tzinfo is None and solution_at.date() == base_at.date():
+        # Two naive values on the same day: a bare date carries no time, so
+        # "2026-08-01" against "2026-08-01T09:00" is not evidence the solution
+        # came afterwards. Unorderable in the conservative direction.
+        return True
+    return solution_at < base_at
 
 
 def git_reachability(repo: str | Path) -> Callable[[str, str], Reachability]:
@@ -249,17 +276,30 @@ class FrozenCorpus:
         return len(self.included) + len(self.exclusions)
 
     def digest(self) -> str:
-        """Content hash of the frozen corpus.
+        """Content hash of the frozen corpus, including what it excluded.
 
         The task list is sorted by id before hashing. That sort is NOT
         redundant here: `canonical_json_bytes` only auto-sorts collections of
         records carrying a DAG identity key, and a task record carries none -
         so without it the same corpus fed in a different order would hash
         differently and read as a CORPUS_CHANGED protocol violation.
+
+        The exclusions are hashed too, and that is load-bearing rather than
+        tidy. The exclusion count is a quantity the pre-registration requires
+        the experiment to publish, and the report reads it from the corpus
+        file. If only the included tasks were hashed, a corpus that recorded
+        fifty contaminated candidates and one that quietly filtered them out
+        before freezing would share a `corpus_version`, and every manifest
+        would pin that same version while the published contamination
+        evidence differed. The digest has to bind the evidence, not just the
+        sample.
         """
         payload = {
             "included": [task.to_dict() for task in
                          sorted(self.included, key=lambda task: task.task_id)],
+            "exclusions": [item.to_dict() for item in
+                           sorted(self.exclusions,
+                                  key=lambda item: (item.task_id, str(item.reason)))],
             "min_stratum_n": self.min_stratum_n,
         }
         return "sha256:" + hashlib.sha256(canonical_json_bytes(payload)).hexdigest()

--- a/scripts/chief_wiggum/dag/report.py
+++ b/scripts/chief_wiggum/dag/report.py
@@ -173,6 +173,27 @@ class Coverage:
         return (self.attempted == self.corpus_n and not self.missing
                 and not self.unknown and not self.duplicates)
 
+    def shortfall(self) -> str:
+        """Why this arm is not a clean full-corpus run, in the operator's terms.
+
+        "PARTIAL" alone sends the reader hunting for missing tasks, which is
+        wrong when the arm covered everything and merely submitted one record
+        for a task outside the corpus. Both block a ratio, and they are not
+        the same problem: one is an arm that did less than registered, the
+        other is an arm that ran something that was never registered.
+        """
+        parts = []
+        if self.missing:
+            parts.append(f"{len(self.missing)} corpus tasks with no outcome")
+        if self.unknown:
+            parts.append(f"{len(self.unknown)} outcomes for tasks outside the corpus")
+        if self.duplicates:
+            parts.append(f"{len(self.duplicates)} duplicate task outcomes")
+        if not parts:
+            return (f"attempted {self.attempted} of {self.corpus_n}"
+                    " corpus tasks")
+        return ", ".join(parts)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "corpus_n": self.corpus_n,
@@ -307,6 +328,7 @@ def _suppression(
     by_arm: Mapping[str, ArmRun],
     violations: Mapping[str, Sequence[str]],
     partial: Sequence[str],
+    shortfalls: Mapping[str, str] | None = None,
 ) -> tuple[ClosureSuppression, str]:
     """Decide whether the registered stopping rules permit a ratio at all."""
     required = [FRONTIER_ARM, STATIC_OPEN_ARM, HEADLINE_ADAPTIVE_ARM]
@@ -320,8 +342,13 @@ def _suppression(
               " manifest; no ratio is computed."
         )
     if partial:
+        detail = shortfalls or {}
+        named = "; ".join(
+            f"{arm} ({detail[arm]})" if arm in detail else arm
+            for arm in sorted(partial)
+        )
         return ClosureSuppression.PARTIAL_RUN, (
-            "incomplete arms: " + ", ".join(sorted(partial))
+            "incomplete arms: " + named
             + ". A partial result is reported as partial, with its N, and does"
               " not produce a gap-closure ratio."
         )
@@ -341,6 +368,23 @@ def assemble_report(
     min_n: int = 100,
 ) -> dict[str, Any]:
     """Assemble the full result: coverage, protocol, closure, frontier, findings."""
+    # Refuse two runs for one arm rather than letting a dict comprehension
+    # decide. Keeping the last silently drops the other, and every downstream
+    # list (`arms`, the frontier, the negative findings) would still carry
+    # both, so the ratio and the table beside it would describe different
+    # runs. It also hands the operator a way to submit two takes of an arm and
+    # have the analysis quietly read one of them.
+    counts: dict[str, int] = {}
+    for run in runs:
+        counts[run.result.arm] = counts.get(run.result.arm, 0) + 1
+    duplicated = sorted(arm for arm, count in counts.items() if count > 1)
+    if duplicated:
+        raise ValueError(
+            "more than one run supplied for " + ", ".join(duplicated)
+            + "; an arm has exactly one result, and choosing between two takes"
+              " after seeing them is not a choice the analysis may make"
+        )
+
     by_arm = {run.result.arm: run for run in runs}
     arms = [run.result for run in runs]
 
@@ -355,7 +399,9 @@ def assemble_report(
                 violations[run.result.arm] = [str(item) for item in found]
 
     partial = sorted(run.result.arm for run in runs if not run.coverage.complete)
-    suppression, detail = _suppression(by_arm, violations, partial)
+    shortfalls = {run.result.arm: run.coverage.shortfall() for run in runs
+                  if not run.coverage.complete}
+    suppression, detail = _suppression(by_arm, violations, partial, shortfalls)
 
     closures: dict[str, Any] = {}
     headline: GapClosure | None = None
@@ -385,10 +431,25 @@ def assemble_report(
 
     findings = list(negative_findings(arms, STATIC_OPEN_ARM))
     failures = list(reporting_failures(arms, findings))
-    failures += [f"{arm} did not attempt the whole corpus; reported as partial"
+    failures += [f"{arm} is not a clean full-corpus run ({shortfalls[arm]});"
+                 " reported as partial"
                  for arm in partial]
     failures += [f"{arm} violated protocol ({', '.join(items)}) and must re-run"
                  for arm, items in sorted(violations.items())]
+
+    # An absent arm 3 or 4 is a reporting failure, not a silent omission.
+    # Gap closure only needs arms 1, 2 and 5, so leaving the other two out
+    # still produces a clean-looking headline ratio. But the reason all three
+    # adaptive arms are shown against one denominator is so the flattering one
+    # cannot be promoted quietly, and that defence is worth nothing if simply
+    # not running an arm makes it disappear from the report.
+    unreported = [name for name in ADAPTIVE_ARMS if name not in by_arm]
+    if unreported and suppression is ClosureSuppression.NONE:
+        failures.append(
+            "no result for " + ", ".join(unreported)
+            + "; the headline ratio is quoted without the adaptive arms it is"
+              " meant to be read beside"
+        )
 
     if headline is not None:
         allowed, claim_detail = readme_claim_allowed(arms, headline, min_n=min_n)

--- a/scripts/chief_wiggum/dag/report.py
+++ b/scripts/chief_wiggum/dag/report.py
@@ -1,0 +1,571 @@
+"""Raw results, coverage, and report assembly for the ablation (chief-wiggum#391).
+
+`experiment.py` holds the pre-registered analysis primitives and is
+deliberately left alone: the formula, the margin and the degenerate cases were
+registered before any arm ran, and a pre-registered artifact that keeps
+growing branches is not pre-registered any more.
+
+This module decides whether there is a number to analyse at all. It folds raw
+per-task outcomes into arm results, establishes what each arm actually
+attempted against the frozen corpus, and enforces the registered stopping
+rules AROUND the formula rather than inside it:
+
+- an arm that ran under different conditions stops and re-runs, so no ratio is
+  computed from the set it is in;
+- a partial experiment is reported as partial, with its N, and produces no
+  ratio;
+- gap closure is reported for arms 3, 4 and 5 against the same denominator, so
+  the flattering one cannot be quietly promoted to the headline.
+
+Suppression is settled before the ratio is computed, not disclaimed after.
+Computing a number and then explaining why it should not be quoted is how a
+suppressed ratio ends up quoted anyway.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from .canonical import canonical_json_bytes
+from .experiment import (
+    ArmResult,
+    GapClosure,
+    Interval,
+    NonInferiority,
+    RunManifest,
+    cost_quality_frontier,
+    gap_closure,
+    negative_findings,
+    protocol_violations,
+    readme_claim_allowed,
+    reporting_failures,
+    wilson_interval,
+)
+
+# The arms the pre-registered formula names. Arm 5 is the adaptive arm: the
+# registered non-inferiority claim is "arm 5 is not worse than arm 1", which
+# is what makes it the headline rather than a choice made after seeing
+# results. Arms 3 and 4 are reported beside it against the same denominator.
+FRONTIER_ARM = "arm-1"
+STATIC_OPEN_ARM = "arm-2"
+ADAPTIVE_ARMS = ("arm-3", "arm-4", "arm-5")
+HEADLINE_ADAPTIVE_ARM = "arm-5"
+
+# The registered arm table, copied from the pre-registration so an arm cannot
+# be relabelled at run time. Tiers, never model names: the roster changes and
+# the experiment has to survive it.
+ARM_SPECS: dict[str, tuple[str, str]] = {
+    FRONTIER_ARM: ("frontier-tier", "static factory"),
+    STATIC_OPEN_ARM: ("open-tier", "static factory"),
+    "arm-3": ("open-tier", "dynamic DAG"),
+    "arm-4": ("open-tier", "dynamic DAG + selective candidates"),
+    "arm-5": ("adaptive hybrid routing", "dynamic DAG"),
+}
+
+
+class ClosureSuppression(StrEnum):
+    """Why a gap-closure ratio was not computed at all.
+
+    Distinct from `GapClosureStatus`, which describes a ratio that WAS
+    computed and came back degenerate. Collapsing the two would let "we never
+    ran enough tasks" read like "the corpus was not discriminative", and only
+    one of those is a finding about the corpus.
+    """
+
+    NONE = "NONE"
+    PROTOCOL_VIOLATION = "PROTOCOL_VIOLATION"
+    PARTIAL_RUN = "PARTIAL_RUN"
+    MISSING_ARM = "MISSING_ARM"
+
+
+@dataclass(frozen=True)
+class TaskOutcome:
+    """One task's result under one arm.
+
+    Money is in whole cents and time in whole seconds because these records
+    are hashed, and INV-dag-004's canonical encoding rejects floats so a hash
+    stays replay stable.
+    """
+
+    task_id: str
+    accepted: bool
+    gate_conformant: bool = True
+    escaped_defect: bool = False
+    operator_seconds: int = 0
+    model_cost_cents: int = 0
+    wall_clock_seconds: int = 0
+    retries: int = 0
+    graph_mutations: int = 0
+    escalations: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "accepted": self.accepted,
+            "gate_conformant": self.gate_conformant,
+            "escaped_defect": self.escaped_defect,
+            "operator_seconds": self.operator_seconds,
+            "model_cost_cents": self.model_cost_cents,
+            "wall_clock_seconds": self.wall_clock_seconds,
+            "retries": self.retries,
+            "graph_mutations": self.graph_mutations,
+            "escalations": self.escalations,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> TaskOutcome:
+        task_id = str(raw.get("task_id", "")).strip()
+        if not task_id:
+            raise ValueError("task outcome is missing task_id")
+        if "accepted" not in raw:
+            raise ValueError(
+                f"task outcome {task_id} has no 'accepted' field; an absent"
+                " verdict must not default to accepted or to rejected"
+            )
+
+        def whole(name: str) -> int:
+            value = raw.get(name, 0)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(
+                    f"task outcome {task_id} field {name}={value!r} must be a"
+                    " whole integer (cents, seconds); these records are hashed"
+                    " and the canonical encoding rejects floats"
+                )
+            return value
+
+        return cls(
+            task_id=task_id,
+            accepted=bool(raw["accepted"]),
+            gate_conformant=bool(raw.get("gate_conformant", True)),
+            escaped_defect=bool(raw.get("escaped_defect", False)),
+            operator_seconds=whole("operator_seconds"),
+            model_cost_cents=whole("model_cost_cents"),
+            wall_clock_seconds=whole("wall_clock_seconds"),
+            retries=whole("retries"),
+            graph_mutations=whole("graph_mutations"),
+            escalations=whole("escalations"),
+        )
+
+
+@dataclass(frozen=True)
+class Coverage:
+    """What an arm actually attempted against the frozen corpus.
+
+    `attempted` is never inferred from how many records were handed in. An
+    outcome for a task outside the corpus is `unknown`, not attempted, and a
+    corpus task with no outcome is `missing`, not a rejection - scoring a
+    missing task as a failure would let an arm that died halfway look merely
+    bad instead of incomplete.
+    """
+
+    corpus_n: int
+    attempted: int
+    missing: tuple[str, ...] = ()
+    unknown: tuple[str, ...] = ()
+    duplicates: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        return (self.attempted == self.corpus_n and not self.missing
+                and not self.unknown and not self.duplicates)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "corpus_n": self.corpus_n,
+            "attempted": self.attempted,
+            "complete": self.complete,
+            "missing": list(self.missing),
+            "unknown": list(self.unknown),
+            "duplicates": list(self.duplicates),
+        }
+
+
+@dataclass(frozen=True)
+class ArmRun:
+    """One arm's manifest, raw outcomes, coverage, and derived result."""
+
+    result: ArmResult
+    manifest: RunManifest
+    coverage: Coverage
+    outcomes: tuple[TaskOutcome, ...]
+
+    def results_digest(self) -> str:
+        """Hash of the raw per-task records, sorted by task id.
+
+        The sort is explicit because a task outcome carries no DAG identity
+        key, so the canonical encoder will not sort the list for us and the
+        same results in a different order would hash differently.
+        """
+        payload = {
+            "arm": self.result.arm,
+            "manifest_digest": self.manifest.digest(),
+            "outcomes": [outcome.to_dict() for outcome in
+                         sorted(self.outcomes, key=lambda item: item.task_id)],
+        }
+        return "sha256:" + hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "results_digest": self.results_digest(),
+            "manifest": self.manifest.to_dict(),
+            "manifest_digest": self.manifest.digest(),
+            "coverage": self.coverage.to_dict(),
+            "result": self.result.to_dict(),
+            "outcomes": [outcome.to_dict() for outcome in
+                         sorted(self.outcomes, key=lambda item: item.task_id)],
+        }
+
+
+def build_arm_run(
+    *,
+    arm: str,
+    model_tier: str,
+    process: str,
+    manifest: RunManifest,
+    outcomes: Sequence[TaskOutcome],
+    strata_by_task: Mapping[str, str],
+) -> ArmRun:
+    """Fold raw per-task outcomes into one arm's result plus its coverage.
+
+    `strata_by_task` comes from the frozen corpus, never from the outcome
+    records. An arm that reported its own strata could relabel a task it lost
+    into a stratum it was winning.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    unknown: list[str] = []
+    scored: list[TaskOutcome] = []
+    for outcome in outcomes:
+        if outcome.task_id in seen:
+            duplicates.append(outcome.task_id)
+            continue
+        seen.add(outcome.task_id)
+        if outcome.task_id not in strata_by_task:
+            unknown.append(outcome.task_id)
+            continue
+        scored.append(outcome)
+
+    coverage = Coverage(
+        corpus_n=len(strata_by_task),
+        attempted=len(scored),
+        missing=tuple(sorted(set(strata_by_task) - seen)),
+        unknown=tuple(sorted(unknown)),
+        duplicates=tuple(sorted(duplicates)),
+    )
+
+    strata: dict[str, tuple[int, int]] = {}
+    for outcome in scored:
+        stratum = strata_by_task[outcome.task_id]
+        accepted, attempted = strata.get(stratum, (0, 0))
+        strata[stratum] = (accepted + int(outcome.accepted), attempted + 1)
+
+    result = ArmResult(
+        arm=arm,
+        model_tier=model_tier,
+        process=process,
+        accepted=sum(1 for outcome in scored if outcome.accepted),
+        attempted=len(scored),
+        escaped_defects=sum(1 for outcome in scored if outcome.escaped_defect),
+        operator_minutes=sum(outcome.operator_seconds for outcome in scored) / 60.0,
+        model_cost=sum(outcome.model_cost_cents for outcome in scored) / 100.0,
+        wall_clock_seconds=float(
+            sum(outcome.wall_clock_seconds for outcome in scored)
+        ),
+        retries=sum(outcome.retries for outcome in scored),
+        graph_mutations=sum(outcome.graph_mutations for outcome in scored),
+        escalations=sum(outcome.escalations for outcome in scored),
+        strata=strata,
+    )
+    return ArmRun(result=result, manifest=manifest, coverage=coverage,
+                  outcomes=tuple(outcomes))
+
+
+def conformance_rate(run: ArmRun) -> Interval:
+    """Contract, test, and gate conformance across the arm's SCORED tasks.
+
+    Scored, not submitted: an outcome for a task outside the corpus does not
+    count towards conformance any more than it counts towards quality.
+    """
+    unknown = set(run.coverage.unknown)
+    seen: set[str] = set()
+    scored = []
+    for outcome in run.outcomes:
+        if outcome.task_id in unknown or outcome.task_id in seen:
+            continue
+        seen.add(outcome.task_id)
+        scored.append(outcome)
+    return wilson_interval(
+        sum(1 for outcome in scored if outcome.gate_conformant), len(scored)
+    )
+
+
+def _suppression(
+    by_arm: Mapping[str, ArmRun],
+    violations: Mapping[str, Sequence[str]],
+    partial: Sequence[str],
+) -> tuple[ClosureSuppression, str]:
+    """Decide whether the registered stopping rules permit a ratio at all."""
+    required = [FRONTIER_ARM, STATIC_OPEN_ARM, HEADLINE_ADAPTIVE_ARM]
+    absent = [name for name in required if name not in by_arm]
+    if violations:
+        return ClosureSuppression.PROTOCOL_VIOLATION, (
+            "arms ran under different conditions: "
+            + "; ".join(f"{arm}: {', '.join(items)}"
+                        for arm, items in sorted(violations.items()))
+            + ". The pre-registration stops the arm and re-runs it from a clean"
+              " manifest; no ratio is computed."
+        )
+    if partial:
+        return ClosureSuppression.PARTIAL_RUN, (
+            "incomplete arms: " + ", ".join(sorted(partial))
+            + ". A partial result is reported as partial, with its N, and does"
+              " not produce a gap-closure ratio."
+        )
+    if absent:
+        return ClosureSuppression.MISSING_ARM, (
+            "the formula needs " + ", ".join(required)
+            + "; missing " + ", ".join(absent)
+        )
+    return ClosureSuppression.NONE, ""
+
+
+def assemble_report(
+    *,
+    corpus: Mapping[str, Any],
+    runs: Sequence[ArmRun],
+    non_inferiority: NonInferiority,
+    min_n: int = 100,
+) -> dict[str, Any]:
+    """Assemble the full result: coverage, protocol, closure, frontier, findings."""
+    by_arm = {run.result.arm: run for run in runs}
+    arms = [run.result for run in runs]
+
+    violations: dict[str, list[str]] = {}
+    baseline = by_arm.get(FRONTIER_ARM)
+    if baseline is not None:
+        for run in runs:
+            if run.result.arm == FRONTIER_ARM:
+                continue
+            found = protocol_violations(baseline.manifest, run.manifest)
+            if found:
+                violations[run.result.arm] = [str(item) for item in found]
+
+    partial = sorted(run.result.arm for run in runs if not run.coverage.complete)
+    suppression, detail = _suppression(by_arm, violations, partial)
+
+    closures: dict[str, Any] = {}
+    headline: GapClosure | None = None
+    if suppression is ClosureSuppression.NONE:
+        frontier_quality = by_arm[FRONTIER_ARM].result.quality.point
+        static_open_quality = by_arm[STATIC_OPEN_ARM].result.quality.point
+        for name in ADAPTIVE_ARMS:
+            run = by_arm.get(name)
+            if run is None:
+                continue
+            closure = gap_closure(
+                frontier_quality=frontier_quality,
+                static_open_quality=static_open_quality,
+                adaptive_open_quality=run.result.quality.point,
+            )
+            closures[name] = closure.to_dict()
+            if name == HEADLINE_ADAPTIVE_ARM:
+                headline = closure
+
+    treatment = by_arm.get(HEADLINE_ADAPTIVE_ARM)
+    control = by_arm.get(FRONTIER_ARM)
+    non_inferiority_result: dict[str, Any] | None = None
+    if treatment is not None and control is not None:
+        non_inferiority_result = non_inferiority.assess(
+            treatment.result.quality, control.result.quality
+        )
+
+    findings = list(negative_findings(arms, STATIC_OPEN_ARM))
+    failures = list(reporting_failures(arms, findings))
+    failures += [f"{arm} did not attempt the whole corpus; reported as partial"
+                 for arm in partial]
+    failures += [f"{arm} violated protocol ({', '.join(items)}) and must re-run"
+                 for arm, items in sorted(violations.items())]
+
+    if headline is not None:
+        allowed, claim_detail = readme_claim_allowed(arms, headline, min_n=min_n)
+    else:
+        allowed, claim_detail = False, (
+            f"no gap-closure ratio was computed ({suppression})"
+            + (f": {detail}" if detail else "")
+        )
+
+    underpowered = set(corpus.get("underpowered_strata") or [])
+    return {
+        "corpus": {
+            key: corpus.get(key) for key in (
+                "corpus_version", "considered", "included_n", "excluded_n",
+                "exclusion_counts", "strata", "underpowered_strata",
+                "pretraining_risk", "min_stratum_n", "notes",
+            )
+        },
+        "arms": [
+            {
+                **run.result.to_dict(),
+                "coverage": run.coverage.to_dict(),
+                "manifest_digest": run.manifest.digest(),
+                "results_digest": run.results_digest(),
+                "conformance": conformance_rate(run).to_dict(),
+                "underpowered_strata": sorted(
+                    name for name in run.result.stratum_intervals()
+                    if name in underpowered
+                ),
+            }
+            for run in runs
+        ],
+        "protocol_violations": violations,
+        "partial_arms": partial,
+        "gap_closure": {
+            "suppressed": str(suppression),
+            "suppression_detail": detail,
+            "headline_arm": HEADLINE_ADAPTIVE_ARM,
+            "by_arm": closures,
+        },
+        "non_inferiority": non_inferiority_result,
+        "cost_quality_frontier": cost_quality_frontier(arms),
+        "negative_findings": findings,
+        "reporting_failures": failures,
+        "public_claim": {"allowed": allowed, "detail": claim_detail},
+    }
+
+
+def _interval_of(raw: Mapping[str, Any]) -> Interval:
+    return Interval(
+        successes=int(raw.get("successes", 0)),
+        n=int(raw.get("n", 0)),
+        low=float(raw.get("ci_low", 0.0)),
+        high=float(raw.get("ci_high", 0.0)),
+    )
+
+
+def render_report(report: Mapping[str, Any]) -> str:
+    """Markdown for humans. Every proportion carries its N and its interval."""
+    corpus = report.get("corpus") or {}
+    considered = corpus.get("considered", 0)
+    lines = [
+        "# Dynamic-DAG ablation results (chief-wiggum#391)",
+        "",
+        "Pre-registration: `docs/experiments/dynamic-dag/pre-registration.md`.",
+        "Arms are capability tiers, never model names. The readable signal is",
+        "the cross-arm difference under fixed conditions, not the absolute score.",
+        "",
+        "## Corpus",
+        "",
+        f"- version: `{corpus.get('corpus_version', 'unknown')}`",
+        f"- considered: {considered}",
+        f"- included: {corpus.get('included_n', 0)}/{considered}",
+        f"- excluded: {corpus.get('excluded_n', 0)}/{considered}",
+    ]
+    for reason, count in sorted((corpus.get("exclusion_counts") or {}).items()):
+        if count:
+            lines.append(f"  - {reason}: {count}")
+    underpowered = corpus.get("underpowered_strata") or []
+    lines.append(
+        f"- underpowered strata (below N={corpus.get('min_stratum_n', 0)}):"
+        f" {len(underpowered)}"
+        + (" - " + ", ".join(underpowered) if underpowered else "")
+    )
+    risky = corpus.get("pretraining_risk") or []
+    lines += [
+        f"- public-benchmark tasks that may sit in pretraining: {len(risky)}"
+        f"/{corpus.get('included_n', 0)}. Stated, not excluded.",
+        "",
+        "## Arms",
+        "",
+        "| Arm | Tier | Process | Accepted-patch rate | Conformance | Cost |"
+        " Escaped | Coverage |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for arm in report.get("arms") or []:
+        quality = _interval_of(arm.get("quality") or {})
+        conformance = _interval_of(arm.get("conformance") or {})
+        coverage = arm.get("coverage") or {}
+        state = "complete" if coverage.get("complete") else (
+            f"**PARTIAL** {coverage.get('attempted', 0)}"
+            f"/{coverage.get('corpus_n', 0)}"
+        )
+        lines.append(
+            f"| {arm.get('arm')} | {arm.get('model_tier')} | {arm.get('process')}"
+            f" | {quality.render()} | {conformance.render()}"
+            f" | ${arm.get('model_cost', 0.0):.2f}"
+            f" | {arm.get('escaped_defects', 0)} | {state} |"
+        )
+
+    closure = report.get("gap_closure") or {}
+    lines += ["", "## Gap closure", ""]
+    if closure.get("suppressed") != str(ClosureSuppression.NONE):
+        lines += [f"**Not computed** ({closure.get('suppressed')}).", "",
+                  closure.get("suppression_detail", "")]
+    else:
+        lines += [
+            f"Headline arm: `{closure.get('headline_arm')}`, the arm the"
+            " registered non-inferiority claim is about. Arms 3 and 4 are shown"
+            " against the same denominator so the flattering one cannot be"
+            " quietly promoted.",
+            "",
+            "| Arm | Status | Value | Detail |",
+            "|---|---|---|---|",
+        ]
+        for name, entry in sorted((closure.get("by_arm") or {}).items()):
+            value = entry.get("value")
+            rendered = "not published" if value is None else f"{value:.1%}"
+            lines.append(
+                f"| {name} | {entry.get('status')} | {rendered}"
+                f" | {entry.get('detail') or '-'} |"
+            )
+
+    non_inferiority = report.get("non_inferiority")
+    lines += ["", "## Non-inferiority", ""]
+    if not non_inferiority:
+        lines.append("Not assessed: arm 1 or arm 5 is absent from the results.")
+    else:
+        verdict = "holds" if non_inferiority["non_inferior"] else "does NOT hold"
+        lines += [
+            "Claim under test: arm 5 is not worse than arm 1 on accepted-patch"
+            " rate.",
+            "",
+            f"- pre-registered margin: {non_inferiority['margin']:.1%} absolute",
+            f"- observed difference: {non_inferiority['difference']:+.1%}",
+            "- worst case (arm 5 lower bound minus arm 1 upper bound):"
+            f" {non_inferiority['worst_case_difference']:+.1%}",
+            f"- **non-inferiority {verdict}**",
+        ]
+
+    lines += ["", "## Cost/quality frontier", "",
+              "Quality is never reported without its cost.", "",
+              "| Arm | Cost | Quality | On frontier |", "|---|---|---|---|"]
+    for point in report.get("cost_quality_frontier") or []:
+        low, high = (point.get("quality_ci") or [0.0, 0.0])[:2]
+        lines.append(
+            f"| {point.get('arm')} | ${point.get('cost', 0.0):.2f}"
+            f" | {point.get('quality', 0.0):.1%} (N={point.get('n', 0)},"
+            f" {low:.1%} to {high:.1%})"
+            f" | {'yes' if point.get('on_frontier') else 'no'} |"
+        )
+
+    findings = report.get("negative_findings") or []
+    lines += ["", "## Negative findings", ""]
+    lines += ([f"- {item}" for item in findings] if findings else
+              ["None recorded. Across five arms that is itself reviewable -"
+               " see reporting failures below."])
+
+    failures = report.get("reporting_failures") or []
+    lines += ["", "## Reporting failures", ""]
+    lines += ([f"- {item}" for item in failures] if failures else ["None."])
+
+    claim = report.get("public_claim") or {}
+    lines += [
+        "", "## Public claim gate", "",
+        f"- allowed: **{'yes' if claim.get('allowed') else 'no'}**",
+        f"- {claim.get('detail', '')}",
+        "",
+    ]
+    return "\n".join(lines)

--- a/scripts/chief_wiggum/experiment_journal.py
+++ b/scripts/chief_wiggum/experiment_journal.py
@@ -70,8 +70,9 @@ def append_experiment_record(journal_path: str | Path, arm: str, *,
     # Robust broken-chain detection: compare the verified prefix against the
     # raw non-empty line count WITHOUT a full JSON parse, so a garbage tail
     # raises here rather than as a JSONDecodeError deep in the reader.
-    raw_lines = ([line for line in path.read_text().splitlines() if line.strip()]
-                 if path.is_file() else [])
+    existing = path.read_text() if path.is_file() else ""
+    raw_lines = [line for line in existing.splitlines() if line.strip()]
+    needs_separator = bool(existing) and not existing.endswith("\n")
     verified = verified_prefix(path)
     if len(verified) != len(raw_lines):
         raise ExperimentJournalError(
@@ -97,6 +98,23 @@ def append_experiment_record(journal_path: str | Path, arm: str, *,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a") as handle:
+        # Separate from an unterminated last line before writing.
+        #
+        # Without this, a journal whose final record lost its newline (a
+        # writer that did not finish, a hand edit) does not fail the chain
+        # check above: the record is complete and verifies, it simply has no
+        # line ending. The append then FUSES the two records onto one line,
+        # reports success, and destroys the record that was already
+        # journaled - `experiment_records` drops from N to 0 because the
+        # fused line no longer parses. Silent loss of the evidence this
+        # module exists to protect.
+        #
+        # Repairing rather than refusing is sound precisely because the chain
+        # verified: the record hash covers the whole body, so a truncated
+        # tail would already have been rejected as a broken chain. Only the
+        # separator is missing, and only the separator is added.
+        if needs_separator:
+            handle.write("\n")
         handle.write(json.dumps(body, sort_keys=True) + "\n")
     return body["record_id"]
 

--- a/scripts/chief_wiggum/experiment_journal.py
+++ b/scripts/chief_wiggum/experiment_journal.py
@@ -1,0 +1,114 @@
+"""Journal an experiment arm's raw results through the ratchet hash chain (#391).
+
+The pre-registration requires raw per-task results to be immutable and
+journaled, "consistent with how gate-validation records are handled (no
+signing/DSSE)". That means the existing ratchet journal: an append-only hash
+chain where lowering the bar is tamper-evident and fails closed.
+
+**Why this lives outside `ratchet.py`.** The ratchet gate's `--scanner-version`
+is derived from the hash of `ratchet.py` and its finding-affecting
+dependencies, deliberately, so nobody has to remember to bump a constant
+(INV-fh-005). Adding an unrelated event type to that file would stale the
+ratchet gate's validation record and demand a re-run of its seeded-defect
+trials, a real cost paid for a change that touches none of the gate's
+finding logic. So the chain primitives are imported and the event is appended
+from here. `ratchet.py` is unchanged and its record stays valid.
+
+Only DIGESTS go in the chain; the per-task records live beside it. The journal
+stays a tamper-evident index rather than a second copy of the data that could
+drift from the first.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .hashing import stable_hash
+
+# One arm's raw results in the dynamic-DAG ablation. Like `gate-authority` it
+# is never `merged`, so `ratchet.derive_highwater` skips it and an experiment
+# record can never move the pass-set high-water mark.
+EXPERIMENT_RECORD = "experiment-record"
+
+
+class ExperimentJournalError(RuntimeError):
+    """A record that cannot be appended, or a chain that must not be extended."""
+
+
+def append_experiment_record(journal_path: str | Path, arm: str, *,
+                             results_digest: str, manifest_digest: str,
+                             corpus_version: str, verifier_hash: str) -> str:
+    """Append one arm's result digests to the ratchet journal.
+
+    Every field a later reader needs to prove the arm ran under the registered
+    conditions is here. Change the corpus, the verifier, the manifest or a
+    single task's outcome and the digest recorded at the time no longer
+    matches what is on disk.
+
+    Refuses to append onto a broken chain, failing closed. A tampered journal
+    must not be silently extended, and an event appended past a torn tail is
+    an event nobody can verify later.
+    """
+    from ratchet import verified_prefix  # noqa: PLC0415 - avoids a cycle
+
+    fields = {
+        "arm": arm,
+        "results_digest": results_digest,
+        "manifest_digest": manifest_digest,
+        "corpus_version": corpus_version,
+        "verifier_hash": verifier_hash,
+    }
+    for name, value in fields.items():
+        if not str(value or "").strip():
+            raise ExperimentJournalError(
+                f"experiment record needs a non-empty {name}; a record missing"
+                " one of its digests cannot prove anything later"
+            )
+
+    path = Path(journal_path)
+    # Robust broken-chain detection: compare the verified prefix against the
+    # raw non-empty line count WITHOUT a full JSON parse, so a garbage tail
+    # raises here rather than as a JSONDecodeError deep in the reader.
+    raw_lines = ([line for line in path.read_text().splitlines() if line.strip()]
+                 if path.is_file() else [])
+    verified = verified_prefix(path)
+    if len(verified) != len(raw_lines):
+        raise ExperimentJournalError(
+            f"cannot append an experiment record: {path} chain is broken"
+            " (fail closed)"
+        )
+
+    previous = verified[-1]["record_hash"] if verified else "genesis"
+    body = {
+        "record_id": f"rec-{len(verified) + 1:05d}",
+        "event": EXPERIMENT_RECORD,
+        "ref": arm,
+        "details": results_digest,
+        "manifest_digest": manifest_digest,
+        "corpus_version": corpus_version,
+        "verifier_hash": verifier_hash,
+        "merged": False,
+    }
+    body["record_hash"] = stable_hash(
+        previous,
+        json.dumps({key: value for key, value in body.items()
+                    if key != "record_hash"}, sort_keys=True),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as handle:
+        handle.write(json.dumps(body, sort_keys=True) + "\n")
+    return body["record_id"]
+
+
+def experiment_records(journal_path: str | Path) -> list[dict]:
+    """Every verified experiment record in the journal, oldest first.
+
+    Reads the VERIFIED prefix only: a record past a torn tail is not evidence
+    of anything, and returning it would let a hand-appended result read as
+    journaled.
+    """
+    from ratchet import verified_prefix  # noqa: PLC0415 - avoids a cycle
+
+    return [record for record in verified_prefix(journal_path)
+            if record.get("event") == EXPERIMENT_RECORD]

--- a/scripts/dag_experiment.py
+++ b/scripts/dag_experiment.py
@@ -240,7 +240,24 @@ def _check_protocol(args: argparse.Namespace) -> int:
 
 
 def _strata_by_task(frozen: dict[str, Any]) -> dict[str, str]:
-    return {task["task_id"]: task["stratum"] for task in frozen.get("included", [])}
+    """Task id -> stratum, from the corpus FILE.
+
+    Reports a missing field as bad input rather than raising KeyError out of a
+    dict comprehension: a hand-built or truncated corpus file is an operator
+    mistake with a clear fix, and a bare traceback reads like a tool bug.
+    """
+    strata: dict[str, str] = {}
+    for task in frozen.get("included", []):
+        task_id = str(task.get("task_id", "")).strip()
+        stratum = str(task.get("stratum", "")).strip()
+        if not task_id or not stratum:
+            raise ValueError(
+                f"corpus task {task_id or '<no id>'} is missing its"
+                " task_id/stratum; re-run freeze-corpus rather than editing"
+                " the corpus file by hand"
+            )
+        strata[task_id] = stratum
+    return strata
 
 
 def _record(args: argparse.Namespace) -> int:
@@ -273,9 +290,13 @@ def _record(args: argparse.Namespace) -> int:
         return _fail(f"bad outcome record: {exc}", EXIT_INPUT)
 
     tier, process = report_mod.ARM_SPECS[manifest.arm]
+    try:
+        strata = _strata_by_task(frozen)
+    except ValueError as exc:
+        return _fail(str(exc), EXIT_INPUT)
     run = report_mod.build_arm_run(
         arm=manifest.arm, model_tier=tier, process=process, manifest=manifest,
-        outcomes=outcomes, strata_by_task=_strata_by_task(frozen),
+        outcomes=outcomes, strata_by_task=strata,
     )
     payload = run.to_dict()
     if args.out:
@@ -332,6 +353,16 @@ def _report(args: argparse.Namespace) -> int:
                 verifier_hash=str(raw["manifest"]["verifier_hash"]),
                 environment=dict(raw["manifest"].get("environment") or {}),
             )
+            if manifest.corpus_version != frozen.get("corpus_version"):
+                return _fail(
+                    f"{path}: recorded against corpus"
+                    f" {manifest.corpus_version} but --corpus is"
+                    f" {frozen.get('corpus_version')}. `record` pins this and"
+                    " `report` re-checks it: without the check the report"
+                    " labels the results with a corpus they never ran"
+                    " against, including its exclusion counts.",
+                    EXIT_INPUT,
+                )
             outcomes = [report_mod.TaskOutcome.from_dict(entry)
                         for entry in raw.get("outcomes", [])]
             tier, process = report_mod.ARM_SPECS[manifest.arm]
@@ -354,15 +385,18 @@ def _report(args: argparse.Namespace) -> int:
     if not runs:
         return _fail("no runs given", EXIT_INPUT)
 
-    report = report_mod.assemble_report(
-        corpus=frozen,
-        runs=runs,
-        non_inferiority=NonInferiority(
-            margin=REGISTERED_MARGIN,
-            justification=REGISTERED_MARGIN_JUSTIFICATION,
-        ),
-        min_n=REGISTERED_MIN_N,
-    )
+    try:
+        report = report_mod.assemble_report(
+            corpus=frozen,
+            runs=runs,
+            non_inferiority=NonInferiority(
+                margin=REGISTERED_MARGIN,
+                justification=REGISTERED_MARGIN_JUSTIFICATION,
+            ),
+            min_n=REGISTERED_MIN_N,
+        )
+    except ValueError as exc:
+        return _fail(str(exc), EXIT_INPUT)
     markdown = report_mod.render_report(report)
     print(markdown)
     if args.out_json:

--- a/scripts/dag_experiment.py
+++ b/scripts/dag_experiment.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""CLI for the dynamic-DAG ablation (chief-wiggum#391).
+
+The pre-registration is committed and binding; this is the machinery that runs
+under it. The order of the subcommands is the order of rung 1:
+
+    freeze-corpus   apply the inclusion rules, count the exclusions, hash it
+    hash-verifier   content-hash the verifier before any arm runs
+    manifest        pin one arm's conditions and hash them
+    check-protocol  prove every arm ran under the same conditions
+    record          fold raw per-task outcomes in, journal their digest
+    report          assemble the result, or refuse to
+
+`check-protocol` runs BEFORE `report` on purpose. The pre-registration stops an
+arm on a protocol violation and re-runs it from a clean manifest, and that
+decision has to be reachable without anyone having looked at a score yet.
+
+Exit codes are distinct: 0 success, 1 a finding the command is gating on (an
+underpowered corpus under `--gate`, a protocol violation, a reporting failure
+under `--gate`), 2 bad input, 3 a failure of the tool itself. A gate that
+cannot run must never read as a gate that passed.
+
+Every gate here is report-only by default and blocks only under `--gate`
+(docs/gate-rollout.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chief_wiggum.dag import corpus as corpus_mod  # noqa: E402
+from chief_wiggum.dag import report as report_mod  # noqa: E402
+from chief_wiggum.dag.experiment import NonInferiority, RunManifest  # noqa: E402
+
+EXIT_OK = 0
+EXIT_FINDING = 1
+EXIT_INPUT = 2
+EXIT_ERROR = 3
+
+# The margin registered in docs/experiments/dynamic-dag/pre-registration.md.
+# It is not a flag. A margin the operator can pass on the command line is a
+# margin chosen after seeing results.
+REGISTERED_MARGIN = 0.05
+REGISTERED_MARGIN_JUSTIFICATION = (
+    "5 percentage points absolute, registered before any arm ran: below the"
+    " run-to-run noise of the existing suite, and below the ~19-point interval"
+    " the README already reports at N=20. See the pre-registration."
+)
+REGISTERED_MIN_N = 100
+
+
+def _fail(message: str, code: int = EXIT_ERROR) -> int:
+    print(json.dumps({"ok": False, "error": message}, indent=2), file=sys.stderr)
+    return code
+
+
+def _load_json(path: str | Path) -> Any:
+    return json.loads(Path(path).read_text())
+
+
+def _write_json(path: str | Path, payload: Any) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _pairs(values: list[str] | None, *, as_int: bool = False) -> dict[str, Any]:
+    """Parse repeated `key=value` flags.
+
+    Integers only where the manifest hashes them: the canonical encoding
+    rejects floats, so a budget passed as `usd=10.5` is refused here with an
+    explanation rather than deep inside the hasher.
+    """
+    out: dict[str, Any] = {}
+    for item in values or []:
+        if "=" not in item:
+            raise ValueError(f"expected key=value, got {item!r}")
+        key, _, value = item.partition("=")
+        key = key.strip()
+        if not key:
+            raise ValueError(f"empty key in {item!r}")
+        if as_int:
+            try:
+                out[key] = int(value)
+            except ValueError:
+                raise ValueError(
+                    f"{key}={value!r} must be a whole integer; manifests are"
+                    " hashed and the canonical encoding rejects floats."
+                    " Express money in cents and time in whole seconds."
+                ) from None
+        else:
+            out[key] = value
+    return out
+
+
+def _freeze_corpus(args: argparse.Namespace) -> int:
+    try:
+        raw = _load_json(args.candidates)
+    except (OSError, json.JSONDecodeError) as exc:
+        return _fail(f"cannot read candidates: {exc}", EXIT_INPUT)
+    entries = raw.get("tasks", raw) if isinstance(raw, dict) else raw
+    if not isinstance(entries, list):
+        return _fail("candidates must be a list, or an object with a 'tasks' list",
+                     EXIT_INPUT)
+    try:
+        candidates = [corpus_mod.TaskRecord.from_dict(entry) for entry in entries]
+    except (ValueError, TypeError, AttributeError) as exc:
+        return _fail(f"bad candidate record: {exc}", EXIT_INPUT)
+
+    oracle = corpus_mod.git_reachability(args.repo) if args.repo else None
+    frozen = corpus_mod.freeze_corpus(
+        candidates,
+        reachable=oracle,
+        min_stratum_n=args.min_stratum_n,
+        notes=args.notes,
+    )
+    print(frozen.render())
+    if args.out:
+        _write_json(args.out, frozen.to_dict())
+        print(f"\nwrote {args.out}")
+    if not frozen.included:
+        return _fail("every candidate was excluded; the corpus is empty",
+                     EXIT_FINDING if args.gate else EXIT_OK)
+    if args.gate and frozen.underpowered:
+        return _fail(
+            f"{len(frozen.underpowered)} of {len(frozen.strata)} strata are below"
+            f" the pre-registered floor of N={frozen.min_stratum_n}:"
+            f" {', '.join(frozen.underpowered)}",
+            EXIT_FINDING,
+        )
+    return EXIT_OK
+
+
+def _hash_verifier(args: argparse.Namespace) -> int:
+    try:
+        fingerprint = corpus_mod.fingerprint_verifier(
+            args.path, root=args.root, command=args.command
+        )
+    except FileNotFoundError as exc:
+        return _fail(str(exc), EXIT_INPUT)
+    payload = fingerprint.to_dict()
+    print(json.dumps(payload, indent=2))
+    if args.out:
+        _write_json(args.out, payload)
+    return EXIT_OK
+
+
+def _manifest(args: argparse.Namespace) -> int:
+    if args.arm not in report_mod.ARM_SPECS:
+        return _fail(
+            f"unknown arm {args.arm!r}; the registered arms are "
+            + ", ".join(sorted(report_mod.ARM_SPECS)),
+            EXIT_INPUT,
+        )
+    try:
+        frozen = _load_json(args.corpus)
+        verifier = _load_json(args.verifier)
+        manifest = RunManifest(
+            arm=args.arm,
+            corpus_version=str(frozen["corpus_version"]),
+            provider_roster=_pairs(args.roster),
+            seeds=_pairs(args.seed, as_int=True),
+            budgets=_pairs(args.budget, as_int=True),
+            verifier_hash=str(verifier["verifier_hash"]),
+            environment=_pairs(args.env),
+        )
+        digest = manifest.digest()
+    except (OSError, json.JSONDecodeError, KeyError) as exc:
+        return _fail(f"cannot build manifest: {exc}", EXIT_INPUT)
+    except ValueError as exc:
+        return _fail(str(exc), EXIT_INPUT)
+    payload = {**manifest.to_dict(), "manifest_digest": digest}
+    print(json.dumps(payload, indent=2))
+    if args.out:
+        _write_json(args.out, payload)
+    return EXIT_OK
+
+
+def _read_manifest(path: str | Path) -> RunManifest:
+    raw = _load_json(path)
+    return RunManifest(
+        arm=str(raw["arm"]),
+        corpus_version=str(raw["corpus_version"]),
+        provider_roster=dict(raw.get("provider_roster") or {}),
+        seeds=dict(raw.get("seeds") or {}),
+        budgets=dict(raw.get("budgets") or {}),
+        verifier_hash=str(raw["verifier_hash"]),
+        environment=dict(raw.get("environment") or {}),
+    )
+
+
+def _check_protocol(args: argparse.Namespace) -> int:
+    try:
+        manifests = {}
+        for path in args.manifest:
+            manifest = _read_manifest(path)
+            if manifest.arm in manifests:
+                return _fail(f"two manifests for {manifest.arm}", EXIT_INPUT)
+            manifests[manifest.arm] = manifest
+    except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        return _fail(f"cannot read manifests: {exc}", EXIT_INPUT)
+
+    baseline = manifests.get(report_mod.FRONTIER_ARM)
+    if baseline is None:
+        return _fail(
+            f"no manifest for {report_mod.FRONTIER_ARM}; it is the baseline every"
+            " other arm is compared against",
+            EXIT_INPUT,
+        )
+    from chief_wiggum.dag.experiment import protocol_violations
+
+    findings: dict[str, list[str]] = {}
+    for arm, manifest in sorted(manifests.items()):
+        if arm == report_mod.FRONTIER_ARM:
+            continue
+        violations = protocol_violations(baseline, manifest)
+        if violations:
+            findings[arm] = [str(item) for item in violations]
+
+    print(json.dumps({
+        "baseline": report_mod.FRONTIER_ARM,
+        "arms_checked": sorted(manifests),
+        "violations": findings,
+    }, indent=2, sort_keys=True))
+    if findings:
+        print(
+            "\nEverything except the varied factor must be fixed. Each arm above"
+            " stops and re-runs from a clean manifest before any result from it"
+            " is read.",
+            file=sys.stderr,
+        )
+        return EXIT_FINDING if args.gate else EXIT_OK
+    return EXIT_OK
+
+
+def _strata_by_task(frozen: dict[str, Any]) -> dict[str, str]:
+    return {task["task_id"]: task["stratum"] for task in frozen.get("included", [])}
+
+
+def _record(args: argparse.Namespace) -> int:
+    try:
+        frozen = _load_json(args.corpus)
+        manifest = _read_manifest(args.manifest)
+        raw = _load_json(args.outcomes)
+    except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        return _fail(f"cannot read inputs: {exc}", EXIT_INPUT)
+    entries = raw.get("outcomes", raw) if isinstance(raw, dict) else raw
+    if not isinstance(entries, list):
+        return _fail("outcomes must be a list, or an object with an 'outcomes' list",
+                     EXIT_INPUT)
+    if manifest.arm != args.arm:
+        return _fail(
+            f"manifest is for {manifest.arm} but --arm says {args.arm};"
+            " recording an arm's results against another arm's conditions is"
+            " the protocol violation the manifest exists to prevent",
+            EXIT_INPUT,
+        )
+    if manifest.corpus_version != frozen.get("corpus_version"):
+        return _fail(
+            f"manifest pins corpus {manifest.corpus_version} but --corpus is"
+            f" {frozen.get('corpus_version')}",
+            EXIT_INPUT,
+        )
+    try:
+        outcomes = [report_mod.TaskOutcome.from_dict(entry) for entry in entries]
+    except (ValueError, TypeError, AttributeError) as exc:
+        return _fail(f"bad outcome record: {exc}", EXIT_INPUT)
+
+    tier, process = report_mod.ARM_SPECS[manifest.arm]
+    run = report_mod.build_arm_run(
+        arm=manifest.arm, model_tier=tier, process=process, manifest=manifest,
+        outcomes=outcomes, strata_by_task=_strata_by_task(frozen),
+    )
+    payload = run.to_dict()
+    if args.out:
+        _write_json(args.out, payload)
+
+    journalled = None
+    if args.journal:
+        try:
+            from chief_wiggum.experiment_journal import append_experiment_record
+
+            journalled = append_experiment_record(
+                args.journal, manifest.arm,
+                results_digest=run.results_digest(),
+                manifest_digest=manifest.digest(),
+                corpus_version=manifest.corpus_version,
+                verifier_hash=manifest.verifier_hash,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced, never swallowed
+            return _fail(f"could not journal the record: {exc}", EXIT_ERROR)
+
+    coverage = run.coverage
+    print(json.dumps({
+        "arm": manifest.arm,
+        "results_digest": run.results_digest(),
+        "manifest_digest": manifest.digest(),
+        "coverage": coverage.to_dict(),
+        "quality": run.result.quality.render(),
+        "journal_record": journalled,
+    }, indent=2, sort_keys=True))
+    if not coverage.complete:
+        print(
+            f"\nPARTIAL: {coverage.attempted}/{coverage.corpus_n} corpus tasks"
+            " attempted. A partial arm is reported as partial and produces no"
+            " gap-closure ratio.",
+            file=sys.stderr,
+        )
+        return EXIT_FINDING if args.gate else EXIT_OK
+    return EXIT_OK
+
+
+def _report(args: argparse.Namespace) -> int:
+    try:
+        frozen = _load_json(args.corpus)
+        strata = _strata_by_task(frozen)
+        runs = []
+        for path in args.run:
+            raw = _load_json(path)
+            manifest = RunManifest(
+                arm=str(raw["manifest"]["arm"]),
+                corpus_version=str(raw["manifest"]["corpus_version"]),
+                provider_roster=dict(raw["manifest"].get("provider_roster") or {}),
+                seeds=dict(raw["manifest"].get("seeds") or {}),
+                budgets=dict(raw["manifest"].get("budgets") or {}),
+                verifier_hash=str(raw["manifest"]["verifier_hash"]),
+                environment=dict(raw["manifest"].get("environment") or {}),
+            )
+            outcomes = [report_mod.TaskOutcome.from_dict(entry)
+                        for entry in raw.get("outcomes", [])]
+            tier, process = report_mod.ARM_SPECS[manifest.arm]
+            run = report_mod.build_arm_run(
+                arm=manifest.arm, model_tier=tier, process=process,
+                manifest=manifest, outcomes=outcomes, strata_by_task=strata,
+            )
+            recorded = raw.get("results_digest")
+            if recorded and recorded != run.results_digest():
+                return _fail(
+                    f"{path}: results_digest {recorded} does not match the"
+                    f" records it contains ({run.results_digest()}); the file"
+                    " changed after it was recorded",
+                    EXIT_INPUT,
+                )
+            runs.append(run)
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+        return _fail(f"cannot read runs: {exc}", EXIT_INPUT)
+
+    if not runs:
+        return _fail("no runs given", EXIT_INPUT)
+
+    report = report_mod.assemble_report(
+        corpus=frozen,
+        runs=runs,
+        non_inferiority=NonInferiority(
+            margin=REGISTERED_MARGIN,
+            justification=REGISTERED_MARGIN_JUSTIFICATION,
+        ),
+        min_n=REGISTERED_MIN_N,
+    )
+    markdown = report_mod.render_report(report)
+    print(markdown)
+    if args.out_json:
+        _write_json(args.out_json, report)
+    if args.out_md:
+        target = Path(args.out_md)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(markdown)
+    if args.gate and report["reporting_failures"]:
+        return EXIT_FINDING
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Dynamic-DAG ablation harness (chief-wiggum#391)"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add(name: str, help_text: str, func: Any) -> argparse.ArgumentParser:
+        command = sub.add_parser(name, help=help_text)
+        command.set_defaults(func=func)
+        command.add_argument(
+            "--gate", action="store_true",
+            help="block on findings (report-only by default; docs/gate-rollout.md)",
+        )
+        return command
+
+    freeze = add("freeze-corpus", "apply the inclusion rules and freeze the corpus",
+                 _freeze_corpus)
+    freeze.add_argument("--candidates", required=True)
+    freeze.add_argument("--out", default="")
+    freeze.add_argument(
+        "--repo", default="",
+        help="repo to ask whether a task's solution is reachable from its base."
+             " Without it reachability is UNKNOWN, not clean: each task falls"
+             " back to its dates, and a task whose dates cannot settle it is"
+             " excluded as unverifiable rather than admitted",
+    )
+    freeze.add_argument("--min-stratum-n", type=int,
+                        default=corpus_mod.MIN_STRATUM_N)
+    freeze.add_argument("--notes", default="")
+
+    verifier = add("hash-verifier", "content-hash the verifier before any arm runs",
+                   _hash_verifier)
+    verifier.add_argument("--path", action="append", required=True)
+    verifier.add_argument("--root", default=".")
+    verifier.add_argument("--command", default="")
+    verifier.add_argument("--out", default="")
+
+    manifest = add("manifest", "pin and hash one arm's conditions", _manifest)
+    manifest.add_argument("--arm", required=True)
+    manifest.add_argument("--corpus", required=True)
+    manifest.add_argument("--verifier", required=True)
+    manifest.add_argument("--roster", action="append",
+                          help="role=provider, repeatable")
+    manifest.add_argument("--seed", action="append", help="name=int, repeatable")
+    manifest.add_argument("--budget", action="append",
+                          help="name=int (cents, whole seconds), repeatable")
+    manifest.add_argument("--env", action="append", help="key=value, repeatable")
+    manifest.add_argument("--out", default="")
+
+    protocol = add("check-protocol",
+                   "prove every arm ran under the same conditions", _check_protocol)
+    protocol.add_argument("--manifest", action="append", required=True)
+
+    record = add("record", "fold an arm's raw outcomes in and journal the digest",
+                 _record)
+    record.add_argument("--arm", required=True)
+    record.add_argument("--corpus", required=True)
+    record.add_argument("--manifest", required=True)
+    record.add_argument("--outcomes", required=True)
+    record.add_argument("--out", default="")
+    record.add_argument("--journal", default="",
+                        help="ratchet journal to append the record digest to")
+
+    report = add("report", "assemble the result, or refuse to", _report)
+    report.add_argument("--corpus", required=True)
+    report.add_argument("--run", action="append", required=True)
+    report.add_argument("--out-json", default="")
+    report.add_argument("--out-md", default="")
+
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (OSError, ValueError) as exc:
+        return _fail(str(exc))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dag_experiment_harness.py
+++ b/tests/test_dag_experiment_harness.py
@@ -1,0 +1,882 @@
+"""Corpus freeze, results recording, and report assembly (chief-wiggum#391).
+
+Two failure modes carry this file, and both are quiet ones.
+
+The first is a corpus that admits what it cannot verify. A contaminated task
+does not announce itself in the results; it just raises every arm that can
+read the answer, and the effect looks like a real difference. So the tests
+below push hard on the direction of the unverifiable case: git that cannot
+answer, dates that do not parse, a base commit nobody recorded.
+
+The second is a number that should never have been computed. A partial arm, or
+one that ran against a different verifier, still produces a perfectly
+plausible-looking ratio. The suppression tests assert that no ratio exists at
+all in those cases, not merely that it was labelled.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from chief_wiggum.dag import corpus as corpus_mod
+from chief_wiggum.dag import report as report_mod
+from chief_wiggum.dag.corpus import (
+    ExclusionReason,
+    Reachability,
+    TaskRecord,
+    fingerprint_verifier,
+    freeze_corpus,
+    git_reachability,
+)
+from chief_wiggum.dag.experiment import NonInferiority, RunManifest
+from chief_wiggum.dag.report import (
+    ClosureSuppression,
+    TaskOutcome,
+    assemble_report,
+    build_arm_run,
+    conformance_rate,
+    render_report,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "dag_experiment.py"
+
+
+def task(task_id: str, **kwargs) -> TaskRecord:
+    fields = {
+        "source": "cw-history",
+        "task_class": "bugfix",
+        "risk": "low",
+        "size": "small",
+        "base_commit": "b" * 40,
+    }
+    fields.update(kwargs)
+    return TaskRecord(task_id=task_id, **fields)
+
+
+def oracle(verdict: Reachability):
+    return lambda _solution, _base: verdict
+
+
+# ---------------------------------------------------------------- corpus ---
+
+
+def test_reachable_solution_is_excluded_and_counted():
+    frozen = freeze_corpus(
+        [task("t1", solution_commit="s" * 40)],
+        reachable=oracle(Reachability.REACHABLE),
+    )
+    assert [item.task_id for item in frozen.included] == []
+    assert frozen.exclusions[0].reason is ExclusionReason.SOLUTION_IN_BASE
+    assert frozen.exclusion_counts["SOLUTION_IN_BASE"] == 1
+    # The denominator matters as much as the count.
+    assert frozen.considered == 1
+
+
+def test_unreachable_solution_is_included():
+    frozen = freeze_corpus(
+        [task("t1", solution_commit="s" * 40)],
+        reachable=oracle(Reachability.UNREACHABLE),
+    )
+    assert [item.task_id for item in frozen.included] == ["t1"]
+    assert frozen.exclusions == ()
+
+
+def test_unknown_reachability_with_no_usable_dates_excludes_rather_than_admits():
+    """Fail closed. An unverifiable task admitted is a contaminated corpus."""
+    frozen = freeze_corpus(
+        [task("t1", solution_commit="s" * 40)],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert frozen.included == ()
+    assert frozen.exclusions[0].reason is ExclusionReason.UNVERIFIABLE_BASE
+
+
+def test_unknown_reachability_falls_back_to_dates_in_both_directions():
+    leaked = freeze_corpus(
+        [task("t1", solution_commit="s" * 40, solution_date="2026-01-01",
+              base_date="2026-07-01")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert leaked.exclusions[0].reason is ExclusionReason.SOLUTION_PREDATES_BASE
+
+    clean = freeze_corpus(
+        [task("t1", solution_commit="s" * 40, solution_date="2026-07-01",
+              base_date="2026-01-01")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert [item.task_id for item in clean.included] == ["t1"]
+
+
+def test_default_oracle_is_unknown_not_clean():
+    """No repository supplied means nothing is known, not "not contaminated".
+
+    The fail-open version of this default admits every task whose solution
+    nobody looked for, and a contaminated corpus does not announce itself.
+    """
+    unverifiable = freeze_corpus([task("t1", solution_commit="s" * 40)])
+    assert unverifiable.included == ()
+    assert unverifiable.exclusions[0].reason is ExclusionReason.UNVERIFIABLE_BASE
+
+    # Dates still settle it when they can.
+    dated = freeze_corpus([task("t1", solution_commit="s" * 40,
+                                solution_date="2026-07-01",
+                                base_date="2026-01-01")])
+    assert [item.task_id for item in dated.included] == ["t1"]
+
+
+def test_malformed_dates_do_not_settle_reachability():
+    """`2026-8-1` sorts before `2026-10-1` as text and after it in reality."""
+    frozen = freeze_corpus(
+        [task("t1", solution_commit="s" * 40, solution_date="2026-8-1",
+              base_date="2026-10-1")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert frozen.exclusions[0].reason is ExclusionReason.UNVERIFIABLE_BASE
+
+
+def test_task_with_no_solution_needs_a_base_commit_to_be_included():
+    frozen = freeze_corpus([task("t1", base_commit="")])
+    assert frozen.exclusions[0].reason is ExclusionReason.UNVERIFIABLE_BASE
+
+    with_base = freeze_corpus([task("t1")])
+    assert [item.task_id for item in with_base.included] == ["t1"]
+
+
+def test_public_benchmark_instance_is_annotated_not_excluded():
+    frozen = freeze_corpus([
+        task("bench-1", base_commit="", public_benchmark=True),
+        task("cw-1"),
+    ])
+    assert sorted(item.task_id for item in frozen.included) == ["bench-1", "cw-1"]
+    assert frozen.pretraining_risk == ("bench-1",)
+
+
+def test_duplicate_ids_and_unknown_strata_are_excluded_with_reasons():
+    frozen = freeze_corpus([
+        task("t1"), task("t1"),
+        task("t2", task_class="nonsense"),
+        task("t3", risk="spicy"),
+        task("t4", size="enormous"),
+    ])
+    reasons = {item.task_id: item.reason for item in frozen.exclusions}
+    assert reasons["t1"] is ExclusionReason.DUPLICATE_ID
+    assert reasons["t2"] is ExclusionReason.INVALID_STRATUM
+    assert reasons["t3"] is ExclusionReason.INVALID_STRATUM
+    assert reasons["t4"] is ExclusionReason.INVALID_STRATUM
+    assert [item.task_id for item in frozen.included] == ["t1"]
+    assert "risk='spicy'" in reasons_detail(frozen, "t3")
+
+
+def reasons_detail(frozen, task_id: str) -> str:
+    return next(item.detail for item in frozen.exclusions if item.task_id == task_id)
+
+
+def test_corpus_digest_ignores_input_order_but_not_content():
+    first = freeze_corpus([task("a"), task("b")])
+    second = freeze_corpus([task("b"), task("a")])
+    assert first.digest() == second.digest()
+
+    changed = freeze_corpus([task("a"), task("b", risk="high")])
+    assert changed.digest() != first.digest()
+
+
+def test_underpowered_strata_are_reported_with_their_n_never_dropped():
+    frozen = freeze_corpus(
+        [task(f"t{index}") for index in range(5)]
+        + [task(f"h{index}", risk="high") for index in range(25)],
+        min_stratum_n=20,
+    )
+    assert frozen.strata["bugfix/low/small"] == 5
+    assert frozen.strata["bugfix/high/small"] == 25
+    assert frozen.underpowered == ("bugfix/low/small",)
+    # Still counted in the corpus, not silently removed.
+    assert len(frozen.included) == 30
+    assert "UNDERPOWERED" in frozen.render()
+
+
+def test_render_carries_denominators_for_every_count():
+    frozen = freeze_corpus([task("t1"), task("t2", task_class="nonsense")])
+    rendered = frozen.render()
+    assert "included:   1/2" in rendered
+    assert "excluded:   1/2" in rendered
+    assert "pretraining risk: 0/1" in rendered
+
+
+# ------------------------------------------------------ git reachability ---
+
+
+def test_git_reachability_answers_unknown_when_git_cannot_answer(tmp_path):
+    """A refused question must never read as a clean 'not contaminated'."""
+    check = git_reachability(tmp_path)  # not a repository
+    assert check("a" * 40, "b" * 40) is Reachability.UNKNOWN
+    assert check("", "b" * 40) is Reachability.UNKNOWN
+
+
+def test_git_reachability_reads_real_ancestry(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+    subprocess.run(["git", "init", "--initial-branch=main", str(repo)],
+                   check=True, capture_output=True, text=True)
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "t")
+    (repo / "a.txt").write_text("one")
+    run("add", "-A")
+    run("commit", "-m", "first")
+    first = run("rev-parse", "HEAD").stdout.strip()
+    (repo / "a.txt").write_text("two")
+    run("add", "-A")
+    run("commit", "-m", "second")
+    second = run("rev-parse", "HEAD").stdout.strip()
+
+    check = git_reachability(repo)
+    assert check(first, second) is Reachability.REACHABLE
+    assert check(second, first) is Reachability.UNREACHABLE
+    assert check("0" * 40, second) is Reachability.UNKNOWN
+
+
+# -------------------------------------------------------------- verifier ---
+
+
+def test_verifier_fingerprint_refuses_to_skip_a_missing_file(tmp_path):
+    (tmp_path / "present.py").write_text("x = 1")
+    with pytest.raises(FileNotFoundError, match="stop, not a skip"):
+        fingerprint_verifier(["present.py", "absent.py"], root=tmp_path)
+
+
+def test_verifier_hash_is_order_stable_and_content_sensitive(tmp_path):
+    (tmp_path / "a.py").write_text("x = 1")
+    (tmp_path / "b.py").write_text("y = 2")
+    first = fingerprint_verifier(["a.py", "b.py"], root=tmp_path, command="pytest")
+    second = fingerprint_verifier(["b.py", "a.py"], root=tmp_path, command="pytest")
+    assert first.digest() == second.digest()
+
+    (tmp_path / "b.py").write_text("y = 3")
+    changed = fingerprint_verifier(["a.py", "b.py"], root=tmp_path, command="pytest")
+    assert changed.digest() != first.digest()
+
+    other_command = fingerprint_verifier(["a.py"], root=tmp_path, command="tox")
+    assert other_command.digest() != fingerprint_verifier(
+        ["a.py"], root=tmp_path, command="pytest"
+    ).digest()
+
+
+# ------------------------------------------------------- outcomes / runs ---
+
+
+def manifest(arm: str, **kwargs) -> RunManifest:
+    fields = {
+        "corpus_version": "sha256:corpus",
+        "provider_roster": {"implementer": "open-tier-a"},
+        "seeds": {"task_order": 7},
+        "budgets": {"usd_cents": 50_000},
+        "verifier_hash": "sha256:verifier",
+        "environment": {"python": "3.11"},
+    }
+    fields.update(kwargs)
+    return RunManifest(arm=arm, **fields)
+
+
+STRATA = {f"t{index}": "bugfix/low/small" for index in range(4)}
+
+
+def outcome(task_id: str, accepted: bool, **kwargs) -> TaskOutcome:
+    return TaskOutcome(task_id=task_id, accepted=accepted, **kwargs)
+
+
+def test_outcome_rejects_a_missing_verdict_and_a_fractional_cost():
+    with pytest.raises(ValueError, match="must not default"):
+        TaskOutcome.from_dict({"task_id": "t1"})
+    with pytest.raises(ValueError, match="whole integer"):
+        TaskOutcome.from_dict({"task_id": "t1", "accepted": True,
+                               "model_cost_cents": 10.5})
+    with pytest.raises(ValueError, match="missing task_id"):
+        TaskOutcome.from_dict({"accepted": True})
+    assert TaskOutcome.from_dict({"task_id": "t1", "accepted": False}).accepted is False
+
+
+def test_missing_corpus_tasks_are_incomplete_coverage_not_rejections():
+    run = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"),
+        outcomes=[outcome("t0", True), outcome("t1", True)],
+        strata_by_task=STRATA,
+    )
+    assert run.coverage.complete is False
+    assert run.coverage.attempted == 2
+    assert run.coverage.missing == ("t2", "t3")
+    # Scored on what it attempted — a crashed arm must not look merely bad.
+    assert run.result.attempted == 2
+    assert run.result.quality.point == 1.0
+
+
+def test_unknown_and_duplicate_outcomes_are_counted_not_scored():
+    run = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"),
+        outcomes=[outcome("t0", True), outcome("t0", False),
+                  outcome("nope", True), outcome("t1", False),
+                  outcome("t2", True), outcome("t3", True)],
+        strata_by_task=STRATA,
+    )
+    assert run.coverage.duplicates == ("t0",)
+    assert run.coverage.unknown == ("nope",)
+    assert run.coverage.complete is False
+    # First record wins; the duplicate is not a second attempt.
+    assert run.result.attempted == 4
+    assert run.result.accepted == 3
+
+
+def test_strata_come_from_the_corpus_not_from_the_arms_own_records():
+    strata = {"t0": "feature/high/large", "t1": "bugfix/low/small"}
+    run = build_arm_run(
+        arm="arm-2", model_tier="open-tier", process="static factory",
+        manifest=manifest("arm-2"),
+        outcomes=[outcome("t0", False), outcome("t1", True)],
+        strata_by_task=strata,
+    )
+    assert run.result.strata == {"feature/high/large": (0, 1),
+                                 "bugfix/low/small": (1, 1)}
+
+
+def test_results_digest_is_order_stable_and_record_sensitive():
+    records = [outcome("t0", True), outcome("t1", False)]
+    build = lambda items: build_arm_run(  # noqa: E731
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"), outcomes=items, strata_by_task=STRATA,
+    )
+    assert build(records).results_digest() == build(records[::-1]).results_digest()
+    flipped = [outcome("t0", True), outcome("t1", True)]
+    assert build(flipped).results_digest() != build(records).results_digest()
+
+
+def test_results_digest_changes_when_the_manifest_changes():
+    records = [outcome("t0", True)]
+    base = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"), outcomes=records, strata_by_task=STRATA,
+    )
+    moved = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1", verifier_hash="sha256:other"),
+        outcomes=records, strata_by_task=STRATA,
+    )
+    assert base.results_digest() != moved.results_digest()
+
+
+def test_conformance_excludes_tasks_outside_the_corpus():
+    run = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"),
+        outcomes=[outcome("t0", True, gate_conformant=True),
+                  outcome("t1", True, gate_conformant=False),
+                  outcome("nope", True, gate_conformant=False)],
+        strata_by_task=STRATA,
+    )
+    interval = conformance_rate(run)
+    assert (interval.successes, interval.n) == (1, 2)
+
+
+# ---------------------------------------------------------------- report ---
+
+
+def full_run(arm: str, accepted: int, *, cost_cents: int = 1000,
+             escaped: int = 0, operator_seconds: int = 0,
+             manifest_kwargs: dict | None = None, drop: int = 0):
+    tier, process = report_mod.ARM_SPECS[arm]
+    outcomes = []
+    for index in range(4 - drop):
+        outcomes.append(TaskOutcome(
+            task_id=f"t{index}",
+            accepted=index < accepted,
+            escaped_defect=index < escaped,
+            operator_seconds=operator_seconds,
+            model_cost_cents=cost_cents,
+        ))
+    return build_arm_run(
+        arm=arm, model_tier=tier, process=process,
+        manifest=manifest(arm, **(manifest_kwargs or {})),
+        outcomes=outcomes, strata_by_task=STRATA,
+    )
+
+
+CORPUS = {
+    "corpus_version": "sha256:corpus",
+    "considered": 6,
+    "included_n": 4,
+    "excluded_n": 2,
+    "exclusion_counts": {"SOLUTION_IN_BASE": 2},
+    "strata": {"bugfix/low/small": 4},
+    "underpowered_strata": ["bugfix/low/small"],
+    "pretraining_risk": [],
+    "min_stratum_n": 20,
+    "notes": "",
+}
+
+MARGIN = NonInferiority(margin=0.05, justification="registered before any arm ran")
+
+
+def report_for(runs):
+    return assemble_report(corpus=CORPUS, runs=runs, non_inferiority=MARGIN)
+
+
+def test_clean_five_arm_run_computes_closure_for_arms_three_four_and_five():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1), full_run("arm-3", 2),
+            full_run("arm-4", 3), full_run("arm-5", 3)]
+    report = report_for(runs)
+    assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.NONE)
+    assert sorted(report["gap_closure"]["by_arm"]) == ["arm-3", "arm-4", "arm-5"]
+    assert report["gap_closure"]["headline_arm"] == "arm-5"
+    # (0.75 - 0.25) / (1.0 - 0.25)
+    assert report["gap_closure"]["by_arm"]["arm-5"]["value"] == pytest.approx(2 / 3)
+    assert report["gap_closure"]["by_arm"]["arm-3"]["value"] == pytest.approx(1 / 3)
+
+
+def test_protocol_violation_means_no_ratio_exists_at_all():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1), full_run("arm-3", 2),
+            full_run("arm-4", 3),
+            full_run("arm-5", 3, manifest_kwargs={"verifier_hash": "sha256:other"})]
+    report = report_for(runs)
+    assert report["protocol_violations"] == {"arm-5": ["VERIFIER_CHANGED"]}
+    assert report["gap_closure"]["suppressed"] == str(
+        ClosureSuppression.PROTOCOL_VIOLATION)
+    assert report["gap_closure"]["by_arm"] == {}
+    assert any("must re-run" in item for item in report["reporting_failures"])
+    assert report["public_claim"]["allowed"] is False
+
+
+def test_partial_arm_means_no_ratio_exists_at_all():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1), full_run("arm-3", 2),
+            full_run("arm-4", 3), full_run("arm-5", 3, drop=2)]
+    report = report_for(runs)
+    assert report["partial_arms"] == ["arm-5"]
+    assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.PARTIAL_RUN)
+    assert report["gap_closure"]["by_arm"] == {}
+    assert any("reported as partial" in item for item in report["reporting_failures"])
+
+
+def test_missing_headline_arm_means_no_ratio_exists_at_all():
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 1),
+                         full_run("arm-3", 3)])
+    assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.MISSING_ARM)
+    assert report["gap_closure"]["by_arm"] == {}
+
+
+def test_suppression_is_distinct_from_a_degenerate_ratio():
+    """"We never ran enough tasks" must not read as "the corpus was flat"."""
+    flat = report_for([full_run("arm-1", 2), full_run("arm-2", 2),
+                       full_run("arm-3", 2), full_run("arm-4", 2),
+                       full_run("arm-5", 2)])
+    assert flat["gap_closure"]["suppressed"] == str(ClosureSuppression.NONE)
+    assert flat["gap_closure"]["by_arm"]["arm-5"]["status"] == "UNDEFINED_NO_GAP"
+    assert flat["gap_closure"]["by_arm"]["arm-5"]["value"] is None
+
+
+def test_negative_numerator_is_reported_never_clipped():
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 3),
+                         full_run("arm-3", 3), full_run("arm-4", 3),
+                         full_run("arm-5", 1)])
+    entry = report["gap_closure"]["by_arm"]["arm-5"]
+    assert entry["status"] == "NEGATIVE_REGRESSION"
+    assert entry["value"] < 0
+    assert any("scored below arm-2" in item for item in report["negative_findings"])
+
+
+def test_non_inferiority_uses_the_registered_margin_against_arm_one():
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 1),
+                         full_run("arm-5", 1)])
+    assessment = report["non_inferiority"]
+    assert assessment["margin"] == 0.05
+    assert assessment["difference"] == pytest.approx(-0.75)
+    assert assessment["non_inferior"] is False
+
+
+def test_clean_sweep_across_five_arms_is_a_reporting_failure():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 4), full_run("arm-3", 4),
+            full_run("arm-4", 4), full_run("arm-5", 4)]
+    report = report_for(runs)
+    # Wide intervals at N=4 are themselves a negative finding, so assert on the
+    # mechanism rather than assuming the list is empty.
+    assert any("too wide to be decisive" in item
+               for item in report["negative_findings"])
+
+
+def test_public_claim_is_refused_below_the_registered_minimum_n():
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 1),
+                         full_run("arm-3", 2), full_run("arm-4", 3),
+                         full_run("arm-5", 3)])
+    assert report["public_claim"]["allowed"] is False
+    assert "below the pre-registered minimum" in report["public_claim"]["detail"]
+
+
+def test_rendered_report_states_partial_and_suppression_in_words():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1), full_run("arm-3", 2),
+            full_run("arm-4", 3), full_run("arm-5", 3, drop=2)]
+    markdown = render_report(report_for(runs))
+    assert "**PARTIAL** 2/4" in markdown
+    assert "**Not computed** (PARTIAL_RUN)" in markdown
+    assert "does not produce a gap-closure ratio" in markdown
+    assert "N=4" in markdown  # every proportion carries its N
+
+
+def test_rendered_report_shows_all_three_adaptive_arms_when_clean():
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1), full_run("arm-3", 2),
+            full_run("arm-4", 3), full_run("arm-5", 3)]
+    markdown = render_report(report_for(runs))
+    for name in ("arm-3", "arm-4", "arm-5"):
+        assert f"| {name} | DEFINED" in markdown
+
+
+def test_cost_quality_frontier_is_reported_beside_quality():
+    runs = [full_run("arm-1", 4, cost_cents=10_000),
+            full_run("arm-2", 1, cost_cents=100),
+            full_run("arm-5", 3, cost_cents=500)]
+    report = report_for(runs)
+    frontier = {point["arm"]: point for point in report["cost_quality_frontier"]}
+    assert frontier["arm-2"]["cost"] == pytest.approx(4.0)
+    assert frontier["arm-2"]["on_frontier"] is True
+    assert frontier["arm-5"]["on_frontier"] is True
+    assert frontier["arm-1"]["on_frontier"] is True
+
+
+# ------------------------------------------------------------------- CLI ---
+
+
+def cli(*args, cwd=None):
+    return subprocess.run(
+        [sys.executable, str(CLI), *args],
+        capture_output=True, text=True, cwd=cwd or ROOT,
+    )
+
+
+def write(path: Path, payload) -> Path:
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+def test_cli_runs_freeze_manifest_protocol_record_report_end_to_end(tmp_path):
+    candidates = [
+        {"task_id": f"t{index}", "source": "cw-history", "task_class": "bugfix",
+         "risk": "low", "size": "small", "base_commit": "b" * 40}
+        for index in range(4)
+    ]
+    candidates.append({"task_id": "leak", "source": "cw-history",
+                       "task_class": "bugfix", "risk": "low", "size": "small",
+                       "base_commit": "b" * 40, "base_date": "2026-07-01",
+                       "solution_commit": "s" * 40, "solution_date": "2026-01-01"})
+    write(tmp_path / "candidates.json", {"tasks": candidates})
+    corpus_path = tmp_path / "corpus.json"
+
+    result = cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+                 "--out", str(corpus_path))
+    assert result.returncode == 0, result.stderr
+    assert "included:   4/5" in result.stdout
+    assert "SOLUTION_PREDATES_BASE: 1" in result.stdout
+
+    # The underpowered-strata gate is report-only until asked to block.
+    assert cli("freeze-corpus", "--candidates",
+               str(tmp_path / "candidates.json")).returncode == 0
+    assert cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+               "--gate").returncode == 1
+
+    (tmp_path / "verify.py").write_text("assert True")
+    verifier_path = tmp_path / "verifier.json"
+    assert cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+               "--command", "pytest", "--out", str(verifier_path)).returncode == 0
+
+    manifests = []
+    for arm in report_mod.ARM_SPECS:
+        target = tmp_path / f"manifest-{arm}.json"
+        result = cli("manifest", "--arm", arm, "--corpus", str(corpus_path),
+                     "--verifier", str(verifier_path), "--roster",
+                     "implementer=tier", "--seed", "order=7", "--budget",
+                     "usd_cents=50000", "--env", "python=3.11", "--out", str(target))
+        assert result.returncode == 0, result.stderr
+        manifests.append(target)
+
+    protocol_args = []
+    for path in manifests:
+        protocol_args += ["--manifest", str(path)]
+    result = cli("check-protocol", "--gate", *protocol_args)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["violations"] == {}
+
+    accepted_by_arm = {"arm-1": 4, "arm-2": 1, "arm-3": 2, "arm-4": 3, "arm-5": 3}
+    runs = []
+    for arm, accepted in accepted_by_arm.items():
+        outcomes = [{"task_id": f"t{index}", "accepted": index < accepted,
+                     "model_cost_cents": 1000, "gate_conformant": True}
+                    for index in range(4)]
+        write(tmp_path / f"outcomes-{arm}.json", {"outcomes": outcomes})
+        run_path = tmp_path / f"run-{arm}.json"
+        result = cli("record", "--arm", arm, "--corpus", str(corpus_path),
+                     "--manifest", str(tmp_path / f"manifest-{arm}.json"),
+                     "--outcomes", str(tmp_path / f"outcomes-{arm}.json"),
+                     "--journal", str(tmp_path / "journal.jsonl"),
+                     "--out", str(run_path), "--gate")
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["journal_record"]
+        runs.append(run_path)
+
+    report_args = []
+    for path in runs:
+        report_args += ["--run", str(path)]
+    result = cli("report", "--corpus", str(corpus_path), "--gate",
+                 "--out-json", str(tmp_path / "report.json"),
+                 "--out-md", str(tmp_path / "report.md"), *report_args)
+    report = json.loads((tmp_path / "report.json").read_text())
+    assert report["gap_closure"]["by_arm"]["arm-5"]["status"] == "DEFINED"
+    assert report["public_claim"]["allowed"] is False
+    assert "Dynamic-DAG ablation results" in (tmp_path / "report.md").read_text()
+    # --gate blocks because N=4 arms produce reporting failures worth seeing.
+    assert result.returncode in (0, 1)
+
+
+def test_cli_record_refuses_an_arms_results_under_another_arms_manifest(tmp_path):
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40}]})
+    corpus_path = tmp_path / "corpus.json"
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(corpus_path))
+    (tmp_path / "verify.py").write_text("assert True")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "verifier.json"))
+    cli("manifest", "--arm", "arm-1", "--corpus", str(corpus_path), "--verifier",
+        str(tmp_path / "verifier.json"), "--out", str(tmp_path / "m1.json"))
+    write(tmp_path / "outcomes.json", {"outcomes": [{"task_id": "t0",
+                                                     "accepted": True}]})
+
+    result = cli("record", "--arm", "arm-2", "--corpus", str(corpus_path),
+                 "--manifest", str(tmp_path / "m1.json"),
+                 "--outcomes", str(tmp_path / "outcomes.json"))
+    assert result.returncode == 2
+    assert "protocol violation the manifest exists to prevent" in result.stderr
+
+
+def test_cli_report_detects_a_run_file_edited_after_it_was_recorded(tmp_path):
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40}]})
+    corpus_path = tmp_path / "corpus.json"
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(corpus_path))
+    (tmp_path / "verify.py").write_text("assert True")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "verifier.json"))
+    cli("manifest", "--arm", "arm-1", "--corpus", str(corpus_path), "--verifier",
+        str(tmp_path / "verifier.json"), "--out", str(tmp_path / "m1.json"))
+    write(tmp_path / "outcomes.json", {"outcomes": [{"task_id": "t0",
+                                                     "accepted": False}]})
+    cli("record", "--arm", "arm-1", "--corpus", str(corpus_path), "--manifest",
+        str(tmp_path / "m1.json"), "--outcomes", str(tmp_path / "outcomes.json"),
+        "--out", str(tmp_path / "run.json"))
+
+    tampered = json.loads((tmp_path / "run.json").read_text())
+    tampered["outcomes"][0]["accepted"] = True
+    write(tmp_path / "run.json", tampered)
+
+    result = cli("report", "--corpus", str(corpus_path), "--run",
+                 str(tmp_path / "run.json"))
+    assert result.returncode == 2
+    assert "changed after it was recorded" in result.stderr
+
+
+def test_cli_check_protocol_names_what_moved(tmp_path):
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40}]})
+    corpus_path = tmp_path / "corpus.json"
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(corpus_path))
+    (tmp_path / "verify.py").write_text("assert True")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "v1.json"))
+    (tmp_path / "verify.py").write_text("assert False")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "v2.json"))
+    cli("manifest", "--arm", "arm-1", "--corpus", str(corpus_path), "--verifier",
+        str(tmp_path / "v1.json"), "--out", str(tmp_path / "m1.json"))
+    cli("manifest", "--arm", "arm-2", "--corpus", str(corpus_path), "--verifier",
+        str(tmp_path / "v2.json"), "--out", str(tmp_path / "m2.json"))
+
+    result = cli("check-protocol", "--gate", "--manifest", str(tmp_path / "m1.json"),
+                 "--manifest", str(tmp_path / "m2.json"))
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["violations"] == {"arm-2": ["VERIFIER_CHANGED"]}
+    assert cli("check-protocol", "--manifest", str(tmp_path / "m1.json"),
+               "--manifest", str(tmp_path / "m2.json")).returncode == 0
+
+
+def test_cli_manifest_refuses_a_fractional_budget(tmp_path):
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40}]})
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(tmp_path / "corpus.json"))
+    (tmp_path / "verify.py").write_text("assert True")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "verifier.json"))
+    result = cli("manifest", "--arm", "arm-1", "--corpus",
+                 str(tmp_path / "corpus.json"), "--verifier",
+                 str(tmp_path / "verifier.json"), "--budget", "usd=10.5")
+    assert result.returncode == 2
+    assert "Express money in cents" in result.stderr
+
+
+def test_cli_manifest_refuses_an_unregistered_arm(tmp_path):
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40}]})
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(tmp_path / "corpus.json"))
+    (tmp_path / "verify.py").write_text("assert True")
+    cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+        "--out", str(tmp_path / "verifier.json"))
+    result = cli("manifest", "--arm", "arm-9", "--corpus",
+                 str(tmp_path / "corpus.json"), "--verifier",
+                 str(tmp_path / "verifier.json"))
+    assert result.returncode == 2
+    assert "unknown arm" in result.stderr
+
+
+def test_corpus_module_exposes_the_registered_floor():
+    """The 20-task floor is pre-registered; it must not drift in code."""
+    assert corpus_mod.MIN_STRATUM_N == 20
+
+
+# --------------------------------------------------------------- journal ---
+
+
+def digests(**overrides) -> dict:
+    payload = {
+        "results_digest": "sha256:results",
+        "manifest_digest": "sha256:manifest",
+        "corpus_version": "sha256:corpus",
+        "verifier_hash": "sha256:verifier",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_experiment_record_chains_onto_the_ratchet_journal(tmp_path):
+    import ratchet
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    first = ej.append_experiment_record(journal, "arm-1", **digests())
+    second = ej.append_experiment_record(
+        journal, "arm-2", **digests(results_digest="sha256:other"))
+    assert (first, second) == ("rec-00001", "rec-00002")
+
+    records = ratchet.verified_prefix(journal)
+    assert len(records) == 2
+    assert records[0]["event"] == ej.EXPERIMENT_RECORD
+    assert records[0]["ref"] == "arm-1"
+    assert records[0]["details"] == "sha256:results"
+    # Never merged: an experiment record must not move the ratchet high-water.
+    assert all(record["merged"] is False for record in records)
+    assert not ratchet.derive_highwater(records)["pass_set"]
+    assert [record["ref"] for record in ej.experiment_records(journal)] == [
+        "arm-1", "arm-2"]
+
+
+def test_experiment_record_fails_closed_on_a_broken_chain(tmp_path):
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    ej.append_experiment_record(journal, "arm-1", **digests())
+    with journal.open("a") as handle:
+        handle.write("garbage\n")
+    with pytest.raises(ej.ExperimentJournalError, match="fail closed"):
+        ej.append_experiment_record(journal, "arm-2", **digests())
+    # The torn tail is not evidence: the reader stops before it.
+    assert len(ej.experiment_records(journal)) == 1
+
+
+def test_reader_refuses_a_well_formed_but_unchained_record(tmp_path):
+    """The dangerous forgery is valid JSON, not garbage.
+
+    A hand-appended record parses fine; only the hash chain says it was never
+    journaled. A reader that merely skipped unparseable lines would hand this
+    one back as evidence.
+    """
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    ej.append_experiment_record(journal, "arm-1", **digests())
+    forged = {
+        "record_id": "rec-00002", "event": ej.EXPERIMENT_RECORD, "ref": "arm-5",
+        "details": "sha256:invented", "manifest_digest": "sha256:invented",
+        "corpus_version": "sha256:corpus", "verifier_hash": "sha256:verifier",
+        "merged": False, "record_hash": "0" * 64,
+    }
+    with journal.open("a") as handle:
+        handle.write(json.dumps(forged, sort_keys=True) + "\n")
+
+    records = ej.experiment_records(journal)
+    assert [record["ref"] for record in records] == ["arm-1"]
+
+
+def test_experiment_record_refuses_a_missing_digest(tmp_path):
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    for field in ("results_digest", "manifest_digest", "corpus_version",
+                  "verifier_hash", "arm"):
+        payload = digests()
+        if field == "arm":
+            with pytest.raises(ej.ExperimentJournalError, match="arm"):
+                ej.append_experiment_record(journal, "", **payload)
+        else:
+            payload[field] = ""
+            with pytest.raises(ej.ExperimentJournalError, match=field):
+                ej.append_experiment_record(journal, "arm-1", **payload)
+    assert not journal.exists()
+
+
+def test_experiment_records_coexist_with_gate_authority_events(tmp_path):
+    """Both event types share one chain; neither breaks the other's reader."""
+    import ratchet
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    ratchet.append_authority_event(journal, "check_thing", "wire", wired_rid="rec-1")
+    ej.append_experiment_record(journal, "arm-1", **digests())
+    ratchet.append_authority_event(journal, "check_thing", "unwire")
+    assert len(ratchet.verified_prefix(journal)) == 3
+    assert ratchet.last_authority_action(journal, "check_thing") == "unwire"
+    assert len(ej.experiment_records(journal)) == 1
+
+
+# -------------------------------------------------------- static fallback ---
+
+
+def test_static_fallback_still_projects_a_wave_plan():
+    """The registered rollback path: back to `plan_waves.py` plus static roles.
+
+    The pre-registration says the fallback is exercised rather than assumed.
+    It shares #385's graph, so the projection is the thing to exercise: if
+    this stops working, there is nothing to roll back TO and the rollback
+    criteria in the pre-registration are unenforceable.
+    """
+    from chief_wiggum.dag import (
+        dependency_block_to_intent_graph,
+        project_legacy_waves,
+    )
+
+    block = "<!-- DEPENDENCIES\n#1: []\n#2: [#1]\n#3: [#1]\n-->"
+    intent = dependency_block_to_intent_graph(
+        block, graph_id="GRF-391-rollback", issues=[1, 2, 3],
+        source_ref="fixture:391-rollback",
+    )
+    result = project_legacy_waves(intent)
+    assert result.exit_code == 0
+    assert result.plan["waves"] == [[1], [2, 3]]

--- a/tests/test_dag_experiment_harness.py
+++ b/tests/test_dag_experiment_harness.py
@@ -334,6 +334,29 @@ def test_unknown_and_duplicate_outcomes_are_counted_not_scored():
     assert run.result.accepted == 3
 
 
+def test_an_arm_that_scored_nothing_reports_no_data_rather_than_crashing():
+    """Zero scored outcomes must reach suppression, not a traceback.
+
+    An arm whose records are all for tasks outside the corpus scores nothing.
+    Every proportion is then N=0, and the report has to survive long enough to
+    say PARTIAL_RUN: a crash here would read to the operator as a tool bug
+    rather than as an incomplete arm.
+    """
+    run = build_arm_run(
+        arm="arm-1", model_tier="frontier-tier", process="static factory",
+        manifest=manifest("arm-1"), outcomes=[outcome("ghost", True)],
+        strata_by_task=STRATA,
+    )
+    assert run.coverage.attempted == 0
+    assert run.result.quality.render() == "no data (N=0)"
+    assert conformance_rate(run).render() == "no data (N=0)"
+    assert run.results_digest().startswith("sha256:")
+
+    report = assemble_report(corpus=CORPUS, runs=[run], non_inferiority=MARGIN)
+    assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.PARTIAL_RUN)
+    assert "no data (N=0)" in render_report(report)
+
+
 def test_strata_come_from_the_corpus_not_from_the_arms_own_records():
     strata = {"t0": "feature/high/large", "t1": "bugfix/low/small"}
     run = build_arm_run(
@@ -775,6 +798,9 @@ def test_experiment_record_chains_onto_the_ratchet_journal(tmp_path):
     second = ej.append_experiment_record(
         journal, "arm-2", **digests(results_digest="sha256:other"))
     assert (first, second) == ("rec-00001", "rec-00002")
+    # A fresh journal gets no leading blank line: the separator is for an
+    # unterminated PREVIOUS line, and there is none before the first record.
+    assert not journal.read_text().startswith("\n")
 
     records = ratchet.verified_prefix(journal)
     assert len(records) == 2
@@ -799,6 +825,27 @@ def test_experiment_record_fails_closed_on_a_broken_chain(tmp_path):
         ej.append_experiment_record(journal, "arm-2", **digests())
     # The torn tail is not evidence: the reader stops before it.
     assert len(ej.experiment_records(journal)) == 1
+
+
+def test_append_does_not_fuse_onto_an_unterminated_last_line(tmp_path):
+    """A missing newline must not destroy the record already journaled.
+
+    The last record verifies and the chain is intact, so the broken-chain
+    guard does not fire; without a separator the append fuses both records
+    onto one line, reports success, and the fused line no longer parses. The
+    journal silently drops to zero readable records.
+    """
+    from chief_wiggum import experiment_journal as ej
+
+    journal = tmp_path / "ratchet-journal.jsonl"
+    ej.append_experiment_record(journal, "arm-1", **digests())
+    journal.write_text(journal.read_text().rstrip("\n"))
+    assert not journal.read_text().endswith("\n")
+
+    ej.append_experiment_record(journal, "arm-2",
+                                **digests(results_digest="sha256:two"))
+    assert [record["ref"] for record in ej.experiment_records(journal)] == [
+        "arm-1", "arm-2"]
 
 
 def test_reader_refuses_a_well_formed_but_unchained_record(tmp_path):

--- a/tests/test_dag_experiment_harness.py
+++ b/tests/test_dag_experiment_harness.py
@@ -156,6 +156,30 @@ def test_public_benchmark_instance_is_annotated_not_excluded():
     assert frozen.pretraining_risk == ("bench-1",)
 
 
+def test_public_benchmark_does_not_exempt_a_reachable_solution():
+    """Two contamination vectors, handled differently.
+
+    Pretraining risk is annotated. Reachability is excluded, and being a
+    public benchmark does not buy an exemption from it: annotating a task
+    whose solution sits in the base leaves an answer key inside the corpus.
+    Both reviewers of this change read "annotated, not excluded" as covering
+    the reachable case, so the distinction is pinned here.
+    """
+    frozen = freeze_corpus(
+        [task("bench-leak", solution_commit="s" * 40, public_benchmark=True)],
+        reachable=oracle(Reachability.REACHABLE),
+    )
+    assert frozen.included == ()
+    assert frozen.exclusions[0].reason is ExclusionReason.SOLUTION_IN_BASE
+    assert frozen.pretraining_risk == ()
+
+    # With nothing recorded to reach, the same task is admitted and annotated.
+    annotated = freeze_corpus([task("bench-ok", base_commit="",
+                                    public_benchmark=True)])
+    assert [item.task_id for item in annotated.included] == ["bench-ok"]
+    assert annotated.pretraining_risk == ("bench-ok",)
+
+
 def test_duplicate_ids_and_unknown_strata_are_excluded_with_reasons():
     frozen = freeze_corpus([
         task("t1"), task("t1"),
@@ -183,6 +207,94 @@ def test_corpus_digest_ignores_input_order_but_not_content():
 
     changed = freeze_corpus([task("a"), task("b", risk="high")])
     assert changed.digest() != first.digest()
+
+
+def test_corpus_digest_binds_the_exclusions_not_only_the_sample():
+    """Filtering contaminated candidates out beforehand must change the hash.
+
+    The exclusion count is a quantity the pre-registration requires the
+    experiment to publish, and the report reads it from the corpus file. If
+    the digest covered only the included tasks, a corpus that recorded three
+    contaminated candidates and one that quietly dropped them before freezing
+    would share a `corpus_version`, every manifest would pin that same
+    version, and the published contamination evidence would be unbound.
+    """
+    leak = dict(solution_commit="s" * 40, solution_date="2020-01-01",
+                base_date="2026-01-01")
+    recorded = freeze_corpus([task("t1"), task("t2"),
+                              task("x1", **leak), task("x2", **leak),
+                              task("x3", **leak)])
+    prefiltered = freeze_corpus([task("t1"), task("t2")])
+
+    assert [item.task_id for item in recorded.included] == ["t1", "t2"]
+    assert [item.task_id for item in prefiltered.included] == ["t1", "t2"]
+    assert len(recorded.exclusions) == 3
+    assert not prefiltered.exclusions
+    assert recorded.digest() != prefiltered.digest()
+
+
+def test_task_identity_is_stripped_so_whitespace_cannot_duplicate_a_task():
+    """`"t1"` and `"t1 "` are one task, and must not both be scored."""
+    frozen = freeze_corpus([
+        TaskRecord.from_dict({"task_id": "t1", "source": "cw",
+                              "task_class": "bugfix", "risk": "low",
+                              "size": "small", "base_commit": "b" * 40}),
+        TaskRecord.from_dict({"task_id": "t1 ", "source": "cw",
+                              "task_class": "bugfix", "risk": "low",
+                              "size": "small", "base_commit": "b" * 40}),
+    ])
+    assert [item.task_id for item in frozen.included] == ["t1"]
+    assert frozen.exclusions[0].reason is ExclusionReason.DUPLICATE_ID
+
+
+def test_timezone_offsets_cannot_make_an_earlier_solution_look_later():
+    """Lexicographic order on a full timestamp ignores the UTC offset.
+
+    2026-08-01T00:00:00+02:00 is 2026-07-31 22:00 UTC, genuinely earlier than
+    a base of 2026-07-31T23:00:00Z. Compared as text it sorts later, so the
+    contaminated task read as clean.
+    """
+    solution = "2026-08-01T00:00:00+02:00"
+    base = "2026-07-31T23:00:00Z"
+    frozen = freeze_corpus(
+        [task("tz", solution_commit="s" * 40, solution_date=solution,
+              base_date=base)],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert frozen.included == ()
+    assert frozen.exclusions[0].reason is ExclusionReason.SOLUTION_PREDATES_BASE
+
+    # Same calendar day cannot be ordered by a date alone, so it excludes.
+    same_day = freeze_corpus(
+        [task("sd", solution_commit="s" * 40,
+              solution_date="2026-08-01T10:00:00", base_date="2026-08-01T09:00:00")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert same_day.included == ()
+
+    # A solution a clear day later is still admitted.
+    later = freeze_corpus(
+        [task("lt", solution_commit="s" * 40,
+              solution_date="2026-08-02T00:00:00Z", base_date="2026-08-01T23:00:00Z")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert [item.task_id for item in later.included] == ["lt"]
+
+
+def test_one_zoned_and_one_bare_date_is_unverifiable_not_a_crash():
+    """A wall-clock date against an instant cannot be ordered.
+
+    Assuming a zone for the bare one would invent the fact that decides
+    contamination. Comparing them anyway raises TypeError, which reaches the
+    operator as a tool crash rather than as an excluded task.
+    """
+    frozen = freeze_corpus(
+        [task("mixed", solution_commit="s" * 40, solution_date="2026-08-01",
+              base_date="2026-07-31T23:00:00Z")],
+        reachable=oracle(Reachability.UNKNOWN),
+    )
+    assert frozen.included == ()
+    assert frozen.exclusions[0].reason is ExclusionReason.UNVERIFIABLE_BASE
 
 
 def test_underpowered_strata_are_reported_with_their_n_never_dropped():
@@ -483,6 +595,33 @@ def test_partial_arm_means_no_ratio_exists_at_all():
     assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.PARTIAL_RUN)
     assert report["gap_closure"]["by_arm"] == {}
     assert any("reported as partial" in item for item in report["reporting_failures"])
+    assert "2 corpus tasks with no outcome" in (
+        report["gap_closure"]["suppression_detail"])
+
+
+def test_an_extra_out_of_corpus_record_is_not_described_as_missing_tasks():
+    """Both block a ratio; they are not the same problem.
+
+    An arm that covered the corpus and also submitted one record for a task
+    outside it did not do less than registered - it ran something never
+    registered. Reporting that as "did not attempt the whole corpus" sends the
+    operator hunting for missing tasks that do not exist.
+    """
+    tier, process = report_mod.ARM_SPECS["arm-5"]
+    outcomes = [TaskOutcome(task_id=f"t{index}", accepted=True)
+                for index in range(4)] + [TaskOutcome(task_id="stray", accepted=True)]
+    stray = build_arm_run(arm="arm-5", model_tier=tier, process=process,
+                          manifest=manifest("arm-5"), outcomes=outcomes,
+                          strata_by_task=STRATA)
+    assert stray.coverage.attempted == 4
+    assert stray.coverage.missing == ()
+    assert stray.coverage.complete is False
+
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 1),
+                         full_run("arm-3", 2), full_run("arm-4", 3), stray])
+    detail = report["gap_closure"]["suppression_detail"]
+    assert "outcomes for tasks outside the corpus" in detail
+    assert "with no outcome" not in detail
 
 
 def test_missing_headline_arm_means_no_ratio_exists_at_all():
@@ -555,6 +694,34 @@ def test_rendered_report_shows_all_three_adaptive_arms_when_clean():
     markdown = render_report(report_for(runs))
     for name in ("arm-3", "arm-4", "arm-5"):
         assert f"| {name} | DEFINED" in markdown
+
+
+def test_two_runs_for_one_arm_are_refused_not_silently_deduplicated():
+    """Choosing between two takes after seeing them is not the analysis's call.
+
+    A dict keyed by arm keeps the last run, while every downstream list still
+    carries both, so the ratio and the table beside it would describe
+    different runs.
+    """
+    runs = [full_run("arm-1", 4), full_run("arm-2", 1),
+            full_run("arm-5", 1), full_run("arm-5", 3)]
+    with pytest.raises(ValueError, match="more than one run supplied for arm-5"):
+        report_for(runs)
+
+
+def test_absent_adaptive_arms_are_a_reporting_failure_not_a_silent_omission():
+    """Gap closure needs arms 1, 2 and 5, so 3 and 4 can vanish unnoticed.
+
+    Showing all three adaptive arms against one denominator is what stops the
+    flattering one being promoted quietly. That defence is worth nothing if
+    simply not running an arm removes it from the report without comment.
+    """
+    report = report_for([full_run("arm-1", 4), full_run("arm-2", 1),
+                         full_run("arm-5", 3)])
+    assert report["gap_closure"]["suppressed"] == str(ClosureSuppression.NONE)
+    assert sorted(report["gap_closure"]["by_arm"]) == ["arm-5"]
+    assert any("arm-3" in item and "arm-4" in item
+               for item in report["reporting_failures"])
 
 
 def test_cost_quality_frontier_is_reported_beside_quality():
@@ -710,6 +877,77 @@ def test_cli_report_detects_a_run_file_edited_after_it_was_recorded(tmp_path):
                  str(tmp_path / "run.json"))
     assert result.returncode == 2
     assert "changed after it was recorded" in result.stderr
+
+
+def _one_task_corpus(tmp_path, task_id="t0"):
+    """freeze a single-task corpus plus a verifier, returning both paths."""
+    write(tmp_path / "candidates.json", {"tasks": [
+        {"task_id": task_id, "source": "s", "task_class": "bugfix",
+         "risk": "low", "size": "small", "base_commit": "b" * 40}]})
+    corpus_path = tmp_path / f"corpus-{task_id}.json"
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates.json"),
+        "--out", str(corpus_path))
+    verifier_path = tmp_path / "verifier.json"
+    if not verifier_path.exists():
+        (tmp_path / "verify.py").write_text("assert True")
+        cli("hash-verifier", "--path", "verify.py", "--root", str(tmp_path),
+            "--out", str(verifier_path))
+    return corpus_path, verifier_path
+
+
+def test_cli_report_refuses_a_run_recorded_against_a_different_corpus(tmp_path):
+    """`record` pins the corpus; `report` must re-check it.
+
+    Without the check the report labels the results with a corpus they never
+    ran against, including its exclusion counts.
+    """
+    corpus_a, verifier = _one_task_corpus(tmp_path, "t0")
+    cli("manifest", "--arm", "arm-1", "--corpus", str(corpus_a), "--verifier",
+        str(verifier), "--out", str(tmp_path / "m1.json"))
+    write(tmp_path / "outcomes.json", {"outcomes": [{"task_id": "t0",
+                                                     "accepted": True}]})
+    cli("record", "--arm", "arm-1", "--corpus", str(corpus_a), "--manifest",
+        str(tmp_path / "m1.json"), "--outcomes", str(tmp_path / "outcomes.json"),
+        "--out", str(tmp_path / "run.json"))
+
+    # A second corpus with the same task but a recorded exclusion: different
+    # contamination evidence, therefore a different corpus_version.
+    write(tmp_path / "candidates-b.json", {"tasks": [
+        {"task_id": "t0", "source": "s", "task_class": "bugfix", "risk": "low",
+         "size": "small", "base_commit": "b" * 40},
+        {"task_id": "leak", "source": "s", "task_class": "bugfix",
+         "risk": "low", "size": "small", "base_commit": "b" * 40,
+         "base_date": "2026-07-01", "solution_commit": "s" * 40,
+         "solution_date": "2026-01-01"}]})
+    corpus_b = tmp_path / "corpus-b.json"
+    cli("freeze-corpus", "--candidates", str(tmp_path / "candidates-b.json"),
+        "--out", str(corpus_b))
+    assert (json.loads(corpus_a.read_text())["corpus_version"]
+            != json.loads(corpus_b.read_text())["corpus_version"])
+
+    result = cli("report", "--corpus", str(corpus_b), "--run",
+                 str(tmp_path / "run.json"))
+    assert result.returncode == 2
+    assert "but --corpus is" in result.stderr
+
+
+def test_cli_reports_a_hand_edited_corpus_file_as_input_not_a_traceback(tmp_path):
+    corpus_path, verifier = _one_task_corpus(tmp_path, "t0")
+    broken = json.loads(corpus_path.read_text())
+    for entry in broken["included"]:
+        entry.pop("stratum", None)
+    write(corpus_path, broken)
+
+    cli("manifest", "--arm", "arm-1", "--corpus", str(corpus_path), "--verifier",
+        str(verifier), "--out", str(tmp_path / "m1.json"))
+    write(tmp_path / "outcomes.json", {"outcomes": [{"task_id": "t0",
+                                                     "accepted": True}]})
+    result = cli("record", "--arm", "arm-1", "--corpus", str(corpus_path),
+                 "--manifest", str(tmp_path / "m1.json"),
+                 "--outcomes", str(tmp_path / "outcomes.json"))
+    assert result.returncode == 2
+    assert "Traceback" not in result.stderr
+    assert "re-run freeze-corpus" in result.stderr
 
 
 def test_cli_check_protocol_names_what_moved(tmp_path):


### PR DESCRIPTION
Advances #391 (parent epic #383). The experiment itself still does not run: arms 1 to 5 need real budget and wall-clock, and the go / hold / rollback call at each rung is a human decision by design.

## What was missing

PR #403 landed the pre-registration and the analysis primitives. Nothing joined them. Rung 1 of the ladder opens with "freeze the corpus and hash the verifier", and no code froze a corpus, counted a contamination exclusion, folded raw per-task outcomes into an arm result, journaled them, or assembled a report.

Five acceptance criteria were unreachable for that reason, not for want of budget:

- reproducible run manifest per arm
- raw per-task results published, immutable, journaled through the ratchet hash chain
- results sliced by class and risk with N and confidence intervals
- cost/quality frontier across the arms
- contamination controls documented with their exclusion count

## The flow

`scripts/dag_experiment.py`, in the order rung 1 needs it:

```
freeze-corpus  ->  hash-verifier  ->  manifest (x5)  ->  [run the arm]
                                          |
                                   check-protocol
                                          |
                                       record (x5)  ->  report
```

`check-protocol` sits before `report` on purpose. The pre-registration stops an arm on a protocol violation and re-runs it from a clean manifest, and that decision has to be reachable without anyone having looked at a score yet.

## Two directions that carry the design

**An unverifiable task is excluded, never admitted.** Reachability is asked of git; a question git cannot answer falls back to dates, and a task the dates cannot settle is excluded as `UNVERIFIABLE_BASE`.

The first cut of the default oracle answered `UNREACHABLE` when no repo was supplied. That is the fail-open version: it silently admitted every task whose solution nobody looked for. The CLI end-to-end test caught it and the default is now `UNKNOWN`. Contamination does not surface as an anomaly in the results. It raises every arm that can read the answer and looks like a real effect.

**A ratio that should not exist is not computed, not disclaimed.** Protocol violations, partial arms and a missing arm suppress gap closure *before* the formula runs. `ClosureSuppression` is deliberately a separate enum from `GapClosureStatus`: "we never ran enough tasks" must not read like "the corpus was not discriminative", and only one of those is a finding about the corpus.

`experiment.py` is untouched. The formula, the margin and the degenerate cases were registered before any arm ran, and a pre-registered artifact that keeps growing branches is not pre-registered.

## What the adversarial review changed

Reviewed under a refute-soundness lens on two independent model families. Every finding below was reproduced against the real code before being fixed. Commits `e86c23d` and `3f87557`.

**The corpus digest did not cover its own exclusions.** It hashed the included tasks and `min_stratum_n`, nothing else. A corpus that recorded three contaminated candidates and one that quietly filtered them out beforehand produced the same `corpus_version` — identical digests, `excluded_n` 3 versus 0 — so every manifest pinned that version and `check-protocol` saw no `CORPUS_CHANGED`. The exclusion count is what the pre-registration requires the experiment to publish as evidence of contamination control, and the report reads it from the corpus file, so that evidence was unbound by the hash it travels under.

**A journal append could destroy the record already journaled.** A file whose last line lost its trailing newline does not trip the broken-chain guard: the record is complete and verifies, and the counts match. The append then fused both records onto one line, reported success, and the fused line no longer parsed, so the journal dropped from one readable record to zero.

**Two runs for one arm were silently deduplicated.** `by_arm` kept the last; `arms`, the frontier and the negative findings kept both, so the ratio and the table beside it would describe different runs. Now refused.

**Absent arm-3/arm-4 vanished without comment**, producing a clean `DEFINED` headline. Showing all three adaptive arms against one denominator is what stops the flattering one being promoted quietly, and that defence is worth nothing if not running an arm deletes it from the report. Now a reporting failure.

**`report` never re-checked the corpus a run was recorded against.** `record` pins it; `report` did not, so it would label results with a corpus they never ran against, exclusion counts included.

**Timezone offsets could hide a contaminated task.** `_dates_ordered` validated the calendar day then compared full strings lexicographically, which ignores the UTC offset. The first fix compared calendar days and was still wrong, because the offset moves the day; the test caught that. Now parsed to instants, with a bare date against a zoned one treated as unorderable rather than assuming a zone.

Plus: whitespace defeated duplicate detection (`from_dict` validated stripped, stored unstripped), and a hand-edited corpus file raised `KeyError` (exit 3, tool failure) instead of reporting bad input (exit 2).

**Two findings rejected with evidence.** Both providers independently reported a `ZeroDivisionError` for an arm with zero scored outcomes. `wilson_interval` guards `n <= 0`, so that path renders "no data (N=0)" and reaches `PARTIAL_RUN` suppression. Neither could see `experiment.py` (not in the diff) and both inferred the same wrong thing from its absence. A test now holds the behaviour rather than a fix being applied to a non-bug.

**One documentation defect.** The runbook said public-benchmark instances are "annotated, not excluded" without qualification, and both reviewers read that as covering a benchmark task whose solution is reachable from its base. It does not, and must not: annotating that leaves an answer key inside the corpus. Pretraining risk is annotated; reachability is excluded. The two vectors are now stated separately and the distinction is pinned by a test.

## Coverage is established, never inferred

- **missing**: a corpus task with no outcome. Not scored as a rejection, so an arm that died halfway reads as incomplete rather than merely bad.
- **unknown**: an outcome for a task outside the corpus. Not counted as an attempt.
- **duplicates**: counted; first record wins.

Both block a ratio, and the suppression detail now says which happened — reporting a stray extra record as "did not attempt the whole corpus" sends the reader hunting for missing tasks that do not exist.

Strata come from the frozen corpus, never from the arm's own records, which could otherwise relabel a lost task into a winning stratum.

## Where the journal lives, and why not in ratchet.py

Adding the `experiment-record` event to `ratchet.py` was the obvious placement. Measuring it showed why it is wrong: the ratchet gate's `--scanner-version` is the hash of `ratchet.py` and its finding-affecting dependencies (INV-fh-005), so the edit staled the gate's validation record and `test_shipped_records_pass_check_gate_validation` went red. That demands a re-run of seeded-defect trials, paid for a change touching none of the gate's finding logic.

`chief_wiggum/experiment_journal.py` imports the chain primitives instead. Only digests ride the chain, the event is never `merged`, appending onto a broken chain fails closed, and the reader takes the verified prefix only, so a hand-appended but well-formed record is not evidence.

**The same newline defect exists in `ratchet.py` and is worse there** — a wired gate reads back as never wired, which would suppress the demotion path and reset the quality high-water mark. Verified on `main` and filed as **#420**, not fixed here, because the fix's mandatory second half is re-deriving the ratchet gate's validation record.

## Gate posture

Every gate is report-only and blocks only under `--gate` (docs/gate-rollout.md): the 20-task stratum floor, the protocol check, partial coverage, and reporting failures. None is wired into `/architect` or `/close-epic`.

## Rollback

The registered fallback is `plan_waves.py` plus static roles, sharing #385's graph. `test_static_fallback_still_projects_a_wave_plan` exercises the static projection on every run: if it stops working there is nothing to roll back to and the pre-registration's rollback criteria are unenforceable.

## Testing

- 60 tests in `tests/test_dag_experiment_harness.py`
- **35/35 mutants caught** across two sweeps. Two were blind on first write and both are now covered: the journal reader skipped unparseable lines (so garbage was caught but a well-formed forged record was not), and a bare date against a zoned one was never exercised.
- Full suite: 4109 passed, 14 skipped.

## Review provenance

Codex is out of account credits until Aug 25, so the required reviewer quorum could not be met as configured. The refute-soundness lens ran on kimi-k3 and deepseek-v4-pro instead, and the completeness lens on deepseek-v4-flash. The optional claude-interactive delegate failed. Stated here rather than left implicit, since a quorum that silently lost a voice is the failure mode `config/providers.json` exists to prevent.

## What is still human

Running the arms, the go / hold / rollback call at each rung, and publishing anything. The public-claim gate can only refuse, never grant.

Operator runbook: `docs/experiments/dynamic-dag/running-the-arms.md`. The pre-registration is not amended.

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
