### PR TITLE
feat(telemetry): wire phase latency so the loop is measured, not felt (#375)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -94,6 +94,17 @@ TICKET_TMP="$CW_TMP/$issue_number"
 mkdir -p "$TICKET_TMP"
 ```
 
+**Time every phase** (chief-wiggum#375 proposal 6). Loop latency was *felt* rather than measured — a live run took ~90 minutes and the phase costs were reconstructed by hand afterwards, so there was no data to rank the fixes against. Stamp a start before each phase and record it after:
+
+```bash
+PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
+# ... the phase runs ...
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \
+  --name step4a_consults --since "$PHASE_T0" --ticket "$issue_number" || true
+```
+
+`|| true` because telemetry is a no-op unless `CW_TELEMETRY=1`, and a measurement must never fail the loop it measures. Pass `--outcome error` when the phase blew up: a phase that failed fast would otherwise read as a phase that went well. `factory_log.py aggregate` rolls these into per-phase totals and names the slowest.
+
 **Preflight the providers — before any phase needs one** (chief-wiggum#375). This is the single highest-leverage thing in Step 1: roughly 15 of a 25-minute consult phase once went on environment failures discovered *serially*, one relaunch at a time, after the prompt was already built.
 
 ```bash
@@ -239,6 +250,10 @@ If you do need to ask, keep it tight:
 
 ### Step 4: Consult AIs on approach
 
+```bash
+PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
+```
+
 This step has two phases, each in its own worker. This keeps the heavy codebase exploration and synthesis out of the main context window.
 
 #### Phase A: Gather approaches (parallel)
@@ -343,7 +358,16 @@ Step 8 re-checks it (report-only for now, per `docs/gate-rollout.md` — teeth
 come only after a gate-validation record). "While I'm in here" is the dominant
 brownfield failure mode; the declared pathset is what makes it visible.
 
+```bash
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \
+  --name step4_consult_and_synthesis --since "$PHASE_T0" --ticket "$issue_number" || true
+```
+
 ### Step 5: Test-first specification
+
+```bash
+PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
+```
 
 #### Ticket kinds: `refactor` inverts this step's objective
 
@@ -481,7 +505,16 @@ The worker should:
 - **Match the conventions the spec or codebase demonstrates.** If some elements are given a naming/id/attribute style (e.g. kebab-case `data-testid`s, BEM classes), apply that SAME style consistently to the equivalent elements you build — the same way you match surrounding code style. Stay consistent; do NOT speculatively decorate elements no requirement calls for.
 - **Build the complete, idiomatic component — not the literal minimum.** A navigation bar gets its brand and the links the app needs; a data table gets proper column headers. Implement the whole feature a user would expect from the requirements, but do not invent features the requirements don't call for.
 
+```bash
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \
+  --name step5_6_tdd_and_implement --since "$PHASE_T0" --ticket "$issue_number" || true
+```
+
 ### Step 7: Multi-AI code review with structured checklist
+
+```bash
+PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
+```
 
 **THIS STEP IS NEVER OPTIONAL.** Every implementation gets a multi-AI code review, regardless of change size. A one-line typo fix, a 10-line config change, a 500-line feature — all get the same review process. You do not get to self-certify your own code. No exceptions, no shortcuts.
 
@@ -592,7 +625,16 @@ The worker should:
 
    (Convention: `docs/factory-telemetry.md` → "LLM validations report their value". A `code-review` that keeps costing tokens across tickets but catches nothing becomes a measured `demote-candidate`.)
 
+```bash
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \
+  --name step7_review_quorum --since "$PHASE_T0" --ticket "$issue_number" || true
+```
+
 ### Step 8: Apply review fixes and verify
+
+```bash
+PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
+```
 
 Apply clear-cut fixes from the review. Flag ambiguous items for the user. Then **the orchestrator independently verifies the final state** — this is not delegatable.
 
@@ -713,6 +755,11 @@ If ANY verification fails: fix it directly, or re-launch the coding worker (cont
 ```
 
 (Convention: `docs/factory-telemetry.md` → "Escapes — measuring gate RECALL, not just catches".)
+
+```bash
+"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \
+  --name step8_verification --since "$PHASE_T0" --ticket "$issue_number" || true
+```
 
 ### Step 9: UX sanity + design-fidelity gate
 

--- a/scripts/factory_log.py
+++ b/scripts/factory_log.py
@@ -94,6 +94,7 @@ SKILL = "skill"
 ESCAPE = "escape"  # a manually-found bug, especially one a gate missed
 DEMOTION = "demotion"  # a gate reverted to report-only after a validated seed class escaped
 QUERY = "query"  # one code_query.py verb call (#159)
+PHASE = "phase"  # wall-clock for one workflow phase (#375 proposal 6)
 CLAUDE_CODE = "claude_code"  # per-request api_request events from Claude Code's own OTEL telemetry
 
 ESCAPE_SEVERITIES = ("low", "medium", "high", "critical")
@@ -1258,6 +1259,9 @@ def aggregate(records: list[dict], repo: str | None = None) -> dict:
         es["caught"] = caught
         es["recall"] = round(caught / (caught + escaped), 4) if (caught + escaped) > 0 else None
     return {"gates": gates, "consults": consults, "claude_code": claude_code,
+            # #375 proposal 6: loop latency measured rather than felt. Before
+            # this, phase_summary() existed and nothing ever called it.
+            "phases": phase_summary(records),
             "cost_by_loop": by_loop, "verdict": cost_value_verdict(gates, by_loop),
             "escapes": escapes, "escapes_total": sum(es["escaped"] for es in escapes.values()),
             "queries": queries, "queries_total": sum(q["calls"] for q in queries.values()),
@@ -1627,7 +1631,7 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     e = sub.add_parser("emit", help="Append a telemetry event")
-    e.add_argument("--event", required=True, choices=[GATE, CONSULT, WORKER, SKILL])
+    e.add_argument("--event", required=True, choices=[GATE, CONSULT, WORKER, SKILL, PHASE])
     for opt in ("repo", "ticket", "name", "result", "provider", "details"):
         e.add_argument(f"--{opt}")
     for opt in ("caught", "tokens-in", "tokens-out"):
@@ -1652,6 +1656,25 @@ def main(argv: list[str] | None = None) -> int:
                         "validation record certified it catches this class.")
     b.add_argument("--validation-dir", default=DEFAULT_VALIDATION_DIR,
                    help=f"Directory of <gate>.json validation records (default: {DEFAULT_VALIDATION_DIR})")
+
+    ph = sub.add_parser(
+        "phase",
+        help="Record how long one workflow phase took (#375). Skills are bash, "
+             "so this verb is how a phase boundary reaches the ledger at all.")
+    ph.add_argument("--name", required=True, help="Phase name, e.g. step4a_consults")
+    ph.add_argument("--since", type=float,
+                    help="Epoch seconds captured by `factory_log.py now` at the phase start")
+    ph.add_argument("--duration-ms", type=float, help="Explicit duration instead of --since")
+    ph.add_argument("--ticket")
+    ph.add_argument("--repo")
+    ph.add_argument("--outcome", default="ok", choices=["ok", "error"],
+                    help="A phase that blew up fast would otherwise look like a "
+                         "phase that went well")
+    ph.add_argument("--detail")
+
+    sub.add_parser("now",
+                   help="Print epoch seconds for `phase --since`. A verb rather "
+                        "than `date` because BSD date has no %%3N and CW targets macOS.")
 
     a = sub.add_parser("aggregate", help="Summarize the log")
     a.add_argument("--repo")
@@ -1728,6 +1751,24 @@ def main(argv: list[str] | None = None) -> int:
         # explicitly that "0 new" means up-to-date rather than broken.
         print(f"factory_log: ingested {n} new Claude Code turn(s) from {args.root}"
               f"{' (already up to date)' if n == 0 else ''}")
+        return 0
+    if args.cmd == "now":
+        print(repr(time.time()))
+        return 0
+    if args.cmd == "phase":
+        if args.duration_ms is None and args.since is None:
+            print("factory_log: pass --since (from `factory_log.py now`) or --duration-ms",
+                  file=sys.stderr)
+            return 2
+        duration = (args.duration_ms if args.duration_ms is not None
+                    else max(0.0, (time.time() - args.since) * 1000.0))
+        extra = {"detail": args.detail} if args.detail else {}
+        ok = emit_phase(args.name, duration_ms=duration, repo=args.repo,
+                        ticket=args.ticket, outcome=args.outcome, **extra)
+        if not ok:
+            print("factory_log: telemetry disabled (set CW_TELEMETRY=1 to enable)",
+                  file=sys.stderr)
+            return 1
         return 0
     if args.cmd == "emit":
         fields = {k: getattr(args, k) for k in

--- a/tests/test_factory_log_phase.py
+++ b/tests/test_factory_log_phase.py
@@ -1,0 +1,196 @@
+"""Phase latency reaches the ledger from a skill (chief-wiggum#375 proposal 6).
+
+`emit_phase`, `phase_timer` and `phase_summary` all existed and **nothing
+called any of them** — the fourth "built but never wired" in this family. Worse,
+`emit --event` did not accept `phase` at all, so a skill could not have emitted
+one even deliberately: the skills are bash, and the Python API was unreachable
+from where the phases actually run.
+
+#375 records the consequence plainly: a live run took ~90 minutes, the phase
+costs were reconstructed by hand afterwards, and "there's no data to rank these
+fixes". These tests keep the path from a bash phase boundary to a per-phase
+rollup open end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import factory_log  # noqa: E402
+
+
+def _run(*args, log: Path, env_extra: dict | None = None):
+    import os
+    env = {**os.environ, "CW_FACTORY_LOG": str(log), **(env_extra or {})}
+    return subprocess.run([sys.executable, str(SCRIPTS / "factory_log.py"), *args],
+                          capture_output=True, text=True, env=env)
+
+
+def _records(log: Path) -> list[dict]:
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+# --- the CLI a skill actually uses --------------------------------------------
+
+def test_phase_verb_records_an_explicit_duration(tmp_path):
+    log = tmp_path / "f.jsonl"
+    result = _run("phase", "--name", "step4a_consults", "--duration-ms", "1500",
+                  "--ticket", "375", log=log)
+    assert result.returncode == 0, result.stderr
+    rec = _records(log)[0]
+    assert rec["event"] == "phase"
+    assert rec["phase"] == "step4a_consults"
+    assert rec["duration_ms"] == 1500.0
+    assert rec["ticket"] == "375"
+    assert rec["outcome"] == "ok"
+
+
+def test_now_and_since_round_trip(tmp_path):
+    """The pattern the skill uses: stamp with `now`, record with `--since`."""
+    log = tmp_path / "f.jsonl"
+    started = _run("now", log=log)
+    assert started.returncode == 0
+    t0 = float(started.stdout.strip())
+
+    # Backdate by a known amount. Asserting `>= 0` passes when --since is
+    # ignored entirely and every phase records as zero — which is exactly what
+    # mutation testing caught this assertion doing.
+    result = _run("phase", "--name", "step7_review_quorum",
+                  "--since", str(t0 - 2.0), log=log)
+    assert result.returncode == 0, result.stderr
+    rec = _records(log)[0]
+    assert rec["phase"] == "step7_review_quorum"
+    assert 1900.0 <= rec["duration_ms"] <= 4000.0, (
+        f"backdated 2s and recorded {rec['duration_ms']}ms — --since is not "
+        f"being used to compute the duration")
+
+
+def test_now_is_a_verb_because_bsd_date_has_no_millis(tmp_path):
+    """CW targets macOS, where `date +%s%3N` prints a literal 3N. The verb is
+    why the skill's timing is portable rather than silently wrong."""
+    log = tmp_path / "f.jsonl"
+    out = _run("now", log=log).stdout.strip()
+    assert float(out) > 1_600_000_000  # a plausible epoch, not "%3N"
+
+
+def test_a_phase_that_blew_up_is_not_recorded_as_a_good_one(tmp_path):
+    """A phase that failed fast would otherwise read as a phase that went well
+    — the same conflation the gate outcomes keep apart."""
+    log = tmp_path / "f.jsonl"
+    assert _run("phase", "--name", "step4a_consults", "--duration-ms", "40",
+                "--outcome", "error", log=log).returncode == 0
+    assert _records(log)[0]["outcome"] == "error"
+
+
+def test_neither_since_nor_duration_is_a_usage_error(tmp_path):
+    log = tmp_path / "f.jsonl"
+    result = _run("phase", "--name", "x", log=log)
+    assert result.returncode == 2
+    assert "--since" in result.stderr
+
+
+def test_detail_is_carried_through(tmp_path):
+    log = tmp_path / "f.jsonl"
+    _run("phase", "--name", "step4a_consults", "--duration-ms", "10",
+         "--detail", "3 providers, 1 exhausted", log=log)
+    assert _records(log)[0]["detail"] == "3 providers, 1 exhausted"
+
+
+def test_emit_accepts_phase_as_an_event(tmp_path):
+    """The gap that made the Python API unreachable from bash: `phase` was not
+    in `emit --event`'s choices."""
+    log = tmp_path / "f.jsonl"
+    result = _run("emit", "--event", "phase", "--name", "x", "--duration-ms", "5", log=log)
+    assert result.returncode == 0, result.stderr
+
+
+# --- telemetry stays optional and never breaks the loop -----------------------
+
+def test_phase_is_a_noop_when_telemetry_is_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("CW_TELEMETRY", raising=False)
+    monkeypatch.delenv("CW_FACTORY_LOG", raising=False)
+    assert factory_log.emit_phase("x", duration_ms=1.0) is False
+
+
+# --- the rollup ---------------------------------------------------------------
+
+def test_phase_summary_totals_and_names_the_slowest():
+    records = [
+        {"event": "phase", "phase": "consults", "duration_ms": 1000.0},
+        {"event": "phase", "phase": "consults", "duration_ms": 500.0},
+        {"event": "phase", "phase": "review", "duration_ms": 2000.0},
+        {"event": "gate", "name": "ratchet", "result": "pass"},
+    ]
+    summary = factory_log.phase_summary(records)
+    assert summary["slowest"] == "review"
+    assert summary["total_ms"] == 3500.0
+    consults = next(p for p in summary["phases"] if p["phase"] == "consults")
+    assert consults["runs"] == 2 and consults["mean_ms"] == 750.0
+
+
+def test_phase_summary_counts_errors_separately():
+    records = [
+        {"event": "phase", "phase": "consults", "duration_ms": 40.0, "outcome": "error"},
+        {"event": "phase", "phase": "consults", "duration_ms": 900.0, "outcome": "ok"},
+    ]
+    summary = factory_log.phase_summary(records)
+    assert summary["phases"][0]["errors"] == 1
+    assert summary["phases"][0]["runs"] == 2
+
+
+def test_phase_summary_is_empty_rather_than_wrong_with_no_phases():
+    summary = factory_log.phase_summary([{"event": "gate", "name": "x"}])
+    assert summary["phases"] == []
+    assert summary["slowest"] is None
+    assert summary["total_ms"] == 0.0
+
+
+def test_aggregate_surfaces_phases(tmp_path):
+    """The rollup existed and `aggregate` never called it, so the numbers were
+    computable and never computed."""
+    log = tmp_path / "f.jsonl"
+    _run("phase", "--name", "step7_review_quorum", "--duration-ms", "2000", log=log)
+    _run("phase", "--name", "step4a_consults", "--duration-ms", "500", log=log)
+    result = _run("aggregate", "--format", "json", log=log)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "phases" in payload, "aggregate does not surface phase latency"
+    assert payload["phases"]["slowest"] == "step7_review_quorum"
+
+
+# --- the skill actually calls it ----------------------------------------------
+
+def test_implement_times_the_phases_375_measured_by_hand():
+    """#375's whole point: the phase costs in that ticket were reconstructed by
+    hand after the fact. If /implement stops calling this, they would be again."""
+    text = (Path(__file__).resolve().parent.parent
+            / ".claude" / "commands" / "implement.md").read_text()
+    assert "factory_log.py\" now" in text, "no phase start stamp in /implement"
+    # Match the exact `--name <phase>` token, not a bare substring: renaming
+    # step7_review_quorum to step7_review_quorum_DISABLED still CONTAINS the
+    # original, so a substring check reports a disabled phase as timed.
+    for phase in ("step4_consult_and_synthesis", "step5_6_tdd_and_implement",
+                  "step7_review_quorum", "step8_verification"):
+        assert f"--name {phase} " in text or f"--name {phase}\n" in text, (
+            f"/implement does not time {phase}")
+
+
+def test_the_skill_never_lets_a_measurement_fail_the_loop():
+    """`|| true`: telemetry is a no-op unless CW_TELEMETRY=1, and an
+    instrument must never break the thing it measures."""
+    text = (Path(__file__).resolve().parent.parent
+            / ".claude" / "commands" / "implement.md").read_text()
+    # The emitted command quotes the script path, so the literal is
+    # `factory_log.py" phase` — matching on `factory_log.py phase` finds
+    # nothing and the guard passes vacuously.
+    blocks = [b for b in text.split("```") if 'factory_log.py" phase' in b]
+    assert blocks, "no phase-record block found in /implement"
+    for block in blocks:
+        assert "|| true" in block, (
+            "a phase measurement without `|| true` can fail the loop it measures")


### PR DESCRIPTION
Partial for #375 — proposal 6, which is the one that unblocks ranking the others.

## Why this one first

The ticket says it outright:

> today ticket-cost tracks tokens but not time-in-phase, so there's no data to rank these fixes

The phase table in #375 was reconstructed **by hand** after a ~90-minute live run. Proposals 2–5 are all latency optimisations with no instrument to tell whether they helped.

## Built, and never wired

`emit_phase`, `phase_timer` **and** `phase_summary` all already existed. Nothing called any of them — the fourth "built but never wired" in this family, after #368, #374, #375's own proposal 1 and #416.

Worse: `emit --event` did not accept `phase` in its choices, so a skill could not have emitted one *even deliberately*. Skills are bash; the Python API was unreachable from where the phases actually run.

## The three missing links

- **a `phase` CLI verb** — `--name`, `--since`/`--duration-ms`, `--ticket`, `--outcome`, `--detail` — plus **`now`** for the start stamp.

  `now` is a verb rather than `date +%s%3N` because **BSD date has no `%3N`** and prints a literal `3N`. CW targets macOS, so the obvious shell idiom would have recorded silently wrong numbers on the operator's own machine.
- **`phase` added to `emit --event`'s choices.**
- **`phase_summary` wired into `aggregate`**, which never called it — the numbers were computable and never computed.

## The skill actually calls it

`/implement` now times the four phases #375 measured by hand: consult+synthesis, TDD+implement, review quorum, verification.

```bash
PHASE_T0=$("${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" now)
# ... the phase runs ...
"${CW_PY:-python3}" "$CW_HOME/scripts/factory_log.py" phase \\
  --name step7_review_quorum --since "$PHASE_T0" --ticket "$issue_number" || true
```

Every call ends `|| true`: telemetry is a no-op unless `CW_TELEMETRY=1`, and **an instrument must never break the thing it measures**. `--outcome error` is carried through, because a phase that blew up fast would otherwise read as a phase that went well — the same conflation the gate outcomes keep apart.

## Mutation testing caught two blind assertions of mine

Both had passed:

- `assert rec["duration_ms"] >= 0.0` is satisfied when `--since` is ignored entirely and every phase records as **zero**. Now backdates a known 2s and asserts the recorded span.
- `assert "step7_review_quorum" in text` still matches after renaming that phase to `step7_review_quorum_DISABLED` — a **disabled** phase would have reported as timed. Now matches the exact `--name <phase>` token. Same substring trap as earlier in this session.

**14 tests, 10/10 mutants caught. Full suite: 4589 passed, 16 skipped, ruff clean.**

## Still open on #375

Proposals 2–5 — overlapping step 7 with step 8's mechanical half, splitting the synthesis plan so the red phase starts earlier, caching consults by ticket hash, delegate budgets — now with the instrument that can tell whether any of them actually helps.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*