### PR TITLE
feat(preflight): wire it into /implement, and stop reporting a spent provider as ok (#375)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -90,6 +90,24 @@ TICKET_TMP="$CW_TMP/$issue_number"
 mkdir -p "$TICKET_TMP"
 ```
 
+**Preflight the providers — before any phase needs one** (chief-wiggum#375). This is the single highest-leverage thing in Step 1: roughly 15 of a 25-minute consult phase once went on environment failures discovered *serially*, one relaunch at a time, after the prompt was already built.
+
+```bash
+python3 "$CW_HOME/scripts/provider_preflight.py" --human --usage \
+  --role explorer --role reviewer --role implementer \
+  | tee "$TICKET_TMP/preflight.txt"
+```
+
+Exit codes are distinct: `0` every role can run, `1` a role is **blocked** by a down required provider, `2` a provider could not be verified at all, `3` the config is unreadable.
+
+Read the result before proceeding, and act on it *here* rather than mid-phase:
+
+- **A blocked role** — decide now whether to proceed on the named healthy fallback voices or to fix the provider. Either is fine; discovering it in Phase A is not.
+- **`unknown`** is not `ok`. A provider whose probe could not run is unverified, and treating it as healthy is how a preflight becomes a rubber stamp.
+- **`exhausted` (`[SPENT]`)** means installed, authenticated, answering `--version`, and out of budget. `--usage` is what surfaces it: a quota-exhausted CLI passes every structural check there is, so without that flag it reports `ok` and fails on the first real call. The probe costs a tiny call when a provider is healthy and nothing at all when it is exhausted, because the provider refuses before doing any work.
+
+Whatever it says, **record the degraded set** — if the quorum runs without a voice, that belongs in the PR body rather than left implicit (see `synthesize_reviews.py --manifest`, chief-wiggum#416).
+
 **Meter this build** (per-ticket implementation cost, `docs/ticket-cost.md`): enable telemetry so consults log their token cost, and stamp the build-start time — Step 11 slices the ledger from this stamp to price the PR's `## Implementation Cost` section:
 
 ```bash

--- a/scripts/chief_wiggum/preflight.py
+++ b/scripts/chief_wiggum/preflight.py
@@ -32,6 +32,13 @@ class Health(StrEnum):
     UNAVAILABLE = "unavailable"   # a hard requirement is missing, and we know which
     UNKNOWN = "unknown"           # the probe itself could not run
     DISABLED = "disabled"         # switched off in config; a real answer, not a fault
+    # Installed, authenticated, answering `--version` — and unable to serve a
+    # single request. A quota-exhausted CLI passes every structural check
+    # there is, so without its own state it reports `ok` and the operator
+    # discovers the truth mid-phase, serially, which is the cost #375 is
+    # about. Distinct from UNAVAILABLE because nothing is missing, and from
+    # UNKNOWN because the probe ran and got a definite answer.
+    EXHAUSTED = "exhausted"
 
 
 class RoleStatus(StrEnum):
@@ -221,6 +228,8 @@ def check_all(
     probes: Probes | None = None,
     *,
     max_workers: int = 8,
+    usage: bool = False,
+    usage_probe: Callable[[str], tuple[Health, str]] | None = None,
 ) -> dict[str, ProviderReport]:
     """Check every provider at once.
 
@@ -235,7 +244,36 @@ def check_all(
         reports = pool.map(
             lambda name: check_provider(name, providers[name], probes), names
         )
-    return dict(zip(names, reports, strict=True))
+    result = dict(zip(names, reports, strict=True))
+    if usage:
+        result = _apply_usage_probes(result, max_workers=max_workers,
+                                     usage_probe=usage_probe)
+    return result
+
+
+def _apply_usage_probes(
+    reports: dict[str, ProviderReport], *, max_workers: int = 8,
+    usage_probe: Callable[[str], tuple[Health, str]] | None = None,
+) -> dict[str, ProviderReport]:
+    """Re-classify structurally-OK providers that cannot actually serve.
+
+    Only OK providers are asked: there is nothing to learn from spending a
+    call on one already known to be missing a requirement, and nothing to
+    gain from asking a disabled one.
+    """
+    probe = usage_probe or (lambda name: probe_command_usable(name))
+    askable = [name for name, report in reports.items()
+               if report.health is Health.OK and name in USAGE_PROBE_COMMANDS]
+    if not askable:
+        return reports
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(askable))) as pool:
+        answers = dict(zip(askable, pool.map(probe, askable), strict=True))
+    for name, (health, detail) in answers.items():
+        if health is Health.OK:
+            continue
+        reports[name] = ProviderReport(name, health, detail=detail,
+                                       duration_ms=reports[name].duration_ms)
+    return reports
 
 
 def role_report(
@@ -282,6 +320,8 @@ def preflight(
     probes: Probes | None = None,
     *,
     roles: Sequence[str] | None = None,
+    usage: bool = False,
+    usage_probe: Callable[[str], tuple[Health, str]] | None = None,
 ) -> dict[str, Any]:
     """Full preflight: every provider, then every role's readiness."""
     providers = dict(config.get("providers") or {})
@@ -289,7 +329,8 @@ def preflight(
     if roles is not None:
         role_specs = {name: spec for name, spec in role_specs.items() if name in roles}
 
-    reports = check_all(providers, probes)
+    reports = check_all(providers, probes, usage=usage,
+                        usage_probe=usage_probe)
     role_reports = {
         name: role_report(name, spec, reports) for name, spec in sorted(role_specs.items())
     }
@@ -302,6 +343,65 @@ def preflight(
         "blocked_roles": blocked,
         "unverifiable_providers": unknown,
     }
+
+
+# Markers that mean "this account cannot serve a request right now", as
+# distinct from "this call was malformed". Matched case-insensitively against
+# the provider's own stderr/stdout.
+EXHAUSTION_MARKERS = (
+    "usage limit",
+    "quota",
+    "rate limit exceeded",
+    "insufficient_quota",
+    "billing",
+    "credit balance is too low",
+    "429",
+)
+
+# How to ask each CLI to do the smallest real unit of work. `--version` cannot
+# answer this question: the binary is installed and answering in exactly the
+# case that matters.
+USAGE_PROBE_COMMANDS: dict[str, tuple[str, ...]] = {
+    "codex": ("codex", "exec", "--sandbox", "read-only", "-"),
+}
+
+
+def probe_command_usable(
+    name: str, *, timeout: float = 60.0, prompt: str = "Reply with: ok",
+) -> tuple[Health, str]:
+    """Ask the provider to do the smallest real thing, and classify the answer.
+
+    Opt-in, because it costs a genuine (tiny) call when the provider is
+    healthy. On an exhausted account it costs nothing — the provider refuses
+    before doing any work, which is exactly why this is worth asking.
+
+    Returns UNKNOWN rather than guessing when the probe cannot run or the
+    output does not clearly say why it failed. A provider that failed for an
+    unnameable reason is not `ok`, and it is not `exhausted` either.
+    """
+    argv = USAGE_PROBE_COMMANDS.get(name)
+    if argv is None:
+        return Health.UNKNOWN, f"no usage probe defined for {name!r}"
+    if shutil.which(argv[0]) is None:
+        return Health.UNAVAILABLE, f"command:{argv[0]}"
+    try:
+        result = subprocess.run(
+            list(argv), input=prompt, capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return Health.UNKNOWN, f"{name} usage probe did not complete: {exc}"
+
+    blob = f"{result.stdout}\n{result.stderr}".lower()
+    hit = next((m for m in EXHAUSTION_MARKERS if m in blob), None)
+    if hit:
+        return Health.EXHAUSTED, f"{name} reports {hit!r} — installed and out of budget"
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout).strip().splitlines()
+        return Health.UNKNOWN, (
+            f"{name} usage probe exited {result.returncode}: "
+            f"{tail[-1][:160] if tail else '(no output)'}")
+    return Health.OK, ""
 
 
 def probe_command_alive(name: str, *, timeout: float = 10.0) -> bool:

--- a/scripts/provider_preflight.py
+++ b/scripts/provider_preflight.py
@@ -40,7 +40,8 @@ def _render_human(result: dict) -> None:
     print("Providers")
     for name, report in result["providers"].items():
         mark = {"ok": "ok  ", "unavailable": "DOWN", "unknown": "????",
-                "disabled": "off "}.get(report["health"], "????")
+                "disabled": "off ", "exhausted": "SPENT"}.get(
+                    report["health"], "????")
         suffix = f"  {report['detail']}" if report["detail"] else ""
         print(f"  [{mark}] {name}{suffix}")
     print("\nRoles")
@@ -68,6 +69,13 @@ def main(argv: list[str] | None = None) -> int:
         "--deep", action="store_true",
         help="Run each CLI's --version instead of only checking PATH",
     )
+    parser.add_argument(
+        "--usage", action="store_true",
+        help="Ask each CLI to do the smallest real unit of work, so a provider "
+             "that is installed and out of budget reports `exhausted` rather "
+             "than `ok`. Costs a tiny real call when healthy; costs nothing "
+             "when exhausted, because the provider refuses before working.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -77,7 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_CONFIG
 
     probes = Probes(command=probe_command_alive) if args.deep else Probes()
-    result = preflight(config, probes, roles=args.roles)
+    result = preflight(config, probes, roles=args.roles, usage=args.usage)
 
     if args.human:
         _render_human(result)

--- a/tests/test_provider_preflight.py
+++ b/tests/test_provider_preflight.py
@@ -16,6 +16,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
+import chief_wiggum.preflight as pf  # noqa: E402
 from chief_wiggum.preflight import (  # noqa: E402
     Health,
     Probes,
@@ -343,3 +344,113 @@ class TestPhaseSummary:
         assert emitted[0]["outcome"] == "ok"
         assert emitted[0]["detail"] == "3 providers"
         assert emitted[0]["duration_ms"] >= 0
+
+
+# --- exhausted providers (chief-wiggum#375) ---------------------------------
+
+
+class TestExhaustedIsItsOwnState:
+    """Installed, authenticated, answering --version, and unable to work.
+
+    A quota-exhausted CLI passes every structural check there is, so without
+    its own state it reports `ok` and the operator discovers the truth
+    mid-phase, serially — which is the cost #375 is about. Observed live: an
+    exhausted `codex` reported `ok` under both the default and `--deep`
+    probes, and failed every real call for a whole session.
+    """
+
+    def _config(self):
+        return {
+            "providers": {"codex": {"tool": "codex", "enabled": True}},
+            "roles": {"reviewer": {"required": ["codex"], "optional": []}},
+        }
+
+    def test_an_exhausted_provider_is_not_usable(self):
+        report = pf.ProviderReport("codex", pf.Health.EXHAUSTED)
+        assert not report.usable, "exhausted must not count as a healthy voice"
+
+    def test_an_exhausted_required_provider_blocks_its_role(self):
+        result = pf.preflight(
+            self._config(), pf.Probes(command=lambda name: True),
+            usage=True,
+            usage_probe=lambda name: (pf.Health.EXHAUSTED, "usage limit"))
+        assert result["providers"]["codex"]["health"] == "exhausted"
+        assert result["roles"]["reviewer"]["status"] == "blocked"
+
+    def test_a_healthy_usage_probe_leaves_the_provider_ok(self):
+        result = pf.preflight(
+            self._config(), pf.Probes(command=lambda name: True),
+            usage=True, usage_probe=lambda name: (pf.Health.OK, ""))
+        assert result["providers"]["codex"]["health"] == "ok"
+        assert result["roles"]["reviewer"]["status"] == "ok"
+
+    def test_without_the_flag_no_usage_call_is_made(self):
+        """The probe costs a real call, so it must be opt-in."""
+        calls = []
+        pf.preflight(self._config(), pf.Probes(command=lambda name: True),
+                     usage=False,
+                     usage_probe=lambda name: calls.append(name) or (pf.Health.OK, ""))
+        assert calls == []
+
+    def test_a_structurally_broken_provider_is_never_asked(self):
+        """Nothing to learn from spending a call on a provider already down."""
+        calls = []
+        result = pf.preflight(
+            self._config(), pf.Probes(command=lambda name: False),
+            usage=True,
+            usage_probe=lambda name: calls.append(name) or (pf.Health.OK, ""))
+        assert calls == [], "spent a call on an already-unavailable provider"
+        assert result["providers"]["codex"]["health"] == "unavailable"
+
+    def test_an_unclassifiable_failure_is_unknown_not_exhausted(self):
+        """A probe that failed for an unnameable reason is not a diagnosis."""
+        result = pf.preflight(
+            self._config(), pf.Probes(command=lambda name: True),
+            usage=True,
+            usage_probe=lambda name: (pf.Health.UNKNOWN, "exited 7"))
+        assert result["providers"]["codex"]["health"] == "unknown"
+
+
+class TestTheUsageProbeClassifiesRealOutput:
+    """Parsing, exercised without invoking a provider."""
+
+    def test_every_exhaustion_marker_is_recognised(self, monkeypatch):
+        for marker in pf.EXHAUSTION_MARKERS:
+            monkeypatch.setattr(pf.shutil, "which", lambda name: "/usr/bin/x")
+            monkeypatch.setattr(pf.subprocess, "run",
+                                lambda *a, _m=marker, **k: type(
+                                    "R", (), {"stdout": "",
+                                              "stderr": f"Error: {_m} reached",
+                                              "returncode": 1})())
+            health, detail = pf.probe_command_usable("codex")
+            assert health is pf.Health.EXHAUSTED, marker
+            # Some marker is named, not necessarily this one: the markers
+            # overlap (`insufficient_quota` contains `quota`), so asserting
+            # the exact match would be testing iteration order.
+            assert any(m in detail for m in pf.EXHAUSTION_MARKERS), detail
+
+    def test_a_provider_with_no_probe_defined_is_unknown(self):
+        health, detail = pf.probe_command_usable("no-such-provider")
+        assert health is pf.Health.UNKNOWN
+        assert "no usage probe" in detail
+
+    def test_a_clean_run_is_ok(self, monkeypatch):
+        monkeypatch.setattr(pf.shutil, "which", lambda name: "/usr/bin/x")
+        monkeypatch.setattr(pf.subprocess, "run", lambda *a, **k: type(
+            "R", (), {"stdout": "ok", "stderr": "", "returncode": 0})())
+        assert pf.probe_command_usable("codex")[0] is pf.Health.OK
+
+    def test_a_nonzero_exit_with_no_marker_is_unknown_not_ok(self, monkeypatch):
+        """Failed for a reason nobody can name is not a clean bill of health."""
+        monkeypatch.setattr(pf.shutil, "which", lambda name: "/usr/bin/x")
+        monkeypatch.setattr(pf.subprocess, "run", lambda *a, **k: type(
+            "R", (), {"stdout": "", "stderr": "segmentation fault",
+                      "returncode": 139})())
+        health, detail = pf.probe_command_usable("codex")
+        assert health is pf.Health.UNKNOWN
+        assert "139" in detail and "segmentation fault" in detail
+
+    def test_a_missing_binary_is_unavailable_not_exhausted(self, monkeypatch):
+        monkeypatch.setattr(pf.shutil, "which", lambda name: None)
+        health, _ = pf.probe_command_usable("codex")
+        assert health is pf.Health.UNAVAILABLE


### PR DESCRIPTION
Addresses proposal 1 of #375. **The issue stays open** for proposals 2–5.

## It was built and never called

`scripts/provider_preflight.py` already existed. Nothing in `.claude/commands/` referenced it — so the failure it was written to prevent kept happening: environment problems discovered mid-phase, serially, after the prompt was already built.

Now invoked in `/implement` Step 1, with the result read *there*, including what to do about each state.

## The preflight was blind to the failure that actually dominates

Its probes prove a binary is on PATH; `--deep` proves it answers `--version`. A quota-exhausted CLI passes both perfectly.

Observed live across this entire session: `codex` reported **`ok`** under both probes while every real call failed with `You've hit your usage limit`. A preflight whose whole purpose is *fail fast, name the fallback* was certifying a provider that could not do a single unit of work.

```
before:  [ok  ] codex                    →  reviewer [ok]
after:   [SPENT] codex  usage limit …    →  reviewer [BLOCKED], exit 1
```

## `Health.EXHAUSTED`

Installed, authenticated, answering — and unable to serve a request.

- distinct from **UNAVAILABLE**: nothing is missing
- distinct from **UNKNOWN**: the probe ran and got a definite answer
- not `usable`, so an exhausted *required* provider blocks its role rather than passing

## `--usage` is opt-in, and deliberately cheap

It costs a genuine tiny call when a provider is healthy, and **nothing** when it is exhausted — the provider refuses before doing any work, which is exactly why the question is worth asking.

- only structurally-OK providers are asked; nothing is learned by spending a call on one already known to be down
- a failure with no recognisable marker is **UNKNOWN, never EXHAUSTED** — a probe that failed for an unnameable reason is not a diagnosis

## What this does not do

Proposals 2–5 are untouched: overlapping Step 7 with Step 8's mechanical half, splitting the synthesis plan so the red phase can start earlier, caching consult outputs by (ticket hash, HEAD), and delegate budgets. Each is a workflow-sequencing change that deserves its own diff and its own measurement — the ticket's own table shows they trade against each other.

## Testing

- 11 tests
- **8/8 mutants caught**: exhausted counted as usable; usage probing never running when asked; running unconditionally (spending money); probing already-down providers; markers ignored; an unclassifiable failure reported as ok; a missing binary reported as ok; the downgrade never applied
- Full suite: 4235 passed, 14 skipped

Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture. See [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).