### PR TITLE
test(external-links): stop the fixtures depending on a real language's tier (#413)

### DIFF
--- a/tests/test_external_links.py
+++ b/tests/test_external_links.py
@@ -197,11 +197,22 @@ def test_missing_file_and_missing_symbol_are_unresolved(tmp_path):
 
 
 def test_no_tier_language_is_skip_with_warning(tmp_path):
-    """A language with neither LSP nor regex tier (e.g. .lua) never resolves
-    silently — the reason names the gap."""
+    """A file with neither LSP nor regex tier never resolves silently — the
+    reason names the gap.
+
+    The fixture extension is deliberately fictional (chief-wiggum#413). These
+    tests used `.lua`, which encodes the premise of external links — the
+    feature exists for languages CW cannot resolve — in a REAL extension's
+    tier. So promoting `.lua` broke four tests here as a side effect of a
+    write-detection fix in #377, and the tier table is shared state: changing
+    an extension's tier is a cross-subsystem decision, not a per-gate one.
+
+    An extension no language will ever claim cannot be promoted, so this
+    subsystem stops having an opinion on which real languages are scannable.
+    """
     root = _target(tmp_path)
-    _write(root, "hook.lua", "function on_save()\n  print('x')\nend\n")
-    span, reason = xl.resolve_symbol_span(root, "hook.lua", "on_save", use_lsp=True)
+    _write(root, "hook.cwnolang", "function on_save()\n  noop()\nend\n")
+    span, reason = xl.resolve_symbol_span(root, "hook.cwnolang", "on_save", use_lsp=True)
     assert span is None
     assert "no symbol-resolution tier" in reason
 
@@ -291,9 +302,9 @@ def test_deleted_file_and_deleted_symbol_are_unresolved_surfaced(tmp_path):
 
 def test_add_without_tier_records_unanchored_entry_with_warning(tmp_path):
     root = _target(tmp_path)
-    _write(root, "hook.lua", "function on_save()\nend\n")
+    _write(root, "hook.cwnolang", "function on_save()\nend\n")
     store = tmp_path / "external-links.json"
-    entry, warning = xl.add_link(store, root, "hook.lua", "on_save", "guards", ["CTR-x-001"])
+    entry, warning = xl.add_link(store, root, "hook.cwnolang", "on_save", "guards", ["CTR-x-001"])
     assert entry["symbol_hash"] is None
     assert warning and "WITHOUT a symbol hash" in warning
     # Never dropped: verify keeps surfacing it as unresolved.
@@ -371,10 +382,10 @@ def test_empty_store_is_inapplicable(tmp_path):
 
 def test_fully_unresolved_populated_store_is_error(tmp_path):
     root = _target(tmp_path)
-    _write(root, "hook.lua", "function on_save()\nend\n")
+    _write(root, "hook.cwnolang", "function on_save()\nend\n")
     store = tmp_path / "external-links.json"
-    xl.add_link(store, root, "hook.lua", "on_save", "guards", ["CTR-x-001"])
-    xl.add_link(store, root, "hook.lua", "on_save2", "verifies", ["CTR-x-001"])
+    xl.add_link(store, root, "hook.cwnolang", "on_save", "guards", ["CTR-x-001"])
+    xl.add_link(store, root, "hook.cwnolang", "on_save2", "verifies", ["CTR-x-001"])
     result = xl.verify_links(store, root)
     assert result["ok"] == [] and result["suspect"] == []
     assert len(result["unresolved"]) == 2
@@ -397,9 +408,9 @@ def test_partially_resolved_store_is_ok_not_error(tmp_path):
 
 def test_cli_verify_prints_measured_denominator(tmp_path, capsys):
     root = _target(tmp_path)
-    _write(root, "hook.lua", "function on_save()\nend\n")
+    _write(root, "hook.cwnolang", "function on_save()\nend\n")
     store = tmp_path / "external-links.json"
-    xl.main(["add", str(store), "--target", str(root), "--file", "hook.lua",
+    xl.main(["add", str(store), "--target", str(root), "--file", "hook.cwnolang",
              "--symbol", "on_save", "--verb", "guards", "--ids", "CTR-x-001"])
     capsys.readouterr()
     rc = xl.main(["verify", str(store), "--target", str(root)])


### PR DESCRIPTION
Addresses decision 1 of #413. **The issue stays open** for decision 2.

## The problem

These tests used `hook.lua` as their canonical unresolvable file — which encodes the premise of external links (the feature exists for languages CW *cannot* resolve) in a **real extension's tier**.

The tier table is shared state. So when #377 moved `.lua` out of `unsupported_extensions` as part of a write-detection fix, four tests here broke, and reverting the promotion was the only cheap option. As the ticket puts it: changing an extension's tier is a cross-subsystem decision, not a per-gate one.

## The fix

The fixture extension is fictional (`.cwnolang`). No language will ever claim it, so it cannot be promoted, and this subsystem stops having an opinion on which real languages are scannable.

This is the ticket's own preferred option: *"a fixture that doesn't depend on any real extension's tier ... more robust — the test would stop breaking every time a language gets promoted."*

## Verified in both directions

Not assumed. With `.lua` genuinely moved into `generic_tier` (confirmed via `all_known_extensions()`):

| fixture | result under a real `.lua` promotion |
|---|---|
| old (`hook.lua`) | **4 failed**, 24 passed — the exact four the ticket describes |
| new (`hook.cwnolang`) | 28 passed |

## What this does not do

**Decision 2 is untouched: which tier `.lua` actually belongs in.** The ticket is right that this needs measuring against a real corpus rather than assuming Lua's `t.field = v` / `t["field"] = v` is close enough to the generic patterns. That is a judgement about emission quality, not a fixture problem, and it is now unblocked — promoting `.lua` no longer breaks this subsystem, so the decision can be made on its own merits.

Full suite: 4224 passed, 14 skipped.

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).