### PR TITLE
fix(skills): run CW scripts under the resolved interpreter, not a bare python3 (#374)

### DIFF
--- a/.claude/commands/adopt.md
+++ b/.claude/commands/adopt.md
@@ -22,19 +22,23 @@ The missing entry arrow: survey the repo's shape, elect a footprint, baseline th
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 ```
 
 ### Step 2: Run the adoption sequence
 
 ```bash
-python3 "$CW_HOME/scripts/adopt.py" run "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" run "$owner_repo"
 # or step by step (same defaults; elect FIRST — the election decides where
 # the survey and every later artifact persist):
-python3 "$CW_HOME/scripts/adopt.py" elect "$owner_repo" --mode sidecar [--scope-from-codeowners]
-python3 "$CW_HOME/scripts/adopt.py" survey "$owner_repo"
-python3 "$CW_HOME/scripts/adopt.py" baseline "$owner_repo"
-python3 "$CW_HOME/scripts/adopt.py" grandfather "$owner_repo" [--expiry-days 90] [--owner NAME]
-python3 "$CW_HOME/scripts/adopt.py" record "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" elect "$owner_repo" --mode sidecar [--scope-from-codeowners]
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" survey "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" baseline "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" grandfather "$owner_repo" [--expiry-days 90] [--owner NAME]
+"${CW_PY:-python3}" "$CW_HOME/scripts/adopt.py" record "$owner_repo"
 ```
 
 What each step writes (all under the #213-resolved meta root — in sidecar mode the target tree gains **nothing**):
@@ -50,7 +54,7 @@ What each step writes (all under the #213-resolved meta root — in sidecar mode
 ### Step 3: Verify and present
 
 ```bash
-python3 "$CW_HOME/scripts/status.py" "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/status.py" "$owner_repo"
 ```
 
 `/status` now shows the Adoption section (brownfield flag, grandfather counts, nearest expiry, EXPIRED warnings). Relay the survey verdicts and the baseline outcome honestly — if the test run failed because dependencies are missing, that IS the baseline; say so.

--- a/.claude/commands/apply-pattern.md
+++ b/.claude/commands/apply-pattern.md
@@ -35,7 +35,11 @@ Run to completion. The one judgement call is **parameter binding** — resolve e
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 2: Pick the pattern and inspect its cluster
@@ -43,7 +47,7 @@ TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 List specified patterns and read the chosen one's manifest so you know its parameters and invariant cluster:
 
 ```bash
-python3 -c "import json; d=json.load(open('$CW_HOME/patterns/registry.json')); [print(p['id'], '—', p.get('invariants','')) for p in d['patterns']]"
+"${CW_PY:-python3}" -c "import json; d=json.load(open('$CW_HOME/patterns/registry.json')); [print(p['id'], '—', p.get('invariants','')) for p in d['patterns']]"
 cat "$CW_HOME/patterns/<id>/manifest.json"
 ```
 
@@ -56,7 +60,7 @@ Read `manifest.json`'s `parameters`. For each, resolve a value from the **target
 ### Step 4: Install
 
 ```bash
-python3 "$CW_HOME/scripts/apply_pattern.py" <id> \
+"${CW_PY:-python3}" "$CW_HOME/scripts/apply_pattern.py" <id> \
   --target-dir "$TARGET_REPO" \
   --param resource=subscription --param projected_field=plan   # example
 ```
@@ -71,7 +75,7 @@ Dry-run first (`--dry-run`) to preview. This writes, in the target repo:
 Confirm the unresolved gate sees any `TBD:` markers (so dependent work can't build on a guess):
 
 ```bash
-python3 "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/patterns/<id>/invariants.md"
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/patterns/<id>/invariants.md"
 ```
 
 Then report the adopted cluster and point the user at the next step: **`/architect`** folds this cluster into the epic's `invariants.md` by stable id, and the traceability / single-writer / ratchet gates hold it from there.

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -26,16 +26,20 @@ Everything else runs autonomously.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 # One tested call resolves CW_HOME, CW_TMP, TARGET_REPO, DEFAULT_BRANCH, EPIC_SLUG, EPIC_DIR.
 # Capture first and check status so a resolver failure aborts cleanly.
-CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
+CW_CTX=$("${CW_PY:-python3}" "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
   echo "workflow_context failed for $owner_repo" >&2; exit 1; }
 eval "$CW_CTX"
 ```
 
 Fetch all issues in the epic via `tracker.py` instead of calling `gh issue` directly — this is what makes the skill usable against non-github tracker backends, including a repo whose upstream has issues disabled entirely (see `docs/tracker.md`):
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
 ```
 This returns every ticket currently grouped into the epic — `ref`, `title`, `body`, `state`, `labels`, `assignee`, `epic`, `url_or_path` — for ANY backend (`gh:owner/repo#N` refs for `github`, `local:docs/issues/NNNN.md` for `local`). Filter client-side to `state == "open"` (matching the previous open-only behavior) unless you deliberately want closed tickets in view too. Keep each ticket's `ref` — Step 8 needs it to post the architecture comment.
 
@@ -55,7 +59,7 @@ ls "$TARGET_REPO/docs/adr/" 2>/dev/null
 # FAIL CLOSED: if the resolver errors (malformed election/scope), STOP and fix the
 # config — an empty META_ROOT must never silently fall through to the heuristic
 # and misclassify an adopted repo as a new product.
-META_ROOT=$(python3 "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | python3 -c "import sys,json; print(json.load(sys.stdin)['meta_root'])") || {
+META_ROOT=$("${CW_PY:-python3}" "$CW_HOME/scripts/artifacts.py" show "$TARGET_REPO" --format json | "${CW_PY:-python3}" -c "import sys,json; print(json.load(sys.stdin)['meta_root'])") || {
   echo "artifacts.py show failed for $TARGET_REPO — fix the election/config before the new-product check (never classify on a resolver error)" >&2
   exit 1
 }
@@ -72,7 +76,7 @@ else
   # the journal: absent/stub/unbaselined = no history; real = journaled
   # baseline; invalid/error = unreadable — treated as ESTABLISHED so a broken
   # state file never silently stamps DST invariants (flag it at Step 6 instead).
-  RATCHET_STATE=$(python3 "$CW_HOME/scripts/ratchet.py" state --repo "$TARGET_REPO" || echo error)
+  RATCHET_STATE=$("${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" state --repo "$TARGET_REPO" || echo error)
   case "$RATCHET_STATE" in
     absent|stub|unbaselined) RATCHET_HISTORY=false ;;
     *)                       RATCHET_HISTORY=true ;;
@@ -88,7 +92,7 @@ The fallback is a **default the operator can override**, not a proof — a repo 
 **Adopted patterns.** If the product has adopted registry patterns (via `/apply-pattern`), load their invariant clusters now — they are **pre-derived contracts** this epic must not re-invent:
 
 ```bash
-python3 "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted --format json
+"${CW_PY:-python3}" "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted --format json
 ```
 
 Each adopted pattern reports its `id`, its invariant cluster (stable `INV-<ABBR>-NNN` ids + statements), its `contract_pack` doc (`docs/patterns/<id>/invariants.md`), and any `unresolved` (unbound required) parameters. Note which of these patterns **this epic realizes** — you'll fold their clusters into `invariants.md` (Step 4e) by their existing stable ids, thread their integration tests (Step 4g), and any `unresolved` parameter is a hard blocker to resolve before contracts depend on it (`check_unresolved.py` already gates the stamped `TBD:` markers).
@@ -108,7 +112,7 @@ Write findings to `$CW_TMP/codebase-context.md`.
 **Hotspot + coupling context (measured, not declared — #187).** Refresh `docs/quality/hotspots.json` so architectural scrutiny concentrates where change-risk is *measured* from git history, not guessed:
 
 ```bash
-python3 "$CW_HOME/scripts/hotspot_discovery.py" --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/hotspot_discovery.py" --repo "$TARGET_REPO" \
   --out "$TARGET_REPO/docs/quality/hotspots.json" --format text
 ```
 
@@ -132,7 +136,7 @@ Prepare a consultation prompt at `$CW_TMP/architect-prompt.md` including:
 Fire the `architecture_critic` quorum (codex + gemini in parallel, with retries + output validation). Every provider gets the **identical** prompt above — the value is in natural divergence, not roleplay — but `config/providers.json` may additionally assign each provider a bounded **review lens** (`role.lenses`, e.g. `codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`; charters live in `config/lenses.json`). When a lens is assigned, `consult_ai.py` appends that provider's charter as a clearly-delimited `## Your charter` section — the shared prompt itself never changes. This decorrelates the reviewers on purpose: a soundness-refuter and a completeness-checker reading the *same* context reliably surface disjoint findings instead of converging on the same top issue three times:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role architecture_critic $CW_TMP/architect-prompt.md \
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role architecture_critic $CW_TMP/architect-prompt.md \
   --output-dir "$CW_TMP/architect-consult" --cwd "$TARGET_REPO"
 ```
 
@@ -164,7 +168,7 @@ For every entity and API endpoint the epic touches, define:
 
 **Verifier-in-the-loop**: After the worker produces `contracts.json`, validate it:
 ```bash
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/contracts.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/contracts.json"
 ```
 If validation fails, feed the errors back to the worker and have it fix the JSON. Repeat until valid.
 
@@ -182,8 +186,8 @@ For every state machine in the epic, define:
 
 **Verifier-in-the-loop**: Validate and run graph analysis:
 ```bash
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/state-machines.json"
-python3 "$CW_HOME/scripts/formal_models.py" graph "$CW_TMP/state-machines.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/state-machines.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" graph "$CW_TMP/state-machines.json"
 ```
 Check for: unreachable states, dead states (non-terminal with no outgoing transitions), terminal states that aren't reachable. Fix any issues before proceeding.
 
@@ -192,16 +196,16 @@ Check for: unreachable states, dead states (non-terminal with no outgoing transi
 Once the structured JSON models are valid, generate the prose markdown mechanically:
 
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
 ```
 
 This produces `contracts.md` and `state-machines.md` in the same format as before — the downstream pipeline and human reviewers see identical prose. The difference is that the prose is now a derived artifact, not the source of truth.
 
 **Also generate the machine and test views** for the commit:
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view all --output "$CW_TMP/models/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view all --output "$CW_TMP/models/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view all --output "$CW_TMP/models/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view all --output "$CW_TMP/models/"
 ```
 
 #### 4d. UI Specification — structured model (`ui-spec.json`)
@@ -240,12 +244,12 @@ Include the worked example from `$CW_HOME/docs/formal-methods/examples/kanban-ap
 
 **Verifier-in-the-loop**: After the worker produces `ui-spec.json`, validate it:
 ```bash
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/ui-spec.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/ui-spec.json"
 ```
 
 **Generate human-readable UI spec**: Render the UI spec to a page-by-page markdown doc:
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/ui-spec.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/ui-spec.json" --view human --output "$CW_TMP/"
 ```
 
 #### 4e. Invariants (`invariants.md`)
@@ -420,7 +424,7 @@ For every deployable and connector this epic's tickets introduce or change, defi
 
 **Verifier-in-the-loop**: validate against the schema as soon as the worker produces it:
 ```bash
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/architecture.json" --type architecture
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/architecture.json" --type architecture
 ```
 Fix and re-validate until clean. The deeper consistency checks (dangling endpoints, retired-node edges, unlabelled externals, tier inversion, label propagation, cross-artifact drift) run in Step 5a below — schema validity here is necessary but not sufficient.
 
@@ -442,7 +446,7 @@ For every AI feature this epic's tickets introduce or change, from the epic's ow
 
 Validate with the gate immediately, report-only (never blocks Step 4, mirrors 4i's verifier-in-the-loop pattern):
 ```bash
-python3 "$CW_HOME/scripts/check_ai_act.py" "$TARGET_REPO"
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_ai_act.py" "$TARGET_REPO"
 ```
 Fix any `fail`-severity finding (malformed feature, undeclared `eu_scope`, an Annex III tier with no named derogation condition, a `transparency_art50` tier with no Art. 50 obligation cited) before Step 6. A `prohibited`-tier hit is not a finding to document around — route the feature away from the prohibited practice before this epic ships it.
 
@@ -456,18 +460,18 @@ Run structural validation on the formal models:
 
 ```bash
 # Schema validation
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/contracts.json"
-python3 "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/state-machines.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/contracts.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$CW_TMP/state-machines.json"
 
 # Graph analysis — check for structural defects
-python3 "$CW_HOME/scripts/formal_models.py" graph "$CW_TMP/state-machines.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" graph "$CW_TMP/state-machines.json"
 
 # Unresolved-unknowns scan — TBD/UNRESOLVED/PLACEHOLDER markers across all
 # artifacts, plus UNVERIFIED where it INTRODUCES a claim ("UNVERIFIED: the live
 # webhook secret", "UNVERIFIED whether ..."). Bare `UNVERIFIED` is NOT a marker:
 # it is also ordinary domain vocabulary (a FactStatus enum member, a
 # state-machine state) — chief-wiggum#350.
-python3 "$CW_HOME/scripts/check_unresolved.py" "$CW_TMP" --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_unresolved.py" "$CW_TMP" --format text
 
 # External-interface provenance — REPORT-ONLY (chief-wiggum#350). An operation
 # marked `"external": true` describes a THIRD-PARTY interface this system calls,
@@ -480,7 +484,7 @@ python3 "$CW_HOME/scripts/check_unresolved.py" "$CW_TMP" --format text
 # design, so an epic that integrates a third-party system and declares nothing
 # passes this gate vacuously — the note is what makes that visible. If this
 # epic calls anything you do not own, go back and declare those operations.
-python3 "$CW_HOME/scripts/check_interface_provenance.py" "$CW_TMP" --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_interface_provenance.py" "$CW_TMP" --format text
 
 # Traceability soundness gate — orphan business rules + dangling/invalid links in
 # the contract/invariant graph (see docs/traceability.md). Code/test coverage is
@@ -497,20 +501,20 @@ python3 "$CW_HOME/scripts/check_interface_provenance.py" "$CW_TMP" --format text
 # Author the IDs before running this, don't run it against stub/TBD prose.
 # (Suspect-link propagation and `--write-links` are a /close-epic concern — no
 # code/test links exist to record yet at this stage.)
-python3 "$CW_HOME/scripts/check_traceability.py" "$CW_TMP" --gate soundness --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_traceability.py" "$CW_TMP" --gate soundness --format text
 
 # Single-writer soundness gate — validates that "single write path"/"single source
 # of truth" invariants carry well-formed `controls_field` + `sanctioned_writers`
 # metadata, and (with --source) surfaces every existing writer of the controlled
 # fields so a second, unsanctioned mutator is visible at design time (see
 # docs/single-writer.md). Degrades gracefully when no such invariant exists.
-python3 "$CW_HOME/scripts/check_single_writer.py" "$CW_TMP" --source "$TARGET_REPO" --gate soundness --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_single_writer.py" "$CW_TMP" --source "$TARGET_REPO" --gate soundness --format text
 ```
 
 **Architecture model consistency (`docs/system/architecture.json`, when 4i produced or updated one).** Report-only — this checker is NOT gated in `/architect` yet (ADR-fh-07: gating requires the #168 gate-validation protocol plus a passing `#184` validation record for `check_architecture`, which freezes its `CHECKS` inventory as a prerequisite). Run it so findings are visible at design time even though they don't block:
 
 ```bash
-python3 "$CW_HOME/scripts/check_architecture.py" "$CW_TMP/architecture.json" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_architecture.py" "$CW_TMP/architecture.json" \
   --system-contracts "$TARGET_REPO/docs/system/system-contracts.json" --format text
 ```
 
@@ -521,7 +525,7 @@ Any invariant that says "single write path" or "single source of truth" for a fi
 **DST-readiness baseline (new products only — `IS_NEW_PRODUCT=true`).** Run the scanner report-only against the target repo to document the current wall-clock/random-call baseline — this NEVER blocks (advisory forever, per the design decision behind it):
 
 ```bash
-python3 "$CW_HOME/scripts/check_dst_readiness.py" "$TARGET_REPO" --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_dst_readiness.py" "$TARGET_REPO" --format text
 ```
 
 Note the finding counts in Step 6's summary (a fresh repo should have ~zero; a real baseline scan may surface some pre-existing calls worth folding into the seam allowlist or fixing before the first ticket lands). This never gates — `--gate` exists in the script for a repo that later opts in via its own ratchet config, but `/architect` never passes it.
@@ -554,7 +558,7 @@ Prepare a validation prompt at `$CW_TMP/validate-artifacts-prompt.md` containing
 Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation). As in Step 3, `reviewer` may carry a lens assignment in `config/providers.json` — check its `lenses` map before assuming two providers scoped alike:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/validate-artifacts-prompt.md \
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/validate-artifacts-prompt.md \
   --output-dir "$CW_TMP/validate-artifacts" --cwd "$TARGET_REPO"
 ```
 
@@ -562,8 +566,8 @@ Responses land at `$CW_TMP/validate-artifacts/reviewer-<provider>.md` (status in
 
 Review both responses. **Union the findings rather than looking for agreement** — a lensed quorum is expected to produce disjoint findings; only cross-verify against the models when two providers make contested/contradictory claims about the same fact. Apply clear improvements to the JSON models. Regenerate prose if models changed:
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
 ```
 
 Flag genuine disagreements for the user in Step 6.
@@ -571,7 +575,7 @@ Flag genuine disagreements for the user in Step 6.
 **Record validation telemetry.** The review's cost already flows (its reviewer consults + the worker tokens); record its *value* — emit one gate event with the count of substantive findings the multi-AI validation raised (contradictions, missing transitions, incomplete invariants, uncovered ACs — exclude nits). No-op unless telemetry is enabled, never blocks:
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name architect-review \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" emit --event gate --name architect-review \
   --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
 ```
 
@@ -596,8 +600,8 @@ The Mermaid diagrams and counterexample traces are the primary review artifacts 
 
 Ask for feedback. Iterate if needed. If the user requests changes, update the JSON models and regenerate prose:
 ```bash
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
-python3 "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/contracts.json" --view human --output "$CW_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_models.py" "$CW_TMP/state-machines.json" --view human --output "$CW_TMP/"
 ```
 
 This is the most important review in the entire pipeline — getting the contracts wrong here means every ticket inherits the wrong constraints.
@@ -609,7 +613,7 @@ Install the artifacts with the tested helper. It validates the required artifact
 ```bash
 cd "$TARGET_REPO"
 git checkout "$DEFAULT_BRANCH" && git pull --ff-only
