### PR TITLE
docs(models): document the OpenRouter providers and refresh them in /update (#368)

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -35,6 +35,21 @@ Research the current state of each provider's models by checking their official 
 - Note flagship, coding, and reasoning models
 - Flag any newly deprecated models
 
+**OpenRouter (the `openrouter` tool's models — chief-wiggum#368, #372):**
+- Check https://openrouter.ai/models for the current slugs of every provider in
+  `config/providers.json` whose `tool` is `openrouter` — today `deepseek`,
+  `deepseek-flash`, `kimi`, `glm`, `qwen`, `minimax`
+- These are **routing slugs, not vendor IDs** (`deepseek/deepseek-v4-flash`,
+  `moonshotai/kimi-k3`), and they change independently of the vendor's own
+  naming. A stale slug does not degrade — the call 404s and the provider drops
+  out of its role, which since #416 is reported as a quorum gap rather than
+  silently absorbed, but is still a dead reviewer
+- Update BOTH `models.md` and the `model` field in `config/providers.json`;
+  they drift apart otherwise, and `providers.json` is the one that actually
+  dispatches
+- Note context-window changes: several roles send whole diffs inline because
+  these providers declare `reads_repo=false`
+
 ### Step 2: Fetch latest library versions
 
 Check PyPI for current versions of each package:
@@ -56,6 +71,8 @@ Read the current `$CW_HOME/models.md` and update it with the new information:
 - Update library version table
 - Keep the same format and structure
 - Add notes about breaking changes if any model IDs changed
+- The OpenRouter table must stay in step with `config/providers.json`: if a
+  slug changed, change it in both, and say so in the diff you show the user
 
 ### Step 3.5: Refresh model pricing (`config/model_pricing.json`)
 

--- a/models.md
+++ b/models.md
@@ -42,6 +42,39 @@ Refresh with `/update`.
 
 **Deprecated** (do not use): `gpt-5.2`, `gpt-5.1-codex`, `gpt-5.1-mini`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o1-mini`
 
+## OpenRouter (chief-wiggum#368, #372)
+
+Reached over the OpenRouter HTTP API by the single `openrouter` tool in
+`scripts/consult_ai.py`; the key is `OPENROUTER_API_KEY` from the keyring,
+passed at call time and never placed in the environment. Provider names below
+are the `config/providers.json` names, which is what roles refer to — the
+`openrouter` tool plus a `model` is the transport underneath.
+
+| Provider | Model ID | Cost tier | Use for |
+|----------|----------|-----------|---------|
+| `deepseek-flash` | `deepseek/deepseek-v4-flash` | 1 | The code-quorum seat gemini vacated. Required in `reviewer` and `risky_diff_review`, optional in `explorer` and `architecture_critic`. Chosen for cost and speed, not distribution entropy. |
+| `deepseek` | `deepseek/deepseek-v4-pro` | 2 | Required in `divergence`. Slower and dearer than flash; note its default 300s budget is often not enough for a large diff — pass `--timeout 900`. |
+| `kimi` | `moonshotai/kimi-k3` | 2 | Required in `divergence`. Carries its own 900s `timeout_seconds`. |
+| `glm` | `z-ai/glm-5.2` | 2 | Optional in `divergence`. |
+| `qwen` | `qwen/qwen3.7-max` | 2 | Optional in `divergence`. |
+| `minimax` | `minimax/minimax-m3` | 2 | Optional in `divergence`. |
+
+All six declare `reads_repo=false`, `needs_inline_diff=true` and
+`accepts_images=false`, with a 128k context window. Two consequences that bite
+in practice:
+
+- **A prompt sent to any of them must be self-contained.** They cannot read the
+  repository, so a review prompt has to carry the diff inline AND enough
+  context about the code the diff calls into. A blind reviewer that is not told
+  what a helper does will infer, and inferred defects arrive at high confidence
+  — verify every finding against the real code before acting on it.
+- **`gemini-vertex` remains only where images are sent** (`design_critic`),
+  because no OpenRouter provider here accepts them.
+
+The `divergence` role exists to widen the quorum's *pretraining distribution*,
+not its prompting, and stays opt-in. `deepseek-flash`'s seat in the code roles
+is a separate decision made on cost and speed.
+
 ## Whisper (Local)
 
 | Model | Params | Notes |

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -319,6 +319,60 @@ def test_validate_config_accepts_well_formed_optional_timeout_seconds():
     assert providers.validate_config(config) == []
 
 
+def _models_md() -> str:
+    from pathlib import Path
+
+    # Explicit encoding: the file carries em dashes, and read_text() would
+    # otherwise decode by locale, which is a portability trap rather than a
+    # today problem.
+    return (Path(__file__).resolve().parents[1] / "models.md").read_text(
+        encoding="utf-8")
+
+
+def _openrouter_section() -> str:
+    """Just the OpenRouter table, so other vendors' slugs are not swept in."""
+    text = _models_md()
+    start = text.index("## OpenRouter")
+    rest = text.index("\n## ", start + 1)
+    return text[start:rest]
+
+
+def _tabled_slugs() -> set[str]:
+    """The Model ID column of the OpenRouter table, lowercased.
+
+    Read from the table's second column rather than by pattern-matching the
+    prose: a "looks like a slug" heuristic also matches `config/providers.json`
+    and `scripts/consult_ai.py`, which is what the first attempt at this did.
+    """
+    slugs = set()
+    for line in _openrouter_section().splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = line.split("|")
+        if len(cells) < 3:
+            continue
+        cell = cells[2].strip()
+        if cell.startswith("`") and cell.endswith("`"):
+            slugs.add(cell.strip("`").strip().lower())
+    return slugs
+
+
+def _routed_openrouter_models(config: dict | None = None) -> dict[str, str]:
+    """Enabled OpenRouter-backed providers, name -> model slug.
+
+    A provider switched off is deliberately not dispatched to, so requiring a
+    reference entry for it would fail CI over a config change that broke
+    nothing — and a guard that cries wolf teaches the operator to bypass it.
+    """
+    config = config if config is not None else providers.load_config()
+    return {
+        name: spec["model"]
+        for name, spec in (config.get("providers") or {}).items()
+        if spec.get("tool") == "openrouter" and spec.get("model")
+        and spec.get("enabled", True)
+    }
+
+
 def test_every_openrouter_model_slug_is_documented_in_models_md():
     """models.md must list every OpenRouter-backed provider (chief-wiggum#368).
 
@@ -330,29 +384,95 @@ def test_every_openrouter_model_slug_is_documented_in_models_md():
     stale slug does not degrade gracefully, it 404s and that reviewer drops
     out of its role.
     """
-    import re
-    from pathlib import Path
-
-    config = providers.load_config()
-    reference = (Path(__file__).resolve().parents[1] / "models.md").read_text()
-    # Exact backticked tokens, not a substring search: `deepseek/x-flash` is a
-    # substring of `deepseek/x-flash-preview`, so a plain `in` check passes
-    # while the two files name different models.
-    documented = set(re.findall(r"`([^`]+)`", reference))
-
-    routed = {
-        name: spec["model"]
-        for name, spec in (config.get("providers") or {}).items()
-        if spec.get("tool") == "openrouter" and spec.get("model")
-    }
+    documented = _tabled_slugs()
+    routed = _routed_openrouter_models()
     assert routed, "expected at least one openrouter-backed provider to exist"
+    assert documented, "the OpenRouter table in models.md has no model column"
 
     missing = {name: model for name, model in routed.items()
-               if model not in documented}
+               if model.lower() not in documented}
     assert not missing, (
         f"models.md does not document these OpenRouter model slugs: {missing}. "
         "Add them, or drop the provider from config/providers.json."
     )
+
+
+def test_a_disabled_provider_is_not_required_to_be_documented():
+    """Switching a provider off must not break CI over the reference.
+
+    Nothing dispatches to a disabled provider, so demanding a models.md entry
+    for it would fail the build over a config change that broke nothing — and
+    a guard that cries wolf teaches the operator to bypass it. Exercised on a
+    synthetic config because no shipped OpenRouter provider is currently
+    disabled, which would otherwise leave this filter untested.
+    """
+    config = {"providers": {
+        "live": {"tool": "openrouter", "model": "vendor/live-v1", "enabled": True},
+        "off": {"tool": "openrouter", "model": "vendor/off-v1", "enabled": False},
+        "implied": {"tool": "openrouter", "model": "vendor/implied-v1"},
+        "other-tool": {"tool": "codex", "model": "vendor/not-routed"},
+    }}
+    assert _routed_openrouter_models(config) == {
+        "live": "vendor/live-v1",
+        "implied": "vendor/implied-v1",  # absent `enabled` means enabled
+    }
+
+
+def test_models_md_does_not_advertise_a_provider_that_is_no_longer_wired():
+    """The reverse drift, which the forward check cannot see.
+
+    A slug left in the reference after its provider was removed from config
+    tells a reader the model is available when nothing dispatches to it. Only
+    the OpenRouter section is scanned, so slugs belonging to other vendors are
+    not swept up.
+    """
+    slugs = _tabled_slugs()
+    routed = {model.lower() for model in _routed_openrouter_models().values()}
+
+    stale = sorted(slugs - routed)
+    assert not stale, (
+        f"models.md advertises OpenRouter slugs nothing dispatches to: {stale}. "
+        "Remove them, or wire the provider back into config/providers.json."
+    )
+
+
+def test_models_md_role_membership_claims_match_the_config():
+    """The prose claims are drift too, and were the untested half.
+
+    models.md states which roles each provider sits in and whether it is
+    required there. That is exactly the kind of hand-maintained assertion this
+    file's slug check exists to stop trusting — raised in review, and fair:
+    guarding the slugs while leaving the surrounding sentences unguarded is
+    half a guard.
+    """
+    config = providers.load_config()
+    roles = config.get("roles") or {}
+
+    def membership(provider: str) -> tuple[set[str], set[str]]:
+        required = {name for name, role in roles.items()
+                    if provider in (role.get("required") or [])}
+        optional = {name for name, role in roles.items()
+                    if provider in (role.get("optional") or [])}
+        return required, optional
+
+    # The claims made in models.md's OpenRouter table, transcribed.
+    claimed = {
+        "deepseek-flash": ({"reviewer", "risky_diff_review"},
+                           {"explorer", "architecture_critic"}),
+        "deepseek": ({"divergence"}, set()),
+        "kimi": ({"divergence"}, set()),
+        "glm": (set(), {"divergence"}),
+        "qwen": (set(), {"divergence"}),
+        "minimax": (set(), {"divergence"}),
+    }
+    for provider, (want_required, want_optional) in claimed.items():
+        got_required, got_optional = membership(provider)
+        assert got_required == want_required, (
+            f"models.md says {provider} is required in {sorted(want_required)},"
+            f" config says {sorted(got_required)}")
+        assert got_optional == want_optional, (
+            f"models.md says {provider} is optional in {sorted(want_optional)},"
+            f" config says {sorted(got_optional)}")
 
 
 def test_default_provider_config_sets_optional_timeout_seconds_on_every_role():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -319,6 +319,42 @@ def test_validate_config_accepts_well_formed_optional_timeout_seconds():
     assert providers.validate_config(config) == []
 
 
+def test_every_openrouter_model_slug_is_documented_in_models_md():
+    """models.md must list every OpenRouter-backed provider (chief-wiggum#368).
+
+    These are ROUTING SLUGS, not vendor IDs, and they change independently of
+    the vendor's own naming. `config/providers.json` is what dispatches;
+    models.md is what a human reads when choosing a voice, and `/update` is
+    what refreshes both. A provider wired into a role but absent from the
+    reference is one nobody knows to re-check when the slug moves — and a
+    stale slug does not degrade gracefully, it 404s and that reviewer drops
+    out of its role.
+    """
+    import re
+    from pathlib import Path
+
+    config = providers.load_config()
+    reference = (Path(__file__).resolve().parents[1] / "models.md").read_text()
+    # Exact backticked tokens, not a substring search: `deepseek/x-flash` is a
+    # substring of `deepseek/x-flash-preview`, so a plain `in` check passes
+    # while the two files name different models.
+    documented = set(re.findall(r"`([^`]+)`", reference))
+
+    routed = {
+        name: spec["model"]
+        for name, spec in (config.get("providers") or {}).items()
+        if spec.get("tool") == "openrouter" and spec.get("model")
+    }
+    assert routed, "expected at least one openrouter-backed provider to exist"
+
+    missing = {name: model for name, model in routed.items()
+               if model not in documented}
+    assert not missing, (
+        f"models.md does not document these OpenRouter model slugs: {missing}. "
+        "Add them, or drop the provider from config/providers.json."
+    )
+
+
 def test_default_provider_config_sets_optional_timeout_seconds_on_every_role():
     # Every shipped role includes claude-interactive as optional (chief-wiggum#188);
     # each must set the knob so the delegate never silently reverts to its full


### PR DESCRIPTION
Partially addresses #368. **The issue stays open** — see "What this does not do".

## What was already done

Most of #368 shipped some time ago, differently and better than the ticket asked. Rather than an `openrouter-deepseek` tool, `scripts/consult_ai.py` grew a single generic `openrouter` tool (#372), and `config/providers.json` names six providers on top of it:

| Provider | Slug | Roles |
|---|---|---|
| `deepseek-flash` | `deepseek/deepseek-v4-flash` | `reviewer`*, `risky_diff_review`*, `explorer`, `architecture_critic` |
| `deepseek` | `deepseek/deepseek-v4-pro` | `divergence`* |
| `kimi` | `moonshotai/kimi-k3` | `divergence`* |
| `glm` | `z-ai/glm-5.2` | `divergence` |
| `qwen` | `qwen/qwen3.7-max` | `divergence` |
| `minimax` | `minimax/minimax-m3` | `divergence` |

(* = required in that role.) Five roles in total dispatch to them. The key comes from the keyring at call time and is never placed in the environment.

## What was missing

Two of the ticket's bullets were never done, and they are the same defect: **nothing outside `providers.json` knew these providers existed.**

- `models.md` had no OpenRouter section at all, so the file a human reads when choosing a voice omitted six providers that five roles dispatch to.
- `/update` Step 1 refreshed Claude, Gemini and OpenAI only, so those six slugs drift unchecked. Pricing was already covered in Step 3.5, which is what made the gap easy to miss.

That matters more than an ordinary doc gap because these are **routing slugs, not vendor IDs** — `deepseek/deepseek-v4-flash`, `moonshotai/kimi-k3` — and they move independently of the vendor's own naming. A stale slug does not degrade: the call 404s and that reviewer drops out of its role. Since #416 that is at least reported as a quorum gap rather than silently absorbed, but it is still a dead voice.

## What this does

- an OpenRouter section in `models.md` with every provider, its slug, its cost tier, and which roles use it
- `/update` Step 1 now refreshes those slugs, and says explicitly to update **both** `models.md` and `config/providers.json` — they drift apart otherwise, and `providers.json` is the one that actually dispatches
- three tests, so the reference is backed by something other than discipline

## What the adversarial review changed

The first cut guarded the slugs and left everything around them unguarded, which is half a guard. Every finding below was reproduced before being fixed.

**The role-membership claims were prose.** `models.md` states which roles each provider sits in and whether it is required there — hand-maintained assertions of exactly the kind the slug check exists to stop trusting. They are now asserted against the config. That also closes **provider-rename drift**: renaming a provider while keeping its slug left the forward check green.

**Reverse drift was invisible.** A slug left in the table after its provider was removed advertises a voice nothing dispatches to. Now checked, scoped to the OpenRouter table so other vendors' rows and the existing "Deprecated" lists are not swept in.

**The forward check scanned the whole file**, so a slug mentioned anywhere — a deprecation note, an evaluation aside — satisfied the guard even with no table row. Both directions now read the table's Model ID column, which also makes the fenced-block and backtick-parity concerns moot.

The first attempt at the reverse check pattern-matched "looks like a slug" and promptly flagged `config/providers.json` and `scripts/consult_ai.py`.

**A disabled provider would have failed CI** over a config change that broke nothing — a guard that cries wolf teaches the operator to bypass it. Filtered, and exercised on a synthetic config, because no shipped provider is currently disabled and the filter would otherwise be untested code.

`read_text` now pins utf-8 rather than decoding by locale.

**And a factual error in my own prose:** the first commit message and PR body said "four roles dispatch to those providers". It is five (`explorer`, `reviewer`, `architecture_critic`, `risky_diff_review`, `divergence`). Caught by arithmetic in review and corrected here.

The models.md entry also records the two things that bite when using these providers, both learned the hard way in this session:

- every prompt must be **self-contained** (they declare `reads_repo=false`), so a blind reviewer that is not told what a helper does will infer — and inferred defects arrive at high confidence
- `deepseek`'s default 300s budget is often not enough for a large diff; pass `--timeout 900`

## What this does not do

**The ticket's actual motivation is unmet: "deepseek slots into the quorum when codex 429s". It does not.**

A required provider that fails fails the role. That happened repeatedly during this session with codex out of account credits:

```
Error: required provider codex failed: ... returned non-zero exit status 1.
Role reviewer quorum failed: codex
```

There is no substitution mechanism. Building one means deciding how a role distinguishes an exhausted provider from a transiently broken one — a `fallbacks` list per provider, an error-class trigger, or something else — and that is a design decision for the repo owner rather than an implementing agent's default. #368 stays open for it.

## Testing

- **7/7 mutants caught** (up from 3): forward slug drift, slug changed, reverse stale row, role claim demoted, forward check going vacuous, table column parsed loosely, disabled providers unfiltered
- Full suite: 4153 passed, 14 skipped

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
