### PR TITLE
feat(gate-validation): earn check_external_smoke a passing record (#353, #437)

### DIFF
--- a/docs/quality/validation/check_external_smoke.json
+++ b/docs/quality/validation/check_external_smoke.json
@@ -1,0 +1,104 @@
+{
+  "authority_boundary": {
+    "artifact": "an epic's contracts.json, a source tree scanned for @cw-smoke annotations, and a junit-xml results file \u2014 all read-only, at fixed content",
+    "assumptions": [
+      "the epic DECLARES its external systems. An integration that is never marked `\"external\": true` is invisible to this gate: it is not in the inventory, so no smoke is demanded for it. That omission belongs to check_interface_provenance's declaration gap (chief-wiggum#350), which reports it for human confirmation, and is deliberately NOT claimed here.",
+      "the results file faithfully reports what the runner did. This gate does not execute the suite; a results file that lies about a skipped case reports the lie.",
+      "LIMIT: that the smoke's assertions are MEANINGFUL. A smoke that connects and asserts nothing satisfies this gate exactly as the original optional `Connect`-only smoke did. That is a review question, not a mechanical one.",
+      "LIMIT: that the external system still behaves as the contract says. One passing round-trip at one moment is evidence of reachability, not of conformance."
+    ],
+    "proves": "every external system DECLARED in contracts.json (`\"external\": true` with an `external_system` name, chief-wiggum#350) is joined to at least one `@cw-smoke` annotated test, and \u2014 when a results file is supplied \u2014 that the annotated smoke actually RAN and PASSED, with `skipped` held distinct from both `passed` and `failed`. A SKIPPED smoke reports `unverified` and is blocking-eligible; it is never collapsed into a pass. An annotation without `case=` can never reach `verified`: matching falls back to the annotated FILE, which matches every case in it, so an unrelated passing test could otherwise award a pass the integration never earned. Weak evidence may raise an alarm, never grant one."
+  },
+  "clean_corpus_runs": [
+    {
+      "coverage": {
+        "external_operations": 1,
+        "results_cases": 2,
+        "source_files_scanned": 2,
+        "systems_declared": 1
+      },
+      "findings": 0,
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    }
+  ],
+  "concurrency_applicable": false,
+  "concurrency_note": "check_external_smoke is a single-pass static read of a contracts declaration, a source tree and a finished results file, all at a fixed content. It never runs the suite itself and never observes a live system, so there is no concurrent or racing dimension in the artifacts to evade. The RACE that matters \u2014 a smoke that passes intermittently against the real system \u2014 is outside this gate entirely: it would appear here as an honest `failed` or `verified` depending on the run, and detecting flakiness is the ratchet's quarantine mechanism, not this one's.",
+  "gate": "check_external_smoke",
+  "protocol_version": "1",
+  "ratchet_record_id": "rec-00089",
+  "scanner_version": "2c79d2d2ab93b3ccefa6c82e8077f8af2e3d8d125aef36b51aceeae2726129e2",
+  "seeded_defect_trials": [
+    {
+      "expected": "fire",
+      "injected": "the smoke's junit case is marked <skipped/> \u2014 credentials absent or the build tag off. The test file, the annotation and the declaration are all untouched; only the RESULT changes, which is exactly how this reaches production behind a green suite.",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "fired",
+      "seed_class": "direct",
+      "seed_id": "es-direct-01",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    },
+    {
+      "expected": "fire",
+      "injected": "the `@cw-smoke SCP` annotation line is deleted while SCP stays declared external and the test body remains. Nothing then claims to exercise the system at all.",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "fired",
+      "seed_class": "evasion-omission",
+      "seed_id": "es-omission-01",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    },
+    {
+      "expected": "fire",
+      "injected": "the smoke stays annotated and fully intact in the tree; a build tag keeps it out of the run, so its case never appears in the results. Disabled by CONFIG rather than by editing the assertion.",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "fired",
+      "seed_class": "evasion-config-indirection",
+      "seed_id": "es-config-indirection-01",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    },
+    {
+      "expected": "fire",
+      "injected": "a SECOND smoke is added for the same system and skipped, while the original still passes. A gate that samples any-one-passes reports clean; a system is only as verified as its weakest smoke.",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "fired",
+      "seed_class": "evasion-sampling-gap",
+      "seed_id": "es-sampling-gap-01",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    },
+    {
+      "expected": "fire",
+      "injected": "the results file is present and unparseable. Its verdicts are UNKNOWN, which is never a pass (chief-wiggum#289's broken-instrument class).",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "fired",
+      "seed_class": "instrument-broken",
+      "seed_id": "es-instrument-broken-01",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    },
+    {
+      "expected": "no-fire",
+      "injected": "BOUNDARY (no-fire) trial: an unrelated NON-external test is skipped in the same results, alongside a non-external declared operation carrying no smoke. Proves the gate samples only DECLARED external systems \u2014 a skip elsewhere in the suite is outside its authority and must not produce a finding.",
+      "passed": true,
+      "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+      "result": "not-fired",
+      "seed_class": "evasion-sampling-gap",
+      "seed_id": "es-sampling-gap-02",
+      "seed_version": "1",
+      "sha": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa"
+    }
+  ],
+  "status": "passed",
+  "telemetry_dependent": false,
+  "validated_at": "2026-08-23T13:55:15Z",
+  "validated_by": "chief-wiggum#353 (first authoring). All six trials and the clean-corpus run were EXECUTED by scripts/check_external_smoke.py's replay_seeded_trial/replay_clean_corpus against the pinned fixture corpus at the sha recorded above \u2014 no result here is asserted from expectation. `gate_validation_designer.py revalidate check_external_smoke` re-runs all of them, so any later edit to the gate or to chief_wiggum/annotations.py stales this record rather than silently inheriting it (INV-fh-005)."
+}

--- a/docs/quality/validation/seeds/check_external_smoke.seeds.json
+++ b/docs/quality/validation/seeds/check_external_smoke.seeds.json
@@ -1,0 +1,61 @@
+{
+  "gate": "check_external_smoke",
+  "extracted_from": "check_external_smoke.json",
+  "note": "Derived artifact (chief-wiggum#218): seeds versioned separately from gate code. Regenerate with `gate_validation_designer.py extract-seeds check_external_smoke` whenever the record's trials change \u2014 `audit` reports drift between record and seeds file otherwise.",
+  "seeds": [
+    {
+      "seed_id": "es-direct-01",
+      "seed_class": "direct",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "the smoke's junit case is marked <skipped/> \u2014 credentials absent or the build tag off. The test file, the annotation and the declaration are all untouched; only the RESULT changes, which is exactly how this reaches production behind a green suite.",
+      "expected": "fire"
+    },
+    {
+      "seed_id": "es-omission-01",
+      "seed_class": "evasion-omission",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "the `@cw-smoke SCP` annotation line is deleted while SCP stays declared external and the test body remains. Nothing then claims to exercise the system at all.",
+      "expected": "fire"
+    },
+    {
+      "seed_id": "es-config-indirection-01",
+      "seed_class": "evasion-config-indirection",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "the smoke stays annotated and fully intact in the tree; a build tag keeps it out of the run, so its case never appears in the results. Disabled by CONFIG rather than by editing the assertion.",
+      "expected": "fire"
+    },
+    {
+      "seed_id": "es-sampling-gap-01",
+      "seed_class": "evasion-sampling-gap",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "a SECOND smoke is added for the same system and skipped, while the original still passes. A gate that samples any-one-passes reports clean; a system is only as verified as its weakest smoke.",
+      "expected": "fire"
+    },
+    {
+      "seed_id": "es-instrument-broken-01",
+      "seed_class": "instrument-broken",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "the results file is present and unparseable. Its verdicts are UNKNOWN, which is never a pass (chief-wiggum#289's broken-instrument class).",
+      "expected": "fire"
+    },
+    {
+      "seed_id": "es-sampling-gap-02",
+      "seed_class": "evasion-sampling-gap",
+      "seed_version": "1",
+      "corpus": "tests/fixtures/gate_validation/external_smoke_clean",
+      "corpus_digest": "sha256:977045c2256ddff0d6eedab15ca32e414654a5a9cc4502293018a378d35e3afa",
+      "injected": "BOUNDARY (no-fire) trial: an unrelated NON-external test is skipped in the same results, alongside a non-external declared operation carrying no smoke. Proves the gate samples only DECLARED external systems \u2014 a skip elsewhere in the suite is outside its authority and must not produce a finding.",
+      "expected": "no-fire"
+    }
+  ]
+}

--- a/scripts/check_external_smoke.py
+++ b/scripts/check_external_smoke.py
@@ -95,6 +95,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from chief_wiggum.annotations import SMOKE_TAG_RE  # noqa: E402
+from chief_wiggum.hashing import scanner_version  # noqa: E402
 
 EXIT_OK = 0
 EXIT_FINDINGS = 1
@@ -482,13 +483,28 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Every declared external system needs one real round-trip (chief-wiggum#353)"
     )
-    parser.add_argument("targets", nargs="+", help="Epic directory or contracts.json file(s)")
-    parser.add_argument("--source", required=True, help="Repo root to scan for @cw-smoke sites")
+    parser.add_argument("targets", nargs="*",
+                        help="Epic directory or contracts.json file(s); "
+                             "not required with --scanner-version")
+    parser.add_argument("--source", help="Repo root to scan for @cw-smoke sites")
     parser.add_argument("--results", help="junit-xml results, to verify the smoke actually ran")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--gate", action="store_true",
                         help="Block (exit 1) on findings. Report-only without it.")
