### PR TITLE
docs(close-epic): say that a CURRENT tutorial verdict is a weak signal (#365)

### DIFF
--- a/.claude/commands/close-epic.md
+++ b/.claude/commands/close-epic.md
@@ -326,6 +326,8 @@ If the repo has no `docs/tutorials/` (or no maintainer script), **skip and say s
 
 This is **report-only** — it never blocks the close (a stale tutorial is a follow-up, not a broken seam). Recommend `/tutorial-videos` to re-produce drifted ones and author the gaps, and **ticket the new-tutorial gaps** so they aren't lost. Do not attempt to record videos inside `/close-epic` — production needs a running instance and is its own workflow.
 
+**`CURRENT` is a weaker signal than it looks — say so in the report rather than implying it (chief-wiggum#365).** The maintainer's drift mapping keys off files the storyboard *directly references* plus test titles; it never resolves what a recorded route actually RENDERS — the layout shell wrapping it or the component tree beneath the page. A shared-layout or shared-component change therefore drifts nothing. Measured on a real re-record session: it reported 10 CURRENT / 1 MISSING while **two** tutorials genuinely needed re-recording, both UI changes having shipped onto "CURRENT" recordings. Manual triage then over-corrected in the other direction and would have paid for one unnecessary re-record. So report the count AND the limit: a `CURRENT` verdict means "no storyboard-referenced file changed", not "the recording still matches the product".
+
 ### Step 2j2: EU AI Act check (report-only) — chief-wiggum#316
 
 Checks `docs/compliance/ai-act.json` against the in-force layer only (Art. 5 prohibitions, Art. 6(4) derogation documentation, Art. 50 transparency) — the Chapter III high-risk conformity pack is parked (deferred by the Digital Omnibus, harmonised standards don't exist yet):


### PR DESCRIPTION
Partial for #365 — the CW-side half. The fix for the under-detection itself is not in this repo, and that's recorded on the ticket.

## The weak signal

`/close-epic` reported the target maintainer's `CURRENT` verdict as-is. #365 establishes that verdict is known to **under-detect**, so a green tutorial line in a close report reads stronger than the evidence behind it.

The drift mapping keys off files the storyboard *directly references*, plus test titles. It never resolves what a recorded route actually **renders** — the layout shell wrapping it, or the component tree beneath the page. A shared-layout or shared-component change therefore drifts nothing.

Measured on a real re-record session:

- **10 CURRENT / 1 MISSING reported**, while **two** tutorials genuinely needed re-recording — a `PublicPreviewPanel` and a footer badge had both shipped onto "CURRENT" recordings.
- The manual triage that corrected it then over-corrected the other way, and would have paid for **one unnecessary re-record** had a ground-truth pass not run first.

Wrong in both directions, from the same blind spot.

## What ships

The close report now carries the count **and** the limit: `CURRENT` means *"no storyboard-referenced file changed"*, not *"the recording still matches the product"*.

Same principle as the rest of this session's work — a signal that cannot see a whole class of change must say so, rather than presenting as clean.

## Why the actual fix isn't here

`maintain_tutorials.py` lives in the **target repo** (`dogeared-coach/scripts/`, with its own test file). CW only consumes its status. #365's own validation plan already assumes that repo's ground truth (#424/#426 as true positives, `check-client-progress` as the true negative).

So the route→render-closure resolver is a PR against dogeared-coach, not this one — a production product repo I'm not going to start committing scanner changes to off the back of a CW queue ticket. The alternative is moving drift detection into CW, which means taking on a per-stack route-resolution dependency (the proposal assumes Vite/ts-morph) that CW doesn't have today.

Both are decisions. Written up on the issue.

**Full suite: 4589 passed, 16 skipped, ruff clean.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*