### PR TITLE
fix(templates): SHA-pin the CI actions instead of trusting mutable tags (#347)

### DIFF
--- a/templates/ci/ci-generic.yml
+++ b/templates/ci/ci-generic.yml
@@ -1,7 +1,7 @@
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # No recognized stack (go.mod / pyproject.toml / package.json) was found.
       # Replace this placeholder with the project's real build, test, and lint steps.
       - name: Placeholder

--- a/templates/ci/ci-go.yml
+++ b/templates/ci/ci-go.yml
@@ -1,8 +1,8 @@
   go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: stable
       - name: Download dependencies

--- a/templates/ci/ci-node.yml
+++ b/templates/ci/ci-node.yml
@@ -1,8 +1,8 @@
   node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
       # `npm install`, NOT `npm ci`: target repos frequently carry lockfile

--- a/templates/ci/ci-python.yml
+++ b/templates/ci/ci-python.yml
@@ -1,8 +1,8 @@
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/tests/test_ci_template_pinning.py
+++ b/tests/test_ci_template_pinning.py
@@ -1,0 +1,103 @@
+"""CI templates pin actions by SHA, not by mutable tag (chief-wiggum#347).
+
+`actions/checkout@v4` resolves to whatever that tag points at TODAY. A tag can
+be force-moved, and a compromised one then runs in every repo CW stamps a
+workflow into. A commit SHA cannot move.
+
+The trailing `# v4` comment is required too: without it the pin is unreadable
+and Dependabot cannot propose a bump, which is how pinned repos end up frozen
+on an action with a known CVE.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+CI_TEMPLATES = REPO / "templates" / "ci"
+
+USES_RE = re.compile(r"^\s*-?\s*uses:\s*(?P<ref>\S+)(?P<rest>.*)$")
+SHA_PIN_RE = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def template_files() -> list[Path]:
+    return sorted(CI_TEMPLATES.glob("*.yml"))
+
+
+def uses_lines() -> list[tuple[Path, int, str, str]]:
+    out = []
+    for path in template_files():
+        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+            m = USES_RE.match(line)
+            if m:
+                out.append((path, lineno, m.group("ref"), m.group("rest")))
+    return out
+
+
+def test_there_are_templates_and_action_references_to_check():
+    """A denominator. An empty glob, or templates that stopped using actions,
+    must not let this file pass by checking nothing."""
+    assert len(template_files()) >= 4
+    assert len(uses_lines()) >= 4
+
+
+@pytest.mark.parametrize("path", template_files(), ids=lambda p: p.name)
+def test_every_action_is_pinned_to_a_sha(path: Path):
+    offenders = []
+    for lineno, line in enumerate(path.read_text().split("\n"), 1):
+        m = USES_RE.match(line)
+        if not m:
+            continue
+        ref = m.group("ref")
+        if not SHA_PIN_RE.match(ref):
+            offenders.append(f"{path.name}:{lineno}: {ref}")
+    assert offenders == [], (
+        "CI template actions must be pinned to a 40-char commit SHA, not a "
+        "mutable tag (chief-wiggum#347):\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("path", template_files(), ids=lambda p: p.name)
+def test_every_pin_carries_its_version_comment(path: Path):
+    """`@<sha> # v4` — the SHA is what runs, the comment is what a human reads
+    and what Dependabot bumps."""
+    offenders = []
+    for lineno, line in enumerate(path.read_text().split("\n"), 1):
+        m = USES_RE.match(line)
+        if not m or not SHA_PIN_RE.match(m.group("ref")):
+            continue
+        if not re.match(r"\s*#\s*v?\d", m.group("rest")):
+            offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert offenders == [], (
+        "a SHA pin needs a trailing `# <version>` comment so it stays readable "
+        "and Dependabot-updatable:\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("stacks", [
+    ["go"], ["python"], ["node"], [], ["go", "python", "node"],
+])
+def test_the_scaffolded_workflow_carries_the_pins(stacks):
+    """The pin has to survive whatever ci_scaffold does to the template. A
+    template pinned on disk and a workflow emitted with mutable tags would be a
+    rule that only holds where nobody runs it."""
+    import sys
+    sys.path.insert(0, str(REPO / "scripts"))
+    from ci_scaffold import render_ci  # noqa: E402
+
+    text = render_ci(stacks)
+    seen = 0
+    for line in text.split("\n"):
+        m = USES_RE.match(line)
+        if not m:
+            continue
+        seen += 1
+        assert SHA_PIN_RE.match(m.group("ref")), (
+            f"scaffolded workflow emits an unpinned action: {line.strip()}"
+        )
+    # Every stack (including the empty/generic one) checks out the repo, so a
+    # render with zero `uses:` lines means the assertion above proved nothing.
+    assert seen > 0, f"render_ci({stacks}) emitted no action references to check"


### PR DESCRIPTION
Partial for #347 — one of the six deferred findings, plus a correction to the ticket's own estimate of another.

## SHA-pin the CI template actions

`actions/checkout@v4` resolves to whatever that tag points at **today**. Tags can be force-moved; a compromised one then runs in every repo CW stamps a workflow into. SHAs can't move.

7 references across the 4 stack templates, pinned to the SHA each tag actually resolved to — fetched live from the GitHub API and dereferenced through the annotated-tag object, not typed from memory:

```yaml
uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
```

The trailing `# v4` is load-bearing, not decoration: without it the pin is unreadable and Dependabot can't propose a bump, which is how pinned repos end up frozen on an action with a known CVE. The guard test requires it.

`tests/test_ci_template_pinning.py` checks the templates on disk **and** what `render_ci()` actually emits for every stack combination — a template pinned on disk and a workflow emitted with tags would be a rule that only holds where nobody runs it. It also asserts a non-zero `uses:` count per render, so a template that stopped referencing actions can't make the check pass vacuously.

## Two findings were already done

- **navigationGraph `additionalProperties: false`** — shipped in #427.
- **Placeholder convention doc line** — already in `CLAUDE.md`, attributed to #347.

The checkboxes just never got ticked.

## One finding is not what the ticket assumed, and I backed it out

The ticket describes the naming inversions (`tim-schema.json` is a data registry; `gap-classification.json` is a schema without the suffix) as *"renames ripple through scripts/docs — do as one mechanical pass"*.

I did the pass. It's small — 6 files, and no target repo carries copies. Then the suite went red in a way the ticket didn't anticipate: the rename **stales the validation records of three gates** — `check_traceability`, `check_architecture`, and `ratchet` — because `chief_wiggum/trace_ids.py` is on their finding-affecting dependency list and `scanner_version` hashes it. Editing a docstring in it is enough.

Two of those revalidate mechanically. `check_architecture` does not:

```
revalidate: check_architecture does not implement replay_seeded_trial(); its
trials are not mechanically replayable (a live repo, a network call, or human
judgement). Re-run them by hand and re-author the record.
```

So a cosmetic rename would require hand-re-deriving a **blocking** gate's validation record. Re-authoring one without genuinely re-running its trials is precisely the manufactured-green this repo cares most about, and doing it properly is a deliberate act that deserves its own decision — not a side effect of tidying two filenames.

**Reverted.** The finding stays open in #347 with its real cost recorded, so the next person doesn't rediscover it halfway through.

## Still open in #347

- `$defs` duplication across 6 schemas — needs the standalone-single-file-stamp call
- Naming inversions — now with the validation-record cost attached
- Slug-case grammar mismatch — needs a direction call
- CI hardening round 2's other half: opt-in dependency caching (`setup-node`/`setup-python` `cache:` hard-fails without a lockfile, so it needs a conditional or a documented opt-in) and golangci-lint parity with pre-merge-check

**Full suite: 4427 passed, 16 skipped.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