+    parser.add_argument(
+        "--scanner-version", action="store_true",
+        help="Print the hash-derived scanner version and exit. The "
+             "gate-validation protocol probes this to detect a record that has "
+             "gone stale against the code it certifies (INV-fh-005).",
+    )
     args = parser.parse_args(argv)
+
+    if args.scanner_version:
+        print(_scanner_version())
+        return EXIT_OK
+
+    if not args.targets or not args.source:
+        parser.error("the following arguments are required: targets, --source")
 
     targets = [Path(t) for t in args.targets]
     missing = [t for t in targets if not t.exists()]
@@ -533,6 +549,166 @@ def main(argv: list[str] | None = None) -> int:
     if report.findings and args.gate:
         return EXIT_FINDINGS
     return EXIT_OK
+
+
+# --- gate-validation replay (docs/gate-validation.md, chief-wiggum#410) -------
+#
+# The seeded trials this gate's validation record cites, as executable
+# mutations of a pinned fixture corpus. `gate_validation_designer.py
+# revalidate check_external_smoke` re-runs every one of them, so a record can
+# never drift into asserting a trial nobody has executed since.
+
+GV_CORPUS = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / \
+    "gate_validation" / "external_smoke_clean"
+
+_SKIPPED_CASE = ('<testcase classname="internal/scp" name="TestSCPLiveVenueInfo" '
+                 'file="internal/scp/live_smoke_test.go"/>')
+
+
+def _gv_paths(corpus: Path) -> tuple[Path, Path, Path]:
+    return corpus / "epic", corpus / "src", corpus / "results" / "junit.xml"
+
+
+def _seed_direct(corpus: Path) -> None:
+    """THE defect: the smoke was SKIPPED — credentials absent, build tag off —
+    and a suite that collapses skipped into "not failed" reads green."""
+    results = corpus / "results" / "junit.xml"
+    text = results.read_text()
+    assert _SKIPPED_CASE in text
+    results.write_text(text.replace(
+        _SKIPPED_CASE,
+        _SKIPPED_CASE.replace("/>", "><skipped/></testcase>")))
+
+
+def _seed_omission(corpus: Path) -> None:
+    """Evasion by omission at THIS gate's layer: the @cw-smoke annotation is
+    deleted while the system stays declared external. Nothing then claims to
+    exercise SCP at all."""
+    src = corpus / "src" / "internal" / "scp" / "live_smoke_test.go"
+    text = src.read_text()
+    assert "@cw-smoke" in text
+    src.write_text("\n".join(
+        line for line in text.split("\n") if "@cw-smoke" not in line))
+
+
+def _seed_config_indirection(corpus: Path) -> None:
+    """Disabled by CONFIG, not by editing the assertion: the smoke stays
+    annotated and fully intact in the tree, and a build tag keeps it out of the
+    run entirely, so it never appears in the results."""
+    results = corpus / "results" / "junit.xml"
+    text = results.read_text()
+    assert _SKIPPED_CASE in text
+    results.write_text(text.replace(_SKIPPED_CASE, ""))
+
+
+def _seed_sampling_gap(corpus: Path) -> None:
+    """A passing sibling must not vouch for a skipped one. A second smoke is
+    added for the SAME system and skipped; the original still passes, so a gate
+    that samples any-one-passes reports clean."""
+    src = corpus / "src" / "internal" / "scp" / "second_smoke_test.go"
+    src.write_text(
+        "package scp\n\nimport \"testing\"\n\n"
+        "// @cw-smoke SCP case=TestSCPLiveBookings\n"
+        "func TestSCPLiveBookings(t *testing.T) {}\n")
+    results = corpus / "results" / "junit.xml"
+    text = results.read_text()
+    results.write_text(text.replace(
+        "</testsuite>",
+        '  <testcase classname="internal/scp" name="TestSCPLiveBookings" '
+        'file="internal/scp/second_smoke_test.go"><skipped/></testcase>\n</testsuite>'))
+
+
+def _seed_instrument_broken(corpus: Path) -> None:
+    """The instrument itself breaks: the results file is present and
+    unparseable. Its verdicts are UNKNOWN, which is never a pass — the #289
+    broken-instrument class."""
+    results = corpus / "results" / "junit.xml"
+    results.write_text("<testsuite><testcase name=\"truncated\"")
+
+
+def _seed_boundary_unrelated_skip(corpus: Path) -> None:
+    """A NO-FIRE trial proving the stated boundary: this gate speaks only about
+    DECLARED external systems. An unrelated skipped test, and a non-external
+    operation with no smoke, must not produce a finding."""
+    results = corpus / "results" / "junit.xml"
+    text = results.read_text()
+    results.write_text(text.replace(
+        "</testsuite>",
+        '  <testcase classname="internal/api" name="TestBookingsHandler" '
+        'file="internal/api/bookings_test.go"><skipped/></testcase>\n</testsuite>'))
+
+
+SEED_EXECUTORS = {
+    "es-direct-01": _seed_direct,
+    "es-omission-01": _seed_omission,
+    "es-config-indirection-01": _seed_config_indirection,
+    "es-sampling-gap-01": _seed_sampling_gap,
+    "es-instrument-broken-01": _seed_instrument_broken,
+    "es-sampling-gap-02": _seed_boundary_unrelated_skip,
+}
+
+
+def _gv_outcome(corpus: Path) -> str:
+    """fired / not-fired for a prepared corpus.
+
+    ``error`` counts as FIRED (#289): a harness that only accepted `findings`
+    would score a broken instrument as a clean run, which is the precise
+    conflation this gate exists to prevent.
+    """
+    epic, src, results = _gv_paths(corpus)
+    report = check([epic], src, results if results.is_file() else None)
+    return "fired" if (report.findings or report.unparsed) else "not-fired"
+
+
+def replay_seeded_trial(seed: dict) -> str:
+    """Re-run one seeded trial against a throwaway copy of the pinned corpus."""
+    import shutil
+    import tempfile
+
+    seed_id = str(seed.get("seed_id", ""))
+    if seed_id not in SEED_EXECUTORS:
+        raise KeyError(f"no seed executor for {seed_id!r}")
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp) / "corpus"
+        shutil.copytree(GV_CORPUS, corpus)
+        SEED_EXECUTORS[seed_id](corpus)
+        return _gv_outcome(corpus)
+
+
+def replay_clean_corpus() -> dict:
+    """Re-run the clean corpus, deriving coverage from the live run."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp) / "corpus"
+        shutil.copytree(GV_CORPUS, corpus)
+        epic, src, results = _gv_paths(corpus)
+        report = check([epic], src, results)
+    return {
+        "repo": "tests/fixtures/gate_validation/external_smoke_clean",
+        "findings": len(report.findings),
+        "coverage": {
+            "external_operations": report.measured["external_operations"],
+            "systems_declared": report.measured["systems_declared"],
+            "source_files_scanned": report.measured["source_files_scanned"],
+            "results_cases": report.measured["results_cases"],
+        },
+        # `applicable` matters as much as the zero: a clean corpus that the gate
+        # found INAPPLICABLE exercised nothing, and would certify the checker on
+        # the strength of a run that never looked at anything.
+        "passed": not report.findings and report.applicability == "applicable",
+    }
+
+
+def _scanner_version() -> str:
+    """Hash-derived ``scanner_version``: this module plus its finding-affecting
+    dependencies. ``annotations.py`` carries the @cw-smoke grammar, so a change
+    there changes which sites this gate sees. No hand-bumped constant to forget
+    (INV-fh-005)."""
+    here = Path(__file__).resolve()
+    cw_dir = here.parent / "chief_wiggum"
+    return scanner_version(here, cw_dir / "annotations.py")
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/gate_validation/external_smoke_clean/epic/contracts.json
+++ b/tests/fixtures/gate_validation/external_smoke_clean/epic/contracts.json
@@ -1,0 +1,27 @@
+{
+  "entities": [
+    {
+      "name": "Venue",
+      "operations": [
+        {
+          "name": "Fetch venue info",
+          "method": "GET",
+          "path": "/venue-info",
+          "external": true,
+          "external_system": "SCP",
+          "derived_from": [
+            {
+              "type": "observed_fact",
+              "ref": "capture 2026-08-23, results/scp-venue-info.json"
+            }
+          ]
+        },
+        {
+          "name": "List own bookings",
+          "method": "GET",
+          "path": "/api/bookings"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/gate_validation/external_smoke_clean/results/junit.xml
+++ b/tests/fixtures/gate_validation/external_smoke_clean/results/junit.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="scp" tests="2">
+  <testcase classname="internal/scp" name="TestSCPLiveVenueInfo" file="internal/scp/live_smoke_test.go"/>
+  <testcase classname="internal/scp" name="TestClientUnit" file="internal/scp/client_test.go"/>
+</testsuite>

--- a/tests/fixtures/gate_validation/external_smoke_clean/src/internal/scp/client.go
+++ b/tests/fixtures/gate_validation/external_smoke_clean/src/internal/scp/client.go
@@ -1,0 +1,8 @@
+package scp
+
+// Not a smoke — present so the corpus has an un-annotated sibling and the
+// scanner's file count is not trivially 1.
+
+type Client struct{ base string }
+
+func (c *Client) VenueInfo() error { return nil }

--- a/tests/fixtures/gate_validation/external_smoke_clean/src/internal/scp/live_smoke_test.go
+++ b/tests/fixtures/gate_validation/external_smoke_clean/src/internal/scp/live_smoke_test.go
@@ -1,0 +1,17 @@
+package scp
+
+import "testing"
+
+// One real round-trip against SCP. Pinned by case= so the results match is
+// exact rather than file-shaped.
+//
+// @cw-smoke SCP case=TestSCPLiveVenueInfo
+func TestSCPLiveVenueInfo(t *testing.T) {
+	resp, err := liveClient(t).VenueInfo(t.Context())
+	if err != nil {
+		t.Fatalf("venue-info: %v", err)
+	}
+	if resp.Opens == "" {
+		t.Fatal("venue-info returned no opening time")
+	}
+}

--- a/tests/test_external_smoke_validation.py
+++ b/tests/test_external_smoke_validation.py
@@ -1,0 +1,180 @@
+"""check_external_smoke's validation record must stay backed by live runs.
+
+chief-wiggum#353 + the gate-validation protocol (docs/gate-validation.md).
+
+A record is only worth what its trials actually prove. `gate_validation_designer
+audit` names the failure mode precisely: a seed_id that appears in no test suite
+"cannot be re-executed, so the record is an aspirational claim for it". These
+tests re-execute every seed the record cites, on every CI run, so the record
+cannot quietly drift into asserting a trial nobody has run since the day it was
+written.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+RECORD = REPO / "docs" / "quality" / "validation" / "check_external_smoke.json"
+VALIDATION_DIR = REPO / "docs" / "quality" / "validation"
+sys.path.insert(0, str(REPO / "scripts"))
+
+import check_external_smoke as gate  # noqa: E402
+from check_gate_validation import corpus_digest  # noqa: E402
+
+
+def record() -> dict:
+    return json.loads(RECORD.read_text())
+
+
+def seeds() -> list[dict]:
+    return record()["seeded_defect_trials"]
+
+
+def test_the_record_exists_and_passes():
+    assert record()["status"] == "passed"
+
+
+def test_every_mandatory_seed_class_is_present():
+    """The protocol's mandatory classes for a non-telemetry gate. A record
+    missing one is not a lighter record, it is an unproven one."""
+    classes = {t["seed_class"] for t in seeds()}
+    assert {"direct", "evasion-omission", "evasion-config-indirection",
+            "evasion-sampling-gap", "instrument-broken"} <= classes
+
+
+# The seed ids, named literally. Two reasons: renaming a seed in the record
+# without updating its executor now fails here loudly, and
+# `gate_validation_designer audit` greps tests/ for each id to confirm the trial
+# is re-executable rather than an aspirational claim in a JSON file.
+EXPECTED_SEED_IDS = {
+    "es-direct-01",
+    "es-omission-01",
+    "es-config-indirection-01",
+    "es-sampling-gap-01",
+    "es-sampling-gap-02",
+    "es-instrument-broken-01",
+}
+
+
+def test_the_record_cites_exactly_the_known_seeds():
+    assert {s["seed_id"] for s in seeds()} == EXPECTED_SEED_IDS
+    assert set(gate.SEED_EXECUTORS) == EXPECTED_SEED_IDS
+
+
+def test_there_are_seeds_to_replay():
+    """A denominator: an empty trial list must never let this file pass by
+    checking nothing."""
+    assert len(seeds()) >= 6
+
+
+@pytest.mark.parametrize("seed", seeds(), ids=lambda s: s["seed_id"])
+def test_each_recorded_trial_is_backed_by_a_live_execution(seed):
+    """Re-run the seed and compare against what the record CLAIMS."""
+    expected = {"fire": "fired", "no-fire": "not-fired"}[seed["expected"]]
+    live = gate.replay_seeded_trial({"seed_id": seed["seed_id"]})
+    assert live == expected, (
+        f"{seed['seed_id']}: the record claims {expected}, a live replay got "
+        f"{live} — re-run `gate_validation_designer.py revalidate check_external_smoke`")
+    assert seed["result"] == live
+    assert seed["passed"] is True
+
+
+def test_every_seed_has_an_executor():
+    """A seed in the record with no executor is unreplayable, which is the
+    aspirational-claim failure the designer audit exists to catch."""
+    missing = [s["seed_id"] for s in seeds() if s["seed_id"] not in gate.SEED_EXECUTORS]
+    assert missing == [], f"seeds with no executor: {missing}"
+
+
+def test_the_direct_seed_reports_unverified_not_merely_fires():
+    """Firing is not enough. The point of this gate is that a SKIPPED smoke is
+    `unverified` — a distinct state from failed and from passed — so a trial
+    that fired for the wrong reason would still be a lie."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp) / "corpus"
+        shutil.copytree(gate.GV_CORPUS, corpus)
+        gate._seed_direct(corpus)
+        epic, src, results = gate._gv_paths(corpus)
+        report = gate.check([epic], src, results)
+    assert [s.state for s in report.systems] == [gate.UNVERIFIED]
+
+
+def test_the_instrument_broken_seed_reports_error_not_merely_fires():
+    """It must fire because the scanner could not READ its input, not because
+    it found a finding — `error` and `findings` are different verdicts."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp) / "corpus"
+        shutil.copytree(gate.GV_CORPUS, corpus)
+        gate._seed_instrument_broken(corpus)
+        epic, src, results = gate._gv_paths(corpus)
+        report = gate.check([epic], src, results)
+    assert report.outcome == "error"
+    assert report.unparsed
+
+
+def test_the_clean_corpus_run_is_backed_by_a_live_execution():
+    live = gate.replay_clean_corpus()
+    stored = record()["clean_corpus_runs"][0]
+    assert live["findings"] == stored["findings"] == 0
+    assert live["coverage"] == stored["coverage"]
+    assert live["passed"] is True
+    assert any(live["coverage"].values()), "the clean run scanned nothing"
+
+
+def test_the_pinned_corpus_digest_still_matches():
+    """The record pins a corpus by sha. If the fixture changed, the trials were
+    run against something else."""
+    assert record()["clean_corpus_runs"][0]["sha"] == corpus_digest(gate.GV_CORPUS)
+    for seed in seeds():
+        assert seed["sha"] == corpus_digest(gate.GV_CORPUS)
+
+
+def test_the_scanner_version_is_not_stale():
+    """INV-fh-005: any edit to the gate or to chief_wiggum/annotations.py must
+    stale this record rather than silently inherit its certification."""
+    assert record()["scanner_version"] == gate._scanner_version(), (
+        "the record certifies a different version of the scanner than the one on "
+        "disk — re-run `gate_validation_designer.py revalidate check_external_smoke`")
+
+
+def test_the_scanner_version_flag_round_trips():
+    """check_gate_validation probes this over the CLI; a broken probe is never
+    evidence of a clean record."""
+    result = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "check_external_smoke.py"),
+         "--scanner-version"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == gate._scanner_version()
+
+
+def test_the_shipped_record_passes_the_protocol_checker():
+    result = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "check_gate_validation.py"),
+         "check_external_smoke", "--validation-dir", str(VALIDATION_DIR), "--gate"],
+        capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout
+    assert "PASSING" in result.stdout
+
+
+def test_the_record_is_journaled_in_the_ratchet_chain():
+    """The chain is the tamper-evidence: a record id that is not journaled
+    grants no provenance (docs/gate-validation.md)."""
+    rid = record()["ratchet_record_id"]
+    journal = REPO / "docs" / "quality" / "ratchet-journal.jsonl"
+    entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+    match = next((e for e in entries if e.get("record_id") == rid), None)
+    assert match is not None, f"{rid} is not in the ratchet journal"
+    assert match["event"] == "gate-validation"
+    assert match["ref"] == "check_external_smoke"

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -209,7 +209,14 @@ def test_gate_ledger_against_this_repos_real_validation_dir(user_dir):
     and the wired state comes from the real journal's gate-authority events."""
     st = status.gather(ROOT)
     gates = {g["gate"]: g for g in st["gates"]}
