### PR TITLE
fix(close-epic): add handler-family consistency to the adversarial checklist (#378)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -271,6 +271,7 @@ Launch a **review-worker** (contract: `docs/worker-contracts.md#review-worker`) 
 - **IDOR / tenant isolation** — every new data-access path scopes by tenant/owner **server-side** (never trusts a client-supplied id); cross-tenant reads/writes are rejected.
 - **PII / secrets in logs** — no email, token, key, or raw request body written to logs.
 - **Input bounds** — unbounded strings/payloads are capped (oversized free-text fields, giant uploads).
+- **Handler-family consistency** (chief-wiggum#378) — for each NEW handler, list its siblings in the same package family and diff the protections. A handler that touches Redis, a database, or an outbound upstream and lacks a guard **every sibling has** (a non-blocking semaphore, a fail-closed client-IP derivation, a blacklist check) is a finding, even when it passes every per-ticket check. This is the one item on this list that no automated gate covers: a new handler once shipped without the concurrency semaphore all three of its siblings had — an unbounded-concurrency DoS on a service whose whole purpose was bounding abuse — and it passed the per-ticket floor, review, traceability and the ratchet. A sibling's own comment named the missing limit. Read the siblings, not just the diff.
 
 Run the same prompt through the reviewer quorum for divergence, then reconcile the two into one findings list:
 


### PR DESCRIPTION
Partial for #378 — ships the ticket's own named fallback, and records why the automated gate is not shippable yet.

## The escape

A new HTTP handler shipped **missing the concurrency semaphore every sibling in its package family had** — an unbounded-concurrency DoS on a service whose entire purpose was bounding abuse.

It passed the per-ticket floor, review, traceability and the ratchet. A sibling's own comment even *named* the missing limit. Only the epic-level adversarial seam review caught it.

## Why not the automated gate

The proposed check infers a norm from siblings: a handler lacking a protection its siblings share is a finding. That is the **noisiest possible gate shape**, and CW's rule is measure-before-shipping — the same rule that got #350's hedge lint rejected (84 hits, every one legitimate) and left #354's circular-schema heuristic unbuilt.

**There is no corpus to measure it on.** Across every cached target repo:

| repo | largest HTTP handler family |
| --- | --- |
| dgrd | 3 files (`backend/cmd/dgrd/internal/client`) |
| dogeared-coach | 2 files (`backend/internal/services`) |

A norm inferred from two siblings is a coin flip. Any precision figure from this corpus would be noise reported as evidence — exactly what I have refused twice already in this family of tickets, and refusing it here too is the consistent call rather than a convenient one.

## What ships instead

The ticket's own fallback, verbatim from its proposal: *"Even as a review-contract checklist item it would have caught #40 before close."*

A sixth item on `/close-epic`'s adversarial security checklist, alongside account enumeration, rate limiting, IDOR, PII-in-logs and input bounds. It carries no precision risk, because a reviewer applies judgement rather than a regex.

It tells the reviewer to **list the siblings and diff the protections** — because the tell in #40 was visible only from the siblings and never from the diff — and it says plainly that this is the one item on that list no automated gate covers.

**Full suite: 4569 passed, 16 skipped.**

#378 stays open for the automated gate, with the corpus finding recorded so the next attempt starts from it instead of rediscovering it.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*