### PR TITLE
fix(templates): close the last open schema object, and document the brace split (#347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,18 @@ patterns/            # Registry of reusable product patterns CW stamps into buil
 models.md            # AI model IDs and library versions (refresh with /update)
 ```
 
+**Template placeholder convention** (chief-wiggum#347). The two brace styles in
+`templates/` mean different things, and the split is deliberate rather than
+accidental:
+
+- `{{DOUBLE_BRACE}}` — **machine-substituted**. A script fills it before the
+  text is used (e.g. `{{KEYWORD}}`, `{{DIFF_REPORT}}` in the prompt templates).
+  Leaving one unsubstituted is a bug: it ships the literal token to a model.
+- `{SINGLE_BRACE}` — **human-filled**. A person completes it when adopting the
+  template (e.g. `{PRODUCT}`, `{GOVERNING_STANDARD}` in
+  `compliance-requirements.md`). These are expected to survive copying and are
+  filled in the target repo.
+
 ### Epic artifacts (in target repos)
 
 `/architect` commits artifacts to `docs/epics/[slug]/` in the target repo:

--- a/templates/formal-models/ui-spec-schema.json
+++ b/templates/formal-models/ui-spec-schema.json
@@ -4,7 +4,10 @@
   "title": "UI Specification",
   "description": "Structured specification of an application's UI: pages, component trees, interaction patterns, and navigation. Populated by observation (an agentic SaaS-cloning tool) or design decisions (chief-wiggum /architect).",
   "type": "object",
-  "required": ["pages", "navigation"],
+  "required": [
+    "pages",
+    "navigation"
+  ],
   "additionalProperties": false,
   "properties": {
     "app": {
@@ -12,8 +15,12 @@
       "description": "Application-level metadata",
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string" },
-        "description": { "type": "string" },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "shell": {
           "$ref": "#/$defs/shell",
           "description": "The persistent app shell (navbar, sidebar, footer) that wraps all pages"
@@ -22,7 +29,7 @@
     },
     "design": {
       "$ref": "#/$defs/design",
-      "description": "Visual design contract — tokens, theme, typography, component-library binding, and brand assets. A frontend can satisfy every interaction contract and still ship off-brand; this section makes visual identity checkable."
+      "description": "Visual design contract \u2014 tokens, theme, typography, component-library binding, and brand assets. A frontend can satisfy every interaction contract and still ship off-brand; this section makes visual identity checkable."
     },
     "patterns": {
       "type": "object",
@@ -33,55 +40,75 @@
     },
     "pages": {
       "type": "object",
-      "description": "Map of route path → page specification",
+      "description": "Map of route path \u2192 page specification",
       "additionalProperties": {
         "$ref": "#/$defs/page"
       }
     },
     "navigation": {
       "$ref": "#/$defs/navigationGraph",
-      "description": "Navigation state machine — pages are states, links are transitions"
+      "description": "Navigation state machine \u2014 pages are states, links are transitions"
     },
     "derived_from": {
       "type": "array",
-      "items": { "$ref": "#/$defs/provenance" }
+      "items": {
+        "$ref": "#/$defs/provenance"
+      }
     }
   },
   "$defs": {
     "design": {
       "type": "object",
       "description": "The visual design contract. Implementations MUST bind these tokens (e.g. as CSS variables) and the design-fidelity gate reviews rendered screenshots against them.",
-      "required": ["source", "tokens"],
+      "required": [
+        "source",
+        "tokens"
+      ],
       "additionalProperties": false,
       "properties": {
         "source": {
           "type": "object",
-          "description": "Where this design comes from — discovered by /seed (existing system, reference product) or authored net-new",
-          "required": ["kind"],
+          "description": "Where this design comes from \u2014 discovered by /seed (existing system, reference product) or authored net-new",
+          "required": [
+            "kind"
+          ],
           "additionalProperties": false,
           "properties": {
             "kind": {
               "type": "string",
-              "enum": ["existing-design-system", "reference-product", "brand-kit", "net-new"]
+              "enum": [
+                "existing-design-system",
+                "reference-product",
+                "brand-kit",
+                "net-new"
+              ]
             },
             "references": {
               "type": "array",
               "description": "URLs, repo paths, or screenshot paths for the design source (e.g. the product being replicated, the Figma export, the tokens file)",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
-            "notes": { "type": "string" }
+            "notes": {
+              "type": "string"
+            }
           }
         },
         "tokens": {
           "type": "object",
-          "description": "Design tokens. Keys are semantic names, values are concrete CSS values. These are binding — a frontend that ignores them fails the conformance check.",
+          "description": "Design tokens. Keys are semantic names, values are concrete CSS values. These are binding \u2014 a frontend that ignores them fails the conformance check.",
           "additionalProperties": false,
           "properties": {
             "colors": {
               "type": "object",
-              "description": "Semantic color name → CSS value (hex/hsl/gradient). MUST include at least 'primary'. Include brand gradients here.",
-              "required": ["primary"],
-              "additionalProperties": { "type": "string" }
+              "description": "Semantic color name \u2192 CSS value (hex/hsl/gradient). MUST include at least 'primary'. Include brand gradients here.",
+              "required": [
+                "primary"
+              ],
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "typography": {
               "type": "object",
@@ -90,30 +117,40 @@
               "properties": {
                 "fonts": {
                   "type": "object",
-                  "description": "Role (heading/body/mono) → font stack",
-                  "additionalProperties": { "type": "string" }
+                  "description": "Role (heading/body/mono) \u2192 font stack",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
                 },
                 "scale": {
                   "type": "object",
-                  "description": "Size name (xs/sm/base/lg/xl/...) → CSS size",
-                  "additionalProperties": { "type": "string" }
+                  "description": "Size name (xs/sm/base/lg/xl/...) \u2192 CSS size",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
                 }
               }
             },
             "spacing": {
               "type": "object",
-              "description": "Spacing scale name → CSS value",
-              "additionalProperties": { "type": "string" }
+              "description": "Spacing scale name \u2192 CSS value",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "radii": {
               "type": "object",
-              "description": "Border-radius name → CSS value",
-              "additionalProperties": { "type": "string" }
+              "description": "Border-radius name \u2192 CSS value",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "shadows": {
               "type": "object",
-              "description": "Shadow name → CSS value",
-              "additionalProperties": { "type": "string" }
+              "description": "Shadow name \u2192 CSS value",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -123,25 +160,47 @@
           "properties": {
             "modes": {
               "type": "array",
-              "items": { "type": "string", "enum": ["light", "dark", "high-contrast"] }
+              "items": {
+                "type": "string",
+                "enum": [
+                  "light",
+                  "dark",
+                  "high-contrast"
+                ]
+              }
             },
-            "default": { "type": "string" }
+            "default": {
+              "type": "string"
+            }
           }
         },
         "component_library": {
           "type": "object",
-          "description": "The component library binding — prefer adopting an existing library over hand-rolling",
-          "required": ["name", "usage"],
+          "description": "The component library binding \u2014 prefer adopting an existing library over hand-rolling",
+          "required": [
+            "name",
+            "usage"
+          ],
           "additionalProperties": false,
           "properties": {
-            "name": { "type": "string" },
-            "version": { "type": "string" },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
             "usage": {
               "type": "string",
-              "enum": ["adopt", "extend", "custom"],
+              "enum": [
+                "adopt",
+                "extend",
+                "custom"
+              ],
               "description": "adopt = use as-is with tokens; extend = themed wrapper components; custom = hand-rolled (justify in notes)"
             },
-            "notes": { "type": "string" }
+            "notes": {
+              "type": "string"
+            }
           }
         },
         "assets": {
@@ -149,42 +208,67 @@
           "description": "Brand assets and reference screenshots, with the pages/regions they apply to",
           "items": {
             "type": "object",
-            "required": ["id", "type"],
+            "required": [
+              "id",
+              "type"
+            ],
             "additionalProperties": false,
             "properties": {
-              "id": { "type": "string" },
+              "id": {
+                "type": "string"
+              },
               "type": {
                 "type": "string",
-                "enum": ["logo", "wordmark", "illustration", "icon-set", "reference-screenshot"]
+                "enum": [
+                  "logo",
+                  "wordmark",
+                  "illustration",
+                  "icon-set",
+                  "reference-screenshot"
+                ]
               },
-              "path": { "type": "string", "description": "Repo path or URL" },
+              "path": {
+                "type": "string",
+                "description": "Repo path or URL"
+              },
               "applies_to": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Page routes or component IDs this asset applies to"
               },
-              "description": { "type": "string" }
+              "description": {
+                "type": "string"
+              }
             }
           }
         },
         "voice": {
           "type": "object",
-          "description": "Copy/personality guidelines — empty states, greetings, error tone",
+          "description": "Copy/personality guidelines \u2014 empty states, greetings, error tone",
           "additionalProperties": false,
           "properties": {
-            "tone": { "type": "string" },
-            "empty_states": { "type": "string", "description": "How empty states should feel (e.g. 'warm, dog-themed illustration + one actionable sentence')" }
+            "tone": {
+              "type": "string"
+            },
+            "empty_states": {
+              "type": "string",
+              "description": "How empty states should feel (e.g. 'warm, dog-themed illustration + one actionable sentence')"
+            }
           }
         },
         "derived_from": {
           "type": "array",
-          "items": { "$ref": "#/$defs/provenance" }
+          "items": {
+            "$ref": "#/$defs/provenance"
+          }
         }
       }
     },
     "shell": {
       "type": "object",
-      "description": "Persistent app shell — always visible regardless of current page",
+      "description": "Persistent app shell \u2014 always visible regardless of current page",
       "additionalProperties": false,
       "properties": {
         "navbar": {
@@ -204,11 +288,16 @@
     "page": {
       "type": "object",
       "description": "A page/route in the application",
-      "required": ["layout"],
+      "required": [
+        "layout"
+      ],
       "additionalProperties": false,
       "properties": {
         "route": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "URL pattern (e.g., '/boards', '/b/:boardId'). Null for overlays/modals that don't have their own route."
         },
         "title": {
@@ -221,52 +310,87 @@
         },
         "layout": {
           "type": "string",
-          "enum": ["full-width", "sidebar-main", "centered", "split", "canvas"],
+          "enum": [
+            "full-width",
+            "sidebar-main",
+            "centered",
+            "split",
+            "canvas"
+          ],
           "description": "Page layout pattern. 'canvas' = free-form like a board view"
         },
         "auth": {
           "type": "string",
-          "enum": ["required", "optional", "public"],
+          "enum": [
+            "required",
+            "optional",
+            "public"
+          ],
           "default": "required",
           "description": "Authentication requirement"
         },
         "components": {
           "type": "object",
-          "description": "Flat map of component ID → component spec. Use IDs to reference children.",
+          "description": "Flat map of component ID \u2192 component spec. Use IDs to reference children.",
           "additionalProperties": {
             "$ref": "#/$defs/component"
           }
         },
         "root": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Ordered list of top-level component IDs (the page's direct children)"
         },
         "design_refs": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "IDs of design assets (from design.assets) that apply to this page — brand treatments, reference screenshots to match"
+          "items": {
+            "type": "string"
+          },
+          "description": "IDs of design assets (from design.assets) that apply to this page \u2014 brand treatments, reference screenshots to match"
         },
         "derived_from": {
           "type": "array",
-          "items": { "$ref": "#/$defs/provenance" }
+          "items": {
+            "$ref": "#/$defs/provenance"
+          }
         }
       }
     },
     "component": {
       "type": "object",
       "description": "A UI component. Uses flat ID references for children, not nested trees.",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "description": "Component type — use ARIA-inspired vocabulary for structural components, descriptive names for custom ones",
+          "description": "Component type \u2014 use ARIA-inspired vocabulary for structural components, descriptive names for custom ones",
           "examples": [
-            "navbar", "sidebar", "dialog", "menu", "tabpanel", "list",
-            "card", "form", "button", "input", "grid", "section",
-            "popover", "toast", "avatar", "badge", "breadcrumb",
-            "search-bar", "board-column", "kanban-board", "card-modal"
+            "navbar",
+            "sidebar",
+            "dialog",
+            "menu",
+            "tabpanel",
+            "list",
+            "card",
+            "form",
+            "button",
+            "input",
+            "grid",
+            "section",
+            "popover",
+            "toast",
+            "avatar",
+            "badge",
+            "breadcrumb",
+            "search-bar",
+            "board-column",
+            "kanban-board",
+            "card-modal"
           ]
         },
         "label": {
@@ -283,7 +407,9 @@
         },
         "children": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Ordered list of child component IDs"
         },
         "data": {
@@ -291,13 +417,21 @@
           "description": "What data this component displays or manages",
           "additionalProperties": true,
           "properties": {
-            "entity": { "type": "string", "description": "Entity type (e.g., 'Board', 'Card')" },
+            "entity": {
+              "type": "string",
+              "description": "Entity type (e.g., 'Board', 'Card')"
+            },
             "fields": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": "Which entity fields are displayed"
             },
-            "source": { "type": "string", "description": "API endpoint or data source" }
+            "source": {
+              "type": "string",
+              "description": "API endpoint or data source"
+            }
           }
         },
         "interactions": {
@@ -314,7 +448,11 @@
           "properties": {
             "default": {
               "type": "string",
-              "enum": ["visible", "hidden", "collapsed"],
+              "enum": [
+                "visible",
+                "hidden",
+                "collapsed"
+              ],
               "default": "visible"
             },
             "condition": {
@@ -330,12 +468,24 @@
           "properties": {
             "mobile": {
               "type": "string",
-              "enum": ["visible", "hidden", "collapsed", "full-screen", "drawer", "bottom-sheet"],
+              "enum": [
+                "visible",
+                "hidden",
+                "collapsed",
+                "full-screen",
+                "drawer",
+                "bottom-sheet"
+              ],
               "description": "Behavior on mobile (<768px)"
             },
             "desktop": {
               "type": "string",
-              "enum": ["visible", "hidden", "sidebar", "inline"],
+              "enum": [
+                "visible",
+                "hidden",
+                "sidebar",
+                "inline"
+              ],
               "description": "Behavior on desktop"
             }
           }
@@ -344,14 +494,25 @@
     },
     "interaction": {
       "type": "object",
-      "description": "An interaction contract — what happens when the user does something",
-      "required": ["trigger", "action"],
+      "description": "An interaction contract \u2014 what happens when the user does something",
+      "required": [
+        "trigger",
+        "action"
+      ],
       "additionalProperties": false,
       "properties": {
         "trigger": {
           "type": "string",
           "description": "What the user does",
-          "examples": ["click", "hover", "focus", "submit", "keypress:Escape", "keypress:n", "drag-drop"]
+          "examples": [
+            "click",
+            "hover",
+            "focus",
+            "submit",
+            "keypress:Escape",
+            "keypress:n",
+            "drag-drop"
+          ]
         },
         "action": {
           "type": "string",
@@ -385,8 +546,11 @@
     },
     "pattern": {
       "type": "object",
-      "description": "A reusable UI pattern — define once, reference by ID in components",
-      "required": ["name", "type"],
+      "description": "A reusable UI pattern \u2014 define once, reference by ID in components",
+      "required": [
+        "name",
+        "type"
+      ],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -399,7 +563,7 @@
         },
         "description": {
           "type": "string",
-          "description": "How this pattern works — the contract sub-agents must follow"
+          "description": "How this pattern works \u2014 the contract sub-agents must follow"
         },
         "structure": {
           "type": "object",
@@ -410,20 +574,27 @@
         },
         "interactions": {
           "type": "array",
-          "items": { "$ref": "#/$defs/interaction" },
+          "items": {
+            "$ref": "#/$defs/interaction"
+          },
           "description": "Standard interactions this pattern provides"
         },
         "examples": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Where this pattern is used in the app"
         }
       }
     },
     "navigationGraph": {
       "type": "object",
-      "description": "Navigation state machine — XState-compatible format. Pages are states, links are transitions.",
-      "required": ["initial", "states"],
+      "description": "Navigation state machine \u2014 XState-compatible format. Pages are states, links are transitions.",
+      "required": [
+        "initial",
+        "states"
+      ],
       "additionalProperties": false,
       "properties": {
         "initial": {
@@ -432,7 +603,7 @@
         },
         "states": {
           "type": "object",
-          "description": "Map of page ID → navigation state",
+          "description": "Map of page ID \u2192 navigation state",
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -443,17 +614,27 @@
               },
               "on": {
                 "type": "object",
-                "description": "Map of event → target page ID (same as XState transitions)",
+                "description": "Map of event \u2192 target page ID (same as XState transitions)",
                 "additionalProperties": {
                   "oneOf": [
-                    { "type": "string" },
+                    {
+                      "type": "string"
+                    },
                     {
                       "type": "object",
                       "properties": {
-                        "target": { "type": "string" },
-                        "guard": { "type": "string" }
+                        "target": {
+                          "type": "string"
+                        },
+                        "guard": {
+                          "type": "string"
+                        }
                       },
-                      "required": ["target"]
+                      "required": [
+                        "target"
+                      ],
+                      "additionalProperties": false,
+                      "description": "Transition object. Closed (additionalProperties: false) like every other object in the formal-models schemas \u2014 it was the one exception, so a misspelled `guard`/`target` validated silently instead of being rejected (chief-wiggum#347)."
                     }
                   ]
                 }
@@ -465,15 +646,29 @@
     },
     "provenance": {
       "type": "object",
-      "required": ["type", "ref"],
+      "required": [
+        "type",
+        "ref"
+      ],
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "screenshot", "user_input"]
+          "enum": [
+            "ticket",
+            "acceptance_criterion",
+            "epic_invariant",
+            "observed_fact",
+            "screenshot",
+            "user_input"
+          ]
         },
-        "ref": { "type": "string" },
-        "description": { "type": "string" }
+        "ref": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
       }
     }
   }

--- a/tests/test_template_schemas.py
+++ b/tests/test_template_schemas.py
@@ -1,0 +1,84 @@
+"""Formal-model template schemas are closed, and stay closed (chief-wiggum#347).
+
+An object with `properties` but no `additionalProperties: false` accepts
+anything extra, so a misspelled key validates cleanly and the mistake surfaces
+much later as absent behaviour rather than as a schema error. Every object in
+these schemas was closed except one transition form, which this file both
+fixes-in-place-forever and generalises: any NEW open object in any
+formal-models schema fails here rather than being noticed in a review months
+later.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import jsonschema.validators
+import pytest
+
+SCHEMA_DIR = Path(__file__).resolve().parents[1] / "templates" / "formal-models"
+SCHEMAS = sorted(SCHEMA_DIR.glob("*-schema.json"))
+
+
+def _open_objects(node, path: str = "root") -> list[str]:
+    """Every `type: object` with `properties` that does not close itself."""
+    found: list[str] = []
+    if isinstance(node, dict):
+        if node.get("type") == "object" and "properties" in node:
+            if "additionalProperties" not in node:
+                found.append(path)
+        for key, value in node.items():
+            found.extend(_open_objects(value, f"{path}.{key}"))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found.extend(_open_objects(value, f"{path}[{index}]"))
+    return found
+
+
+def test_there_are_schemas_to_check():
+    """Guard the denominator: an empty glob would make every test below vacuous."""
+    assert SCHEMAS, f"no *-schema.json under {SCHEMA_DIR}"
+
+
+@pytest.mark.parametrize("path", SCHEMAS, ids=lambda p: p.name)
+def test_the_schema_is_itself_a_valid_json_schema(path):
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+
+
+@pytest.mark.parametrize("path", SCHEMAS, ids=lambda p: p.name)
+def test_every_object_is_closed(path):
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    open_objects = _open_objects(schema)
+    assert not open_objects, (
+        f"{path.name} has objects that accept unknown keys, so a typo in a "
+        f"stamped artifact would validate silently: {open_objects}")
+
+
+class TestTheTransitionObjectRejectsTypos:
+    """The specific hole #347 named, pinned by behaviour rather than by shape."""
+
+    @pytest.fixture
+    def transition(self):
+        schema = json.loads(
+            (SCHEMA_DIR / "ui-spec-schema.json").read_text(encoding="utf-8"))
+        return (schema["$defs"]["navigationGraph"]["properties"]["states"]
+                ["additionalProperties"]["properties"]["on"])
+
+    def test_the_string_shorthand_is_still_accepted(self, transition):
+        jsonschema.validate({"CLICK": "home"}, transition)
+
+    def test_the_object_form_is_still_accepted(self, transition):
+        jsonschema.validate({"CLICK": {"target": "home", "guard": "isAuthed"}},
+                            transition)
+
+    def test_a_misspelled_key_is_rejected(self, transition):
+        with pytest.raises(jsonschema.ValidationError, match="gaurd"):
+            jsonschema.validate({"CLICK": {"target": "home", "gaurd": "x"}},
+                                transition)
+
+    def test_target_is_still_required(self, transition):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"CLICK": {"guard": "isAuthed"}}, transition)


### PR DESCRIPTION
Partially addresses #347 — two of the six deferred findings, specifically the two that needed **evidence** rather than a design call. **The issue stays open** for the other four.

## The one object that accepted anything

`ui-spec-schema.json`'s `navigationGraph` transition-object form had `properties` but no `additionalProperties: false` — alone among every object in the formal-models schemas. A misspelled `guard` validated cleanly, so the mistake surfaced later as *absent behaviour* rather than as a schema error. Same shape as every other fail-open in this repo, one level down.

The ticket asked to verify before tightening, so I did:

- scanned every `ui-spec.json` in the repo — **1 file**, a small denominator and worth stating rather than glossing
- found **no transition objects in the object form at all**, so nothing shipped relies on extra keys there

Tightened, and confirmed by behaviour rather than by shape:

| input | before | after |
|---|---|---|
| `{"CLICK": "home"}` (string shorthand) | accepted | accepted |
| `{"CLICK": {"target": "home", "guard": "isAuthed"}}` | accepted | accepted |
| `{"CLICK": {"target": "home", "gaurd": "x"}}` | **accepted** | rejected |
| `{"CLICK": {"guard": "isAuthed"}}` (no target) | rejected | rejected |

## The test generalises rather than pinning one line

`tests/test_template_schemas.py` asserts that **every** object in **every** formal-models schema closes itself, so a new open object fails here instead of being noticed in a review months later. It also checks each schema is itself valid JSON Schema.

The glob has its own denominator guard — an empty match would make the whole file vacuous, which is the failure mode a "checks all the schemas" test is most likely to have.

## The brace convention was real but undocumented

Both styles exist in the wild:

- `{{KEYWORD}}`, `{{DIFF_REPORT}}` — machine-substituted, in the prompt templates
- `{PRODUCT}`, `{GOVERNING_STANDARD}` — human-filled, in `compliance-requirements.md`

Nothing said the split was deliberate. Now documented in CLAUDE.md's repo layout, including the consequence that actually distinguishes them: an unsubstituted `{{DOUBLE_BRACE}}` is a **bug** that ships a literal token to a model, while a `{SINGLE_BRACE}` is **expected** to survive copying and gets filled in the target repo.

## What this does not do

The remaining four findings each need a decision or a wider mechanical pass, not evidence — so leaving them is the point rather than an omission:

- **Shared `$defs` via `$ref`** would stop `provenance` drifting across 6 schemas, but the templates would stop being standalone single-file stamps. The ticket itself calls this a deliberate call.
- **The `tim-schema.json` / `gap-classification.json` naming inversion** ripples through scripts and docs. Worth one mechanical pass, not a side effect of this one.
- **The slug-case grammar mismatch** is reconciled at ingestion by `trace_ids.canonical_id()`, so it is a written-grammar disagreement rather than a live defect.
- **CI template hardening round 2** (SHA-pinned actions, conditional caching, golangci parity) is its own piece of work.

## Testing

- 21 tests
- **3/3 mutants caught**: the transition object reopened; a *new* open object added anywhere in any schema; the schema glob matching nothing
- Full suite: 4224 passed, 14 skipped

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).