-    assert len(gates) == 7, f"expected the 7 shipped records, got {sorted(gates)}"
+    # A named set plus a floor, rather than an exact count: a record VANISHING
+    # is the regression worth catching, and a legitimate new gate should not
+    # have to bump a magic number to land (chief-wiggum#353 added the eighth).
+    known = {"check_architecture", "check_single_writer", "check_traceability",
+             "ci_scaffold", "quality_slop_gate", "ratchet", "saas_gate",
+             "check_external_smoke"}
+    assert known <= set(gates), f"shipped record(s) missing: {sorted(known - set(gates))}"
+    assert len(gates) >= len(known), f"expected at least {len(known)} records, got {sorted(gates)}"
     failing = [n for n, g in gates.items() if g["verdict"] != "passing"]
     assert not failing, f"stale/failing validation record(s): {failing}"
     # ratchet was journaled-wired in the real journal (chief-wiggum#198 era).
@@ -219,7 +226,7 @@ def test_gate_ledger_against_this_repos_real_validation_dir(user_dir):
 def test_gate_ledger_verifies_shared_journal_chain_once(user_dir, monkeypatch):
     """#323: every gate under one validation_dir shares the SAME ratchet
     journal — gate_ledger() must hash-verify that chain ONCE for the whole
-    7-gate ledger, not once per gate (the amplification the ticket flagged
+    ledger, not once per gate (the amplification the ticket flagged
     at status.py:91-101)."""
     import check_gate_validation as gv
 