-python3 "$CW_HOME/scripts/install_epic_artifacts.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/install_epic_artifacts.py" \
   --source "$CW_TMP" --epic-dir "$EPIC_DIR" \
   --epic-name "$epic_name" --epic-slug "$EPIC_SLUG" --target-repo "$TARGET_REPO"
 git push
@@ -646,9 +650,9 @@ gh pr merge --squash --auto
 **Ratchet baseline** (see `docs/ratchet.md`): once the artifacts are on the default branch, enter the approved contract definitions into the quality ratchet's high-water mark so implementation workers can't weaken them silently. If the target repo has no ratchet config yet, initialize it first:
 
 ```bash
-python3 "$CW_HOME/scripts/ratchet.py" init --repo "$TARGET_REPO"   # no-op if config exists
-python3 "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --no-tests
-python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" init --repo "$TARGET_REPO"   # no-op if config exists
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --no-tests
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
   --event baseline --ref "$EPIC_SLUG" --merged --notes "epic architecture approved"
 git -C "$TARGET_REPO" add docs/quality && git -C "$TARGET_REPO" commit -m "chore: ratchet baseline for $EPIC_SLUG" && git -C "$TARGET_REPO" push
 ```
@@ -661,7 +665,7 @@ For each ticket in the epic (using the `ref` values from Step 1's `tracker.py me
 
 ```bash
 # Reuse the installer's issue_comment, or post the equivalent below:
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" comment "$ref" "## Epic Architecture
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" comment "$ref" "## Epic Architecture
 
 This ticket is part of **[Epic Name]**. Before implementing, read:
 - [Contracts](../docs/epics/$EPIC_SLUG/contracts.md) — REQUIRES/ENSURES for APIs and entities

--- a/.claude/commands/business-consultant.md
+++ b/.claude/commands/business-consultant.md
@@ -65,13 +65,17 @@ fabricated number.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 2: Check the inputs are there
 
 ```bash
-python3 "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted
+"${CW_PY:-python3}" "$CW_HOME/scripts/apply_pattern.py" --target-dir "$TARGET_REPO" --list-adopted
 ```
 
 If `tiered-subscription` isn't adopted, note it — the run will still produce a
@@ -90,7 +94,7 @@ data, not the code path.
 ### Step 3: Run the deriver
 
 ```bash
-python3 "$CW_HOME/scripts/business_consultant.py" --repo "$TARGET_REPO"
+"${CW_PY:-python3}" "$CW_HOME/scripts/business_consultant.py" --repo "$TARGET_REPO"
 # auto-uses $TARGET_REPO/docs/cost-inputs.json if present, else the illustrative seed;
 # pass --cost-inputs <path> only to point at a non-default location
 ```
@@ -123,7 +127,7 @@ This derives, purely mechanically (no AI consultation, no network calls):
 ### Step 4: Verify the unresolved seam is gated
 
 ```bash
-python3 "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/pricing.md"
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_unresolved.py" "$TARGET_REPO/docs/pricing.md"
 ```
 
 Confirm it reports the market-comparable-floor marker — that's expected and

--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -24,9 +24,13 @@ Individual ticket quality is handled by `/implement`. This skill validates what 
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 # One tested call resolves CW_HOME, CW_TMP, TARGET_REPO, DEFAULT_BRANCH, EPIC_SLUG, EPIC_DIR.
 # Capture first and check status so a resolver failure aborts cleanly.
-CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
+CW_CTX=$("${CW_PY:-python3}" "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
   echo "workflow_context failed for $owner_repo" >&2; exit 1; }
 eval "$CW_CTX"
 ```
@@ -41,7 +45,7 @@ Load epic artifacts from `$EPIC_DIR/`:
 **Load the target's own review authorities (#264)** — an adopted repo's house rules are as binding on the epic-level review as CW's own checklist:
 
 ```bash
-python3 "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
   --phase review > "$CW_TMP/review-authorities.txt" || {
   echo "review-authorities binding is malformed — refusing to close the epic against CW defaults alone" >&2
   exit 2; }
@@ -51,7 +55,7 @@ Exit 2 means the binding exists but is unreadable — stop and fix it rather tha
 
 Fetch the epic's tickets via `tracker.py` instead of calling `gh issue` directly — this is what makes the skill usable against non-github tracker backends, including a repo whose upstream has issues disabled entirely (see `docs/tracker.md`):
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$TARGET_REPO" members "$owner_repo" "$epic_name"
 ```
 This returns every ticket currently grouped into the epic — `ref`, `title`, `state`, `labels`, ... — for ANY backend.
 
@@ -62,7 +66,7 @@ Verify all tickets are closed (`state == "closed"` for every returned ticket). I
 Run the audit orchestrator once up front. It coordinates the deterministic audits — traceability coverage, unresolved markers + blocked tickets, transition-map verification (when a state machine model exists), optional stitch findings, mutation-tooling availability, and the integration test run — and writes `close-epic-manifest.json` + `close-epic-report.md`. **It exits non-zero if the epic cannot be closed** (integration tests failed, or unresolved markers still block tickets):
 
 ```bash
-python3 "$CW_HOME/scripts/close_epic_audit.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/close_epic_audit.py" \
   --epic-dir "$EPIC_DIR" --target-repo "$TARGET_REPO" \
   --output-dir "$CW_TMP/close-epic"
 ```
@@ -76,7 +80,7 @@ The manifest carries `target_sha` — the target repo's HEAD at the moment this 
 Parse and audit the traceability matrix with the tested helper. It returns per-status counts, coverage %, and the gap list (rows with no test, or `missing`/`failing` status):
 
 ```bash
-python3 "$CW_HOME/scripts/traceability.py" audit "$EPIC_DIR/traceability.md"
+"${CW_PY:-python3}" "$CW_HOME/scripts/traceability.py" audit "$EPIC_DIR/traceability.md"
 ```
 
 Then, for each acceptance criterion the audit flags as a gap (or still `covered` rather than `passing`):
@@ -84,7 +88,7 @@ Then, for each acceptance criterion the audit flags as a gap (or still `covered`
 1. Run the specific test referenced in the row and verify it passes.
 2. Record the verified status with the updater (`passing` / `failing` / `missing`):
    ```bash
-   python3 "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" --ticket 43 --status passing --ac "Create order"
+   "${CW_PY:-python3}" "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" --ticket 43 --status passing --ac "Create order"
    ```
 
 Report:
@@ -111,7 +115,7 @@ if [ "$(git -C "$TARGET_REPO" rev-parse HEAD)" = "$(jq -r .target_sha "$MANIFEST
 else
   # HEAD moved since Step 1b (the manifest no longer describes the current
   # tree) — this is the ONLY case that re-runs the scan.
-  python3 "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$EPIC_DIR/models/state-machines.json" \
+  "${CW_PY:-python3}" "$CW_HOME/scripts/verify_transitions.py" "$TARGET_REPO" "$EPIC_DIR/models/state-machines.json" \
     --output "$CW_TMP/transition-map-final.json" --format json > /dev/null
 fi
 jq -r '.outcome as $o | .summary as $s |
@@ -150,7 +154,7 @@ MANIFEST="$CW_TMP/close-epic/close-epic-manifest.json"
 if [ "$(git -C "$TARGET_REPO" rev-parse HEAD)" = "$(jq -r .target_sha "$MANIFEST")" ]; then
   jq -r '.unresolved[] | "\(.file):\(.location) [\(.marker)] \(.text)  blocks: \(.tickets | join(", "))"' "$MANIFEST"
 else
-  python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format text
+  "${CW_PY:-python3}" "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format text
 fi
 ```
 
@@ -161,7 +165,7 @@ Any surviving `TBD:`/`UNRESOLVED:`/`PLACEHOLDER` marker is a finding: either the
 Before Steps 2d and 2e pass `--gate coverage` to `check_traceability.py` / `check_single_writer.py`, and before Step 2f passes `--gate-verifier-tests` to `ratchet.py check`, confirm each checker has EARNED that blocking authority — a passing gate-validation-protocol record proving it fires on seeded defects (including the mandatory evasion classes) and stays clean on a known-good corpus with coverage evidence, not just an assertion in a ledger. The records for CW's own gate suite ship **with chief-wiggum** at `$CW_HOME/docs/quality/validation/` (corroborated by the ratchet journal beside them), so this normally passes and Steps 2d/2e/2f keep their existing enforcement unchanged. **One process checks all three gates** (#323) — `check_gate_validation.py` accepts multiple gate names and verifies the shared ratchet journal chain once for the whole call, instead of three separate processes each re-walking the same chain from genesis:
 
 ```bash
-GATE_VALIDATION=$(python3 "$CW_HOME/scripts/check_gate_validation.py" \
+GATE_VALIDATION=$("${CW_PY:-python3}" "$CW_HOME/scripts/check_gate_validation.py" \
   check_traceability check_single_writer ratchet \
   --validation-dir "$CW_HOME/docs/quality/validation" --format json)
 echo "$GATE_VALIDATION"
@@ -181,7 +185,7 @@ If a checker that was previously wired blocking (`check_gate_validation.py ... -
 Prove every contract/invariant is realized, guarded by code, and verified by a test — from the `@cw-trace` annotations (see `docs/traceability.md`). Only pass `--gate coverage` if Step 2c2's `$TRACEABILITY_VALIDATED` is `true`; otherwise drop `--gate coverage` and report the finding instead. **One invocation does both the coverage scan and the sidecar write** (#323 — `--write-links` is a no-op when the gate doesn't pass, so it always rides the same run instead of a second full annotation scan of the whole repo moments later):
 
 ```bash
-python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --write-links --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --write-links --format text
 ```
 
 **Uncovered contracts** (no code `@cw-trace guards/ensures`) and **untested contracts** (no test `@cw-trace verifies`) are findings — the contract isn't proven implemented/tested. Dangling annotations (a tag referencing an ID that no longer exists) indicate a refactor left a stale link; fix the link or the ID. Degrades gracefully when the epic uses no annotations.
@@ -197,7 +201,7 @@ python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_R
 For every invariant that declares a **single write path** / **single source of truth** (carrying `controls_field` + `sanctioned_writers` metadata — see `docs/single-writer.md`), prove no second mutator exists. This catches the class of bug where a pre-existing control (e.g. a legacy admin `ChangePlan` dropdown) is a second writer of a field an epic's invariant said had one atomic write path — something traceability and the ratchet cannot see, because they check contract↔code↔test *links* and the pass-set, not *who writes a field*. Only pass `--gate coverage` if Step 2c2's `$SINGLE_WRITER_VALIDATED` is `true`; otherwise drop `--gate coverage` and report the finding instead:
 
 ```bash
-python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" --gate coverage --format text
 ```
 
 Any writer of a controlled field whose enclosing symbol/file is **not** in `sanctioned_writers` is a hard-blocking violation — either route it through the sanctioned path or add it to (and re-justify) the invariant's sanctioned set. Test-file writes are treated as fixtures, not violations. Degrades gracefully when the epic declares no single-write-path invariants.
@@ -209,15 +213,15 @@ Any writer of a controlled field whose enclosing symbol/file is **not** in `sanc
 **Reuse Step 1b's verification run instead of paying for the suite twice** (chief-wiggum#322, same pattern as `/implement` Step 4b) — `close_epic_audit.py` already ran `ver.verify(repo, ["test"])` on this exact `$TARGET_REPO` commit and recorded it in `close-epic-manifest.json`'s `verification.steps`. When that run named a `report` for its `test`-profile step (a pytest junit-xml file) and the ratchet config has exactly one `junit-xml` suite, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
 
 ```bash
-REPORT=$(python3 -c "import json; d=json.load(open('$CW_TMP/close-epic/close-epic-manifest.json')); v=d.get('verification') or {}; print(next((s['report'] for s in v.get('steps', []) if s['profile']=='test' and s.get('report')), ''))")
-SUITE=$(python3 -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
+REPORT=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$CW_TMP/close-epic/close-epic-manifest.json')); v=d.get('verification') or {}; print(next((s['report'] for s in v.get('steps', []) if s['profile']=='test' and s.get('report')), ''))")
+SUITE=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
 if [ -n "$REPORT" ] && [ -n "$SUITE" ] && [ -f "$TARGET_REPO/$REPORT" ]; then
-  python3 "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --reuse-report "$SUITE=$TARGET_REPO/$REPORT"
+  "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --reuse-report "$SUITE=$TARGET_REPO/$REPORT"
 else
-  python3 "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO"
+  "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO"
 fi
-python3 "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO" --gate-verifier-tests
-python3 "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 10   # per-wave/ticket history for the retrospective
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO" --gate-verifier-tests
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 10   # per-wave/ticket history for the retrospective
 ```
 
 Pass `--gate-verifier-tests` only if Step 2c2's `$RATCHET_VALIDATED` is `true`; otherwise drop the flag (the check still *prints* `weakened_verifier_tests`/`removed_verifier_tests` findings report-only — surface them in the close report) and direct the operator to the gate-validation protocol, same as 2d/2e.
@@ -225,10 +229,10 @@ Pass `--gate-verifier-tests` only if Step 2c2's `$RATCHET_VALIDATED` is `true`; 
 A violation blocks the close: a regression means something merged that shouldn't have; a weakened/removed contract means the spec was edited outside the sanctioned path. A `weakened_verifier_tests`/`removed_verifier_tests` violation (chief-wiggum#206, channel C1c) means a test annotated `@cw-trace verifies` — the executable expression of a contract — was rewritten or dropped behind its still-green test ID; fix the code, or if the verifier test was *deliberately* revised, journal it via `ratchet.py record --amend-verifier <ref>` (a human act, same semantics as `--amend` for contracts). A `missing_tests` entry caused by a genuinely flaky/order-dependent case (not a real regression) is fixed by `ratchet.py record --retire-case` with a reason and expiry (#278) — surface it to the user and get their approval; never self-approve it, and never `--force` past the gate instead; state the quarantine count (and nearest expiry) in the close report so it isn't discovered later. `check`'s output also surfaces `suspect_links` (#169) — if `docs/quality/trace-links.json` exists, any link recorded against a contract whose definition hash just changed is printed explicitly, so a weakening is never silently absorbed into "the ratchet held"; this is report-only and does not change the exit code. If a contract revision was a *deliberate* decision made during the epic (confirm with the user — it should be visible in review threads, not discovered here), journal it explicitly so the baseline moves in the open, then re-check:
 
 ```bash
-python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-close \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-close \
   --ref "$EPIC_SLUG" --merged --amend CTR-xxx-001 --retire INV-xxx-002 \
   --notes "<why the contract changed, link to the decision>"
-python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-close \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" --event epic-close \
   --ref "$EPIC_SLUG" --retire-case 'pytest::tests/test_flaky.py::*' \
   --retire-case-reason "order-dependent shared state" --retire-case-owner plwp \
   --retire-case-expiry 2026-11-01   # quarantine a flaky class (#278)
@@ -241,7 +245,7 @@ Otherwise, once the check passes, record the epic close (same command without `-
 An epic's quality is only as durable as the enforcement layer that keeps it green on `main`. Report whether the target repo has any GitHub Actions workflow at all — a repo with no CI lets red tests, lint errors, and uninstallable deps merge unnoticed:
 
 ```bash
-python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
+"${CW_PY:-python3}" "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
 ```
 
 This is **report-only** (always exits 0, per `docs/gate-rollout.md`) — surface a `MISSING` finding in the close report, don't block on it. It also prints the detected stack(s); `/setup` can scaffold a minimal CI workflow (`--scaffold`) for a repo that has none.
@@ -251,7 +255,7 @@ This is **report-only** (always exits 0, per `docs/gate-rollout.md`) — surface
 For SaaS products, validate non-functional requirements (security headers + CSRF posture, auth rate-limiting, tenant isolation, health + structured logging) against the running app. Start the app if needed (don't punt), then:
 
 ```bash
-python3 "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" --base-url "$BASE_URL" --gate --markdown
+"${CW_PY:-python3}" "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" --base-url "$BASE_URL" --gate --markdown
 ```
 
 It reports five statuses (`pass`/`fail`/`warn`/`skipped`/`not_applicable`); a real `fail` (e.g. missing CSP, a cross-tenant data leak) blocks the epic close, while `warn`/`skipped` are surfaced but don't block. See `/saas-gate` for the full check list (tenant isolation, performance, data integrity need the live multi-user app).
@@ -271,7 +275,7 @@ Launch a **review-worker** (contract: `docs/worker-contracts.md#review-worker`) 
 Run the same prompt through the reviewer quorum for divergence, then reconcile the two into one findings list:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer "$CW_TMP/security-review-prompt.md" --output-dir "$CW_TMP/security-review" --cwd "$TARGET_REPO"
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role reviewer "$CW_TMP/security-review-prompt.md" --output-dir "$CW_TMP/security-review" --cwd "$TARGET_REPO"
 ```
 
 Triage every finding like the other gates: a confirmed exploitable issue is **blocking** (fix before close); a plausible-but-unproven one is **parked for the human** with the `file:line` and the concrete attack. Never close a user-facing/auth/money epic on an unreviewed security surface. Skip only when the epic is purely internal/back-office with **no new external surface** — and say so explicitly in the close report.
@@ -279,7 +283,7 @@ Triage every finding like the other gates: a confirmed exploitable issue is **bl
 **Log a real finding as an escape.** When this adversarial review (or the cross-surface/UX review in Step 9) confirms a genuine bug that an *earlier* gate should have caught — the ticket's own tests/review, `traceability`, `ratchet`, `check_single_writer` — that's exactly the class of miss `caught` counters can't see: the gate reported clean while a real bug shipped anyway. Log it so `/reflect` can measure gate RECALL, not just catches (no-op unless telemetry is enabled, never blocks):
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
   --summary "reset endpoint leaks account existence via timing" --severity high \
   --missed-by ticket-gate --found-in close-epic-review --ticket 42 --fixed
 ```
@@ -291,7 +295,7 @@ python3 "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
 Two signals the literature converged on for AI-generated code degradation: **elevated 2-week churn** (code reverted/reworked soon after authoring — GitClear; DORA 2024 stability drop) and **rising production duplication** (copy/paste written to be added, not reused). Run them over the target as a standing guardrail on top of the one-off `/code-metrics` audit:
 
 ```bash
-python3 "$CW_HOME/scripts/quality_slop_gate.py" --repo "$TARGET_REPO" --report
+"${CW_PY:-python3}" "$CW_HOME/scripts/quality_slop_gate.py" --repo "$TARGET_REPO" --report
 ```
 
 This is **report-only** (per `docs/gate-rollout.md`): it computes code survival (% of added lines surviving 14/30 days via git-of-theseus) and production-only duplication (% clones, tests excluded, via jscpd), prints each against GitClear's `[VENDOR]` reference bands (survival: pre-AI ~96.9% / AI-assisted ~94.3%; duplication: pre-AI 8.3% / AI 12.3%), and **always exits 0** — it never blocks the close. Surface its output verbatim in the final report under `### AI-slop signals`. It degrades gracefully: if git-of-theseus / jscpd / node are absent it prints `skipped (tool not found)`, and survival self-skips when the repo has < 14 days of history (too young to measure 2-week survival) — report that caveat honestly rather than treating a young repo as a pass. A future blocking mode is behind `--gate` (off by default, and even then only a regression *past* the AI band counts — the bands are directional).
@@ -326,7 +330,7 @@ This is **report-only** — it never blocks the close (a stale tutorial is a fol
 Checks `docs/compliance/ai-act.json` against the in-force layer only (Art. 5 prohibitions, Art. 6(4) derogation documentation, Art. 50 transparency) — the Chapter III high-risk conformity pack is parked (deferred by the Digital Omnibus, harmonised standards don't exist yet):
 
 ```bash
-python3 "$CW_HOME/scripts/check_ai_act.py" "$TARGET_REPO" --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_ai_act.py" "$TARGET_REPO" --format text
 ```
 
 **Report-only** (always exits 0 here, per `docs/gate-rollout.md` — this gate has no `--gate` wired into any workflow yet, and won't until a dry-run against a real shipped target and a `docs/quality/validation/check_ai_act.json` record exist per `docs/gate-validation.md`). Surface the finding count in the close report under `### EU AI Act`, distinguishing the four states: `pass` (all declared features clean), `findings` (a `fail`-severity hit — a `prohibited` tier, an undocumented Annex III derogation claim, an undeclared `eu_scope`, or a **missing artifact entirely** — Art. 6(4): absence is never a silent pass), `inapplicable` (the artifact exists with an explicit empty `features: []` — a genuine, recorded "no AI functionality here"), `error` (the artifact exists and could not be parsed). A `missing` classification_status on a product with an obvious AI feature (a chat widget, a recommendation surface) is worth flagging prominently in the close report even though it doesn't block — it means the Art. 6(4) assessment was never made, which the operator should fix before, not after, this epic ships.
@@ -345,8 +349,8 @@ TICKETED id:
 
 ```bash
 # $QUALITY_DIR already resolved at Step 1 (#324).
-python3 "$CW_HOME/scripts/debt_inventory.py" --repo "$TARGET_REPO" --out "$CW_TMP/close-epic/fresh-debt"
-python3 "$CW_HOME/scripts/plan_from_debt.py" verify --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/debt_inventory.py" --repo "$TARGET_REPO" --out "$CW_TMP/close-epic/fresh-debt"
+"${CW_PY:-python3}" "$CW_HOME/scripts/plan_from_debt.py" verify --repo "$TARGET_REPO" \
   --plan "$QUALITY_DIR/remediation-plan.json" \
   --debt "$CW_TMP/close-epic/fresh-debt/debt.json"
 ```
@@ -411,8 +415,8 @@ If the target repo has Playwright or E2E infrastructure, use it for UI-surface a
 Run `/stitch-audit` for each major feature keyword in the epic. This traces data flow across the full stack and flags where fields get lost, names drift, or validation diverges between layers.
 
 ```bash
-python3 "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --trace "$keyword" -o "$CW_TMP/stitch-extraction.json"
-python3 "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/stitch-extraction.json" --format text -o "$CW_TMP/stitch-findings.txt"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --trace "$keyword" -o "$CW_TMP/stitch-extraction.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/stitch-extraction.json" --format text -o "$CW_TMP/stitch-findings.txt"
 ```
 
 If findings exist, run provenance and Gemini analysis (same as `/stitch-audit` Steps 4-5).
@@ -615,14 +619,14 @@ Prepare a findings prompt at `$CW_TMP/close-epic-review-prompt.md` containing:
 Run the `reviewer` quorum (codex + gemini in parallel, with retries + output validation):
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/close-epic-review-prompt.md \
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role reviewer $CW_TMP/close-epic-review-prompt.md \
   --output-dir "$CW_TMP/close-review" --cwd "$TARGET_REPO"
 ```
 
 Synthesise the reviews via the manifest, never by naming the files:
 
 ```bash
-python3 "$CW_HOME/scripts/synthesize_reviews.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/synthesize_reviews.py" \
   --manifest "$CW_TMP/close-review/reviewer-manifest.json"
 ```
 
@@ -652,7 +656,7 @@ Write the retrospective to `$EPIC_DIR/retrospective.md` and commit.
 **Record validation telemetry.** `/close-epic` is the epic-level validation — record its value. The deterministic audits (traceability, unresolved, single-writer, ratchet) already emit their own gate events; this captures the epic-level LLM analysis (Step 9) + cross-surface/UX findings. Emit one gate event with the total count of substantive findings surfaced across the close (exclude nits) — no-op unless telemetry is enabled, never blocks:
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name close-epic \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" emit --event gate --name close-epic \
   --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
 ```
 

--- a/.claude/commands/code-metrics.md
+++ b/.claude/commands/code-metrics.md
@@ -43,21 +43,25 @@ Flags (passed through to `scripts/quality_metrics.py`):
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 ```
 
 If given `owner/repo`, resolve it (clones/pulls into the cache); otherwise the orchestrator defaults to the current repo or uses `--repo`:
 
 ```bash
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")   # only for owner/repo
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")   # only for owner/repo
 ```
 
 ### Step 2: Run the metric battery
 
 ```bash
-python3 "$CW_HOME/scripts/quality_metrics.py" "$owner_repo" --out "$CW_TMP/metrics"
+"${CW_PY:-python3}" "$CW_HOME/scripts/quality_metrics.py" "$owner_repo" --out "$CW_TMP/metrics"
 # or, for a local path:
-python3 "$CW_HOME/scripts/quality_metrics.py" --repo "$TARGET_REPO" --out "$CW_TMP/metrics"
+"${CW_PY:-python3}" "$CW_HOME/scripts/quality_metrics.py" --repo "$TARGET_REPO" --out "$CW_TMP/metrics"
 ```
 
 The orchestrator runs each engine, writes per-engine JSON (`churn.json`, `complexity.json`, `trend.json`, `survival.json`, `process.json`, `duplication.json`), builds `combined.json`, renders PNG charts, and writes `report.md`. It prints the `report.md` path on stdout.

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -18,7 +18,11 @@ Create a well-structured GitHub issue with clear title, description, acceptance 
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-target_root=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+target_root=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 `$target_root` is the local checkout of the target repo. Every `tracker.py`
@@ -65,7 +69,7 @@ Using the template at `$CW_HOME/templates/issue.md`, fill in:
 - **Nominal cost**: After picking the Effort size, derive the estimate mechanically — never from intuition:
 
   ```bash
-  python3 "$CW_HOME/scripts/ticket_cost.py" estimate --effort <S|M|L|XL>
+  "${CW_PY:-python3}" "$CW_HOME/scripts/ticket_cost.py" estimate --effort <S|M|L|XL>
   ```
 
   Stamp its output line verbatim into the template's `Nominal cost` field. An `UNRESOLVED (N prior ... tickets logged, need >=3)` answer is a valid value — leave it as-is; it self-calibrates as `/implement` records actuals on merged PRs (see `docs/ticket-cost.md`). Never replace UNRESOLVED with a guessed dollar figure.
@@ -90,7 +94,7 @@ public artifact, and #317's decision is to disclose AI authorship on every one
 of them rather than argue Art. 50(2) (see `docs/ai-act-posture.md`):
 
 ```bash
-ref=$(python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" create "$owner_repo" \
+ref=$("${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" create "$owner_repo" \
   --title "$title" \
   --body "$body" \
   --label "$label1" --label "$label2" \
@@ -103,7 +107,7 @@ a local frontmatter `epic` field as appropriate):
 
 ```bash
 if [ -n "$milestone" ]; then
-  python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" update "$ref" --set "epic=$milestone"
+  "${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" update "$ref" --set "epic=$milestone"
 fi
 ```
 
@@ -112,7 +116,7 @@ fi
 Fetch the created issue back to show its URL/path and confirm the fields landed:
 
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" get "$ref"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" get "$ref"
 ```
 
 Show the created issue's `url_or_path` and ref. Ask if the user wants to:

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -32,9 +32,13 @@ Product-level, once per product. Re-run it to evolve the brand. Epics inherit it
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 DESIGN_TMP="$CW_TMP/design" && mkdir -p "$DESIGN_TMP"
-TARGET_DIR=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+TARGET_DIR=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 1: Gather inputs and pick the path
@@ -74,7 +78,7 @@ Generate each direction with a **design-direction worker** (contract: `docs/work
 ```bash
 for f in "$DESIGN_TMP"/directions/*/*.html; do
   d=$(basename "$(dirname "$f")"); s=$(basename "$f" .html)
-  python3 - "$f" "$DESIGN_TMP/screenshots/$d-$s" <<'EOF'
+  "${CW_PY:-python3}" - "$f" "$DESIGN_TMP/screenshots/$d-$s" <<'EOF'
 import sys
 from pathlib import Path
 from playwright.sync_api import sync_playwright
@@ -108,7 +112,7 @@ The critique is a **review worker** task (contract: `docs/worker-contracts.md#re
 Unless `--skip-critique`: send the approved direction's screenshots to the `design_critic` quorum with the **same prompt** (value is in natural divergence). The role runs its providers in parallel with retries + output validation:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role design_critic "$DESIGN_TMP/critique-prompt.md" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role design_critic "$DESIGN_TMP/critique-prompt.md" \
   --cwd "$DESIGN_TMP" --output-dir "$DESIGN_TMP/critique"
 ```
 
@@ -128,7 +132,7 @@ Reconcile the three critiques. Fold **high-confidence findings** (a contrast fai
 Tokens are **extracted, not transcribed** — `design.json` comes mechanically from the approved mock's CSS, so the contract cannot drift from what the human approved.
 
 ```bash
-python3 "$CW_HOME/scripts/extract_design.py" extract \
+"${CW_PY:-python3}" "$CW_HOME/scripts/extract_design.py" extract \
   "$DESIGN_TMP/directions/$CHOSEN/<primary-screen>.html" \
   --source-kind net-new \
   --out "$DESIGN_TMP/design.json"
@@ -147,8 +151,8 @@ Then **add what CSS can't carry** by editing `design.json`:
 Validate and render the styleguide:
 
 ```bash
-python3 "$CW_HOME/scripts/extract_design.py" validate "$DESIGN_TMP/design.json"
-python3 "$CW_HOME/scripts/extract_design.py" styleguide "$DESIGN_TMP/design.json" --out "$DESIGN_TMP/styleguide.html"
+"${CW_PY:-python3}" "$CW_HOME/scripts/extract_design.py" validate "$DESIGN_TMP/design.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/extract_design.py" styleguide "$DESIGN_TMP/design.json" --out "$DESIGN_TMP/styleguide.html"
 ```
 
 Validation must pass before anything is committed. Any decision you could not make (e.g. the user has no logo yet) is recorded as `TBD:` in the relevant `notes` field — `scripts/check_unresolved.py` will gate dependent frontend tickets on it, which is correct.
@@ -171,7 +175,7 @@ Assemble and commit with the tested helper. It re-validates `design.json`, rende
 
 ```bash
 cd "$TARGET_DIR" && git checkout "$DEFAULT_BRANCH" && git pull --ff-only
-python3 "$CW_HOME/scripts/install_design_artifacts.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/install_design_artifacts.py" \
   --design-json "$DESIGN_TMP/design.json" \
   --mockups "$DESIGN_TMP/directions/<chosen>" \
   --screenshots "$DESIGN_TMP/reference" \

--- a/.claude/commands/implement-wave.md
+++ b/.claude/commands/implement-wave.md
@@ -38,9 +38,13 @@ Kill it when the workflow completes (or fails): `kill $CAFFEINATE_PID 2>/dev/nul
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 # One tested call resolves CW_HOME, CW_TMP, TARGET_REPO, DEFAULT_BRANCH, EPIC_SLUG, EPIC_DIR.
 # Capture first and check status so a resolver failure aborts cleanly.
-CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
+CW_CTX=$("${CW_PY:-python3}" "$CW_HOME/scripts/workflow_context.py" "$owner_repo" --epic "$epic_name" --shell) || {
   echo "workflow_context failed for $owner_repo" >&2; exit 1; }
 eval "$CW_CTX"
 
@@ -50,7 +54,7 @@ eval "$CW_CTX"
 export CW_TELEMETRY=1
 # Wave-level catch-up ingest: fold in Claude Code turns from BEFORE this wave
 # starts, so no worker's Step-11 slice has to recover them by cwd+window alone.
-python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 7 || true
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 7 || true
 ```
 
 `$EPIC_DIR/` holds this epic's artifacts:
@@ -66,7 +70,7 @@ python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days
 **Build the artifact inventory** — one tested pass that discovers prose/model/design artifacts, sets `HAS_FORMAL_MODELS`/`HAS_UI_SPEC`/`HAS_TRANSITION_MAP`, validates model JSON, and runs the unresolved-marker scan:
 
 ```bash
-python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "$EPIC_SLUG" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "$EPIC_SLUG" \
   ${EPIC_DIR:+--epic-dir "$EPIC_DIR"} > "$CW_TMP/inventory.json"
 # Tickets gated by unresolved markers, as a comma-separated list for the planner.
 BLOCKED_TICKETS=$(jq -r '.blocked_tickets | join(",")' "$CW_TMP/inventory.json")
@@ -103,7 +107,7 @@ Parse the dependency graph from the milestone description. `/plan-epic` writes a
 Parse the block into an adjacency list with the tested helper (no brittle inline parsing):
 
 ```bash
-python3 "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name"
+"${CW_PY:-python3}" "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name"
 ```
 
 This emits JSON like:
@@ -118,8 +122,8 @@ milestone surface in `warnings` rather than crashing.
 Compute the wave plan with the tested planner instead of sorting by hand. Feed it the dependency edges, the full epic issue list, the already-closed issues, and the tickets gated by the Step 1 unresolved scan (`blocked_tickets`):
 
 ```bash
-python3 "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name" > "$CW_TMP/deps.json"
-python3 "$CW_HOME/scripts/plan_waves.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/epic_metadata.py" deps "$owner_repo" --milestone "$epic_name" > "$CW_TMP/deps.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/plan_waves.py" \
   --deps-json "$CW_TMP/deps.json" \
   --issues "$EPIC_ISSUES" \
   --closed "$CLOSED_ISSUES" \
@@ -181,7 +185,7 @@ git pull --ff-only
 # LEAK from a previous run — a worker that ran `git checkout` in the main checkout
 # instead of its worktree leaves main on a feature branch, contaminating every base
 # branched off it. Re-run this before each wave's worktree creation and before merging.
-python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
+"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
 ```
 
 **If any AI tool fails auth, fix it now.** Do not discover auth failures 20 minutes into a parallel wave. If the user needs to run an interactive login, tell them to run `! codex auth login` or similar.
@@ -190,13 +194,13 @@ python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_RE
 
 **Sweep orphaned worktrees from prior runs** (#329) — no workflow ever ran `git worktree remove`, so a crashed/killed prior session can leave merged-ticket worktrees sitting in the shared checkout indefinitely. Report-only signal, never a blocker: this only removes a worktree whose branch is PROVABLY merged into `$DEFAULT_BRANCH` (`git branch --merged`) — a parked ticket's branch was never merged, so it is never touched without any separate "is this parked" bookkeeping:
 ```bash
-python3 "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
+"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
 ```
 
 **Load amnesia context** (`$QUALITY_DIR` already resolved at Step 1, #324; if `$QUALITY_DIR/ratchet.json` exists): replay the recent ratchet journal so this session doesn't re-litigate decisions a previous wave already made (a parked ticket, an amended contract, a known-flaky suite):
 
 ```bash
-python3 "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 5
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" recent --repo "$TARGET_REPO" --n 5
 ```
 
 ### Step 4: Execute waves
@@ -222,7 +226,7 @@ if [ "$HAS_FORMAL_MODELS" = true ]; then
   # One idempotent call generates every model-derived test artifact (test paths,
   # test plan, contract assertions, Hypothesis skeleton, guard templates) plus a
   # manifest, for whichever models exist in $MODELS_DIR.
-  python3 "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" \
+  "${CW_PY:-python3}" "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" \
     --output "$CW_TMP/formal-test-artifacts/"
 fi
 ```
@@ -259,7 +263,7 @@ For each ticket in the current wave (up to `--max-parallel`):
 
 2. **Compute the shared dependency-cache plan** (#329) — `/implement`'s single-ticket rule ("symlink `node_modules`/`.venv` instead of reinstalling") is UNSAFE here: `--max-parallel` workers install concurrently in separate worktrees, and a raw symlink to a shared tree lets one worker's install (prune/relink/rewrite) race a sibling's read of the same files. Detect the worktree's ecosystem(s) and point each package manager at a SHARED, concurrency-safe cache **store** instead — never at the installed tree itself (`chief_wiggum/dep_provisioning.py` — every ecosystem's cache format uses its own per-entry locking and is designed for exactly this multi-process sharing):
    ```bash
-   DEP_CACHE_ENV=$(python3 "$CW_HOME/scripts/dep_cache.py" plan --worktree "<worker's worktree path>" --shell)
+   DEP_CACHE_ENV=$("${CW_PY:-python3}" "$CW_HOME/scripts/dep_cache.py" plan --worktree "<worker's worktree path>" --shell)
    ```
    Pass `$DEP_CACHE_ENV` (the `export`/`mkdir -p` lines) to the worker to `eval` before it installs dependencies. The worker still runs its own `npm install`/`pip install`/`go mod download` into its OWN `node_modules`/`.venv`/module cache — only the download/extraction cost is shared, so concurrent workers stay isolated (no shared writable install tree) while skipping the network round-trip. If no recognized ecosystem is detected, the plan is empty and the worker installs normally.
 
@@ -281,9 +285,9 @@ For each ticket in the current wave (up to `--max-parallel`):
    - **Costing attribution** (chief-wiggum#345): if the worker's own `/implement` flow reaches its Step-11 transcript ingest, it MUST pass `--cwd-prefix "<its own worktree path>"` (never bare `--repo`) — every worker in this wave shares the same target repo, so a cwd-derived repo match alone would cross-bill a sibling ticket's spend onto this one. `ticket_cost.py actual` should get the matching `--cwd-prefix`/`--since-ts` pair for the same reason.
    - **HARD RULES**:
      - Do NOT create or merge pull requests. Return the branch name and a summary.
-     - You are in a git worktree. Assert isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"` (it aborts if you are in the main checkout). Never operate on the main checkout.
+     - You are in a git worktree. Assert isolation with `"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"` (it aborts if you are in the main checkout). Never operate on the main checkout.
      - **Bootstrap the guarded Git path before any other Git action**: run
-       `eval "$(python3 "$CW_HOME/scripts/git_safety.py" wave-git-env --main "$TARGET_REPO" --worktree "$PWD")"`,
+       `eval "$("${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" wave-git-env --main "$TARGET_REPO" --worktree "$PWD")"`,
        then `git status --short` to prove the shim is active. Every subsequent
        worker Git operation and child-process invocation now routes through
        `wave-git`. The guard keeps commands in this worktree and rejects active
@@ -337,7 +341,7 @@ If any PRs were created by a worker during this wave (matching ticket branch nam
    REUSE_OK=false
    if [ -f "$VERIFY_JSON" ]; then
      LAST_COMMIT_TS=$(git -C "$worktree" log -1 --format=%ct)
-     VERIFY_TS=$(python3 -c "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" "$VERIFY_JSON")
+     VERIFY_TS=$("${CW_PY:-python3}" -c "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" "$VERIFY_JSON")
      TEST_STEPS=$(jq '[.steps[] | select(.profile=="test")] | length' "$VERIFY_JSON")
      if [ "$VERIFY_TS" -ge "$LAST_COMMIT_TS" ] && [ "$(jq .ok "$VERIFY_JSON")" = "true" ] && [ "$TEST_STEPS" != "0" ]; then
        REUSE_OK=true
@@ -347,7 +351,7 @@ If any PRs were created by a worker during this wave (matching ticket branch nam
      echo "reusing #$ticket_number's own verify.json (fresh, ok, $TEST_STEPS test step(s)) — skipping a redundant re-run"
    else
      echo "no fresh/ok verify.json for #$ticket_number — falling back to a full re-run"
-     python3 "$CW_HOME/scripts/run_verification.py" --repo "$worktree" --profile test,lint,build --json > "$VERIFY_JSON"
+     "${CW_PY:-python3}" "$CW_HOME/scripts/run_verification.py" --repo "$worktree" --profile test,lint,build --json > "$VERIFY_JSON"
    fi
    ```
    The fallback re-run is never skipped when the artifact is missing, stale (older than the branch's last commit — e.g. the worker amended after verifying), or reports a non-passing/empty result; only a genuinely fresh, green, non-empty artifact is reused.
@@ -355,7 +359,7 @@ If any PRs were created by a worker during this wave (matching ticket branch nam
 4. Verify the branch has the expected commits
 5. **Protected-path guard** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324; see `docs/ratchet.md`) — workers must not move their own goalposts. Check the worker's diff against the protected pathset (contracts, invariants, integration-test specs, formal models, ratchet state):
    ```bash
-   python3 "$CW_HOME/scripts/ratchet.py" protected --repo "$worktree" --base "origin/$DEFAULT_BRANCH"
+   "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" protected --repo "$worktree" --base "origin/$DEFAULT_BRANCH"
    ```
    If it exits non-zero, **park the ticket**: do NOT merge it this wave. Surface the touched files and the diff to the user — a worker editing a contract to make its implementation pass is exactly what this guard exists to catch. If the user approves the contract change, journal it with `ratchet.py record --amend/--retire` and re-admit the ticket next wave.
 6. **For frontend tickets**: verify screenshots exist in `$TICKET_TMP/ux-screenshots/` and LOOK at them. A worker reporting "design review passed" without screenshots is a worker that skipped the gate. If the epic has a design contract and the screenshots show default-theme output, the ticket is not done.
@@ -374,9 +378,9 @@ SESSION_ID=$(basename "$CW_TMP")
 # holds it (session id, pid, acquired-at) so the operator can tell this is a
 # collision, not a bug. Poll with a visible message rather than hard-failing:
 # a second wave's staging/promote phase is normally short-lived.
-until python3 "$CW_HOME/scripts/wave_lock.py" acquire --repo "$TARGET_REPO" --session "$SESSION_ID" --wave "$wave_number"; do
+until "${CW_PY:-python3}" "$CW_HOME/scripts/wave_lock.py" acquire --repo "$TARGET_REPO" --session "$SESSION_ID" --wave "$wave_number"; do
   echo "Waiting for the wave lock on $TARGET_REPO (held by another /implement-wave run)..." >&2
-  python3 "$CW_HOME/scripts/wave_lock.py" status --repo "$TARGET_REPO" >&2
+  "${CW_PY:-python3}" "$CW_HOME/scripts/wave_lock.py" status --repo "$TARGET_REPO" >&2
   sleep 30
 done
 ```
@@ -390,7 +394,7 @@ done
    git pull --ff-only
    # Re-assert main is pristine before branching the staging base off it (a worker in
    # this wave may have leaked a checkout into main).
-   python3 "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
+   "${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" assert-main-pristine --main "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
    git checkout -b "wave-$wave_number-staging"
    ```
 
@@ -411,7 +415,7 @@ Run the integration check **on the staging branch, before promoting to main**:
 
 1. **Full test suite**, captured as structured evidence (chief-wiggum#284) rather than bare prose — this is the run item 5 below reuses instead of paying for the suite twice:
    ```bash
-   python3 "$CW_HOME/scripts/run_verification.py" --repo "$TARGET_REPO" --profile test,lint,build --json > "$CW_TMP/wave-$wave_number-verify.json"
+   "${CW_PY:-python3}" "$CW_HOME/scripts/run_verification.py" --repo "$TARGET_REPO" --profile test,lint,build --json > "$CW_TMP/wave-$wave_number-verify.json"
    ```
    All steps must pass (`jq .ok "$CW_TMP/wave-$wave_number-verify.json"`).
 2. **Linting**: covered by the `lint` profile above (or `golangci-lint run ./...` / `npx eslint` directly) — zero high-severity findings
@@ -419,27 +423,27 @@ Run the integration check **on the staging branch, before promoting to main**:
 4. **Smoke test**: If services can be started, start them and verify health endpoints respond
 5. **Ratchet check** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324; see `docs/ratchet.md`) — the merged wave may not shrink the high-water pass-set, weaken any contract definition, or rewrite a verifier-test body behind its still-green test ID. **Reuse item 1's run instead of re-executing the suite on the identical staging commit** (chief-wiggum#322, same pattern as `/implement` Step 4b): when item 1's JSON names a `report` for its `test`-profile step and the ratchet config has exactly one suite of the matching parser, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
    ```bash
-   REPORT=$(python3 -c "import json; d=json.load(open('$CW_TMP/wave-$wave_number-verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
-   SUITE=$(python3 -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
+   REPORT=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$CW_TMP/wave-$wave_number-verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
+   SUITE=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
    if [ -n "$REPORT" ] && [ -n "$SUITE" ] && [ -f "$TARGET_REPO/$REPORT" ]; then
-     python3 "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --reuse-report "$SUITE=$TARGET_REPO/$REPORT"
+     "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO" --reuse-report "$SUITE=$TARGET_REPO/$REPORT"
    else
-     python3 "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO"
+     "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$TARGET_REPO"
    fi
-   python3 "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO" --gate-verifier-tests
+   "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" check --repo "$TARGET_REPO" --gate-verifier-tests
    ```
    Pass `--gate-verifier-tests` only if `check_gate_validation.py ratchet --validation-dir "$CW_HOME/docs/quality/validation" --gate` passes (same record-gated posture as `/implement` Step 8 and `/close-epic` Step 2f, chief-wiggum#208); otherwise drop the flag and surface the printed `weakened_verifier_tests` findings in the wave log. A violation is a hard blocker exactly like a test failure: fix it on the staging branch (or drop the offending ticket's merge from the wave) before promoting. Never resolve a violation by editing the contract, a verifier test, or the journal — a deliberate revision is a journaled human act (`record --amend`/`--amend-verifier`). A `missing_tests` finding caused by a flaky/order-dependent case is fixed by `ratchet.py record --retire-case` with a reason and expiry (#278) — surface it to the user and get their approval; never self-approve it, and never `--force` past the gate instead.
 6. **Single-writer / traceability quick check** (report-only, wave-scoped) — if the epic has `docs/epics/<slug>/`, scope both checkers to what THIS wave changed with `--changed-since "$DEFAULT_BRANCH"` (see `docs/single-writer.md`, `docs/traceability.md`):
    ```bash
-   python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$TARGET_REPO" \
      --changed-since "$DEFAULT_BRANCH" --format text
-   python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$TARGET_REPO" \
      --changed-since "$DEFAULT_BRANCH" --gate soundness --gate-scope changed --format text
    ```
    Single-writer is report-only: a fast wave-scoped signal, not the authoritative gate — `--changed-since` cannot see a stale writer outside this wave's diff. `/close-epic`'s coverage gate always scans the whole repo and is what actually blocks the epic.
 
    Traceability **soundness blocks**, scoped to this wave's diff (chief-wiggum#379): a `@cw-trace` direction error introduced by a worker is a hard blocker here, fixed on the staging branch before promoting, rather than being discovered an epic later. `--gate-scope changed` keeps epic-doc findings (malformed IDs, orphan BRs) report-only, since no worker may edit goalposts. Surface the remaining findings for the fixer; don't hard-block the wave on those.
-7. **Prevention signals** (#216, report-only — NEVER blocking): `python3 "$CW_HOME/scripts/prevention_signals.py" --repo "$TARGET_REPO" --base "$DEFAULT_BRANCH"` over the merged staging diff — new duplication / dead code introduced / assertion-free tests added, appended to the wave report as reviewer information (same posture as `/implement` Step 7's 3b).
+7. **Prevention signals** (#216, report-only — NEVER blocking): `"${CW_PY:-python3}" "$CW_HOME/scripts/prevention_signals.py" --repo "$TARGET_REPO" --base "$DEFAULT_BRANCH"` over the merged staging diff — new duplication / dead code introduced / assertion-free tests added, appended to the wave report as reviewer information (same posture as `/implement` Step 7's 3b).
 
 If the integration check fails:
 - **Test failure caused by merge**: Fix it on the staging branch. Launch an implementation worker (contract: `docs/worker-contracts.md#implementation-worker`) to diagnose and fix.
@@ -456,12 +460,12 @@ if [ "$HAS_FORMAL_MODELS" = true ]; then
 
   # Check guard clause presence: for each REQUIRES in contracts.json,
   # grep the implementation for a corresponding guard/validation
-  python3 "$CW_HOME/scripts/formal_models.py" validate "$MODELS_DIR/contracts.json"
-  python3 "$CW_HOME/scripts/formal_models.py" validate "$MODELS_DIR/state-machines.json"
+  "${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$MODELS_DIR/contracts.json"
+  "${CW_PY:-python3}" "$CW_HOME/scripts/formal_models.py" validate "$MODELS_DIR/state-machines.json"
 
   # Verify invariants are covered by tests
   # For each invariant ID in the model, grep the test files
-  for inv_id in $(python3 -c "
+  for inv_id in $("${CW_PY:-python3}" -c "
 import json
 sm = json.load(open('$MODELS_DIR/state-machines.json'))
 for inv in sm.get('invariants', []):
@@ -479,14 +483,14 @@ for inv in sm.get('invariants', []):
   # hardcoded pattern from one target repo. code_query.py wraps
   # check_single_writer.py's writer inventory as a per-invariant query, so a
   # future epic's INV-<whatever> is covered without editing this skill.
-  for inv_id in $(python3 -c "
+  for inv_id in $("${CW_PY:-python3}" -c "
 import json
 sm = json.load(open('$MODELS_DIR/state-machines.json'))
 for inv in sm.get('invariants', []):
     if inv.get('controls_field') and inv.get('sanctioned_writers'):
         print(inv['id'])
 "); do
-    result=$(python3 "$CW_HOME/scripts/code_query.py" --repo "$TARGET_REPO" --epic "$EPIC_SLUG" --format json writers "$inv_id")
+    result=$("${CW_PY:-python3}" "$CW_HOME/scripts/code_query.py" --repo "$TARGET_REPO" --epic "$EPIC_SLUG" --format json writers "$inv_id")
     violations=$(echo "$result" | jq '[.facts[] | select(.sanctioned == false)] | length')
     if [ "$violations" -gt 0 ]; then
       echo "  $inv_id: WARN — $violations unsanctioned writer(s)"
@@ -535,14 +539,14 @@ Only proceed to the next wave after the push succeeds.
 
 **Remove this wave's merged-ticket worktrees** (#329) — every ticket branch just merged into `$DEFAULT_BRANCH` above; its worktree has no more local work to do. `gc-worktrees` only removes a worktree whose branch is provably merged, so a PARKED ticket (protected-path violation, unresolved conflict — never merged this wave) survives without any separate bookkeeping; pass `--keep` for any ticket branch you know is parked as defense in depth:
 ```bash
-python3 "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH" \
   $(for b in "${PARKED_BRANCHES[@]:-}"; do echo "--keep $b"; done)
 ```
 
 **Release the wave lock** acquired in 4d — every exit from the staging/promote phase (success, integration-check abort, or fast-forward failure requiring manual intervention) must release it, or the next wave (in this same run) blocks on itself:
 
 ```bash
-python3 "$CW_HOME/scripts/wave_lock.py" release --repo "$TARGET_REPO" --session "$SESSION_ID"
+"${CW_PY:-python3}" "$CW_HOME/scripts/wave_lock.py" release --repo "$TARGET_REPO" --session "$SESSION_ID"
 ```
 
 #### 4h: Update traceability
@@ -554,7 +558,7 @@ After the wave merges, update the traceability matrix for all tickets in the wav
 **Journal the ratchet** (if `$QUALITY_DIR/ratchet.json` exists — `$QUALITY_DIR` already resolved at Step 1, #324): record the merged wave so its passing tests advance the high-water mark, and give the next session amnesia context:
 
 ```bash
-python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
   --event wave --ref "wave-$wave_number" --merged \
   --notes "<tickets merged, anything parked and why>"
 ```

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -29,7 +29,7 @@ message you author for this ticket (test commits, implementation commits,
 fix-up commits):
 
 ```bash
-python3 "$CW_HOME/scripts/ai_disclosure.py" commit-trailer --file "$CW_TMP/<ticket>/commit-msg.txt"
+"${CW_PY:-python3}" "$CW_HOME/scripts/ai_disclosure.py" commit-trailer --file "$CW_TMP/<ticket>/commit-msg.txt"
 git commit -F "$CW_TMP/<ticket>/commit-msg.txt"
 ```
 
@@ -73,10 +73,14 @@ Resolve the chief-wiggum install directory and the target repo path. **Never har
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 # One tested call resolves CW_HOME, CW_TMP, TARGET_REPO, DEFAULT_BRANCH, ISSUE_NUMBER.
 # Capture first and check status so a resolver failure aborts instead of
 # continuing with unset/stale variables.
-CW_CTX=$(python3 "$CW_HOME/scripts/workflow_context.py" "$owner_repo#$issue_number" --shell) || {
+CW_CTX=$("${CW_PY:-python3}" "$CW_HOME/scripts/workflow_context.py" "$owner_repo#$issue_number" --shell) || {
   echo "workflow_context failed for $owner_repo#$issue_number" >&2; exit 1; }
 eval "$CW_CTX"
 ```
@@ -93,7 +97,7 @@ mkdir -p "$TICKET_TMP"
 **Preflight the providers — before any phase needs one** (chief-wiggum#375). This is the single highest-leverage thing in Step 1: roughly 15 of a 25-minute consult phase once went on environment failures discovered *serially*, one relaunch at a time, after the prompt was already built.
 
 ```bash
-python3 "$CW_HOME/scripts/provider_preflight.py" --human --usage \
+"${CW_PY:-python3}" "$CW_HOME/scripts/provider_preflight.py" --human --usage \
   --role explorer --role reviewer --role implementer \
   | tee "$TICKET_TMP/preflight.txt"
 ```
@@ -118,7 +122,7 @@ date +%s > "$TICKET_TMP/build-start-ts"
 # bounded by --until-ts so it can never consume this ticket's own turns (dedup is
 # by request id and tagging happens at first ingest — an unbounded catch-up here
 # would permanently strand this build's Claude layer untagged, chief-wiggum#345).
-python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
   --since-days 7 --until-ts "$(cat "$TICKET_TMP/build-start-ts")" || true
 ```
 
@@ -130,7 +134,7 @@ All per-ticket files (`approach-prompt.md`, `approach-codex.md`, `approach-gemin
 # Find the ticket's milestone
 MILESTONE=$(gh issue view "$issue_number" --repo "$owner_repo" --json milestone -q '.milestone.title // empty')
 if [ -n "$MILESTONE" ]; then
-  EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "$MILESTONE")
+  EPIC_SLUG=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" slug "$MILESTONE")
   # epics_dir = meta_root/epics (artifacts.Resolver.epics_dir) — $CW_META_ROOT
   # is already resolved (Step 1's workflow_context.py, #324), so this needs
   # no `artifacts.py show` call of its own.
@@ -159,7 +163,7 @@ Also check for **formal model artifacts** in `$EPIC_DIR/models/`:
 
 Build the artifact inventory once with the tested helper, then read its flags (it discovers prose/model/design artifacts, validates model JSON, and runs the unresolved-marker scan in one pass — sidecar-aware: it resolves the epic/design location itself, but `$EPIC_DIR` is already resolved above, so pass it through rather than paying to re-derive it):
 ```bash
-python3 "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "${EPIC_SLUG:-}" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/epic_inventory.py" "$TARGET_REPO" --epic-slug "${EPIC_SLUG:-}" \
   ${EPIC_DIR:+--epic-dir "$EPIC_DIR"} --issue "$issue_number" > "$TICKET_TMP/inventory.json"
 EPIC_STATUS=$(jq -r '.epic_status' "$TICKET_TMP/inventory.json")
 if [ "$EPIC_STATUS" = "missing" ]; then
@@ -177,7 +181,7 @@ These artifacts are **hard constraints** on the implementation. The coding worke
 
 **Query the architecture live instead of re-deriving it** — when `$HAS_FORMAL_MODELS == true`, `scripts/code_query.py` (see `docs/code-query.md`) answers "what governs this file/field/contract" from the epic artifacts + code annotations, as small JSON with `file:line` handles instead of a full context-load of these docs. Steps 4/6/8 below use it — `orient` for a specific file, `contract`/`state` for a specific ID, `show` to dereference a handle to its actual text — in place of both ad hoc grepping AND the full doc load this section used to do:
 ```bash
-python3 "$CW_HOME/scripts/code_query.py" --repo "$TARGET_REPO" --epic "$EPIC_SLUG" orient path/to/file.go
+"${CW_PY:-python3}" "$CW_HOME/scripts/code_query.py" --repo "$TARGET_REPO" --epic "$EPIC_SLUG" orient path/to/file.go
 ```
 
 **Unresolved-unknowns gate**: `epic_inventory.py` already ran this exact scan (over this exact `$EPIC_DIR`, zero intervening writes) building `$TICKET_TMP/inventory.json` above — read its `.unresolved`/`.blocked_tickets` rather than re-scanning:
@@ -186,7 +190,7 @@ jq '.unresolved' "$TICKET_TMP/inventory.json"
 ```
 If any finding's `tickets` list includes this ticket (or the finding sits on an entity/operation this ticket implements), do NOT implement on the guessed value. Resolve the unknown first — introspect the real source, read the upstream repo, or ask the user — update the artifact with a citation, then proceed. Building a query layer against `TBD:` schema names produces code that compiles, passes mocked tests, and fails on first contact with reality.
 
-Fallback (only if `$TICKET_TMP/inventory.json` is missing or unreadable — the standalone case, never the normal path): `python3 "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json`.
+Fallback (only if `$TICKET_TMP/inventory.json` is missing or unreadable — the standalone case, never the normal path): `"${CW_PY:-python3}" "$CW_HOME/scripts/check_unresolved.py" "$EPIC_DIR" --format json`.
 
 If `$EPIC_STATUS` is `none` (this ticket was never on a milestone), proceed without epic context — the skill works standalone too. That is the ONLY case that silently proceeds; `missing` already stopped above.
 
@@ -212,7 +216,7 @@ Present to the user:
 **Write `$TICKET_TMP/ticket.json`** — the reusable ticket context Step 4's approach prompt and Step 7's review pipeline both read. Comments (including `authorAssociation`) MUST be fetched and serialized here: before #83, this writer didn't exist at all, so `TicketComment`/`review.TicketContext.from_dict` had nothing to preserve and reviewers judged diffs against stale body-only acceptance criteria even after a maintainer amended them in a comment.
 
 ```bash
-python3 "$CW_HOME/scripts/write_ticket_context.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/write_ticket_context.py" \
   --issue-json "$TICKET_TMP/issue-raw.json" \
   --number "$issue_number" \
   --acceptance-criteria "<AC line 1 you extracted above>" \
@@ -243,8 +247,8 @@ Run **four** tasks in parallel — three AI consultations plus a codebase explor
 
 1. **Codex + Gemini** — Launch as background bash commands:
    ```bash
-   python3 "$CW_HOME/scripts/consult_ai.py" codex $TICKET_TMP/approach-prompt.md -o $TICKET_TMP/approach-codex.md --cwd "$TARGET_REPO" --ticket "$issue_number" &
-   python3 "$CW_HOME/scripts/consult_ai.py" gemini $TICKET_TMP/approach-prompt.md -o $TICKET_TMP/approach-gemini.md --cwd "$TARGET_REPO" --ticket "$issue_number" &
+   "${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" codex $TICKET_TMP/approach-prompt.md -o $TICKET_TMP/approach-codex.md --cwd "$TARGET_REPO" --ticket "$issue_number" &
+   "${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" gemini $TICKET_TMP/approach-prompt.md -o $TICKET_TMP/approach-gemini.md --cwd "$TARGET_REPO" --ticket "$issue_number" &
    wait
    ```
 
@@ -325,7 +329,7 @@ in the shape `ratchet.py pathset` consumes:
   derive it mechanically, adding collateral (callers/tests that must move) as
   `--collateral` args:
   ```bash
-  python3 "$CW_HOME/scripts/plan_from_debt.py" pathset \
+  "${CW_PY:-python3}" "$CW_HOME/scripts/plan_from_debt.py" pathset \
     --plan "$QUALITY_DIR/remediation-plan.json" --id RT-001 \
     --collateral "tests/test_pricing.py" -o "$TICKET_TMP/pathset.json"
   ```
@@ -384,7 +388,7 @@ For every other ticket kind, Step 5 proceeds as written below.
 # One idempotent call generates every model-derived test artifact (test paths,
 # test plan, contract assertions, Hypothesis skeleton, guard templates) and a
 # manifest, for whichever models exist in $MODELS_DIR.
-python3 "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" --output "$TICKET_TMP/"
+"${CW_PY:-python3}" "$CW_HOME/scripts/generate_formal_test_artifacts.py" "$MODELS_DIR" --output "$TICKET_TMP/"
 ```
 
 The manifest (`$TICKET_TMP/formal-artifacts-manifest.json`) lists the generated files and per-model status; a non-zero exit means a present model failed validation — fix the model before building on it.
@@ -399,7 +403,7 @@ Launch an **implementation worker** (contract: `docs/worker-contracts.md#impleme
 - **If UI spec exists** (`$HAS_UI_SPEC == true`): include the UI spec's page, component, and interaction definitions for the pages this ticket touches. Read `$MODELS_DIR/ui-spec.json` and extract the relevant pages and their component trees. The worker MUST follow the UI spec's structural decisions — if the spec says "sidebar-panel", don't build a separate page; if it says "3-dot-menu", don't use a tab bar. Interaction contracts (trigger → action → target) are binding, not suggestions. If the spec has a `design` section, also pass its tokens, component-library binding, relevant assets, and voice guidelines — bind tokens as CSS variables/theme values, never hardcode the component library's defaults. The design-fidelity gate (Step 9) will review rendered screenshots against this contract.
 **HARD RULES for worker**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code and commit to the feature branch. The orchestrator owns PR creation (Step 11).
-- You work in an **isolated checkout** (required isolation behavior). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the checkout root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
+- You work in an **isolated checkout** (required isolation behavior). At the start, assert isolation with the tested check (it aborts non-zero if you are in the main checkout): `"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Work ONLY in the checkout root it prints. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 - **Carry over gitignored runtime files** the checkout needs but git doesn't bring: for each `.env.local` / `.env.*.local` present in the main checkout, COPY it into the same relative path in the worktree; symlink dependency dirs (`node_modules`, `.venv`) instead of reinstalling. A worktree without `.env.local` runs dev servers against the wrong backend/project — tests then fail in ways that look like app bugs (empty lists, 404s on writes) while direct API calls succeed. Copy them BEFORE starting any dev server or test run.
 
 The worker should:
@@ -423,7 +427,7 @@ The worker should:
 **Load the target's own authoring authorities first (#264).** A repo CW didn't build usually already has house rules — naming conventions, test standards, framework-specific patterns — and on a mature codebase they are often packaged as harness skills. CW's generic checklist knows nothing about them, and a worker cannot infer them from a diff:
 
 ```bash
-python3 "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
   --phase authoring > "$TICKET_TMP/authoring-authorities.txt" || {
   echo "review-authorities binding is malformed — refusing to build against CW defaults while the target's own conventions are unreadable" >&2
   exit 2; }
@@ -435,10 +439,10 @@ Launch an **implementation worker** (contract: `docs/worker-contracts.md#impleme
 
 **HARD RULES for worker**:
 - Do NOT create pull requests, do NOT merge branches, do NOT run `gh pr create` or `gh pr merge`. Your job is to write code, run tests, and commit. The orchestrator owns PR creation (Step 11).
-- You are working in a **git worktree** (the same one from Step 5). Confirm isolation with `python3 "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
+- You are working in a **git worktree** (the same one from Step 5). Confirm isolation with `"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" assert-worktree --main "$TARGET_REPO"`. Do NOT `cd` to `$TARGET_REPO`. Never run destructive git operations (`reset --hard`, `clean -f`) on the main checkout.
 - **Found ≠ fixed (adopted repos — `$IS_ADOPTED`)**: anything you discover mid-ticket that the ticket doesn't cover — dead code nearby, a clone, a smell, a stale comment — is filed **in the same turn** as a `DEBT-` candidate and left UNTOUCHED in the diff:
   ```bash
-  python3 "$CW_HOME/scripts/debt_inventory.py" append-candidate --repo "$TARGET_REPO" \
+  "${CW_PY:-python3}" "$CW_HOME/scripts/debt_inventory.py" append-candidate --repo "$TARGET_REPO" \
     --engine manual --path "pkg/orders/handler.py:88" --note "duplicate retry loop, clone of billing.py"
   ```
   (or file a tracker issue for anything bigger than a code smell). Candidates land in the **mode-independent pending store** (`~/.chief-wiggum/pending/<target-id>/candidates.json`) — never the target tree, so this works identically in embedded and sidecar mode, and every future inventory run merges them in automatically. A candidate leaves the store only via the explicit operator act `debt_inventory.py resolve-candidate --repo X --id DEBT-...` (after actually fixing it in a reviewed change) — never as a side effect of an engine re-run. Scope discipline must not cost information — the pending store is the pressure valve. No opportunistic fixes, no drive-by formatting/renames outside the declared pathset: those hunks get flagged in review and parked.
@@ -448,13 +452,13 @@ The worker should:
 
    **Semantic code intelligence (optional, Go/Python)**: while writing, resolve ground-truth facts with the LSP helper instead of guessing — go-to-definition, references, hover types, and live diagnostics. It degrades gracefully (if the language server isn't installed it returns `available: false` and you fall back):
    ```bash
-   python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" --line <L> --col <C> hover path/to/file.go
-   python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics path/to/file.py
+   "${CW_PY:-python3}" "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" --line <L> --col <C> hover path/to/file.go
+   "${CW_PY:-python3}" "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics path/to/file.py
    ```
 
    **Architecture knowledge (if $EPIC_DIR exists)**: before editing a file this ticket touches, ask what already governs it instead of re-reading the whole epic — `orient` surfaces the contracts/invariants/state-transitions bound to it (by annotation OR by artifact — an un-annotated handler still gets a real answer), so you don't silently miss a REQUIRES/invariant that isn't yet annotated:
    ```bash
-   python3 "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --epic "$EPIC_SLUG" orient path/to/file.go
+   "${CW_PY:-python3}" "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --epic "$EPIC_SLUG" orient path/to/file.go
    ```
 2. Enforce epic contracts as runtime guards:
    - Every REQUIRES block → input validation / guard clause at function entry
@@ -499,7 +503,7 @@ The worker should:
 1b. **Load the target's own review authorities (#264).** The multi-AI quorum reviews against CW's checklist; a brownfield repo's standing objections are invisible to it unless they are supplied:
 
    ```bash
-   python3 "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/review_authorities.py" show "$TARGET_REPO" \
      --phase review --format json > "$TICKET_TMP/review-authorities.json" || {
      echo "review-authorities binding is malformed — refusing to review against CW defaults alone" >&2
      exit 2; }
@@ -525,7 +529,7 @@ The worker should:
 
 2. Run the review pipeline in one call. It captures the `base...HEAD` diff, assembles the review prompt from `templates/review-prompt.md` + `review-checklist.md` (plus any epic artifacts you pass), runs the `reviewer` quorum (parallel, retries, output validation), and writes the synthesis prompt + a manifest. Every provider gets the **identical** assembled prompt — but check `config/providers.json`'s `reviewer.lenses` map first: providers may be assigned a bounded review lens (e.g. `codex: refute-soundness`, `gemini: completeness`, `claude-interactive: adoption-cost`; charters in `config/lenses.json`), in which case `run_review.py` appends each provider's charter as a `## Your charter` section before calling it — the shared diff/context every provider sees never changes. Pass the `ticket.json` written in Step 2 — title/body/acceptance criteria plus the comment thread (`comments`, always an array — CTR-fh-002), which `run_review.py` renders as two labeled, authority-separated regions ("Accepted AC amendments" vs "Discussion/context" — CTR-fh-003/ADR-fh-02) so reviewers judge the diff against the CURRENT authoritative state, not a stale body-only baseline — and optionally epic artifacts:
    ```bash
-   python3 "$CW_HOME/scripts/run_review.py" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/run_review.py" \
      --ticket-context "$TICKET_TMP/ticket.json" \
      --worktree "$(git rev-parse --show-toplevel)" --base "$DEFAULT_BRANCH" \
      --output-dir "$TICKET_TMP/reviews" \
@@ -540,7 +544,7 @@ The worker should:
 3. **Hotspot-aware review depth (#187, report-only — NEVER a gate).** Check whether any changed file is a measured hotspot (or coupled to one) via `code_query.py orient` — a top-decile churn×complexity file, or one tightly coupled to it, deserves deeper scrutiny than a routine diff, same as a file with a governing invariant would:
    ```bash
    for f in $(git diff --name-only "$DEFAULT_BRANCH"...HEAD); do
-     python3 "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --format text orient "$f" \
+     "${CW_PY:-python3}" "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --format text orient "$f" \
        | grep -q '^- (hotspot)' && echo "$f: measured hotspot — escalate review depth"
    done
    ```
@@ -548,14 +552,14 @@ The worker should:
 
 3b. **Prevention signals (#216, report-only — NEVER blocking).** Run the diff-scoped slop signals and append the output to the review context as reviewer information: new duplication (this diff clones EXISTING code — clone-class join), dead code introduced (added exports unused anywhere), assertion-free tests added:
    ```bash
-   python3 "$CW_HOME/scripts/prevention_signals.py" --repo "$(git rev-parse --show-toplevel)" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/prevention_signals.py" --repo "$(git rev-parse --show-toplevel)" \
      --base "$DEFAULT_BRANCH" >> "$TICKET_TMP/reviews/review-context-extra.md"
    ```
    It always exits 0 and never gates — the findings are for the reviewers' eyes (promotion to a blocking gate would require the full `docs/gate-validation.md` protocol first).
 
 3c. **Out-of-pathset flagging (adopted repos — `$IS_ADOPTED`, report-only).** Check the diff against the declared touch plan from Step 4 and feed any escapes to the reviewers as a flagged section:
    ```bash
-   python3 "$CW_HOME/scripts/ratchet.py" pathset --repo "$(git rev-parse --show-toplevel)" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" pathset --repo "$(git rev-parse --show-toplevel)" \
      --base "$DEFAULT_BRANCH" --pathset-file "$TICKET_TMP/pathset.json" --report-only \
      2>> "$TICKET_TMP/reviews/review-context-extra.md"
    ```
@@ -565,7 +569,7 @@ The worker should:
 
 5. Synthesize using:
    ```bash
-   python3 "$CW_HOME/scripts/synthesize_reviews.py" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/synthesize_reviews.py" \
      --manifest "$TICKET_TMP/reviews/reviewer-manifest.json"
    ```
    **Pass `--manifest`, do not list the review files by hand** (chief-wiggum#416). Naming them means the command drifts every time the role roster changes — this line said `reviewer-gemini.md` long after gemini left the `reviewer` role, so it was passing a path that could never resolve. More importantly, counting the files that happen to exist cannot tell "every reviewer answered" from "one never did": the synthesis opened with a confident `N reviews received` while silently describing a narrowed quorum. The manifest carries who was EXPECTED and in which tier, so the prompt now reports `2 of 3 expected reviews received — QUORUM INCOMPLETE` and names the absentee where the reconciler reads it. A missing OPTIONAL provider is still a legitimate outcome and does not block; a missing REQUIRED one is reported to stderr, and `--gate` turns it into a non-zero exit.
@@ -582,7 +586,7 @@ The worker should:
 7. **Record validation telemetry.** The review's cost already flows (its reviewer consults + the review worker's tokens); record its *value* so the cost↔value verdict can rate it. Emit one gate event with the count of substantive findings (high + medium + low real defects; exclude style-only) — no-op unless telemetry is enabled, never blocks:
 
    ```bash
-   python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name code-review \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" emit --event gate --name code-review \
      --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
    ```
 
@@ -595,27 +599,27 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 1. **Apply clear-cut fixes** directly (don't re-run a worker for trivial changes)
 2. **Flag ambiguous feedback** for user decision — only block on items that genuinely need input
 3. **Run static analysis** on the changed files:
-   - **Live LSP diagnostics first (Go/Python, optional)** — surface semantic errors (undefined symbols, type mismatches) before the linter gate, per changed file: `python3 "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics <changed-file>`. This augments, never replaces, the linter; it returns `available: false` and is skipped when the language server isn't installed.
+   - **Live LSP diagnostics first (Go/Python, optional)** — surface semantic errors (undefined symbols, type mismatches) before the linter gate, per changed file: `"${CW_PY:-python3}" "$CW_HOME/scripts/lsp_query.py" --root "$(git rev-parse --show-toplevel)" diagnostics <changed-file>`. This augments, never replaces, the linter; it returns `available: false` and is skipped when the language server isn't installed.
    - Go: `golangci-lint run ./...`
    - TypeScript/JavaScript: `npx eslint --no-warn-ignored` or `npx biome check`
    - Python: `ruff check` or `flake8`
    - Feed violations back to the code — fix them before proceeding. Gate on zero high-severity findings.
 4. **Run the full test suite** from the repo root. The verification runner detects the project type and emits structured evidence (command, exit code, duration, log tail, and — for a pytest-based `test` step, chief-wiggum#284 — the junit-xml report path it wrote via `PYTEST_ADDOPTS`) for the PR body — it prefers a `make` target named for the profile when present. Capture **JSON**, run once (Step 4b reuses this same run's report instead of re-running the suite — build the PR-body evidence section from this JSON rather than invoking `--markdown` a second time):
    ```bash
-   python3 "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint,build --json > "$TICKET_TMP/verify.json"
+   "${CW_PY:-python3}" "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint,build --json > "$TICKET_TMP/verify.json"
    ```
    It exits non-zero if any step fails (`jq .ok "$TICKET_TMP/verify.json"`). ALL tests must pass. Zero tolerance.
 4b. **Ratchet check** (see `docs/ratchet.md`) — `$QUALITY_DIR` is already resolved (Step 1, #324 — embedded targets `<repo>/docs/quality`, sidecar targets the external meta root); if `$QUALITY_DIR/ratchet.json` exists, verify this ticket doesn't slide quality backward. **Reuse Step 4's run instead of paying for the suite twice** (chief-wiggum#284): when Step 4's JSON names a `report` for its `test`-profile step (a pytest junit-xml file) and the ratchet config has exactly one `junit-xml` suite, pass that report straight through with `--reuse-report`; otherwise fall back to a normal (re-run) `score` — never a silent skip of scoring:
    ```bash
-   REPORT=$(python3 -c "import json; d=json.load(open('$TICKET_TMP/verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
-   SUITE=$(python3 -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
+   REPORT=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$TICKET_TMP/verify.json')); print(next((s['report'] for s in d['steps'] if s['profile']=='test' and s.get('report')), ''))")
+   SUITE=$("${CW_PY:-python3}" -c "import json; d=json.load(open('$QUALITY_DIR/ratchet.json')); js=[s['name'] for s in d['suites'] if s['parser']=='junit-xml']; print(js[0] if len(js)==1 else '')")
    REPO_ROOT="$(git rev-parse --show-toplevel)"
    if [ -n "$REPORT" ] && [ -n "$SUITE" ] && [ -f "$REPO_ROOT/$REPORT" ]; then
-     python3 "$CW_HOME/scripts/ratchet.py" score --repo "$REPO_ROOT" --reuse-report "$SUITE=$REPO_ROOT/$REPORT"
+     "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$REPO_ROOT" --reuse-report "$SUITE=$REPO_ROOT/$REPORT"
    else
-     python3 "$CW_HOME/scripts/ratchet.py" score --repo "$REPO_ROOT"
+     "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" score --repo "$REPO_ROOT"
    fi
-   python3 "$CW_HOME/scripts/ratchet.py" check --repo "$REPO_ROOT" --gate-verifier-tests
+   "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" check --repo "$REPO_ROOT" --gate-verifier-tests
    ```
    `score --reuse-report` fails loudly (never silently) if the report is missing or older than `--reuse-report-max-age` (default 1800s) — that's the signal to drop back to a plain `score` re-run, not to `--force` past it.
    Pass `--gate-verifier-tests` only if `check_gate_validation.py ratchet --validation-dir "$CW_HOME/docs/quality/validation" --gate` passes (it normally does — the record ships with chief-wiggum); otherwise drop the flag and surface the printed `weakened_verifier_tests` findings report-only, per `docs/gate-rollout.md`. A violation is a hard blocker, same as a failing test: a `missing_tests` entry means a previously-passing case regressed; `weakened_contracts`/`removed_contracts` means the branch edited a contract definition to make the implementation pass; `weakened_verifier_tests`/`removed_verifier_tests` (#206, channel C1c) means a `@cw-trace verifies`-annotated test body was rewritten or dropped behind its still-green test ID. Fix the code — never the contract or its verifier test. If a contract (or a verifier test) genuinely needs revising, that is a human decision: surface it to the user and journal it with `record --amend`/`--retire` (contracts) or `record --amend-verifier`/`--retire-verifier` (verifier tests), don't edit around the gate. A `missing_tests` entry caused by a genuinely flaky/order-dependent case (not a real regression) is fixed by `ratchet.py record --retire-case` with a reason and expiry (#278) — surface it to the user and get their approval; never self-approve it, and never `--force` past the gate instead. Skip this item only when the repo has no ratchet config (not yet adopted).
@@ -623,20 +627,20 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 
    **Traceability soundness DOES block here (chief-wiggum#379)**, scoped to this diff. `@cw-trace` direction errors (`guards` on a test, `verifies` on production code) are unambiguous, entirely determined by the annotation the worker just wrote, and cheap to detect — but before #379 they were not in the per-ticket floor, so they surfaced three merges later at wave-merge (two separate `fix(trace): correct @cw-trace direction` commits in one epic). `--gate-scope changed` blocks ONLY on findings originating in the scanned diff; epic-doc findings (malformed IDs, orphan BRs, unparsed artifacts) stay report-only here because the worker may not edit goalposts — blocking it on a defect it is forbidden to fix is how an operator learns to `--force` past gates. Those still block in `/architect` and `/close-epic`, where the actor can act on them:
    ```bash
-   python3 "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/check_single_writer.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
      --changed-since "$DEFAULT_BRANCH" --format text
-   python3 "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/check_traceability.py" "$EPIC_DIR" --source "$(git rev-parse --show-toplevel)" \
      --changed-since "$DEFAULT_BRANCH" --gate soundness --gate-scope changed --format text
    ```
    The traceability call exits non-zero on a direction error in this ticket's diff — treat that exactly like a failing test: fix the annotation, don't `--force` past it. Its report still PRINTS every soundness finding, including the ones scoped out of blocking, under a `Gate scope: **changed**` line saying how many of them could block. Surface the rest to the fixer as early feedback (a new unsanctioned writer, a missing `@cw-trace guards`/`verifies` on the code this ticket just wrote); don't hard-block on those here. Skip this item if the ticket has no epic context.
 
    **Inspecting a finding**: `code_query.py` turns a bare ID from either report into its full governing context in one call, instead of re-opening `invariants.md`/`contracts.md` — `trace <BR-or-CTR-ID>` for the full BR→contract→code→test slice, `writers <INV-ID>` for every writer of that invariant's controlled field (sanctioned/unsanctioned), `guards`/`verifies <CTR-ID>` for just the code or test side:
    ```bash
-   python3 "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --epic "$EPIC_SLUG" trace CTR-order-001
+   "${CW_PY:-python3}" "$CW_HOME/scripts/code_query.py" --repo "$(git rev-parse --show-toplevel)" --epic "$EPIC_SLUG" trace CTR-order-001
    ```
 4d. **Scope check after review fixes (adopted repos — `$IS_ADOPTED`, report-only)** — the fixes applied in this step can themselves creep out of scope; re-run the pathset check from Step 7 (3c) against the final diff:
    ```bash
-   python3 "$CW_HOME/scripts/ratchet.py" pathset --repo "$(git rev-parse --show-toplevel)" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" pathset --repo "$(git rev-parse --show-toplevel)" \
      --base "$DEFAULT_BRANCH" --pathset-file "$TICKET_TMP/pathset.json" --report-only
    ```
    Any file it names goes into the PR body under a "Out of declared pathset" section for the human's eyes — a legitimate late addition means updating the declaration WITH a one-line reason; an illegitimate one gets dropped and its motivation filed via `debt_inventory.py append-candidate` (found ≠ fixed). Report-only for now per `docs/gate-rollout.md`.
@@ -671,7 +675,7 @@ Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then *
 8b. **Transition-map verification** (if `$HAS_TRANSITION_MAP == true`):
    Run the verification script **once**, in JSON mode, scoped to this ticket — it writes the transition-map AND the JSON this step renders from, in the same pass (the separate `--format text` run used to be a second full re-scan of the same code producing the same comparison — #324):
    ```bash
-   python3 "$CW_HOME/scripts/verify_transitions.py" "$(git rev-parse --show-toplevel)" "$MODELS_DIR/state-machines.json" \
+   "${CW_PY:-python3}" "$CW_HOME/scripts/verify_transitions.py" "$(git rev-parse --show-toplevel)" "$MODELS_DIR/state-machines.json" \
      --ticket "#$issue_number" --format json --output "$MODELS_DIR/transition-map.json" > "$TICKET_TMP/verify-transitions.json"
    git add "$MODELS_DIR/transition-map.json"
    ```
@@ -703,7 +707,7 @@ If ANY verification fails: fix it directly, or re-launch the coding worker (cont
 **Log a real finding as an escape.** This orchestrator validation is exactly where a bug that the earlier steps (TDD/tests, Step 7's multi-AI code review, static analysis) should have caught but didn't gets found independently — walking the AC, hitting a real endpoint, or reading the code turns up something the automated checks missed. When that happens, log it so gate RECALL (not just catches) is measurable (no-op unless telemetry is enabled, never blocks):
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" bug --repo "$owner_repo" \
   --summary "..." --severity medium --missed-by code-review \
   --found-in implement-verify --ticket "$issue_number" --fixed
 ```
@@ -716,7 +720,7 @@ Run the tested gate to do all the mechanical setup — frontend-impact detection
 
 ```bash
 git diff "$DEFAULT_BRANCH"...HEAD --name-only > "$TICKET_TMP/changed.txt"
-python3 "$CW_HOME/scripts/ux_gate.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ux_gate.py" \
   --changed-files "$TICKET_TMP/changed.txt" \
   $(gh issue view "$issue_number" --repo "$owner_repo" --json labels -q '.labels[].name' | sed 's/^/--label /') \
   --ui-spec "$MODELS_DIR/ui-spec.json" --design-dir "$TARGET_REPO/docs/design" \
@@ -770,7 +774,7 @@ If screenshot capture fails entirely (services won't start, no browser tooling a
 If `$MODELS_DIR/ui-spec.json` has a `design` section, run a cheap mechanical check before the AI review: for each color token value in `design.tokens.colors`, grep the frontend's theme/CSS files for it. If the primary brand color appears nowhere in the codebase, the frontend ignored the design contract — that's a hard finding, no screenshot review needed to call it.
 
 ```bash
-python3 -c "
+"${CW_PY:-python3}" -c "
 import json, sys
 spec = json.load(open('$MODELS_DIR/ui-spec.json'))
 for name, value in spec.get('design', {}).get('tokens', {}).get('colors', {}).items():
@@ -899,10 +903,10 @@ If no browser-use or E2E setup exists at all, note it as a gap in the final summ
 3. **Price the build** (`docs/ticket-cost.md`). Fold this session's own token spend into the factory ledger — windowed to this ticket's build-start stamp so a multi-ticket session doesn't cross-bill — then render the measured actual:
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
   --repo "$owner_repo" --ticket "$issue_number" \
   --since-ts "$(cat "$TICKET_TMP/build-start-ts")"
-python3 "$CW_HOME/scripts/ticket_cost.py" actual \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ticket_cost.py" actual \
   --repo "$owner_repo" --ticket "$issue_number" \
   --cwd-prefix "$(git rev-parse --show-toplevel)" \
   --since-ts "$(cat "$TICKET_TMP/build-start-ts")" \
@@ -916,7 +920,7 @@ python3 "$CW_HOME/scripts/ticket_cost.py" actual \
 4. Draft the PR body with the tested helper. It folds in the verification evidence and (when present) the review/UX/model-conformance manifests plus the implementation-cost section, themes the Mermaid diagram with the shared palette automatically, validates the required sections, and links the issue:
 
 ```bash
-python3 "$CW_HOME/scripts/draft_pr.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/draft_pr.py" \
   --issue "$issue_number" --title "$pr_title" --summary "$summary" \
   --change "Change 1" --change "Change 2" \
   --mermaid-file "$TICKET_TMP/architecture.mmd" \
@@ -939,7 +943,7 @@ gh pr create --repo "$owner_repo" --title "$pr_title" --body-file "$TICKET_TMP/p
 6. **Record the calibration point** so future `/create-issue` estimates ground in this build's actual. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure. Pass the **same** `--cwd-prefix`/`--since-ts` pair used for the `actual` call above — `record` computes its own slice independently, and without the matching window flags it silently reverts to tag-match-only, journaling a consult-only "clean" sample into the estimator while the real windowed slice (Claude Code layers included) is far larger (chief-wiggum#345):
 
 ```bash
-python3 "$CW_HOME/scripts/ticket_cost.py" record \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ticket_cost.py" record \
   --repo "$owner_repo" --ticket "$issue_number" --effort "$effort" \
   --cwd-prefix "$(git rev-parse --show-toplevel)" \
   --since-ts "$(cat "$TICKET_TMP/build-start-ts")"
@@ -974,7 +978,7 @@ python3 "$CW_HOME/scripts/ticket_cost.py" record \
 If epic context exists, flip this ticket's rows from `pending` to `covered` with the tested updater (it parses, updates by ticket/AC, and re-renders the table in place — no brittle manual markdown edits):
 
 ```bash
-python3 "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/traceability.py" update "$EPIC_DIR/traceability.md" \
   --ticket "$issue_number" --status covered
 # Narrow to specific rows with --ac "<criterion text>" when a ticket only
 # partially addresses its ACs.
@@ -985,7 +989,7 @@ Commit the updated `traceability.md` (or comment on the epic milestone if other 
 **Journal the ratchet** (`$QUALITY_DIR` already resolved at Step 1, #324; if `$QUALITY_DIR/ratchet.json` exists): once the PR is merged, record the ticket so its passing tests enter the high-water mark:
 
 ```bash
-python3 "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ratchet.py" record --repo "$TARGET_REPO" \
   --event ticket --ref "#$issue_number" --merged --notes "<one line: what shipped>"
 # Embedded mode only — in sidecar mode the journal/state live outside the
 # target, so there is nothing to commit in-tree ($CW_META_MODE already
@@ -1000,7 +1004,7 @@ fi
 **Sweep this ticket's worktree if it already merged** (#329) — no prior step ever ran `git worktree remove`, so the worker's worktree from Step 5/6 would otherwise sit in the shared checkout forever. `gc-worktrees` only removes a worktree whose branch is provably merged into `$DEFAULT_BRANCH`, so this is a safe no-op if the PR hasn't merged yet (human/CI review still pending) — a later `/implement` or `/implement-wave` run's own sweep will catch it once it has:
 ```bash
 git -C "$TARGET_REPO" fetch origin "$DEFAULT_BRANCH"
-python3 "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
+"${CW_PY:-python3}" "$CW_HOME/scripts/git_safety.py" gc-worktrees --repo "$TARGET_REPO" --default-branch "$DEFAULT_BRANCH"
 ```
 
 Close the loop:

--- a/.claude/commands/plan-bet.md
+++ b/.claude/commands/plan-bet.md
@@ -32,7 +32,11 @@ Bet-level, once per bet (re-run via `plan_bet.py rebaseline` to revise, never a 
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 PLAN_TMP="$CW_TMP/plan-bet/$bet_id" && mkdir -p "$PLAN_TMP"
 PORTFOLIO_DIR="${portfolio_dir_flag:-${CHIEF_WIGGUM_PORTFOLIO:-$HOME/.chief-wiggum/portfolio}}"
 ```
@@ -63,7 +67,7 @@ Generate each candidate with a **design-direction-shaped worker** (contract: `do
 
 ```bash
 for f in "$PLAN_TMP"/candidates/*/business-model.json; do
-  python3 "$CW_HOME/scripts/plan_bet.py" author "$bet_id" --file "$f" --portfolio-dir "$PORTFOLIO_DIR" --min-failure-modes 5
+  "${CW_PY:-python3}" "$CW_HOME/scripts/plan_bet.py" author "$bet_id" --file "$f" --portfolio-dir "$PORTFOLIO_DIR" --min-failure-modes 5
 done
 ```
 
@@ -82,7 +86,7 @@ This is the **only** step that blocks on the user. Do not add approval gates els
 ### Step 4: Author the binding artifact
 
 ```bash
-python3 "$CW_HOME/scripts/plan_bet.py" author "$bet_id" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/plan_bet.py" author "$bet_id" \
   --file "$PLAN_TMP/candidates/$CHOSEN/business-model.json" \
   --portfolio-dir "$PORTFOLIO_DIR"
 ```

--- a/.claude/commands/plan-epic.md
+++ b/.claude/commands/plan-epic.md
@@ -24,7 +24,7 @@ feed its ticket plan through the NORMAL epic flow below. See
 ### Step F1: Run the planner (budget is REQUIRED)
 
 ```bash
-python3 "$CW_HOME/scripts/plan_from_debt.py" plan "$owner_repo" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/plan_from_debt.py" plan "$owner_repo" \
   --budget-count 5            # and/or --budget-severity-floor medium and/or --budget-cluster-cap 8
 ```
 
@@ -78,8 +78,12 @@ this epic's acceptance test.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-target_root=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
-backend=$(python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" backend)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+target_root=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+backend=$("${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" backend)
 ```
 
 `$target_root` is the local checkout of the target repo; every `tracker.py`
@@ -96,7 +100,7 @@ this is what makes the workflow backend-agnostic. See `docs/tracker.md` for
 the full interface.
 
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" list "$owner_repo"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" list "$owner_repo"
 ```
 
 This returns every issue (any state) with full metadata (`ref`, `title`,
@@ -212,7 +216,7 @@ with the tested formatter (it de-dupes and sorts deps so the output always
 matches the parser). This is backend-independent:
 
 ```bash
-DEPS=$(python3 "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43], "45": [43], "46": [42]}')
+DEPS=$("${CW_PY:-python3}" "$CW_HOME/scripts/epic_metadata.py" format-deps '{"42": [], "43": [42], "44": [43], "45": [43], "46": [42]}')
 ```
 
 The block is an HTML comment (invisible in rendered markdown) with one line per ticket in the format `#N: [#dep1, #dep2]`; empty brackets `[]` means no dependencies. This block is the **canonical source** for the dependency graph. Do not hand-write it; always generate it with `format-deps` so it round-trips through the parser.
@@ -233,7 +237,7 @@ $DEPS
 EOF
 )"
 else
-  EPIC_SLUG=$(python3 "$CW_HOME/scripts/env.py" slug "Epic: [Name]")
+  EPIC_SLUG=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" slug "Epic: [Name]")
   mkdir -p "$target_root/docs/epics/$EPIC_SLUG"
   cat > "$target_root/docs/epics/$EPIC_SLUG/epic.md" <<EOF
 # Epic: [Name]
@@ -254,7 +258,7 @@ milestone above already exists, so this only assigns issues to it;
 `epic` field):
 
 ```bash
-python3 "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" group "Epic: [Name]" "$ref1" "$ref2" "$ref3"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tracker.py" --repo-root "$target_root" group "Epic: [Name]" "$ref1" "$ref2" "$ref3"
 ```
 
 ### Step 7: Offer next steps

--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -35,8 +35,12 @@ Run the analysis to completion autonomously. **Filing issues is the one checkpoi
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 1b: Catch up the Claude-layer cost ingest
@@ -44,7 +48,7 @@ TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 `/reflect`'s own telemetry-health finding (Step 3, "Factory-log health") reads the ledger's `claude_code` layer as-is — a factory that ran on Claude Code but never had its transcripts ingested reads as "no AI cost logged", which is silence, not a measurement (chief-wiggum#345). Fold in a wide catch-up window before the analysis so the finding reflects reality:
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 30 || true
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts --since-days 30 || true
 ```
 
 30 days (wider than `/implement`'s 7-day catch-up) because `/reflect` looks back across a whole factory run, not one build.
@@ -56,7 +60,7 @@ Fetch merged-PR history (review outcomes + bodies carry gate signal) and run the
 ```bash
 gh --repo "$owner_repo" pr list --state merged --limit 200 \
   --json number,title,body,reviewDecision,labels > "$CW_TMP/prs.json" 2>/dev/null || echo '[]' > "$CW_TMP/prs.json"
-python3 "$CW_HOME/scripts/reflect.py" "$TARGET_REPO" --prs "$CW_TMP/prs.json" --commits "${commits:-400}" --format json > "$CW_TMP/reflection.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/reflect.py" "$TARGET_REPO" --prs "$CW_TMP/prs.json" --commits "${commits:-400}" --format json > "$CW_TMP/reflection.json"
 ```
 
 The report has: `commit_kinds`, `gate_mentions`, `force_bypasses`, `slippage_commits`, `assumptions` (TBD markers), `ratchet` health, `pattern_coverage`, `retrospectives`, and mechanical `findings` seeding your analysis.
@@ -64,7 +68,7 @@ The report has: `commit_kinds`, `gate_mentions`, `force_bypasses`, `slippage_com
 Also run the deferred-rigor trigger check (report-only — see `docs/deferred-rigor.json`, the durable index that replaced chief-wiggum#171/#161's open-issue parking):
 
 ```bash
-python3 "$CW_HOME/scripts/check_deferred_triggers.py" --repo "$TARGET_REPO" --format text
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_deferred_triggers.py" --repo "$TARGET_REPO" --format text
 ```
 
 Each deferred system-layer decision carries a quorum-settled design and a concrete build trigger. A `FIRED` item means its mechanical trigger is now true: file the full issue **from the item's `settled_notes`** (the design is settled — do not relitigate it) in Step 4 alongside the other drafted issues. A `CANDIDATE` item has soft evidence (heuristic counts, matching bug events) — confirm with the human before filing. `UNEVALUATED` items need human judgment and are listed so nothing is silently dropped.
@@ -94,7 +98,7 @@ Prefer a few high-signal issues over many speculative ones. Group related slippa
 Present the drafted issues (titles + one-line rationale). On confirmation (or `--create-issues`):
 
 ```bash
-gh --repo "$(python3 "$CW_HOME/scripts/repo.py" home >/dev/null; echo plwp/chief-wiggum)" \
+gh --repo "$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" home >/dev/null; echo plwp/chief-wiggum)" \
   issue create --title "<title>" --body-file "$CW_TMP/issue-<n>.md" --label reflection --label enhancement
 ```
 
@@ -105,7 +109,7 @@ Report the filed issue URLs and a one-paragraph factory-health summary (what's w
 `/reflect` is itself a validation — record its value (findings) so the cost↔value verdict can judge it. After filing, emit one gate event with the finding count (no-op unless telemetry is enabled; never blocks):
 
 ```bash
-python3 "$CW_HOME/scripts/factory_log.py" emit --event gate --name reflect \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" emit --event gate --name reflect \
   --result "$([ "$n_findings" -gt 0 ] && echo fail || echo pass)" --caught "$n_findings" --repo "$owner_repo"
 ```
 

--- a/.claude/commands/saas-gate.md
+++ b/.claude/commands/saas-gate.md
@@ -22,10 +22,14 @@ The gate reports five statuses so it never claims more than it proved: `pass`, `
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
-`saas_gate.py` auto-detects the stack (Go/Node/Python) from the repo. Confirm the dependency profile if needed: `python3 "$CW_HOME/scripts/check_deps.py" --for core`.
+`saas_gate.py` auto-detects the stack (Go/Node/Python) from the repo. Confirm the dependency profile if needed: `"${CW_PY:-python3}" "$CW_HOME/scripts/check_deps.py" --for core`.
 
 ### Step 2: Get a running app
 
@@ -36,7 +40,7 @@ If you genuinely cannot start the app, run the gate without `--base-url` — it 
 ### Step 3: Run the gate
 
 ```bash
-python3 "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/saas_gate.py" --repo "$TARGET_REPO" \
   --base-url "$BASE_URL" --auth-mode cookie \
   --rate-limit-path /login --markdown
 ```

--- a/.claude/commands/seed.md
+++ b/.claude/commands/seed.md
@@ -17,12 +17,16 @@ Interactive brainstorming session that explores a project's requirements, establ
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 ```
 
 Resolve the target repo:
 ```bash
-TARGET_DIR=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+TARGET_DIR=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 1: Understand the project
@@ -123,7 +127,7 @@ Registry patterns are proven, opinionated architecture + process shapes CW can s
 Load the selectable catalog:
 
 ```bash
-python3 "$CW_HOME/scripts/apply_pattern.py" --catalog --format json
+"${CW_PY:-python3}" "$CW_HOME/scripts/apply_pattern.py" --catalog --format json
 ```
 
 Each entry has an `id`, `category`, and `applies_when` (the selection criteria). **Reason over `applies_when` against this product's shape** and propose the patterns that fit — think in groups: the **saas-infra floor** (`multi-tenant-isolation` for any multi-tenant product; `provider-neutral-adapter` for any swappable external vendor), the **monetization surface** you're actually charging for (`tiered-subscription`, `frictionless-onboarding`), and always the **monitoring group** underneath (`engagement-instrumentation`) so the rest are measurable. Note `depends_on` — selecting a pattern pulls its floor.
@@ -135,7 +139,7 @@ Each entry has an `id`, `category`, and `applies_when` (the selection criteria).
 For each confirmed pattern, install its contract pack into the target repo (binding what you can from the architecture decisions; leave required params you can't confirm as `TBD:`):
 
 ```bash
-python3 "$CW_HOME/scripts/apply_pattern.py" <id> --target-dir "$TARGET_REPO" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/apply_pattern.py" <id> --target-dir "$TARGET_REPO" \
   --param <k>=<v> ...   # e.g. --param billing_provider=stripe --param tenant_key=provider_id
 ```
 
@@ -152,7 +156,7 @@ Write a consultation prompt to `$CW_TMP/consultation-prompt.md` asking for a cri
 
 Fire the `explorer` quorum (providers run in parallel, with retries + output validation) using `consult_ai.py`:
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" --role explorer "$CW_TMP/consultation-prompt.md" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" --role explorer "$CW_TMP/consultation-prompt.md" \
   --context "$CW_TMP/architecture-decisions.md" --output-dir "$CW_TMP/consult"
 ```
 

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -14,6 +14,10 @@ Check that all tools required by chief-wiggum are installed and working.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 ```
 
 ### Step 1: Run dependency check
@@ -21,28 +25,28 @@ CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
 Run the check script to see what's installed and what's missing:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py --for core
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core
 ```
 
 Dependency checks are profile-based. Use only the profiles the current harness and workflow need. Rather than guessing the profiles, ask the checker to recommend them for the workflows and provider roles in play (`check_deps.py` is the source of truth for the mapping):
 
 ```bash
 # Recommend the flags for a workflow + the provider roles it uses, then run the check:
-RECO=$(python3 $CW_HOME/scripts/check_deps.py --recommend --workflow implement --role reviewer)
-python3 $CW_HOME/scripts/check_deps.py $RECO
-python3 $CW_HOME/scripts/check_deps.py --list-profiles   # see every available profile
+RECO=$("${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --recommend --workflow implement --role reviewer)
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py $RECO
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --list-profiles   # see every available profile
 ```
 
 The profiles map to flags like:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py --for core
-python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-code
-python3 $CW_HOME/scripts/check_deps.py --for core --provider codex --provider gemini
-python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
-python3 $CW_HOME/scripts/check_deps.py --for transcription
-python3 $CW_HOME/scripts/check_deps.py --for browser-validation
-python3 $CW_HOME/scripts/check_deps.py --for vertex
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core --provider claude-code
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core --provider codex --provider gemini
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for transcription
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for browser-validation
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for vertex
 ```
 
 ### Step 2: Report results
@@ -69,12 +73,12 @@ If anything is missing, ask the user if they want to install it. For each missin
 If the user agrees, run the installer for specific missing tools:
 
 ```bash
-python3 $CW_HOME/scripts/install_deps.py --tool <tool_name>
+"${CW_PY:-python3}" $CW_HOME/scripts/install_deps.py --tool <tool_name>
 ```
 
 For Vertex AI packages:
 ```bash
-python3 $CW_HOME/scripts/install_deps.py --vertex
+"${CW_PY:-python3}" $CW_HOME/scripts/install_deps.py --vertex
 ```
 
 ### Step 4: Set up secrets in Keychain
@@ -83,14 +87,14 @@ For any missing secrets, help the user store them securely in macOS Keychain. Se
 
 Show current keychain status:
 ```bash
-python3 $CW_HOME/scripts/keychain.py list
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py list
 ```
 
 To store each key (prompts securely, no echo):
 ```bash
-python3 $CW_HOME/scripts/keychain.py set ANTHROPIC_API_KEY
-python3 $CW_HOME/scripts/keychain.py set OPENAI_API_KEY
-python3 $CW_HOME/scripts/keychain.py set GEMINI_API_KEY
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py set ANTHROPIC_API_KEY
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py set OPENAI_API_KEY
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py set GEMINI_API_KEY
 ```
 
 Explain where to get each key:
@@ -100,8 +104,8 @@ Explain where to get each key:
 
 For Vertex AI (alternative to GEMINI_API_KEY):
 ```bash
-python3 $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_PROJECT
-python3 $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_LOCATION
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_PROJECT
+"${CW_PY:-python3}" $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_LOCATION
 ```
 
 ### Step 5: Final verification
@@ -109,15 +113,15 @@ python3 $CW_HOME/scripts/keychain.py set GOOGLE_CLOUD_LOCATION
 Re-run the check script to confirm everything is green:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py --for core
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core
 ```
 
 For workflow-specific preflight checks:
 ```bash
-python3 $CW_HOME/scripts/check_deps.py --for implement
-python3 $CW_HOME/scripts/check_deps.py --for transcription
-python3 $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
-python3 $CW_HOME/scripts/check_deps.py --for vertex
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for implement
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for transcription
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for core --provider claude-interactive
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for vertex
 ```
 
 Provider roles are configured in `$CW_HOME/config/providers.json`. Validate role dependencies by running the matching provider profiles before a workflow starts.
@@ -127,9 +131,9 @@ Provider roles are configured in `$CW_HOME/config/providers.json`. Validate role
 A target repo with no CI lets red tests, lint errors, and uninstallable deps sit unnoticed on `main`. Check whether the repo has any GitHub Actions workflow, and offer to scaffold a minimal, stack-appropriate one (checkout → install deps → build → test → lint) if it has none:
 
 ```bash
-python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
+"${CW_PY:-python3}" "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --report
 # If MISSING, scaffold one (idempotent; won't overwrite an existing workflow without --force):
-python3 "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --scaffold
+"${CW_PY:-python3}" "$CW_HOME/scripts/ci_scaffold.py" --repo "$TARGET_REPO" --scaffold
 ```
 
 The stack is auto-detected (Go / Python / Node — possibly several) from `go.mod`, `pyproject.toml`/`requirements.txt`/`setup.py`, and `package.json`. Commit the generated `.github/workflows/ci.yml` so CI runs on the next push.
@@ -139,9 +143,9 @@ The stack is auto-detected (Go / Python / Node — possibly several) from `go.mo
 Per-ticket implementation costing (`docs/ticket-cost.md`) needs the full Claude Code layer ingested — orchestrator turns AND every delegated turn — not just consult spend; chief-wiggum#345 found this had silently never run. Check, then provision if needed:
 
 ```bash
-python3 $CW_HOME/scripts/check_deps.py --for telemetry
+"${CW_PY:-python3}" $CW_HOME/scripts/check_deps.py --for telemetry
 # If the Claude layer has never been ingested:
-python3 $CW_HOME/scripts/install_deps.py --tool telemetry-capture
+"${CW_PY:-python3}" $CW_HOME/scripts/install_deps.py --tool telemetry-capture
 ```
 
 The default route is the **transcript** ingest — zero-config and retroactive over whatever's already on disk at `~/.claude/projects/`; `install_deps.py --tool telemetry-capture` runs a bounded 7-day catch-up automatically. The OTEL console-exporter route is optional and suits headless (`claude -p`) runs only — it fights an interactive TUI session (`docs/factory-telemetry.md`). **`/setup` prints the OTEL env + wrapper snippet for operators who want it but never edits `~/.claude/settings.json` or a shell rc file — those stay the operator's own files.**

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -18,7 +18,7 @@ The PR body drafted in Step 5 carries an AI-authorship disclosure line
 automatically — `draft_pr.py` builds it via `chief_wiggum.shipping.build_pr_body`,
 which appends it. If any commit on this branch was authored outside `/implement`
 (so it never ran through that workflow's Disclosure step), append the trailer
-before pushing: `python3 "$CW_HOME/scripts/ai_disclosure.py" commit-trailer --file <msg>`.
+before pushing: `"${CW_PY:-python3}" "$CW_HOME/scripts/ai_disclosure.py" commit-trailer --file <msg>`.
 See `docs/ai-act-posture.md`.
 
 ## Workflow
@@ -28,7 +28,11 @@ See `docs/ai-act-posture.md`.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
 ```
 
@@ -122,7 +126,7 @@ Guidelines for diagrams:
 The verification runner detects the project type (Go/Node/Python/Make/Docker/Playwright), runs the requested profiles, and emits structured evidence (command, exit code, duration, log tail) for the PR body:
 
 ```bash
-python3 "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint --markdown
+"${CW_PY:-python3}" "$CW_HOME/scripts/run_verification.py" --repo "$(git rev-parse --show-toplevel)" --profile test,lint --markdown
 ```
 
 It exits non-zero if any step fails. **If tests fail, stop and fix them** — do not create a PR with failing tests. Use `--dry-run` first to see the planned commands, and add `build`/`smoke` to `--profile` when relevant.
@@ -139,10 +143,10 @@ Fold this session's token spend into the factory ledger and render the measured 
 
 ```bash
 branch_start_ts=$(git log "$DEFAULT_BRANCH..HEAD" --format=%ct | tail -1)
-python3 "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" ingest-claude-transcripts \
   --repo "$owner_repo" --ticket "$issue_number" \
   --since-ts "$branch_start_ts"
-python3 "$CW_HOME/scripts/ticket_cost.py" actual \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ticket_cost.py" actual \
   --repo "$owner_repo" --ticket "$issue_number" \
   --format markdown > "$CW_TMP/implementation-cost.md"
 cat >> "$CW_TMP/implementation-cost.md" <<'EOF'
@@ -160,7 +164,7 @@ If the issue body carries a `Nominal cost: ~$X.XX` line (stamped by `/create-iss
 Assemble the PR body with the tested helper. It folds in the verification evidence, optional model-conformance/UX manifests, the implementation-cost section from Step 4, and a Mermaid diagram (themed with the shared palette automatically), validates the required sections, and can print the `gh pr create` command:
 
 ```bash
-python3 "$CW_HOME/scripts/draft_pr.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/draft_pr.py" \
   --issue "$issue_number" --title "$title" --summary "$summary" \
   --change "Change 1" --change "Change 2" \
   --mermaid-file "$CW_TMP/architecture.mmd" \
@@ -198,7 +202,7 @@ If an issue was specified, it should be linked via "Closes #N" in the body.
 Then, if Step 4 priced the build, **record the calibration point** so standalone PRs feed the estimator too. Read the Effort size (`S|M|L|XL`) from the issue body's Labels section; omit `--effort` if the issue has none, and pass `--estimate` when the issue carried a nominal-cost figure:
 
 ```bash
-python3 "$CW_HOME/scripts/ticket_cost.py" record \
+"${CW_PY:-python3}" "$CW_HOME/scripts/ticket_cost.py" record \
   --repo "$owner_repo" --ticket "$issue_number" --effort "$effort"
 ```
 

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -23,16 +23,20 @@ One screen, derived live at call time — never a hand-maintained doc: footprint
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 ```
 
 ### Step 2: Run the status script
 
 ```bash
-python3 "$CW_HOME/scripts/status.py" "$owner_repo"          # owner/repo (resolved via repo.py)
+"${CW_PY:-python3}" "$CW_HOME/scripts/status.py" "$owner_repo"          # owner/repo (resolved via repo.py)
 # or, for a local path:
-python3 "$CW_HOME/scripts/status.py" --repo "$TARGET_REPO"
+"${CW_PY:-python3}" "$CW_HOME/scripts/status.py" --repo "$TARGET_REPO"
 # machine-readable:
-python3 "$CW_HOME/scripts/status.py" --repo "$TARGET_REPO" --format json
+"${CW_PY:-python3}" "$CW_HOME/scripts/status.py" --repo "$TARGET_REPO" --format json
 ```
 
 The script derives everything live from the target's resolved meta locations (`scripts/artifacts.py`) and **never writes anything**. Gate verdicts come from `check_gate_validation.check` (never the record's own status field); wired state comes from the tamper-evident ratchet journal's gate-authority events.

--- a/.claude/commands/stitch-audit.md
+++ b/.claude/commands/stitch-audit.md
@@ -37,8 +37,12 @@ No existing tool does this. Contract testing covers one boundary. OpenAPI codege
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 ```
 
 ### Step 2: Discovery + Extraction
@@ -46,7 +50,7 @@ TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 Run the extraction orchestrator to find and parse all schemas related to the keyword:
 
 ```bash
-python3 "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --trace "$keyword" -o "$CW_TMP/extraction.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --trace "$keyword" -o "$CW_TMP/extraction.json"
 ```
 
 This uses the pluggable extractor architecture — whichever extractors match the repo's tech stack run automatically (Go+MongoDB, TypeScript, etc.).
@@ -63,8 +67,8 @@ If extraction finds nothing, stop and report: "No schemas found for keyword '$ke
 Run the stack-agnostic differ on the extraction output:
 
 ```bash
-python3 "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format json -o "$CW_TMP/findings.json"
-python3 "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format text -o "$CW_TMP/findings.txt"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format json -o "$CW_TMP/findings.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_diff.py" "$CW_TMP/extraction.json" --format text -o "$CW_TMP/findings.txt"
 ```
 
 Read `$CW_TMP/findings.txt` for a quick overview. Read `$CW_TMP/findings.json` for structured data.
@@ -76,7 +80,7 @@ If there are zero findings, report "Clean — no mismatches detected" and skip S
 For BREAK/WARN findings, trace how each break was introduced:
 
 ```bash
-python3 "$CW_HOME/scripts/stitch_provenance.py" "$CW_TMP/findings.json" --repo "$TARGET_REPO" --gh-repo "$owner_repo" -o "$CW_TMP/provenance.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_provenance.py" "$CW_TMP/findings.json" --repo "$TARGET_REPO" --gh-repo "$owner_repo" -o "$CW_TMP/provenance.json"
 ```
 
 This enriches each finding with:
@@ -103,7 +107,7 @@ Replace placeholders:
 Write the filled prompt to `$CW_TMP/stitch-prompt.md`, then consult Gemini:
 
 ```bash
-python3 "$CW_HOME/scripts/consult_ai.py" gemini "$CW_TMP/stitch-prompt.md" -o "$CW_TMP/stitch-gemini.md"
+"${CW_PY:-python3}" "$CW_HOME/scripts/consult_ai.py" gemini "$CW_TMP/stitch-prompt.md" -o "$CW_TMP/stitch-gemini.md"
 ```
 
 If Gemini times out, retry once. If it fails again, proceed without it — the automated findings are still valuable.
@@ -151,7 +155,7 @@ Same as trace mode.
 ### Step 2: Convention scan
 
 ```bash
-python3 "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --patterns "$scan_path" -o "$CW_TMP/patterns.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/stitch_extract.py" "$TARGET_REPO" --patterns "$scan_path" -o "$CW_TMP/patterns.json"
 ```
 
 ### Step 3: Report

--- a/.claude/commands/transcribe.md
+++ b/.claude/commands/transcribe.md
@@ -17,7 +17,11 @@ Transcribe an audio or video recording of a client conversation and parse it int
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
 ```
 
 ### Step 1: Validate input
@@ -40,7 +44,7 @@ ffmpeg -i "$file_path" -vn -acodec pcm_s16le -ar 16000 -ac 1 $CW_TMP/transcribe-
 Run local Whisper transcription. Use the `base` model by default (fast, good enough for English):
 
 ```bash
-python3 -c "
+"${CW_PY:-python3}" -c "
 import whisper
 model = whisper.load_model('base')
 result = model.transcribe('$audio_path', fp16=False)
@@ -52,7 +56,7 @@ for seg in result['segments']:
 If the file is a video AND the user wants screenshot cross-references, use the full transcription script:
 
 ```bash
-python3 "$CW_HOME/scripts/transcribe_with_screenshots.py" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/transcribe_with_screenshots.py" \
   --audio "$audio_path" \
   --video "$file_path" \
   --out $CW_TMP/transcription/

--- a/.claude/commands/tutorial-video.md
+++ b/.claude/commands/tutorial-video.md
@@ -39,12 +39,16 @@ it with one command, so it must stay accurate as the UI evolves.
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
-TARGET=$(python3 "$CW_HOME/scripts/repo.py" resolve owner/repo)
-python3 "$CW_HOME/scripts/check_deps.py" --for tutorial-video
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
+TARGET=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve owner/repo)
+"${CW_PY:-python3}" "$CW_HOME/scripts/check_deps.py" --for tutorial-video
 ```
 
-If dependencies are missing, install them (`python3 "$CW_HOME/scripts/install_deps.py"`)
+If dependencies are missing, install them (`"${CW_PY:-python3}" "$CW_HOME/scripts/install_deps.py"`)
 — do not punt to the user.
 
 ### Step 1: Get the app running
@@ -134,7 +138,7 @@ add a mapping and re-produce.
 Validate the schema:
 
 ```bash
-python3 "$CW_HOME/scripts/tutorial_video.py" validate "$CW_TMP/tutorial-<slug>/storyboard.json"
+"${CW_PY:-python3}" "$CW_HOME/scripts/tutorial_video.py" validate "$CW_TMP/tutorial-<slug>/storyboard.json"
 ```
 
 ### Step 4: Dry-run the storyboard
@@ -142,7 +146,7 @@ python3 "$CW_HOME/scripts/tutorial_video.py" validate "$CW_TMP/tutorial-<slug>/s
 Execute every action against the live app without recording:
 
 ```bash
-python3 "$CW_HOME/scripts/tutorial_video.py" record "$CW_TMP/tutorial-<slug>/storyboard.json" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/tutorial_video.py" record "$CW_TMP/tutorial-<slug>/storyboard.json" \
   --out "$CW_TMP/tutorial-<slug>/dry" --dry-run
 ```
 
@@ -153,7 +157,7 @@ validate before acting.
 ### Step 5: Produce
 
 ```bash
-python3 "$CW_HOME/scripts/tutorial_video.py" produce "$CW_TMP/tutorial-<slug>/storyboard.json" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/tutorial_video.py" produce "$CW_TMP/tutorial-<slug>/storyboard.json" \
   --out-dir "$CW_TMP/tutorial-<slug>/out"
 ```
 
@@ -175,7 +179,7 @@ downgrade, and say so in your summary.
 Never ship a video you have not looked at. Verify it yourself:
 
 ```bash
-python3 "$CW_HOME/scripts/tutorial_video.py" probe "$CW_TMP/tutorial-<slug>/out/tutorial.mp4" \
+"${CW_PY:-python3}" "$CW_HOME/scripts/tutorial_video.py" probe "$CW_TMP/tutorial-<slug>/out/tutorial.mp4" \
   --frames-dir "$CW_TMP/tutorial-<slug>/frames" --frame-interval 5
 ```
 

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -14,6 +14,10 @@ Fetch the latest AI model IDs and library versions, update `models.md`, and push
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 ```
 
 ### Step 1: Fetch latest model information
@@ -83,14 +87,14 @@ Read the current `$CW_HOME/models.md` and update it with the new information:
 - Google — `ai.google.dev/gemini-api/docs/pricing`
 - Zhipu (GLM) — `docs.z.ai/guides/overview/pricing`
 
-For tiered models, record the base (≤200k-context) rate. Leave a row `null` + `verified: false` if a price genuinely can't be confirmed (don't fabricate). `python3 -c "import json;json.load(open('config/model_pricing.json'))"` must stay valid.
+For tiered models, record the base (≤200k-context) rate. Leave a row `null` + `verified: false` if a price genuinely can't be confirmed (don't fabricate). `"${CW_PY:-python3}" -c "import json;json.load(open('config/model_pricing.json'))"` must stay valid.
 
 ### Step 3.6: Refresh the language support matrix doc (`docs/languages.md`)
 
 `docs/languages.md` is mechanically rendered from `config/languages.json` (#162) — never hand-edit it. If the matrix changed (a new language, tier promotion, dep_profile change), regenerate the doc so it can't drift from the artifact:
 
 ```bash
-python3 "$CW_HOME/scripts/render_languages_doc.py"
+"${CW_PY:-python3}" "$CW_HOME/scripts/render_languages_doc.py"
 ```
 
 ### Step 3.7: Refresh the design-taste brief (`docs/design-taste.md`)

--- a/.claude/commands/ux-review.md
+++ b/.claude/commands/ux-review.md
@@ -45,8 +45,12 @@ Getting authenticated access is where this skill meets the safety rules. Hold th
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
-TARGET_REPO=$(python3 "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
+# Pin the interpreter CW scripts run under. A bare `python3` is whatever
+# the shell resolves, so a Homebrew bump silently strands keyring /
+# jsonschema / google-genai and kills consults mid-phase (chief-wiggum#374).
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp)
+TARGET_REPO=$("${CW_PY:-python3}" "$CW_HOME/scripts/repo.py" resolve "$owner_repo")
 UX_TMP="$CW_TMP/ux-review"; mkdir -p "$UX_TMP"
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Chief Wiggum dependency checks are profile-based:
 Example:
 
 ```bash
-python3 scripts/check_deps.py --for core --provider claude-interactive
+"${CW_PY:-python3}" scripts/check_deps.py --for core --provider claude-interactive
 ```
 
 ## Secret Management
@@ -137,7 +137,8 @@ Temp files go in `~/.chief-wiggum/tmp/`, **not** `/tmp/`. Each session must crea
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
-CW_TMP=$(python3 "$CW_HOME/scripts/env.py" tmp)
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
+CW_TMP=$("$CW_PY" "$CW_HOME/scripts/env.py" tmp)
 ```
 
 All temp file references (`approach-prompt.md`, `approach-codex.md`, etc.) go inside `$CW_TMP`. Per-ticket files go in `$CW_TMP/<ticket-number>/` to avoid collisions when implementing multiple tickets in one session (see `/implement` Step 1).
@@ -149,9 +150,16 @@ All temp file references (`approach-prompt.md`, `approach-codex.md`, etc.) go in
 ```bash
 CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
 CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
+CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
 ```
 
-In practice, skills reference scripts as `python3 "$CW_HOME/scripts/..."` after resolving `CW_HOME` once. Use `python3 "$CW_HOME/scripts/env.py" tmp` for session temp directories and `python3 "$CW_HOME/scripts/env.py" slug "$epic_name"` for `docs/epics/<slug>` paths.
+**Runtime interpreter**: a bare `python3` is whatever the shell happens to resolve — an unpinned, per-machine accident. Homebrew bumping `python3` from 3.11 to 3.13 silently strands every dependency installed for the old one, and CW discovers it as `ModuleNotFoundError: keyring` inside a backgrounded consult, where the exit is instant and the output file never appears (chief-wiggum#374). `env.py python` resolves and caches a **validated** interpreter — one that actually has the profile's imports — preferring a `CW_PYTHON` override.
+
+The rule, which `tests/test_skill_interpreter_pinning.py` enforces: **every python invocation in a skill runs under `$CW_PY`**, with exactly two exceptions — the two bootstrap calls above (chicken-and-egg; `env.py` imports nothing outside the stdlib), and anything running the TARGET repo's own tooling (`cd "$TARGET_REPO" && python3 tests/browser-use/run.py`, `python3 "$TUT_STATUS_SCRIPT"`), which belongs to the target's interpreter and not CW's.
+
+Call sites use `"${CW_PY:-python3}"` rather than `"$CW_PY"`, so a bash block run in a fresh shell that never saw the bootstrap degrades to exactly today's behaviour instead of failing on an empty command.
+
+In practice, skills reference scripts as `"${CW_PY:-python3}" "$CW_HOME/scripts/..."` after resolving `CW_HOME` and `CW_PY` once. Use `"${CW_PY:-python3}" "$CW_HOME/scripts/env.py" tmp` for session temp directories and `"${CW_PY:-python3}" "$CW_HOME/scripts/env.py" slug "$epic_name"` for `docs/epics/<slug>` paths.
 
 ## Target Repo Resolution
 

--- a/tests/test_skill_interpreter_pinning.py
+++ b/tests/test_skill_interpreter_pinning.py
@@ -1,0 +1,129 @@
+"""Every python invocation in a skill runs under the resolved interpreter.
+
+chief-wiggum#374: the skills hardcoded `python3`, so CW's runtime interpreter
+was whatever the shell resolved -- an unpinned, per-machine accident. Homebrew
+bumping `python3` from 3.11 to 3.13 stranded keyring / jsonschema /
+google-genai, and CW found out as a `ModuleNotFoundError` inside a backgrounded
+consult, where the exit is instant and the output file never appears.
+
+`env.py python` resolves a VALIDATED interpreter and nothing called it. This
+test is what keeps it called: a new `python3 "$CW_HOME/scripts/..."` added to
+any workflow file fails here rather than a year later on somebody's machine.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+COMMANDS = REPO / ".claude/commands"
+
+BOOTSTRAP_HOME = 'CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)'
+BOOTSTRAP_PY = 'CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3'
+
+# The only bare `python3` invocations a skill may contain.
+#
+#   1-2. the bootstrap pair -- chicken-and-egg. `env.py` imports nothing
+#        outside the stdlib, so it runs anywhere a python3 exists at all.
+#   3.   the TARGET repo's own tooling, which belongs to the target's
+#        interpreter and its dependencies, not CW's.
+ALLOWED = (
+    re.compile(re.escape(BOOTSTRAP_HOME)),
+    re.compile(re.escape(BOOTSTRAP_PY)),
+    re.compile(r'TARGET_REPO"?\s*&&\s*python3\b'),
+    re.compile(r'python3 "\$TUT_STATUS_SCRIPT"'),
+)
+
+BARE_PYTHON3 = re.compile(r'(?<!\{)(?<!-)\bpython3\b')
+
+
+def workflow_files() -> list[Path]:
+    return sorted(COMMANDS.glob("*.md"))
+
+
+def test_there_are_workflow_files_to_check():
+    """A denominator, so an empty glob can never read as a clean pass."""
+    assert len(workflow_files()) >= 20
+
+
+@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
+def test_every_python_invocation_is_pinned(path: Path):
+    offenders = []
+    for lineno, line in enumerate(path.read_text().split("\n"), 1):
+        if "python3" not in line:
+            continue
+        if line.lstrip().startswith("#"):  # commentary about the rule itself
+            continue
+        stripped = line
+        for allowed in ALLOWED:
+            stripped = allowed.sub("", stripped)
+        # `"${CW_PY:-python3}"` is the pinned form; its own literal fallback
+        # must not read as an offender.
+        stripped = stripped.replace('"${CW_PY:-python3}"', "")
+        if BARE_PYTHON3.search(stripped):
+            offenders.append(f"{path.name}:{lineno}: {line.strip()[:120]}")
+    assert offenders == [], (
+        "unpinned `python3` in a workflow file (chief-wiggum#374) — use "
+        '`"${CW_PY:-python3}"`:\n' + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
+def test_a_file_that_calls_cw_scripts_resolves_the_interpreter(path: Path):
+    text = path.read_text()
+    if "$CW_HOME/scripts/" not in text:
+        pytest.skip("no CW script calls")
+    assert BOOTSTRAP_HOME in text, f"{path.name} calls CW scripts without resolving CW_HOME"
+    assert BOOTSTRAP_PY in text, (
+        f"{path.name} calls CW scripts without resolving CW_PY — its scripts would "
+        f"run under whatever `python3` the shell happens to resolve (chief-wiggum#374)"
+    )
+
+
+@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
+def test_the_interpreter_is_resolved_after_the_home_it_depends_on(path: Path):
+    text = path.read_text()
+    if BOOTSTRAP_PY not in text:
+        pytest.skip("no CW_PY bootstrap")
+    # CW_PY's own resolution reads $CW_HOME, so it cannot come first.
+    assert text.index(BOOTSTRAP_HOME) < text.index(BOOTSTRAP_PY), (
+        f"{path.name} resolves CW_PY before CW_HOME, so it would probe an empty path"
+    )
+
+
+def test_the_resolution_falls_back_rather_than_leaving_it_empty():
+    """`|| CW_PY=python3` matters: without it a resolver failure leaves CW_PY
+    unset and every later call becomes `"" script.py`, which is a worse failure
+    than the unpinned interpreter this ticket set out to fix."""
+    for path in workflow_files():
+        text = path.read_text()
+        if "CW_PY=$(" not in text:
+            continue
+        assert BOOTSTRAP_PY in text, f"{path.name} resolves CW_PY without a fallback"
+
+
+def test_call_sites_use_the_defaulting_form():
+    """Call sites use `${CW_PY:-python3}`, not a bare `$CW_PY`, so a bash block
+    run in a fresh shell that never saw the bootstrap degrades to exactly
+    today's behaviour instead of failing on an empty command."""
+    offenders = []
+    for path in workflow_files():
+        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+            if re.search(r'"\$CW_PY"|\$CW_PY(?![:_}])', line) and "CW_PY=$(" not in line:
+                offenders.append(f"{path.name}:{lineno}: {line.strip()[:120]}")
+    assert offenders == [], (
+        'use `"${CW_PY:-python3}"` at call sites, not a bare `$CW_PY`:\n'
+        + "\n".join(offenders)
+    )
+
+
+def test_the_migration_actually_happened():
+    """Guards against the whole rule passing vacuously because someone deleted
+    the call sites rather than pinning them."""
+    pinned = sum(
+        path.read_text().count('"${CW_PY:-python3}"') for path in workflow_files()
+    )
+    assert pinned > 250, f"only {pinned} pinned invocations; expected the full migration"


### PR DESCRIPTION
Closes #374 (proposal 1's second half — the migration).

## What was wrong

`env.py python` resolves and caches a **validated** interpreter — one that actually has the profile's imports. #424 built it. Nothing called it.

So CW's runtime interpreter stayed whatever the shell happened to resolve. Homebrew bumping `python3` from 3.11 to 3.13 silently stranded `keyring`, `jsonschema` and `google-genai`, and the failure surfaced as `ModuleNotFoundError` **inside a backgrounded consult** — where the exit is instant, the output file never appears, and a naive `wait`-less launch reports success.

## What ships

**297 call sites across 23 workflow files** now run under `"${CW_PY:-python3}"`. The ticket estimated ~40; the real count is 297 (282 script invocations + 15 inline snippets). `skills/chief-wiggum/references/workflows/*.md` are symlinks, so they follow automatically.

Each file's existing `CW_HOME` bootstrap gained one line:

```bash
CW_HOME="${CHIEF_WIGGUM_HOME:-$HOME/repos/chief-wiggum}"
CW_HOME=$(python3 "$CW_HOME/scripts/env.py" home)
CW_PY=$(python3 "$CW_HOME/scripts/env.py" python) || CW_PY=python3
```

## The rule

Stated exactly, so a test can enforce it rather than a convention drifting:

> **Every python invocation in a skill runs under `$CW_PY`**, with two exceptions.

1. **The two bootstrap calls** (`env.py home`, `env.py python`) — chicken-and-egg. `env.py` imports nothing outside the stdlib, so it runs anywhere a `python3` exists at all.
2. **The target repo's own tooling** — `cd "$TARGET_REPO" && python3 tests/browser-use/run.py`, `python3 "$TUT_STATUS_SCRIPT"`. Those belong to the *target's* interpreter and dependencies, not CW's.

Two of the 15 inline snippets were genuine drift victims rather than consistency cleanup: `transcribe.md` does `import whisper`, `design.md` does `from playwright.sync_api import sync_playwright`.

## Why `${CW_PY:-python3}` and not `$CW_PY`

A skill is a long document, and an agent may run a later bash block in a shell that never saw the bootstrap. With a bare `"$CW_PY"` that block becomes `"" script.py` — a *worse* failure than the unpinned interpreter this ticket set out to fix.

The defaulting form degrades to exactly today's behaviour instead: strictly no worse than before this change, anywhere, and better everywhere the bootstrap did run. The bootstrap falls back the same way (`|| CW_PY=python3`) so a resolver failure can't leave the variable unset either.

This is a deliberate choice rather than a silent fail-open: `check_deps.py` already warns when the resolved interpreter differs from the `python3` the shell would pick, so the mismatch stays visible.

## Verification

**The emitted bash, run for real — all four paths:**

```
1. normal bootstrap    → CW_PY=/opt/homebrew/opt/python@3.14/bin/python3.14, call site OK
2. CW_PY never set     → degraded to bare python3 OK
3. resolver fails      → fallback assigns python3, runs OK
4. CW_PY empty string  → still resolves OK
```

**`tests/test_skill_interpreter_pinning.py`** enforces pinning, bootstrap presence, bootstrap **order** (`CW_PY` reads `$CW_HOME`, so it can't come first), the fallback, the defaulting call form, and a floor on the pinned count so the rule can't pass vacuously by someone deleting call sites instead of pinning them.

**74 tests, 6/6 mutants caught:** new unpinned call site added, bootstrap deleted, fallback dropped, bare `$CW_PY` at a call site, whole migration reverted in the largest file, unpinned inline snippet added.

**Full suite: 4373 passed, 16 skipped.**

## Not in scope

Proposal 3 — a `uv`-managed venv under `~/.chief-wiggum/venv` as the canonical runtime — stays untouched. It's marked optional in the ticket and it changes install topology, which is a decision rather than a default.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
