### PR TITLE
fix(review): state the quorum delta in the synthesis prompt (#416)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -619,7 +619,14 @@ python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/close-epic-revi
   --output-dir "$CW_TMP/close-review" --cwd "$TARGET_REPO"
 ```
 
-Read `$CW_TMP/close-review/reviewer-codex.md` and `reviewer-gemini.md` (status in `reviewer-manifest.json`). Synthesise both reviews. Categorise findings:
+Synthesise the reviews via the manifest, never by naming the files:
+
+```bash
+python3 "$CW_HOME/scripts/synthesize_reviews.py" \
+  --manifest "$CW_TMP/close-review/reviewer-manifest.json"
+```
+
+Naming them drifts as the `reviewer` role's roster changes (this step read `reviewer-gemini.md` long after gemini left the role), and a file list cannot tell "every reviewer answered" from "one never did" — chief-wiggum#416. The manifest carries who was expected and in which tier, so an absent provider is reported instead of quietly shrinking the quorum. Categorise findings:
 - **Consensus risks**: Both AIs flagged the same area — high confidence, address before shipping
 - **Unique insights**: Only one AI flagged — investigate, may be a genuine blind spot or a false positive
 - **Recommendations**: Suggestions for the retrospective and future epics

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -547,8 +547,10 @@ The worker should:
 
 5. Synthesize using:
    ```bash
-   python3 "$CW_HOME/scripts/synthesize_reviews.py" $TICKET_TMP/reviews/reviewer-codex.md $TICKET_TMP/reviews/reviewer-gemini.md
+   python3 "$CW_HOME/scripts/synthesize_reviews.py" \
+     --manifest "$TICKET_TMP/reviews/reviewer-manifest.json"
    ```
+   **Pass `--manifest`, do not list the review files by hand** (chief-wiggum#416). Naming them means the command drifts every time the role roster changes — this line said `reviewer-gemini.md` long after gemini left the `reviewer` role, so it was passing a path that could never resolve. More importantly, counting the files that happen to exist cannot tell "every reviewer answered" from "one never did": the synthesis opened with a confident `N reviews received` while silently describing a narrowed quorum. The manifest carries who was EXPECTED and in which tier, so the prompt now reports `2 of 3 expected reviews received — QUORUM INCOMPLETE` and names the absentee where the reconciler reads it. A missing OPTIONAL provider is still a legitimate outcome and does not block; a missing REQUIRED one is reported to stderr, and `--gate` turns it into a non-zero exit.
    **When `reviewer` is lensed, expect disjoint findings, not convergence** — each provider was scoped to a different concern over the same diff, so agreement across reviewers is the exception, not the confirmation signal. `synthesize_reviews.py` reconciles by **union, then cross-verifies only contested items**: every concrete finding is retained regardless of whether one reviewer raised it or several (a soundness issue only the refuter caught is not weaker for being unique to it), and cross-verification against the diff is reserved for cases where two reviewers make genuinely *contradictory* claims about the same fact — not merely where one mentions something the other didn't. Do not fall back to majority-vote reasoning when reconciling a lensed quorum; it defeats the reason the lenses were assigned.
 
 6. Return a concise summary categorising each piece of feedback:

--- a/scripts/synthesize_reviews.py
+++ b/scripts/synthesize_reviews.py
@@ -3,21 +3,43 @@
 Synthesize feedback from multiple AI reviewers into a single actionable list.
 
 Usage:
-    python3 synthesize-reviews.py review1.md review2.md review3.md
+    python3 synthesize_reviews.py --manifest reviews/reviewer-manifest.json
+    python3 synthesize_reviews.py review1.md review2.md review3.md
 
-Each input file should contain one AI's review output. The script produces a
-merged report on stdout highlighting:
-  - Points of agreement (high confidence)
-  - Points of disagreement (needs human decision)
-  - Unique suggestions from individual reviewers
+Each input file contains one AI's review output. The script produces a merged
+report on stdout highlighting points of agreement, disagreement, and findings
+unique to one reviewer.
+
+**Pass `--manifest` wherever you can** (chief-wiggum#416). Counting the review
+files that happen to exist cannot distinguish "three reviewers ran" from "four
+were asked and one never answered", so without it the synthesis opened with a
+confident `N reviews received` that silently described a narrowed quorum. The
+role manifest `consult_ai.py --role` writes records who was EXPECTED and which
+tier they were in, which is the only way the reconciler can be told a voice is
+missing. With no manifest the header says the expected set is unknown rather
+than implying completeness.
+
+A missing OPTIONAL provider stays non-fatal — roles model that outcome
+deliberately — but it is still reported, because under review lenses each
+provider is scoped to findings nobody else is looking for.
 """
 
+import argparse
+import json
 import sys
 from pathlib import Path
 
 
 def load_reviews(paths: list[str]) -> list[dict]:
-    """Load review files and return list of {source, content}."""
+    """Load review files and return list of {source, content}.
+
+    A missing file is still skipped rather than fatal: `config/providers.json`
+    distinguishes required from optional providers precisely so an optional
+    one may fail without blocking the role, and that outcome is legitimate.
+    What must not happen is the SYNTHESIS reporting the reduced set as though
+    it were the whole picture — see `quorum_delta` and `synthesize`
+    (chief-wiggum#416).
+    """
     reviews = []
     for p in paths:
         path = Path(p)
@@ -31,13 +53,111 @@ def load_reviews(paths: list[str]) -> list[dict]:
     return reviews
 
 
-def synthesize(reviews: list[dict]) -> str:
+def load_manifest(path: str | Path) -> dict:
+    """Read the role manifest `consult_ai.py --role` writes beside the reviews.
+
+    The manifest is what makes the quorum checkable: it records every provider
+    the role EXPECTED, whether each was required, and what became of it. A
+    synthesis that counts only the files it found can never notice a voice
+    that was supposed to be there.
+    """
+    return json.loads(Path(path).read_text())
+
+
+def quorum_delta(reviews: list[dict], manifest: dict | None) -> dict:
+    """What the synthesis received, against what the role expected.
+
+    Returns a four-state answer rather than a count. `unknown` is a real
+    state: with no manifest there is no expectation to compare against, and
+    printing a bare confident number in that case is the thing this exists to
+    stop.
+    """
+    received = [r["source"] for r in reviews]
+    if not manifest:
+        return {
+            "status": "unknown",
+            "received": received,
+            "received_n": len(reviews),
+            "expected_n": None,
+            "absent": [],
+            "absent_required": [],
+        }
+
+    results = manifest.get("results") or []
+    absent = [
+        {
+            "name": entry.get("name", "?"),
+            "required": bool(entry.get("required")),
+            "error": (entry.get("error") or "").strip().splitlines()[0]
+            if entry.get("error") else "",
+        }
+        for entry in results
+        if entry.get("status") != "ok"
+    ]
+    absent_required = [a["name"] for a in absent if a["required"]]
+    return {
+        "status": "complete" if not absent else (
+            "degraded-required" if absent_required else "degraded-optional"),
+        "received": received,
+        "received_n": len(reviews),
+        "expected_n": len(results),
+        "absent": absent,
+        "absent_required": absent_required,
+        "role": manifest.get("role", ""),
+    }
+
+
+def _quorum_block(delta: dict) -> list[str]:
+    """The header the reconciler reads before it reads a single finding."""
+    if delta["status"] == "unknown":
+        return [
+            f"**{delta['received_n']} reviews received. The expected set is "
+            "UNKNOWN** — no role manifest was supplied, so this synthesis "
+            "cannot tell you whether a reviewer is missing. Treat coverage as "
+            "unverified rather than complete.\n"
+        ]
+
+    expected, got = delta["expected_n"], delta["received_n"]
+    if delta["status"] == "complete":
+        return [f"**{got} of {expected} expected reviews received — quorum "
+                f"complete.**\n"]
+
+    lines = [f"**{got} of {expected} expected reviews received — QUORUM "
+             f"INCOMPLETE.**\n"]
+    if delta["absent_required"]:
+        lines.append(
+            "> A **required** provider is missing. The role treats it as "
+            "required because the quorum is not considered sound without it, "
+            "so the findings below are a NARROWED result, not a clean one. "
+            "Say so in the synthesis rather than presenting it as complete.\n"
+        )
+    else:
+        lines.append(
+            "> Only optional providers are missing, which the role permits. "
+            "Findings below are still narrower than a full run: under review "
+            "lenses each provider is scoped to a concern nobody else covers, "
+            "so an absent voice removes exactly the findings it was there to "
+            "produce.\n"
+        )
+    lines.append("Absent:\n")
+    for entry in delta["absent"]:
+        tier = "required" if entry["required"] else "optional"
+        reason = f" — {entry['error']}" if entry["error"] else ""
+        lines.append(f"- `{entry['name']}` ({tier}){reason}")
+    lines.append("")
+    return lines
+
+
+def synthesize(reviews: list[dict], delta: dict | None = None) -> str:
     """Produce a synthesis prompt that Claude can use to merge reviews."""
     if not reviews:
         return "No reviews to synthesize."
 
+    if delta is None:
+        delta = quorum_delta(reviews, None)
+
     parts = ["# Multi-AI Review Synthesis\n"]
-    parts.append(f"**{len(reviews)} reviews received.**\n")
+    parts.extend(_quorum_block(delta))
 
     for i, r in enumerate(reviews, 1):
         parts.append(f"## Review {i}: {r['source']}\n")
@@ -86,14 +206,54 @@ def synthesize(reviews: list[dict]) -> str:
     return "\n".join(parts)
 
 
-def main():
-    if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <review1.md> [review2.md] ...", file=sys.stderr)
-        sys.exit(1)
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Synthesize multiple AI reviews into one actionable list.")
+    parser.add_argument("reviews", nargs="*", help="review markdown files")
+    parser.add_argument(
+        "--manifest", default="",
+        help="role manifest written by `consult_ai.py --role` (e.g."
+             " reviewer-manifest.json). Supplies the EXPECTED provider set so"
+             " the synthesis can report a missing voice instead of counting"
+             " only the files it found. With no review paths given, the"
+             " successful providers' paths are taken from it.")
+    parser.add_argument(
+        "--gate", action="store_true",
+        help="exit 1 when a REQUIRED provider is absent (report-only by"
+             " default, per docs/gate-rollout.md)")
+    args = parser.parse_args(argv)
 
-    reviews = load_reviews(sys.argv[1:])
-    print(synthesize(reviews))
+    manifest = None
+    if args.manifest:
+        try:
+            manifest = load_manifest(args.manifest)
+        except (OSError, ValueError) as exc:
+            # A manifest that cannot be read is not the same as no manifest:
+            # the caller asked for the quorum to be checked and it could not
+            # be, which must not degrade quietly into "expected set unknown".
+            print(f"Error: cannot read manifest {args.manifest}: {exc}",
+                  file=sys.stderr)
+            return 2
+
+    paths = list(args.reviews)
+    if not paths and manifest:
+        paths = [entry["path"] for entry in (manifest.get("results") or [])
+                 if entry.get("status") == "ok" and entry.get("path")]
+    if not paths:
+        parser.error("no review files given (pass paths, or --manifest with"
+                     " at least one successful provider)")
+
+    reviews = load_reviews(paths)
+    delta = quorum_delta(reviews, manifest)
+    print(synthesize(reviews, delta))
+
+    if delta["absent_required"]:
+        print(f"Quorum incomplete: required provider(s) absent: "
+              f"{', '.join(delta['absent_required'])}", file=sys.stderr)
+        if args.gate:
+            return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/synthesize_reviews.py
+++ b/scripts/synthesize_reviews.py
@@ -64,6 +64,54 @@ def load_manifest(path: str | Path) -> dict:
     return json.loads(Path(path).read_text())
 
 
+class MalformedManifest(ValueError):
+    """A manifest that cannot answer "who was expected?"."""
+
+
+def _validated_results(manifest: dict) -> list[dict]:
+    """The manifest's provider entries, or a refusal naming what is wrong.
+
+    Everything here is bad input, and bad input must exit 2. Left unchecked,
+    these shapes raised AttributeError or IndexError out of the middle of the
+    delta computation, which surfaces as a traceback at exit 1 — the code
+    reserved for a finding being gated on. A crash caused by a malformed file
+    would then be indistinguishable from a real quorum failure, which is the
+    same state confusion this whole change is about.
+    """
+    if not isinstance(manifest, dict):
+        raise MalformedManifest(
+            f"manifest must be a JSON object, got {type(manifest).__name__}")
+    results = manifest.get("results")
+    if not results:
+        raise MalformedManifest(
+            "manifest lists no providers, so it cannot say who was expected")
+    if not isinstance(results, list):
+        raise MalformedManifest(
+            f"manifest 'results' must be a list, got {type(results).__name__}")
+
+    names = []
+    for entry in results:
+        if not isinstance(entry, dict):
+            raise MalformedManifest(
+                f"manifest 'results' entries must be objects, got"
+                f" {type(entry).__name__}")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise MalformedManifest(
+                f"manifest entry has no usable provider name: {entry!r}")
+        error = entry.get("error")
+        if error is not None and not isinstance(error, str):
+            raise MalformedManifest(
+                f"manifest entry {name!r} has a non-string error:"
+                f" {type(error).__name__}")
+        names.append(name)
+
+    if len(set(names)) != len(names):
+        raise MalformedManifest(
+            f"manifest lists a provider twice: {sorted(names)}")
+    return results
+
+
 def quorum_delta(reviews: list[dict], manifest: dict | None) -> dict:
     """What the synthesis received, against what the role expected.
 
@@ -71,38 +119,77 @@ def quorum_delta(reviews: list[dict], manifest: dict | None) -> dict:
     state: with no manifest there is no expectation to compare against, and
     printing a bare confident number in that case is the thing this exists to
     stop.
+
+    Every expected provider is matched to a review that actually LOADED, by
+    the stem of the path the manifest recorded for it. Deriving absence from
+    the manifest's own `status` alone is not enough, and review found three
+    ways it produced headers that contradict themselves:
+
+    - a provider marked `ok` whose file has since been deleted was counted as
+      present, giving "0 of 1 expected reviews received - quorum complete";
+    - extra review files nobody expected inflated the received count past the
+      expected one, giving "3 of 2 ... complete";
+    - a manifest with no `results` made the expected count zero, giving
+      "1 of 0 ... complete".
+
+    The first is the fail-open this function exists to close, wearing the
+    fixed version's clothes. So `received_n` now counts expected reviews that
+    are genuinely in hand, and can never exceed `expected_n`; anything loaded
+    that the manifest never mentioned is reported separately as `unexpected`.
     """
-    received = [r["source"] for r in reviews]
-    if not manifest:
+    # `is None` means NOT SUPPLIED. A manifest that was supplied but is empty
+    # or falsy (`{}`, `[]`) must not slide into the unknown branch and report
+    # "no role manifest was supplied" — that is false, and it makes an
+    # unusable instrument look like one nobody asked for.
+    if manifest is None:
         return {
             "status": "unknown",
-            "received": received,
+            "received": [r["source"] for r in reviews],
             "received_n": len(reviews),
             "expected_n": None,
             "absent": [],
             "absent_required": [],
+            "unexpected": [],
         }
 
-    results = manifest.get("results") or []
-    absent = [
-        {
-            "name": entry.get("name", "?"),
-            "required": bool(entry.get("required")),
-            "error": (entry.get("error") or "").strip().splitlines()[0]
-            if entry.get("error") else "",
-        }
-        for entry in results
-        if entry.get("status") != "ok"
-    ]
+    results = _validated_results(manifest)
+
+    by_source = {r["source"] for r in reviews}
+    absent: list[dict] = []
+    matched: set[str] = set()
+    for entry in results:
+        name = entry.get("name", "?")
+        required = bool(entry.get("required"))
+        error = (entry.get("error") or "").strip()
+        first_line = error.splitlines()[0] if error else ""
+        if entry.get("status") != "ok":
+            absent.append({"name": name, "required": required,
+                           "error": first_line})
+            continue
+        stem = Path(entry["path"]).stem if entry.get("path") else ""
+        if stem and stem in by_source:
+            matched.add(stem)
+            continue
+        # Reported ok, but its review is not among the loaded ones. The
+        # manifest and the filesystem disagree, and the filesystem is what
+        # the synthesis is actually built from.
+        absent.append({
+            "name": name, "required": required,
+            "error": "reported ok, but its review was not loaded"
+                     + (f" ({entry['path']})" if entry.get("path")
+                        else " (no path recorded)"),
+        })
+
     absent_required = [a["name"] for a in absent if a["required"]]
     return {
         "status": "complete" if not absent else (
             "degraded-required" if absent_required else "degraded-optional"),
-        "received": received,
-        "received_n": len(reviews),
+        "received": sorted(matched),
+        "received_n": len(matched),
         "expected_n": len(results),
         "absent": absent,
         "absent_required": absent_required,
+        "unexpected": sorted(by_source - matched),
         "role": manifest.get("role", ""),
     }
 
@@ -118,9 +205,16 @@ def _quorum_block(delta: dict) -> list[str]:
         ]
 
     expected, got = delta["expected_n"], delta["received_n"]
+    extra = delta.get("unexpected") or []
+    extra_note = ([
+        f"\nAlso included, though the role never recorded them: "
+        f"{', '.join('`' + name + '`' for name in extra)}. Treat these as"
+        " unattributed — the manifest cannot vouch for what produced them.\n"
+    ] if extra else [])
+
     if delta["status"] == "complete":
         return [f"**{got} of {expected} expected reviews received — quorum "
-                f"complete.**\n"]
+                f"complete.**\n"] + extra_note
 
     lines = [f"**{got} of {expected} expected reviews received — QUORUM "
              f"INCOMPLETE.**\n"]
@@ -145,16 +239,27 @@ def _quorum_block(delta: dict) -> list[str]:
         reason = f" — {entry['error']}" if entry["error"] else ""
         lines.append(f"- `{entry['name']}` ({tier}){reason}")
     lines.append("")
+    lines.extend(extra_note)
     return lines
 
 
 def synthesize(reviews: list[dict], delta: dict | None = None) -> str:
     """Produce a synthesis prompt that Claude can use to merge reviews."""
-    if not reviews:
-        return "No reviews to synthesize."
-
     if delta is None:
         delta = quorum_delta(reviews, None)
+
+    if not reviews:
+        # The maximally degraded quorum used to produce the LEAST informative
+        # output: every provider failed, so nothing loaded, so this returned a
+        # bare "No reviews to synthesize." and the delta — which knows exactly
+        # which required providers were absent and why — was discarded. The
+        # worst case is the one the operator most needs told.
+        if delta["status"] in ("unknown", "complete"):
+            return "No reviews to synthesize."
+        return "\n".join(
+            ["# Multi-AI Review Synthesis\n", *_quorum_block(delta),
+             "**No reviews were loaded at all**, so there is nothing below to"
+             " reconcile. This is a failed review step, not a clean one.\n"])
 
     parts = ["# Multi-AI Review Synthesis\n"]
     parts.extend(_quorum_block(delta))
@@ -227,6 +332,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.manifest:
         try:
             manifest = load_manifest(args.manifest)
+            if manifest is None:
+                # A file containing literal `null` parses to None, which would
+                # otherwise be indistinguishable from no manifest at all.
+                raise MalformedManifest("manifest is null")
         except (OSError, ValueError) as exc:
             # A manifest that cannot be read is not the same as no manifest:
             # the caller asked for the quorum to be checked and it could not
@@ -235,16 +344,33 @@ def main(argv: list[str] | None = None) -> int:
                   file=sys.stderr)
             return 2
 
+    if args.gate and not manifest:
+        # A gate that cannot run must not report success. Without a manifest
+        # there is no expected set, so `--gate` could never fire and would
+        # exit 0 — automation adding the flag would believe the quorum had
+        # been verified when nothing was checked.
+        print("Error: --gate requires --manifest; without the expected"
+              " provider set there is nothing to gate on", file=sys.stderr)
+        return 2
+
     paths = list(args.reviews)
     if not paths and manifest:
         paths = [entry["path"] for entry in (manifest.get("results") or [])
-                 if entry.get("status") == "ok" and entry.get("path")]
-    if not paths:
-        parser.error("no review files given (pass paths, or --manifest with"
-                     " at least one successful provider)")
+                 if isinstance(entry, dict)
+                 and entry.get("status") == "ok" and entry.get("path")]
+    if not paths and not manifest:
+        parser.error("no review files given (pass paths, or --manifest)")
 
     reviews = load_reviews(paths)
-    delta = quorum_delta(reviews, manifest)
+    try:
+        delta = quorum_delta(reviews, manifest)
+    except MalformedManifest as exc:
+        # Same reasoning as an unreadable manifest: the caller asked for the
+        # quorum to be checked, and this manifest cannot answer it. Falling
+        # back to "unknown" would make a broken instrument look like never
+        # having asked.
+        print(f"Error: {args.manifest}: {exc}", file=sys.stderr)
+        return 2
     print(synthesize(reviews, delta))
 
     if delta["absent_required"]:

--- a/tests/test_synthesize_reviews.py
+++ b/tests/test_synthesize_reviews.py
@@ -212,9 +212,10 @@ class TestQuorumDelta:
             codex=(True, "ok", "/x/reviewer-codex.md", None),
             deepseek=(True, "ok", "/x/reviewer-deepseek.md", None),
         )
-        delta = synthesize_reviews.quorum_delta(_reviews("a", "b"), manifest)
+        reviews = _reviews("reviewer-codex", "reviewer-deepseek")
+        delta = synthesize_reviews.quorum_delta(reviews, manifest)
         assert delta["status"] == "complete"
-        prompt = synthesize_reviews.synthesize(_reviews("a", "b"), delta)
+        prompt = synthesize_reviews.synthesize(reviews, delta)
         assert "2 of 2 expected reviews received" in prompt
         assert "quorum complete" in prompt.lower()
 
@@ -223,11 +224,12 @@ class TestQuorumDelta:
             codex=(True, "failed", None, "usage limit reached"),
             deepseek=(True, "ok", "/x/reviewer-deepseek.md", None),
         )
-        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        reviews = _reviews("reviewer-deepseek")
+        delta = synthesize_reviews.quorum_delta(reviews, manifest)
         assert delta["status"] == "degraded-required"
         assert delta["absent_required"] == ["codex"]
 
-        prompt = synthesize_reviews.synthesize(_reviews("a"), delta)
+        prompt = synthesize_reviews.synthesize(reviews, delta)
         assert "1 of 2 expected reviews received" in prompt
         assert "QUORUM INCOMPLETE" in prompt
         assert "codex" in prompt
@@ -239,11 +241,12 @@ class TestQuorumDelta:
             codex=(True, "ok", "/x/reviewer-codex.md", None),
             claude_interactive=(False, "failed", None, "delegate timed out"),
         )
-        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        reviews = _reviews("reviewer-codex")
+        delta = synthesize_reviews.quorum_delta(reviews, manifest)
         assert delta["status"] == "degraded-optional"
         assert delta["absent_required"] == []
 
-        prompt = synthesize_reviews.synthesize(_reviews("a"), delta)
+        prompt = synthesize_reviews.synthesize(reviews, delta)
         assert "QUORUM INCOMPLETE" in prompt
         assert "which the role permits" in prompt
         assert "claude_interactive" in prompt
@@ -257,12 +260,140 @@ class TestQuorumDelta:
         never report a gap, which is the fail-open being closed.
         """
         manifest = _manifest(
-            a=(True, "ok", "/x/a.md", None),
+            a=(True, "ok", "/x/reviewer-a.md", None),
             b=(True, "failed", None, "boom"),
             c=(False, "failed", None, "boom"),
         )
-        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        delta = synthesize_reviews.quorum_delta(
+            _reviews("reviewer-a"), manifest)
         assert (delta["received_n"], delta["expected_n"]) == (1, 3)
+
+
+class TestTheManifestIsNotTakenAtItsWord:
+    """Expected providers are matched to reviews that actually loaded (#416).
+
+    Deriving absence from the manifest's own `status` alone is not enough, and
+    review found three ways it produced headers that contradict themselves.
+    The first is the fail-open this whole change exists to close, wearing the
+    fixed version's clothes.
+    """
+
+    def test_a_provider_marked_ok_whose_review_never_loaded_is_absent(self):
+        """"0 of 1 expected reviews received - quorum complete."
+
+        The manifest says the provider succeeded; its file is gone. The
+        filesystem is what the synthesis is actually built from, so the
+        manifest does not get the last word.
+        """
+        manifest = _manifest(
+            codex=(True, "ok", "/gone/reviewer-codex.md", None),
+        )
+        delta = synthesize_reviews.quorum_delta([], manifest)
+        assert delta["status"] == "degraded-required"
+        assert delta["absent_required"] == ["codex"]
+        assert "was not loaded" in delta["absent"][0]["error"]
+
+        prompt = synthesize_reviews.synthesize(_reviews("x"), delta)
+        assert "0 of 1 expected reviews received" in prompt
+        assert "QUORUM INCOMPLETE" in prompt
+
+    def test_an_optional_provider_marked_ok_but_unloaded_does_not_escalate(self):
+        manifest = _manifest(
+            codex=(True, "ok", "/x/reviewer-codex.md", None),
+            extra=(False, "ok", "/gone/reviewer-extra.md", None),
+        )
+        delta = synthesize_reviews.quorum_delta(
+            [{"source": "reviewer-codex", "content": "c"}], manifest)
+        assert delta["status"] == "degraded-optional"
+        assert delta["absent_required"] == []
+
+    def test_unexpected_reviews_cannot_inflate_the_received_count(self):
+        """"3 of 2 expected reviews received - quorum complete."
+
+        received_n counts expected reviews genuinely in hand, so it can never
+        exceed expected_n. Anything else loaded is reported, not counted.
+        """
+        manifest = _manifest(
+            a=(True, "ok", "/x/reviewer-a.md", None),
+            b=(True, "ok", "/x/reviewer-b.md", None),
+        )
+        reviews = [{"source": "reviewer-a", "content": "A"},
+                   {"source": "reviewer-b", "content": "B"},
+                   {"source": "reviewer-stray", "content": "S"}]
+        delta = synthesize_reviews.quorum_delta(reviews, manifest)
+        assert (delta["received_n"], delta["expected_n"]) == (2, 2)
+        assert delta["status"] == "complete"
+        assert delta["unexpected"] == ["reviewer-stray"]
+
+        prompt = synthesize_reviews.synthesize(reviews, delta)
+        assert "2 of 2 expected reviews received" in prompt
+        assert "reviewer-stray" in prompt
+        assert "unattributed" in prompt
+
+    def test_a_manifest_listing_no_providers_is_malformed(self):
+        """"1 of 0 expected reviews received - quorum complete."."""
+        with pytest.raises(synthesize_reviews.MalformedManifest,
+                           match="lists no providers"):
+            synthesize_reviews.quorum_delta(_reviews("a"), {"role": "reviewer"})
+
+    def test_the_worst_case_still_reports_who_was_absent(self):
+        """Every provider failed, so nothing loaded.
+
+        This used to produce the LEAST informative output of any path: a bare
+        "No reviews to synthesize." with the delta discarded, or a usage error
+        from the CLI. The maximally degraded quorum is the one the operator
+        most needs told about.
+        """
+        manifest = _manifest(
+            codex=(True, "failed", None, "usage limit reached"),
+            deepseek=(True, "failed", None, "timed out"),
+        )
+        delta = synthesize_reviews.quorum_delta([], manifest)
+        prompt = synthesize_reviews.synthesize([], delta)
+
+        assert "0 of 2 expected reviews received" in prompt
+        assert "QUORUM INCOMPLETE" in prompt
+        assert "codex" in prompt and "usage limit reached" in prompt
+        assert "deepseek" in prompt and "timed out" in prompt
+        assert "No reviews were loaded at all" in prompt
+        assert prompt != "No reviews to synthesize."
+
+    def test_no_reviews_and_nothing_expected_stays_terse(self):
+        """The bare message is still right when there is nothing to say."""
+        assert synthesize_reviews.synthesize([]) == "No reviews to synthesize."
+
+    @pytest.mark.parametrize("payload,match", [
+        ({}, "lists no providers"),
+        ([], "must be a JSON object"),
+        ({"role": "r", "results": "codex"}, "must be a list"),
+        ({"role": "r", "results": ["codex"]}, "entries must be objects"),
+        ({"role": "r", "results": [{"required": True, "status": "ok"}]},
+         "no usable provider name"),
+        ({"role": "r", "results": [
+            {"name": "x", "required": True, "status": "failed", "error": 123}]},
+         "non-string error"),
+    ])
+    def test_off_shape_manifests_are_refused_by_name(self, payload, match):
+        """Bad input must be bad input, not a crash mid-computation.
+
+        Left unchecked these raised AttributeError or IndexError out of the
+        delta computation, surfacing as a traceback at exit 1 — the code
+        reserved for a finding being gated on, so a malformed file was
+        indistinguishable from a real quorum failure.
+        """
+        with pytest.raises(synthesize_reviews.MalformedManifest, match=match):
+            synthesize_reviews.quorum_delta(_reviews("a"), payload)
+
+    def test_a_manifest_naming_a_provider_twice_is_malformed(self):
+        manifest = {"role": "reviewer", "results": [
+            {"name": "codex", "required": True, "status": "ok",
+             "path": "/x/reviewer-codex.md", "error": None},
+            {"name": "codex", "required": True, "status": "failed",
+             "path": None, "error": "boom"},
+        ]}
+        with pytest.raises(synthesize_reviews.MalformedManifest,
+                           match="twice"):
+            synthesize_reviews.quorum_delta(_reviews("a"), manifest)
 
 
 class TestCli:
@@ -327,3 +458,76 @@ class TestCli:
         assert synthesize_reviews.main(
             ["--manifest", str(broken), str(review)]) == 2
         assert "cannot read manifest" in capsys.readouterr().err
+
+    def test_a_manifest_that_cannot_say_who_was_expected_is_also_an_error(
+            self, tmp_path, capsys):
+        """Readable JSON, but it answers nothing. Same treatment."""
+        empty = tmp_path / "reviewer-manifest.json"
+        empty.write_text(json.dumps({"role": "reviewer", "results": []}))
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a finding")
+        assert synthesize_reviews.main(
+            ["--manifest", str(empty), str(review)]) == 2
+        assert "lists no providers" in capsys.readouterr().err
+
+    def test_a_manifest_file_containing_null_is_not_read_as_absent(
+            self, tmp_path, capsys):
+        """`null` parses to None, which looks exactly like "not supplied".
+
+        Without the distinction the header would claim no manifest was given
+        when one was, and `--gate` would go inert.
+        """
+        manifest = tmp_path / "reviewer-manifest.json"
+        manifest.write_text("null")
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a finding")
+        assert synthesize_reviews.main(
+            ["--manifest", str(manifest), str(review)]) == 2
+        assert "null" in capsys.readouterr().err
+
+    def test_gate_without_a_manifest_is_refused_not_silently_inert(
+            self, tmp_path, capsys):
+        """A gate that cannot run must not report success.
+
+        Without a manifest there is no expected set, so `--gate` could never
+        fire and exited 0 — automation adding the flag would believe the
+        quorum had been verified when nothing was checked. That is the
+        "failed to run = pass" pattern at the gate level.
+        """
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a finding")
+        assert synthesize_reviews.main(["--gate", str(review)]) == 2
+        assert "--gate requires --manifest" in capsys.readouterr().err
+
+    def test_a_total_provider_failure_reports_instead_of_erroring_out(
+            self, tmp_path, capsys):
+        """No provider succeeded, so no paths can be derived.
+
+        The CLI used to treat that as a usage error and exit 2, losing the
+        quorum report entirely at exactly the moment it mattered most.
+        """
+        manifest = tmp_path / "reviewer-manifest.json"
+        manifest.write_text(json.dumps({"role": "reviewer", "results": [
+            {"name": "codex", "required": True, "status": "failed",
+             "path": None, "error": "usage limit reached"},
+        ]}))
+        assert synthesize_reviews.main(["--manifest", str(manifest), "--gate"]) == 1
+        out = capsys.readouterr().out
+        assert "0 of 1 expected reviews received" in out
+        assert "codex" in out
+
+    def test_gate_blocks_when_a_required_review_is_missing_from_disk(
+            self, tmp_path, capsys):
+        """The manifest says ok; the file is gone. --gate must still block."""
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a finding")
+        manifest = tmp_path / "reviewer-manifest.json"
+        manifest.write_text(json.dumps({"role": "reviewer", "results": [
+            {"name": "codex", "required": True, "status": "ok",
+             "path": str(tmp_path / "reviewer-codex.md"), "error": None},
+            {"name": "deepseek-flash", "required": True, "status": "ok",
+             "path": str(review), "error": None},
+        ]}))
+        assert synthesize_reviews.main(
+            ["--manifest", str(manifest), "--gate"]) == 1
+        assert "QUORUM INCOMPLETE" in capsys.readouterr().out

--- a/tests/test_synthesize_reviews.py
+++ b/tests/test_synthesize_reviews.py
@@ -26,6 +26,8 @@ clothes.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 import synthesize_reviews
 
@@ -160,21 +162,168 @@ class TestLoadReviews:
         assert loaded == [{"source": "reviewer-codex", "content": "a finding"}]
 
     def test_a_missing_file_is_skipped_with_a_warning(self, tmp_path, capsys):
-        """Pins CURRENT behaviour, which is not the behaviour I would choose.
+        """Loading stays non-fatal, and that is deliberate (chief-wiggum#416).
 
-        A missing reviewer file is dropped and the synthesis proceeds with a
-        silently smaller quorum — `synthesize()` will then report the REDUCED
-        count as though it were the whole picture. That is the quorum-integrity
-        fail-open this repo keeps finding, filed as #416 rather than changed
-        here — the fix has a real design question in it (a missing OPTIONAL
-        provider is a legitimate outcome, so this cannot simply become fatal).
+        `config/providers.json` distinguishes required from optional providers
+        precisely so an optional one may fail without blocking the role, so a
+        missing file cannot simply become fatal here.
 
-        This test exists so that change is a deliberate, visible edit to an
-        assertion rather than something that slides in unnoticed.
+        What changed in #416 is downstream: the SYNTHESIS no longer reports the
+        reduced set as though it were the whole picture. See
+        `TestQuorumDelta` — the fix went where the lie was, not where the file
+        was missing.
         """
         present = tmp_path / "reviewer-codex.md"
         present.write_text("a finding")
         loaded = synthesize_reviews.load_reviews([str(present), str(tmp_path / "gone.md")])
 
-        assert len(loaded) == 1, "current behaviour: the missing file is skipped, not fatal"
+        assert len(loaded) == 1, "a missing file is skipped, not fatal"
         assert "not found" in capsys.readouterr().err
+
+
+def _manifest(**providers):
+    """A role manifest in the shape `consult_ai.py --role` writes."""
+    return {
+        "role": "reviewer",
+        "results": [
+            {"name": name, "required": required, "status": status,
+             "path": path, "error": error}
+            for name, (required, status, path, error) in providers.items()
+        ],
+    }
+
+
+class TestQuorumDelta:
+    """What the synthesis received, against what the role expected (#416).
+
+    The failure this guards is not a crash. It is a synthesis that opens with
+    a confident count while a provider that was supposed to run never did —
+    which under review lenses removes exactly the findings nobody else was
+    scoped to produce, and presents the narrowed result as complete.
+    """
+
+    def test_no_manifest_reports_the_expected_set_as_unknown(self):
+        prompt = synthesize_reviews.synthesize(_reviews("a", "b"))
+        assert "expected set is UNKNOWN" in prompt
+        assert "unverified rather than complete" in prompt
+
+    def test_a_complete_quorum_says_so_with_both_numbers(self):
+        manifest = _manifest(
+            codex=(True, "ok", "/x/reviewer-codex.md", None),
+            deepseek=(True, "ok", "/x/reviewer-deepseek.md", None),
+        )
+        delta = synthesize_reviews.quorum_delta(_reviews("a", "b"), manifest)
+        assert delta["status"] == "complete"
+        prompt = synthesize_reviews.synthesize(_reviews("a", "b"), delta)
+        assert "2 of 2 expected reviews received" in prompt
+        assert "quorum complete" in prompt.lower()
+
+    def test_an_absent_required_provider_is_named_and_flagged(self):
+        manifest = _manifest(
+            codex=(True, "failed", None, "usage limit reached"),
+            deepseek=(True, "ok", "/x/reviewer-deepseek.md", None),
+        )
+        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        assert delta["status"] == "degraded-required"
+        assert delta["absent_required"] == ["codex"]
+
+        prompt = synthesize_reviews.synthesize(_reviews("a"), delta)
+        assert "1 of 2 expected reviews received" in prompt
+        assert "QUORUM INCOMPLETE" in prompt
+        assert "codex" in prompt
+        assert "usage limit reached" in prompt, "the reason belongs in the prompt"
+        assert "NARROWED result" in prompt
+
+    def test_an_absent_optional_provider_is_reported_but_not_alarming(self):
+        manifest = _manifest(
+            codex=(True, "ok", "/x/reviewer-codex.md", None),
+            claude_interactive=(False, "failed", None, "delegate timed out"),
+        )
+        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        assert delta["status"] == "degraded-optional"
+        assert delta["absent_required"] == []
+
+        prompt = synthesize_reviews.synthesize(_reviews("a"), delta)
+        assert "QUORUM INCOMPLETE" in prompt
+        assert "which the role permits" in prompt
+        assert "claude_interactive" in prompt
+        # An optional absence must not be dressed up as a required one.
+        assert "A **required** provider is missing" not in prompt
+
+    def test_the_counts_track_the_manifest_not_the_files_found(self):
+        """The whole point: expected comes from the role, received from disk.
+
+        A synthesis that derived both numbers from the files it found could
+        never report a gap, which is the fail-open being closed.
+        """
+        manifest = _manifest(
+            a=(True, "ok", "/x/a.md", None),
+            b=(True, "failed", None, "boom"),
+            c=(False, "failed", None, "boom"),
+        )
+        delta = synthesize_reviews.quorum_delta(_reviews("a"), manifest)
+        assert (delta["received_n"], delta["expected_n"]) == (1, 3)
+
+
+class TestCli:
+    """End-to-end: the reconciler reads stdout, so the delta must land there."""
+
+    def _setup(self, tmp_path, codex_ok: bool):
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a concrete finding")
+        manifest = tmp_path / "reviewer-manifest.json"
+        manifest.write_text(json.dumps({
+            "role": "reviewer",
+            "results": [
+                {"name": "codex", "required": True,
+                 "status": "ok" if codex_ok else "failed",
+                 "path": str(review) if codex_ok else None,
+                 "error": None if codex_ok else "usage limit reached"},
+                {"name": "deepseek-flash", "required": True, "status": "ok",
+                 "path": str(review), "error": None},
+            ],
+        }))
+        return manifest
+
+    def test_paths_are_derived_from_the_manifest_when_none_are_given(
+            self, tmp_path, capsys):
+        """Callers listing filenames by hand drift as the roster changes.
+
+        `/implement` Step 8 hardcoded `reviewer-gemini.md` long after gemini
+        left the reviewer role, so the name it passed could never resolve.
+        """
+        manifest = self._setup(tmp_path, codex_ok=True)
+        assert synthesize_reviews.main(["--manifest", str(manifest)]) == 0
+        assert "a concrete finding" in capsys.readouterr().out
+
+    def test_an_absent_required_provider_is_reported_but_does_not_block(
+            self, tmp_path, capsys):
+        manifest = self._setup(tmp_path, codex_ok=False)
+        assert synthesize_reviews.main(["--manifest", str(manifest)]) == 0
+        captured = capsys.readouterr()
+        assert "QUORUM INCOMPLETE" in captured.out
+        assert "codex" in captured.err
+
+    def test_gate_blocks_on_an_absent_required_provider(self, tmp_path, capsys):
+        manifest = self._setup(tmp_path, codex_ok=False)
+        assert synthesize_reviews.main(["--manifest", str(manifest), "--gate"]) == 1
+        assert "QUORUM INCOMPLETE" in capsys.readouterr().out
+
+    def test_gate_does_not_block_on_a_complete_quorum(self, tmp_path):
+        manifest = self._setup(tmp_path, codex_ok=True)
+        assert synthesize_reviews.main(["--manifest", str(manifest), "--gate"]) == 0
+
+    def test_an_unreadable_manifest_is_an_error_not_a_silent_unknown(
+            self, tmp_path, capsys):
+        """The caller asked for the quorum to be checked and it could not be.
+
+        Degrading to "expected set unknown" would turn a broken instrument
+        into the same output as never having asked.
+        """
+        broken = tmp_path / "reviewer-manifest.json"
+        broken.write_text("{not json")
+        review = tmp_path / "reviewer-deepseek.md"
+        review.write_text("a finding")
+        assert synthesize_reviews.main(
+            ["--manifest", str(broken), str(review)]) == 2
+        assert "cannot read manifest" in capsys.readouterr().err


### PR DESCRIPTION
Closes #416.

## The defect

`synthesize_reviews` counted the review files it happened to find and opened the prompt with `**N reviews received.**`. That count cannot distinguish "every reviewer answered" from "one was asked and never did", so a synthesis built from a silently narrowed quorum read as complete, and the reconciler downstream had no way to know a voice was missing.

**This bug ate a review during the session that fixed it.** `codex` hit its account usage limit, the role quorum abandoned it, and a synthesis of what remained would have presented one reviewer's findings as the whole picture.

Under review lenses (#163) this is worse than a smaller sample. Each provider is scoped to a concern nobody else is looking for, so an absent voice removes exactly the findings it was there to produce.

## Where "expected" comes from

The issue left this open: *"whether that expectation comes from an argument, the role plan, or a manifest written by `consult_ai.py` is the design question."*

It comes from the manifest, because **it already exists**. `consult_ai.py --role` writes `reviewer-manifest.json` beside the reviews, recording every provider the role expected, whether it was required, its status, its path, and its error. No new plumbing was needed — the fact was on disk and nothing read it.

## The states

| Situation | Header |
|---|---|
| all providers answered | `2 of 2 expected reviews received — quorum complete.` |
| a **required** one absent | `1 of 2 ... — QUORUM INCOMPLETE` + "a NARROWED result, not a clean one" |
| only **optional** ones absent | `1 of 2 ... — QUORUM INCOMPLETE` + "which the role permits" |
| nothing loaded at all | the full block, plus "No reviews were loaded at all ... a failed review step, not a clean one" |
| no manifest supplied | `the expected set is UNKNOWN ... treat coverage as unverified rather than complete` |

Each absentee is named with its tier and its error, in the prompt, where the reconciler reads it.

## Required vs optional is honoured, not collapsed

- a missing **optional** provider is reported and does **not** block — roles model that outcome deliberately
- a missing **required** provider is reported to stderr, and `--gate` turns it into a non-zero exit (report-only by default, per `docs/gate-rollout.md`)
- `load_reviews` stays non-fatal on a missing file: the fix went where the lie was, not where the file was absent

## What the adversarial review changed

Every finding below was reproduced against the real code before being fixed. The first is the original bug wearing the fixed version's clothes.

**The manifest's own `status` was trusted over the filesystem.** Absence came from `status != "ok"` alone, so a provider marked ok whose file had since been deleted counted as present:

```
**0 of 1 expected reviews received — quorum complete.**
```

Self-contradictory in one sentence, and overstating coverage in exactly the case a delta check exists for — when the manifest and the disk disagree. Two siblings of the same root cause: review files nobody expected inflated the received count past the expected one (`3 of 2 ... complete`), and a manifest with no `results` made the expected count zero (`1 of 0 ... complete`).

Expected providers are now matched to reviews that actually loaded, by the stem of the recorded path. `received_n` can never exceed `expected_n`; anything else loaded is reported as unattributed rather than counted.

**The maximally degraded quorum produced the least informative output.** Every provider failed → no paths derivable → the CLI called it a usage error and exited 2, losing the report at the moment it mattered most. Every provider marked ok but every file gone → a bare `No reviews to synthesize.` with the delta discarded. Both now print the full quorum block.

**`--gate` without `--manifest` was an inert gate returning success.** With no expected set it could never fire, so automation adding the flag would believe the quorum had been verified when nothing was checked — "failed to run = pass" at the gate level. Now exit 2.

**Off-shape manifests crashed instead of being refused.** A non-string `error`, a `results` list of strings, a top-level JSON array — all raised `AttributeError` out of the middle of the delta computation, surfacing as a traceback at **exit 1**, the code reserved for a finding being gated on. All are now named and refused at exit 2, alongside duplicate provider names and a non-list `results`.

**A supplied-but-falsy manifest claimed none was supplied.** `{}`, `[]`, and a file containing `null` took the unknown branch and printed "no role manifest was supplied" — false, and the gate went inert. "Not supplied" is now `None` specifically.

## A second defect found on the way

With `--manifest` and no paths, the review paths come from the manifest. That kills a drift bug: `/implement` Step 8 passed `reviewer-gemini.md` long after gemini left the `reviewer` role, so it handed over a path that could never resolve — and the resulting "1 review received" would have looked deliberate. `/close-epic` read the same stale pair. Both now go through the manifest and cannot drift as the roster changes.

## Dogfooded on itself

Running the real `reviewer` role for this diff lost codex to its usage limit. The new synthesizer, fed that live manifest:

```
**1 of 3 expected reviews received — QUORUM INCOMPLETE.**

Absent:
- `codex` (required) — execution failed: ... exit status 1.
- `claude-interactive` (optional) — execution failed: ... exit status 3.
```

Before the change: `**1 reviews received.**`

## Testing

- 28 new tests; the #361 pinning test is **updated rather than deleted**, exactly as its docstring asked — it still asserts loading is non-fatal, and now points at the tests covering where the behaviour actually changed
- **18/18 mutants caught** (7/18 before the review pass)
- Full suite: 4149 passed, 14 skipped

## Acceptance criteria

- [x] a synthesis produced from fewer reviews than expected says so, in the prompt, where the reconciler will read it
- [x] required vs optional honoured — a missing optional provider does not block, a missing required one is not silently absorbed
- [x] the pinning test in `tests/test_synthesize_reviews.py` is updated to assert the new behaviour rather than deleted

## Review provenance

Codex is out of account credits until Aug 25, so the configured quorum could not be met — which is how the bug came to be dogfooded. The review ran on kimi-k3 and deepseek-v4-flash.

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