@@ -232,7 +239,10 @@ def test_gate_ledger_verifies_shared_journal_chain_once(user_dir, monkeypatch):
 
     monkeypatch.setattr(gv, "_load_and_verify_chain", spy)
     st = status.gather(ROOT)
-    assert len(st["gates"]) == 7
+    # The claim under test is the ONE walk, not the gate count — but the count
+    # still needs a floor, or a ledger that collapsed to zero gates would
+    # "verify the chain once" by never verifying it at all.
+    assert len(st["gates"]) >= 8
     assert calls == [1], f"expected the journal to be verified exactly once, got {len(calls)} walks"
 
 


### PR DESCRIPTION
Follows up #432 (#353) and **corrects #437 by demonstration**.

## I was wrong in #437

I filed #437 claiming the five new gates can't be promoted until a target repo adopts their metadata. That's not how the shipped records work.

**Validation trials run against in-repo fixtures.** Every shipped record pins a corpus under `tests/fixtures/gate_validation/` — `check_single_writer`'s clean-corpus coverage is *three fixture files*. "Validated on a real, already-shipped repo" in `docs/gate-rollout.md` describes the **precision dry-run**, and that half was already done: 22 real epics, 0 findings, 0 crashes.

So `check_external_smoke` now has a passing record:

```
# Gate Validation — check_external_smoke
Record: found (docs/quality/validation/check_external_smoke.json)
Verdict: PASSING
Blocking authority: unwired -> validated (author_record)
```

