### PR TITLE
docs(languages): record why .lua is unsupported before someone re-derives it (#413)

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -26,6 +26,23 @@ Encountering one of these during a full-repo scan is NEVER a silent skip — `ch
 
 `.c`, `.cc`, `.clj`, `.cljs`, `.cpp`, `.dart`, `.erl`, `.ex`, `.exs`, `.groovy`, `.h`, `.hpp`, `.hs`, `.jl`, `.kt`, `.kts`, `.lua`, `.m`, `.mm`, `.php`, `.pl`, `.r`, `.scala`, `.swift`
 
+### Pending tier decision: `.lua` (chief-wiggum#413)
+
+`.lua` sits in the list above **deliberately**, and not because the scanner cannot read it.
+
+**The emitter already works.** chief-wiggum#377 added Redis write-command detection, `KIND_SCRIPT` emission and the `--` comment marker, so feeding a `.lua` file to the write-site emitter produces facts today. The reported case (inline Lua inside a scanned Go file) is fixed. A *standalone* `.lua` file is surfaced as a coverage gap — and if a single-write-path field's only writer lives in one, `check_single_writer` reports the field `blind` rather than finding the writer.
+
+**The blocker is the shared tier table, not the emitter.** Moving `.lua` into `generic_tier` was tried during #377 and broke four tests in `tests/test_external_links.py`, which used `hook.lua` as its canonical *unscannable* language. That fixture encoded the premise of external links — the feature exists for languages CW cannot resolve — in a real extension's tier, so promoting a language silently redefined a whole subsystem's assumption as a side effect of a write-detection fix.
+
+That coupling is now gone: those tests use a deliberately fictional `.cwnolang` extension, which no language will ever claim and therefore cannot be promoted. The subsystem no longer has an opinion on which real languages are scannable, so a future tier change cannot break it the same way.
+
+**What promoting `.lua` still costs**, per `docs/gate-rollout.md` and `docs/gate-validation.md`:
+
+- a clean-corpus run with coverage evidence, because the gate would start producing findings from files it has never looked at — Lua's assignment syntax (`t.field = v`, `t["field"] = v`) is *plausibly* close enough to the generic regex patterns, and plausible is not measured
+- re-deriving `check_single_writer`'s validation record (`gate_validation_designer.py revalidate check_single_writer`) rather than hand-editing it, since the scanned population changes
+
+Changing an extension's tier is a cross-subsystem decision, not a per-gate one. Until that decision is taken with the corpus evidence behind it, `.lua` stays recognized-but-unsupported — a loud coverage gap, never a silent skip.
+
 ## Partially supported (tier 2)
 
 These languages ARE scanned and measured — the quality/debt population, clone detection and the ratchet pass-set all see them — but no dedicated emitter module or LSP exists, so write-site/trace facts come from the generic regex tier. Listed here with exactly what is still missing for tier 1.

--- a/scripts/render_languages_doc.py
+++ b/scripts/render_languages_doc.py
@@ -82,6 +82,60 @@ def render(path: Path | str = cw_languages.DEFAULT_PATH) -> str:
         ", ".join(f"`{e}`" for e in unsupported) or "(none)",
     ]
 
+    # A recognized-but-unsupported extension is usually just "nobody needed it
+    # yet". `.lua` is not: its emitter works and the blocker is elsewhere, so
+    # the state is written down rather than left to be re-derived from a broken
+    # test run (chief-wiggum#413's own acceptance criterion).
+    if ".lua" in unsupported:
+        lines += [
+            "",
+            "### Pending tier decision: `.lua` (chief-wiggum#413)",
+            "",
+            "`.lua` sits in the list above **deliberately**, and not because the "
+            "scanner cannot read it.",
+            "",
+            "**The emitter already works.** chief-wiggum#377 added Redis "
+            "write-command detection, `KIND_SCRIPT` emission and the `--` comment "
+            "marker, so feeding a `.lua` file to the write-site emitter produces "
+            "facts today. The reported case (inline Lua inside a scanned Go file) "
+            "is fixed. A *standalone* `.lua` file is surfaced as a coverage gap — "
+            "and if a single-write-path field's only writer lives in one, "
+            "`check_single_writer` reports the field `blind` rather than finding "
+            "the writer.",
+            "",
+            "**The blocker is the shared tier table, not the emitter.** Moving "
+            "`.lua` into `generic_tier` was tried during #377 and broke four tests "
+            "in `tests/test_external_links.py`, which used `hook.lua` as its "
+            "canonical *unscannable* language. That fixture encoded the premise of "
+            "external links — the feature exists for languages CW cannot resolve — "
+            "in a real extension's tier, so promoting a language silently redefined "
+            "a whole subsystem's assumption as a side effect of a write-detection "
+            "fix.",
+            "",
+            "That coupling is now gone: those tests use a deliberately fictional "
+            "`.cwnolang` extension, which no language will ever claim and therefore "
+            "cannot be promoted. The subsystem no longer has an opinion on which "
+            "real languages are scannable, so a future tier change cannot break it "
+            "the same way.",
+            "",
+            "**What promoting `.lua` still costs**, per `docs/gate-rollout.md` and "
+            "`docs/gate-validation.md`:",
+            "",
+            "- a clean-corpus run with coverage evidence, because the gate would "
+            "start producing findings from files it has never looked at — Lua's "
+            "assignment syntax (`t.field = v`, `t[\"field\"] = v`) is *plausibly* "
+            "close enough to the generic regex patterns, and plausible is not "
+            "measured",
+            "- re-deriving `check_single_writer`'s validation record "
+            "(`gate_validation_designer.py revalidate check_single_writer`) rather "
+            "than hand-editing it, since the scanned population changes",
+            "",
+            "Changing an extension's tier is a cross-subsystem decision, not a "
+            "per-gate one. Until that decision is taken with the corpus evidence "
+            "behind it, `.lua` stays recognized-but-unsupported — a loud coverage "
+            "gap, never a silent skip.",
+        ]
+
     # Two kinds of not-yet-tier-1 slot, rendered separately so "designed,
     # unbuilt" (nothing runs) is never confused with "tier 2" (it runs, it
     # measures, it just has no dedicated emitter/LSP behind it).


### PR DESCRIPTION
Partial for #413 — acceptance criterion 4's decision-independent half, plus confirmation that criterion 1 is already met.

## The gap

`.lua` sits in `docs/languages.md`'s recognized-but-unsupported list and the doc gives **no hint that its position is deliberate**. It reads exactly like the other 23 extensions, which are there because nobody needed them yet.

`.lua` is there for a different reason, and that difference is the entire ticket. The acceptance criterion says it plainly:

> the reason is written down in `docs/languages.md` so the next person doesn't re-derive it from a broken test run

## What's now recorded

- **The emitter already works.** #377 added Redis write-command detection, `KIND_SCRIPT` emission and the `--` comment marker, so feeding a `.lua` file produces facts today. A *standalone* `.lua` file is a coverage gap, and a single-write-path field whose only writer lives in one reports `blind`.
- **The blocker is the shared tier table.** Promoting it during #377 broke four tests in `test_external_links.py`, which used `hook.lua` as its canonical *unscannable* language — encoding that subsystem's premise in a real extension's tier.
- **That coupling is gone** — criterion 1, already satisfied. Those tests now use a fictional `.cwnolang`, which no language will ever claim and therefore cannot be promoted, so a future tier change can't break the subsystem the same way.
- **What promoting still costs:** a clean-corpus run with coverage evidence — Lua's `t.field = v` is *plausibly* close to the generic regex patterns, and plausible is not measured — plus re-deriving `check_single_writer`'s validation record rather than hand-editing it.

## A guard caught me, correctly

I hand-edited `docs/languages.md` first and `test_render_languages_doc` failed. That doc is **generated** from `config/languages.json`, and the test exists so the prose can never drift from the artifact `check_deps.py` and `scripts/emitters/` actually consume. Working exactly as designed.

The note now lives in `scripts/render_languages_doc.py`, rendered under `if ".lua" in unsupported` — so **promoting the extension removes the note automatically** rather than leaving a stale one behind.

## Still open

Criteria 2 and 3 — which tier `.lua` belongs in, and the corpus evidence behind it. That's the cross-subsystem decision this ticket exists to force, and it isn't mine to make.

**Full suite: 4589 passed, 16 skipped, ruff clean.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*