### PR TITLE
fix(deps): probe the interpreter CW will run, and name it when a dep is missing (#374)

### DIFF
--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -181,20 +181,65 @@ def check_cmd(name: str, cmd: str, version_flag: str = "--version", required: bo
             warn_count += 1
 
 
-def check_python_pkg(name: str, import_name: str, required: bool = True):
-    global pass_count, fail_count, warn_count
+def runtime_python() -> str:
+    """The interpreter CW's scripts will actually be run under (#374).
+
+    Not necessarily the one running this check. `python3` is whatever the
+    shell resolves, so Homebrew bumping it from 3.11 to 3.13 strands every
+    dependency installed for the old one — and a green check under the
+    checker's own interpreter says nothing about that. Falls back to the
+    current interpreter only when resolution fails, and `verify_python_env`
+    reports that rather than hiding it.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     try:
-        mod = importlib.import_module(import_name)
-        ver = getattr(mod, "__version__", "installed")
+        from chief_wiggum.interpreter import resolve
+
+        return resolve(["core"]).python
+    except Exception:  # noqa: BLE001 - any failure means "cannot resolve"
+        # Deliberately broad: NoValidInterpreter is only importable if the
+        # import itself succeeded, so naming it in the handler would leave it
+        # unbound on the path this exists to survive.
+        return sys.executable
+
+
+def check_python_pkg(name: str, import_name: str, required: bool = True,
+                     python: str | None = None):
+    """Probe the module under the RUNTIME interpreter, not this one.
+
+    `importlib.import_module` here would answer for whichever interpreter is
+    running check_deps.py. That is the bug this check exists to catch: the
+    machine in #374 had a working python3.11 with keyring while `python3`
+    resolved to a 3.13 without it, and this check passed.
+    """
+    global pass_count, fail_count, warn_count
+    target = python or sys.executable
+    if target == sys.executable:
+        try:
+            mod = importlib.import_module(import_name)
+            ver = getattr(mod, "__version__", "installed")
+        except ImportError:
+            ver = None
+    else:
+        probe = subprocess.run(
+            [target, "-c",
+             f"import {import_name} as m;"
+             f"print(getattr(m, '__version__', 'installed'))"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        ver = probe.stdout.strip() if probe.returncode == 0 else None
+
+    if ver:
         print(f"{GREEN}[OK]{NC}  {name:<14s} {ver}")
         pass_count += 1
-    except ImportError:
-        if required:
-            print(f"{RED}[MISSING]{NC}  {name:<14s} python package not found")
-            fail_count += 1
-        else:
-            print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not installed")
-            warn_count += 1
+        return
+    if required:
+        print(f"{RED}[MISSING]{NC}  {name:<14s} python package not found")
+        print(f"        fix: uv pip install --python {target} {name}")
+        fail_count += 1
+    else:
+        print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not installed")
+        warn_count += 1
 
 
 def check_secret(name: str, required: bool = False):
@@ -475,9 +520,17 @@ def main():
     check_cmd("gopls", "gopls", "version", is_required("cmds", "gopls", workflows))
     check_cmd("pyright-langserver", "pyright-langserver", "--version", is_required("cmds", "pyright-langserver", workflows))
 
+    runtime = runtime_python()
     print("\n--- Python Packages ---")
-    check_python_pkg("keyring", "keyring", is_required("pkgs", "keyring", workflows))
-    check_python_pkg("whisper", "whisper", is_required("pkgs", "whisper", workflows))
+    print(f"      probing: {runtime}")
+    if runtime != sys.executable:
+        # Worth saying out loud: a green result here is about the interpreter
+        # CW will run, which is not the one you invoked this with.
+        print(f"      (this check is running under {sys.executable})")
+    check_python_pkg("keyring", "keyring", is_required("pkgs", "keyring", workflows),
+                     python=runtime)
+    check_python_pkg("whisper", "whisper", is_required("pkgs", "whisper", workflows),
+                     python=runtime)
 
     print("\n--- Python Packages (browser-use — optional, for /implement validation) ---")
     check_python_pkg("browser-use", "browser_use", is_required("pkgs", "browser-use", workflows))

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -181,25 +181,50 @@ def check_cmd(name: str, cmd: str, version_flag: str = "--version", required: bo
             warn_count += 1
 
 
+def _remediation(python: str, modules: list[str]) -> str:
+    """The shared remediation string, or a plain one if it cannot be imported."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        from chief_wiggum.interpreter import remediation
+
+        return remediation(python, modules)
+    except Exception:  # noqa: BLE001 - advice must survive a broken import
+        return f"uv pip install --python {python} {' '.join(modules)}"
+
+
 def runtime_python() -> str:
     """The interpreter CW's scripts will actually be run under (#374).
 
     Not necessarily the one running this check. `python3` is whatever the
     shell resolves, so Homebrew bumping it from 3.11 to 3.13 strands every
     dependency installed for the old one — and a green check under the
-    checker's own interpreter says nothing about that. Falls back to the
-    current interpreter only when resolution fails, and `verify_python_env`
-    reports that rather than hiding it.
+    checker's own interpreter says nothing about that.
+
+    When resolution fails this falls back to the current interpreter and SAYS
+    SO. A silent fallback reproduces the original incident exactly: run the
+    check under a working 3.11, resolution fails, the fallback quietly reports
+    on 3.11, every line comes back green, and the pipeline then runs under the
+    broken `python3` and dies. The point of this function is that the operator
+    knows which interpreter a green result describes.
     """
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     try:
         from chief_wiggum.interpreter import resolve
 
         return resolve(["core"]).python
-    except Exception:  # noqa: BLE001 - any failure means "cannot resolve"
+    except Exception as exc:  # noqa: BLE001 - any failure means "cannot resolve"
         # Deliberately broad: NoValidInterpreter is only importable if the
         # import itself succeeded, so naming it in the handler would leave it
         # unbound on the path this exists to survive.
+        print(
+            f"{YELLOW}[WARN]{NC}  could not resolve CW's runtime interpreter"
+            f" ({type(exc).__name__}: {exc})\n"
+            f"        falling back to {sys.executable} — a green result below"
+            " describes THAT\n"
+            "        interpreter, which may not be the one the skills invoke."
+            "  (see: env.py python --json)",
+            file=sys.stderr,
+        )
         return sys.executable
 
 
@@ -221,13 +246,38 @@ def check_python_pkg(name: str, import_name: str, required: bool = True,
         except ImportError:
             ver = None
     else:
-        probe = subprocess.run(
-            [target, "-c",
-             f"import {import_name} as m;"
-             f"print(getattr(m, '__version__', 'installed'))"],
-            capture_output=True, text=True, timeout=30, check=False,
-        )
-        ver = probe.stdout.strip() if probe.returncode == 0 else None
+        try:
+            probe = subprocess.run(
+                # -I: ignore the ambient environment and cwd. Without it the
+                # probe answers a different question than the runtime does —
+                # a stray keyring.py in the operator's cwd would read as [OK].
+                [target, "-I", "-c",
+                 f"import {import_name} as m;"
+                 f"print(getattr(m, '__version__', 'installed'))"],
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            # A probe that could not RUN is not a missing package. Reporting
+            # it as one hands the operator a remediation that cannot work,
+            # and letting the exception escape kills the whole audit with the
+            # kind of traceback this change exists to remove.
+            print(f"{RED}[ERROR]{NC}  {name:<14s} probe failed under {target}")
+            print(f"        {type(exc).__name__}: {exc}")
+            fail_count += 1
+            return
+        # LAST line, not the whole of stdout: interpreter wrappers (conda,
+        # some virtualenv shims) print a banner before running the -c script,
+        # and taking everything would report the banner as the version.
+        lines = [line for line in probe.stdout.splitlines() if line.strip()]
+        ver = lines[-1].strip() if probe.returncode == 0 and lines else None
+        if ver is None and import_name.split(".")[0] not in probe.stderr:
+            # Non-zero for a reason unrelated to this import: a broken
+            # sitecustomize, a mis-set PYTHONHOME. Not missing, not present.
+            tail = probe.stderr.strip().splitlines()
+            print(f"{RED}[ERROR]{NC}  {name:<14s} probe failed under {target}")
+            print(f"        {tail[-1][:160] if tail else '(no stderr)'}")
+            fail_count += 1
+            return
 
     if ver:
         print(f"{GREEN}[OK]{NC}  {name:<14s} {ver}")
@@ -235,7 +285,14 @@ def check_python_pkg(name: str, import_name: str, required: bool = True,
         return
     if required:
         print(f"{RED}[MISSING]{NC}  {name:<14s} python package not found")
-        print(f"        fix: uv pip install --python {target} {name}")
+        # Through the shared table, never the bare import name: advising
+        # `whisper` installs a DIFFERENT PyPI package that also provides a
+        # `whisper` module, so the next run reads green while the runtime is
+        # still broken. A remediation that manufactures a false pass is worse
+        # than no remediation. This is also the deduplication this change
+        # applied to keychain.py — hand-rolling the string here repeated the
+        # very thing it was fixing.
+        print(f"        fix: {_remediation(target, [import_name])}")
         fail_count += 1
     else:
         print(f"{YELLOW}[OPTIONAL]{NC}  {name:<14s} not installed")
@@ -527,6 +584,22 @@ def main():
         # Worth saying out loud: a green result here is about the interpreter
         # CW will run, which is not the one you invoked this with.
         print(f"      (this check is running under {sys.executable})")
+
+    # The skills still invoke a bare `python3`, so THAT is what actually
+    # executes CW's helpers today — not necessarily what `resolve()` picked.
+    # If they differ, a green report below describes an interpreter the
+    # workflows will not use, which is the #374 condition wearing a tick.
+    shell_python = shutil.which("python3")
+    if shell_python and os.path.realpath(shell_python) != os.path.realpath(runtime):
+        print(
+            f"{YELLOW}[WARN]{NC}  the skills invoke `python3`, which resolves to"
+            f" {shell_python}\n"
+            f"        but the checks below describe {runtime}. Until the skills"
+            " are migrated to\n"
+            "        `$(env.py python)`, the interpreter that actually runs CW"
+            " is the former.",
+            file=sys.stderr,
+        )
     check_python_pkg("keyring", "keyring", is_required("pkgs", "keyring", workflows),
                      python=runtime)
     check_python_pkg("whisper", "whisper", is_required("pkgs", "whisper", workflows),

--- a/scripts/chief_wiggum/interpreter.py
+++ b/scripts/chief_wiggum/interpreter.py
@@ -125,6 +125,29 @@ def remediation(python: str, missing: Sequence[str]) -> str:
     return f"uv pip install --python {python} {' '.join(packages)}"
 
 
+def missing_dependency_message(module: str, python: str | None = None) -> str:
+    """What a script should print instead of dying on an ImportError.
+
+    Names the INTERPRETER, not just the package: `python3` is unpinned across
+    the skills, so "install jsonschema" is useless advice when the question is
+    which of several interpreters is missing it. uv rather than pip because
+    installing into an externally-managed system Python is what stranded these
+    dependencies in the first place.
+
+    Shared so the call sites cannot drift into saying different things — the
+    same reason #420 extracted its journal append rather than fixing two
+    hand-rolled copies.
+    """
+    runtime = python or sys.executable
+    return (
+        f"Missing dependency: {module}\n"
+        f"  interpreter: {runtime}\n"
+        f"  fix:         {remediation(runtime, [module])}\n"
+        "  or point CW at a working interpreter:\n"
+        "               export CW_PYTHON=$(python3 scripts/env.py python)"
+    )
+
+
 def probe(python: str, modules: Sequence[str], *, timeout: float = 30.0) -> Candidate:
     """Ask the CANDIDATE whether it can import these, by running it.
 

--- a/scripts/chief_wiggum/interpreter.py
+++ b/scripts/chief_wiggum/interpreter.py
@@ -47,6 +47,13 @@ PACKAGE_FOR_IMPORT = {
     "google.cloud.aiplatform": "google-cloud-aiplatform",
     "anthropic": "anthropic",
     "yaml": "pyyaml",
+    # `whisper` is the trap in this table: PyPI's `whisper` is a DIFFERENT
+    # package that also provides a `whisper` module, so advising the import
+    # name installs something that imports cleanly and behaves wrongly — a
+    # remediation that manufactures a green check is worse than none.
+    "whisper": "openai-whisper",
+    "browser_use": "browser-use",
+    "langchain_anthropic": "langchain-anthropic",
 }
 
 # What each profile needs. Profiles mirror check_deps.py's vocabulary.

--- a/scripts/consult_ai.py
+++ b/scripts/consult_ai.py
@@ -846,7 +846,17 @@ def consult_gemini_vertex(
         sys.exit(1)
 
     # Import here so the dependency is only needed for this path
-    from google import genai  # type: ignore
+    try:
+        from google import genai  # type: ignore
+    except ImportError:
+        # The third failure in chief-wiggum#374's report, and the least
+        # obvious: `google` imports fine as a namespace package, so the error
+        # is "cannot import name 'genai' from 'google'" rather than a missing
+        # module — which reads like a broken install instead of an absent one.
+        from chief_wiggum.interpreter import missing_dependency_message
+
+        print(missing_dependency_message("google.genai"), file=sys.stderr)
+        sys.exit(1)
 
     requested_model = model or DEFAULT_VERTEX_MODEL
     client = genai.Client(vertexai=True, project=project, location=location)

--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -30,18 +30,25 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
 try:
     import jsonschema
 except ImportError:  # pragma: no cover - exercised as a subprocess
     # chief-wiggum#374: this was one of the three scripts that died on a bare
     # ModuleNotFoundError when `python3` resolved to an interpreter without
     # the dependency. Same treatment keychain.py gives keyring.
+    #
+    # The sys.path insert happens HERE rather than above the import, so the
+    # third-party jsonschema keeps resolving exactly as it did before this
+    # change. Hoisting it would put scripts/ ahead of site-packages for the
+    # very import being guarded, which is a shadowing risk introduced by the
+    # guard rather than fixed by it.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     from chief_wiggum.interpreter import missing_dependency_message
 
     print(missing_dependency_message("jsonschema"), file=sys.stderr)
     sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from chief_wiggum.trace_ids import near_miss_ids  # noqa: E402
 

--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -30,9 +30,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import jsonschema
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - exercised as a subprocess
+    # chief-wiggum#374: this was one of the three scripts that died on a bare
+    # ModuleNotFoundError when `python3` resolved to an interpreter without
+    # the dependency. Same treatment keychain.py gives keyring.
+    from chief_wiggum.interpreter import missing_dependency_message
+
+    print(missing_dependency_message("jsonschema"), file=sys.stderr)
+    sys.exit(1)
 
 from chief_wiggum.trace_ids import near_miss_ids  # noqa: E402
 

--- a/scripts/keychain.py
+++ b/scripts/keychain.py
@@ -32,14 +32,12 @@ except ImportError:
     # advice when the question is WHICH interpreter is missing it. uv rather
     # than pip because installing into an externally-managed system Python is
     # what stranded these dependencies in the first place.
-    print(
-        "Missing dependency: keyring\n"
-        f"  interpreter: {sys.executable}\n"
-        f"  fix:         uv pip install --python {sys.executable} keyring\n"
-        "  or point CW at a working interpreter:\n"
-        "               export CW_PYTHON=$(python3 scripts/env.py python)",
-        file=sys.stderr,
-    )
+    from pathlib import Path as _Path
+
+    sys.path.insert(0, str(_Path(__file__).resolve().parent))
+    from chief_wiggum.interpreter import missing_dependency_message
+
+    print(missing_dependency_message("keyring"), file=sys.stderr)
     sys.exit(1)
 
 SERVICE = "chief-wiggum"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -324,6 +324,36 @@ class TestMissingDependencyIsActionable:
                   for line in proc.stdout.splitlines() if "probing:" in line]
         assert probed and probed[0].startswith("/"), probed
 
+    def test_a_failed_resolution_is_announced_not_silently_absorbed(
+            self, tmp_path, capsys, monkeypatch):
+        """Raised in review, and its worst case is the original incident.
+
+        Run the check under a working 3.11, let resolution fail, fall back
+        quietly to 3.11, and every line comes back green — while the pipeline
+        then runs under the broken `python3` and dies. The fallback is fine;
+        being silent about it is not.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "cw_check_deps_warn", ROOT / "scripts" / "check_deps.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        import chief_wiggum.interpreter as interp
+
+        def boom(*a, **k):
+            raise interp.NoValidInterpreter("nothing validated")
+
+        monkeypatch.setattr(interp, "resolve", boom)
+        result = module.runtime_python()
+
+        assert result == sys.executable, "it should still fall back"
+        err = capsys.readouterr().err
+        assert "could not resolve" in err, err
+        assert sys.executable in err, "say which interpreter it fell back to"
+        assert "may not be the one the skills invoke" in err
+
     def test_check_python_pkg_reports_a_module_absent_from_another_interpreter(
             self, tmp_path, capsys):
         """Probing really crosses the process boundary.
@@ -339,14 +369,24 @@ class TestMissingDependencyIsActionable:
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
+        # A faithful stand-in for a missing module: real interpreters
+        # say so on stderr. A bare `exit 1` is an unrunnable probe,
+        # which is a different state and is reported as one.
         fake = tmp_path / "fake-python"
-        fake.write_text("#!/bin/sh\nexit 1\n")
+        fake.write_text(
+            "#!/bin/sh\n"
+            "echo \"ModuleNotFoundError: No module named '$3'\" >&2\n"
+            "exit 1\n")
         fake.chmod(0o755)
 
         module.fail_count = 0
         module.pass_count = 0
         module.warn_count = 0
-        module.check_python_pkg("keyring", "keyring", True, python=str(fake))
+        # `json`, not `keyring`: a module guaranteed importable in the test
+        # interpreter. With `keyring` the kill was accidental — it depended on
+        # the dev box happening not to have it, so on a box that did, the
+        # "always use importlib" mutation would survive.
+        module.check_python_pkg("json", "json", True, python=str(fake))
         assert module.fail_count == 1, (
             "a module absent from the RUNTIME interpreter must be reported "
             "missing even when the checker's own interpreter has it")
@@ -355,7 +395,92 @@ class TestMissingDependencyIsActionable:
         # Saying "missing" without saying where to install it is how the
         # operator ends up guessing, which is the cost #374 recorded.
         out = capsys.readouterr().out
-        assert f"uv pip install --python {fake} keyring" in out, out
+        assert f"uv pip install --python {fake} json" in out, out
+
+    def test_the_fix_line_names_the_distribution_not_the_import(
+            self, tmp_path, capsys):
+        """A remediation that manufactures a false green is worse than none.
+
+        PyPI's `whisper` is a different package that also provides a `whisper`
+        module. Advising the import name installs something that imports
+        cleanly and behaves wrongly, so the NEXT check reads green while the
+        runtime stays broken.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "cw_check_deps_dist", ROOT / "scripts" / "check_deps.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        # A faithful stand-in for a missing module: real interpreters
+        # say so on stderr. A bare `exit 1` is an unrunnable probe,
+        # which is a different state and is reported as one.
+        fake = tmp_path / "fake-python"
+        fake.write_text(
+            "#!/bin/sh\n"
+            "echo \"ModuleNotFoundError: No module named '$3'\" >&2\n"
+            "exit 1\n")
+        fake.chmod(0o755)
+
+        module.pass_count = module.fail_count = module.warn_count = 0
+        module.check_python_pkg("whisper", "whisper", True, python=str(fake))
+        out = capsys.readouterr().out
+        assert "openai-whisper" in out, out
+        assert "python whisper" not in out, (
+            "advising the import name installs the wrong distribution")
+
+    def test_a_probe_that_cannot_run_is_an_error_not_a_missing_package(
+            self, tmp_path, capsys):
+        """Three states, not two: present, absent, and could-not-ask.
+
+        An unrunnable interpreter reported as "missing" hands the operator a
+        uv command that cannot help, and letting the OSError escape kills the
+        whole audit with the sort of traceback this change exists to remove.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "cw_check_deps_err", ROOT / "scripts" / "check_deps.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        module.pass_count = module.fail_count = module.warn_count = 0
+        module.check_python_pkg("keyring", "keyring", True,
+                                python=str(tmp_path / "does-not-exist"))
+        out = capsys.readouterr().out
+        assert "probe failed" in out, out
+        assert "python package not found" not in out, (
+            "a probe that could not run is not evidence the package is absent")
+        assert module.fail_count == 1
+
+    def test_a_wrapper_banner_is_not_reported_as_the_version(
+            self, tmp_path, capsys):
+        """Some interpreter wrappers print before running the -c script.
+
+        conda and a few virtualenv shims emit a line of their own, and taking
+        the whole of stdout would report that banner as the package version —
+        a green tick carrying nonsense.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "cw_check_deps_banner", ROOT / "scripts" / "check_deps.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        chatty = tmp_path / "chatty-python"
+        chatty.write_text("#!/bin/sh\necho 'Activating env foo'\necho '4.25.1'\n")
+        chatty.chmod(0o755)
+
+        module.pass_count = module.fail_count = module.warn_count = 0
+        module.check_python_pkg("jsonschema", "jsonschema", True,
+                                python=str(chatty))
+        out = capsys.readouterr().out
+        assert module.pass_count == 1, out
+        assert "4.25.1" in out
+        assert "Activating env foo" not in out, (
+            "the wrapper's banner was reported as the version")
 
     def test_no_script_advises_pip_into_the_system_interpreter(self):
         """pip into an externally-managed Python is what caused #374."""

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -235,11 +235,132 @@ class TestEnvPythonCLI:
         )
 
 
-class TestKeychainRemediation:
-    def test_the_missing_keyring_message_names_the_interpreter_and_uv(self):
-        source = (ROOT / "scripts" / "keychain.py").read_text()
-        assert "uv pip install --python" in source
-        assert "pip3 install keyring" not in source, (
-            "pip into an externally-managed system Python is what caused #374"
+def _blocking_env(module: str, tmp_path: Path) -> dict:
+    """An environment where importing `module` raises, for the child process.
+
+    A meta_path finder rather than a stub file on sys.path: a stub would
+    import successfully, which is the opposite of the condition under test.
+    """
+    import os
+
+    (tmp_path / "sitecustomize.py").write_text(
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        f"        if name == {module!r} or name.startswith({module + '.'!r}):\n"
+        f"            raise ModuleNotFoundError('blocked', name={module!r})\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path)
+    return env
+
+
+class TestMissingDependencyIsActionable:
+    """A missing dependency must name the interpreter, not just the package.
+
+    Asserted by RUNNING the scripts with the module blocked, rather than by
+    grepping their source for the message. The source check this replaces
+    broke the moment the message moved into a shared helper — it was pinned to
+    where the words lived, not to what the operator sees.
+
+    #374's cost was three failed launches and three ad-hoc repairs, and the
+    worst case is a backgrounded consult: the process exits instantly, the
+    output file never appears, and a wait-less launch reads as success.
+    """
+
+    @pytest.mark.parametrize("script,module", [
+        ("keychain.py", "keyring"),
+        ("formal_models.py", "jsonschema"),
+        ("generate_formal_test_artifacts.py", "jsonschema"),
+    ])
+    def test_the_message_names_the_interpreter_and_the_uv_command(
+            self, script, module, tmp_path):
+        path = ROOT / "scripts" / script
+        if not path.is_file():
+            pytest.skip(f"{script} is not present")
+        proc = subprocess.run(
+            [sys.executable, str(path), "--help"],
+            capture_output=True, text=True, cwd=str(ROOT),
+            env=_blocking_env(module, tmp_path),
         )
-        assert "CW_PYTHON" in source
+        assert proc.returncode != 0, "a missing dependency must not exit 0"
+        assert "Traceback" not in proc.stderr, (
+            f"{script} died on a bare traceback: {proc.stderr[:300]}")
+        assert f"Missing dependency: {module}" in proc.stderr
+
+        # The child resolves symlinks, so its sys.executable need not equal
+        # ours (/opt/homebrew/opt/... vs /opt/homebrew/Cellar/...). Assert the
+        # PROPERTY: an absolute interpreter is named, and the fix targets that
+        # same one — a remediation pointing at a different interpreter than
+        # the one that failed is the advice that wasted the operator's time.
+        named = [line.split("interpreter:", 1)[1].strip()
+                 for line in proc.stderr.splitlines() if "interpreter:" in line]
+        assert named, f"no interpreter named in: {proc.stderr[:300]}"
+        interpreter = named[0]
+        assert interpreter.startswith("/"), interpreter
+        assert f"uv pip install --python {interpreter}" in proc.stderr
+        assert "CW_PYTHON" in proc.stderr, "offer the override too"
+
+    def test_check_deps_probes_the_runtime_interpreter_not_its_own(self, tmp_path):
+        """The original defect, stated as a property.
+
+        `check_deps.py` used `importlib.import_module`, which answers for
+        whichever interpreter is running the checker. The #374 machine had a
+        working python3.11 with keyring while `python3` resolved to a 3.13
+        without it — and this check passed. So the probe must happen inside
+        the interpreter CW will actually invoke, and the report must say which
+        one that was.
+        """
+        proc = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "check_deps.py"), "--for", "core"],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        assert "probing:" in proc.stdout, (
+            "check_deps must name the interpreter it probed, or a green result "
+            f"says nothing about which one: {proc.stdout[:300]}")
+        probed = [line.split("probing:", 1)[1].strip()
+                  for line in proc.stdout.splitlines() if "probing:" in line]
+        assert probed and probed[0].startswith("/"), probed
+
+    def test_check_python_pkg_reports_a_module_absent_from_another_interpreter(
+            self, tmp_path, capsys):
+        """Probing really crosses the process boundary.
+
+        Exercised against a stub interpreter that fails every import, because
+        a same-interpreter shortcut would otherwise make the cross-process
+        path untested — and that path IS the fix.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "cw_check_deps", ROOT / "scripts" / "check_deps.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        fake = tmp_path / "fake-python"
+        fake.write_text("#!/bin/sh\nexit 1\n")
+        fake.chmod(0o755)
+
+        module.fail_count = 0
+        module.pass_count = 0
+        module.warn_count = 0
+        module.check_python_pkg("keyring", "keyring", True, python=str(fake))
+        assert module.fail_count == 1, (
+            "a module absent from the RUNTIME interpreter must be reported "
+            "missing even when the checker's own interpreter has it")
+
+        # And the report has to be actionable, aimed at THAT interpreter.
+        # Saying "missing" without saying where to install it is how the
+        # operator ends up guessing, which is the cost #374 recorded.
+        out = capsys.readouterr().out
+        assert f"uv pip install --python {fake} keyring" in out, out
+
+    def test_no_script_advises_pip_into_the_system_interpreter(self):
+        """pip into an externally-managed Python is what caused #374."""
+        for name in ("keychain.py", "formal_models.py", "consult_ai.py"):
+            source = (ROOT / "scripts" / name).read_text(encoding="utf-8")
+            assert "pip3 install keyring" not in source
+            assert "pip install keyring" not in source.replace(
+                "uv pip install", "")


### PR DESCRIPTION
Partially addresses #374. **The issue stays open** — see "What this does not do".

## What was already done

Proposal 1 shipped earlier: `env.py python --profile ...` resolves and caches a validated interpreter via `chief_wiggum/interpreter.py`, honouring `CW_PYTHON`.

## What this fixes

**`check_deps.py` verified the wrong interpreter.** `check_python_pkg` called `importlib.import_module`, which answers for whichever interpreter is running the checker — saying nothing about the one the skills invoke. That is precisely the machine in the report: a working `python3.11` with keyring, `python3` resolving to a 3.13 without it, and this check passing.

It now probes inside the resolved runtime interpreter and prints which one.

**Two of the three reported failures still died on a bare traceback.** `keychain.py` already handled keyring well; the other two did not.

| Script | Missing | Before | After |
|---|---|---|---|
| `formal_models.py` (and `generate_formal_test_artifacts.py`) | `jsonschema` | traceback | `Missing dependency:` + interpreter + uv command |
| `consult_ai.py` Vertex path | `google.genai` | traceback | same |

The `google.genai` one is the least obvious: `google` imports fine as a namespace package, so the error reads `cannot import name 'genai' from 'google'` and looks like a broken install rather than an absent dependency.

The message moved into `interpreter.missing_dependency_message` so the call sites cannot drift — the reason #420 extracted its journal append rather than fixing two hand-rolled copies.

## What the adversarial review changed

Every finding reproduced before being fixed. One was refuted by test.

**The remediation could manufacture a false green.** The fix line was hand-rolled as `uv pip install --python X {name}` — and PyPI's `whisper` is a **different package** that also provides a `whisper` module. An operator following that advice installs something that imports cleanly and behaves wrongly, so the *next* check reads green while transcription stays broken. A remediation that produces a false pass is worse than none.

It now goes through `interpreter.remediation` and `PACKAGE_FOR_IMPORT` (whisper, browser-use and langchain-anthropic added). Hand-rolling the string repeated the exact duplication this change had just removed from `keychain.py`.

**A silent fallback reproduced the original incident.** When resolution failed, `runtime_python` returned the current interpreter with no signal — and the "running under" note *cannot* fire in that state, because the two are then equal. Run the check under a working 3.11, resolution fails, every line comes back green, and the pipeline dies under the broken `python3`.

The docstring even claimed a `verify_python_env` reported it: a comment describing a guard that does not exist, which is worse than no comment. It now warns and names the interpreter the result actually describes.

**The check answered a different question than the one that matters.** It probes `resolve()`'s pick, but the skills still invoke a bare `python3`, so that is what executes CW's helpers today. If those differ, a green report describes an interpreter the workflows will not use. It now compares the two and warns when they disagree.

**A probe that could not run was reported as a missing package.** A timeout or unrunnable interpreter propagated and killed the audit with a traceback; a non-zero exit for an unrelated reason (broken `sitecustomize`, mis-set `PYTHONHOME`) printed `[MISSING]` with a uv command that cannot help. Three states now: present, absent, could-not-ask.

Smaller, same review: the probe runs with `-I` so a stray `keyring.py` in the operator's cwd cannot read as `[OK]`; a wrapper banner on stdout is no longer taken for a version; and `formal_models.py` keeps its original import order, because hoisting the `sys.path` insert above the guarded import would put `scripts/` ahead of site-packages for the very import being guarded.

**Refuted, and recorded rather than acted on:** review reported that `import a.b as c` binds the top-level package, making the dotted probe a false positive. It binds the submodule. Checked before changing anything.

## Two of my own mistakes, found by probing

**A handler I wrote was dead code.** I first wrapped `consult_ai.py`'s `from keychain import get_secret`. Probing showed it can never fire — `keychain.py` exits first with a better message. Reverted before it shipped.

**Two tests were wrong in the same direction.** The fake interpreters exited 1 with no output, which the new three-state logic correctly reads as an *unrunnable probe* rather than a *missing module*. Real interpreters say `ModuleNotFoundError` on stderr; the fakes now do too. A third used `keyring` as its probe target, so its mutation kill depended on this box happening not to have it — it uses `json` now and is deterministic.

And the test this change replaced grepped `keychain.py`'s **source** for the remediation string, so moving the message into a shared helper broke it. It was pinned to where the words lived, not what the operator sees. The behavioural rewrite then surfaced something the source check could not: the child process resolves symlinks, so its `sys.executable` differs from the parent's. The real property is that the interpreter *named* in the message is the one the fix *targets*.

## What this does not do

**The skills still hardcode `python3` across ~40 call sites**, so CW's runtime interpreter remains whatever the shell resolves. `env.py python` exists to be called; nothing calls it yet. The new warning makes that visible rather than fixing it.

That migration touches every workflow file and belongs in its own change. #374 stays open for it. Proposal 3 (a `uv`-managed venv as the canonical runtime) is untouched — marked optional in the ticket, and it changes install topology, which is a decision rather than a default.

Exit-code conflation was also raised (all three sites use `sys.exit(1)`, which `formal_models.py` already uses for validation findings). Left alone deliberately: changing a validator's exit semantics is a behaviour change for its callers, not a tail-end of an error-message fix.

## Testing

- **10/10 mutants caught** (up from 7)
- Full suite: 4162 passed, 14 skipped

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