and **zero findings** from `gate_validation_designer audit`.

## The seeds — executed, not asserted

Every `result` in the record came back from a live `replay_seeded_trial` call.

| seed | class | injects |
| --- | --- | --- |
| `es-direct-01` | direct | the smoke's case marked `<skipped/>`. Declaration, annotation and test body untouched — **only the result changes**, which is exactly how this reaches production behind a green suite |
| `es-omission-01` | omission | the `@cw-smoke` line deleted while the system stays declared external |
| `es-config-indirection-01` | config-indirection | the smoke intact and annotated; a build tag keeps it out of the run entirely |
| `es-sampling-gap-01` | sampling-gap | a second smoke for the same system, skipped, beside a passing one |
| `es-instrument-broken-01` | instrument-broken | the results file present and unparseable → `error`, which counts as **fired**: a harness that only accepted `findings` would score a broken instrument as clean |
| `es-sampling-gap-02` | sampling-gap | **no-fire boundary** — an unrelated non-external test skipped elsewhere in the suite must not produce a finding |

Plus the machinery that keeps them honest: `replay_seeded_trial` / `replay_clean_corpus` / `_scanner_version`, so `revalidate` re-runs everything and no later edit inherits the certification silently (INV-fh-005); `--scanner-version` on the CLI, which `check_gate_validation` probes (without it the staleness probe itself errors, and a broken probe is never evidence of a clean record); and `rec-00089` in the hash-chained ratchet journal, since an unjournaled record id grants no provenance.

## Three audit findings, fixed rather than argued with

1. **"the trial cannot be re-executed, so the record is an aspirational claim"** — the seeds appeared in no test suite. `tests/test_external_smoke_validation.py` now re-executes every one on every CI run, and names the seed ids literally so a rename fails loudly. It also asserts the direct seed reports `unverified` specifically and the instrument-broken seed reports `error` specifically — firing for the *right reason*, since a trial that fired for the wrong one is still a lie.
2. **An unprovable boundary claim** — "an unpinned annotation can never reach `verified`". No fire/no-fire trial can prove it, because neither `verified` nor `smoke_declared` fires. Moved into `proves` where it belongs; unit tests cover it.
3. **No seeds file** — extracted, so seeds version independently of gate code.

## Deliberately NOT wiring `--gate`

The record certifies the gate catches seeded defects on a fixture corpus. Its **precision has never met a real positive**, because no repo declares an external system yet — the 22-epic dry-run was 22 × `inapplicable`.

Blocking an epic close on evidence that has never seen a true positive is the wrong order. The record makes promotion *available*; wiring it is a separate, deliberate act once one target carries the metadata.

## One test relaxed, on purpose

`test_status.py` hardcoded *"expected the 7 shipped records"*. Replaced with a named set plus a floor: a record **vanishing** is the regression worth catching, and a legitimate new gate shouldn't have to bump a magic number to land.

## Note for review

This branch touches `docs/quality/**` — the ratchet-protected goalpost pathset. The record, the seeds file and the journal entry all live there by design, so **it is expected to park for human review**. That's the mechanism working, not a problem with the branch.

**18 tests on the record. Full suite: 4584 passed, 16 skipped.**

#437 stays open for what it should have been about from the start: whether a declaration-driven gate may claim `n/a` on the `omission` class when the declaration is optional by design. That question blocks the other four, and it's yours to settle.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
