### PR TITLE
fix(ci-templates): lint parity with CW's own loop, and opt-in caching (#347)

### DIFF
--- a/templates/ci/ci-go.yml
+++ b/templates/ci/ci-go.yml
@@ -13,3 +13,17 @@
         run: go vet ./...
       - name: Test
         run: go test ./...
+      # CW's own loop requires `golangci-lint run ./...` (/implement Step 7,
+      # /implement-wave's wave integration check), so a scaffolded CI that
+      # never runs it is out of parity with the gate the loop applies anyway.
+      #
+      # continue-on-error is docs/gate-rollout.md applied to a scaffolded job:
+      # a NEW gate ships report-only. Scaffolding runs on repos that had no CI
+      # at all, which may carry real lint debt, and a hard-failing linter on
+      # day one blocks every PR and gets deleted rather than fixed. Drop this
+      # line once the repo is clean — that promotion is the point.
+      - name: Lint (report-only until the repo is clean)
+        continue-on-error: true
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        with:
+          version: latest

--- a/templates/ci/ci-node.yml
+++ b/templates/ci/ci-node.yml
@@ -2,6 +2,13 @@
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # Dependency caching is OPT-IN, not defaulted: `cache: npm` hard-fails
+      # when package-lock.json is absent, and this template is stamped into
+      # repos whose lockfile situation is unknown. Add it once the lockfile is
+      # committed:
+      #   with:
+      #     node-version: lts/*
+      #     cache: npm
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*

--- a/templates/ci/ci-python.yml
+++ b/templates/ci/ci-python.yml
@@ -2,6 +2,11 @@
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # Opt-in for the same reason as the node template: `cache: pip` hard-fails
+      # without a requirements file to hash. Add once one is committed:
+      #   with:
+      #     python-version: "3.11"
+      #     cache: pip
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"

--- a/tests/test_ci_template_pinning.py
+++ b/tests/test_ci_template_pinning.py
@@ -101,3 +101,77 @@ def test_the_scaffolded_workflow_carries_the_pins(stacks):
     # Every stack (including the empty/generic one) checks out the repo, so a
     # render with zero `uses:` lines means the assertion above proved nothing.
     assert seen > 0, f"render_ci({stacks}) emitted no action references to check"
+
+
+# --- parity with the gates CW's own loop applies (chief-wiggum#347) -----------
+
+def _rendered(stacks):
+    import sys
+    sys.path.insert(0, str(REPO / "scripts"))
+    from ci_scaffold import render_ci  # noqa: PLC0415
+    return render_ci(stacks)
+
+
+def test_every_rendered_workflow_is_valid_yaml():
+    """A template that renders to broken YAML fails at the target's first push,
+    after CW has told the operator CI is scaffolded."""
+    yaml = pytest.importorskip("yaml")
+    for stacks in (["go"], ["python"], ["node"], [], ["go", "python", "node"]):
+        doc = yaml.safe_load(_rendered(stacks))
+        assert doc.get("jobs"), f"render_ci({stacks}) produced no jobs"
+
+
+def test_the_go_workflow_runs_the_linter_cw_requires():
+    """/implement Step 7 and /implement-wave's integration check both require
+    `golangci-lint run ./...`. A scaffolded CI that never runs it is out of
+    parity with the gate the loop applies anyway — the operator then meets the
+    findings at review time instead of at push time."""
+    text = _rendered(["go"])
+    assert "golangci-lint" in text, (
+        "the scaffolded Go workflow does not lint, while CW's own loop requires "
+        "golangci-lint (chief-wiggum#347)")
+
+
+def test_the_scaffolded_linter_starts_report_only():
+    """docs/gate-rollout.md applied to a scaffolded job: a NEW gate ships
+    report-only. Scaffolding runs on repos that had no CI at all and may carry
+    real lint debt; a hard-failing linter on day one blocks every PR and gets
+    deleted rather than fixed."""
+    yaml = pytest.importorskip("yaml")
+    doc = yaml.safe_load(_rendered(["go"]))
+    steps = doc["jobs"]["go"]["steps"]
+    lint = [s for s in steps if "golangci-lint-action" in str(s.get("uses", ""))]
+    assert lint, "no golangci-lint step in the rendered Go workflow"
+    # Parse the step rather than string-windowing around the first mention:
+    # the first "golangci-lint" in the file is the COMMENT explaining why the
+    # step exists, and a window before it proved nothing.
+    assert lint[0].get("continue-on-error") is True, (
+        "the scaffolded linter blocks from day one; it should ship report-only "
+        "and be promoted once the repo is clean")
+
+
+def test_dependency_caching_is_opt_in_not_defaulted():
+    """`cache:` HARD-FAILS when the lockfile it hashes is absent, and these
+    templates are stamped into repos whose lockfile situation is unknown. A
+    default that breaks the workflow it scaffolds is worse than no cache."""
+    for stacks in (["node"], ["python"]):
+        text = _rendered(stacks)
+        for line in text.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue  # the documented opt-in, which is the point
+            assert not stripped.startswith("cache:"), (
+                f"render_ci({stacks}) enables caching by default: {stripped}")
+
+
+def test_the_opt_in_is_actually_documented():
+    """Opt-in with no instructions is just a missing feature."""
+    # Match the copy-pasteable directive, not the prose. `"cache:" in text`
+    # is satisfied by the sentence explaining why caching is off, so deleting
+    # the snippet passed it — caught by mutation testing.
+    for stacks, directive in ((["node"], "#     cache: npm"),
+                              (["python"], "#     cache: pip")):
+        text = _rendered(stacks)
+        assert directive in text, (
+            f"render_ci({stacks}) neither enables caching nor shows how to: "
+            f"expected the commented snippet {directive!r}")


### PR DESCRIPTION
Completes "CI template hardening round 2" for #347. #433 did the SHA-pinning.

## The parity gap

`/implement` Step 7 and `/implement-wave`'s wave integration check both require `golangci-lint run ./...`.

The Go workflow CW scaffolds ran **build, vet and test — and never linted**. So a repo CW set up got a CI that skipped the gate CW's own loop applies anyway, and the operator met those findings at review time instead of at push time.

golangci-lint now runs, SHA-pinned like its siblings, with `continue-on-error: true`.

**That flag is `docs/gate-rollout.md` applied to a scaffolded job, not timidity.** A new gate ships report-only. Scaffolding runs on repos that had *no CI at all*, which may carry real lint debt — a hard-failing linter on day one blocks every PR and gets deleted rather than fixed. The comment tells the operator to drop the line once the repo is clean; that promotion is the point.

## Caching stays opt-in, and documented

The ticket offered *"a conditional or a documented opt-in"*. Documented is the conservative one.

`cache: npm` / `cache: pip` **hard-fail** when the lockfile they hash is absent, and these templates are stamped into repos whose lockfile situation is unknown. A default that breaks the workflow it scaffolds is worse than no cache. Both templates now carry the copy-pasteable snippet.

## Guards

Alongside the pinning ones:

- the Go workflow runs the linter CW requires
- that linter starts report-only
- caching is never defaulted, **and** the opt-in is actually documented
- every rendered workflow parses as YAML — a template that renders broken fails at the target's first push, *after* CW has said CI is scaffolded

**7/7 mutants caught.** Two of those guards were blind on first write, and mutation testing found both:

- the report-only check string-windowed backwards from the first `golangci-lint` in the file — which is the **comment** explaining the step, so it proved nothing. Now parses the YAML and reads the step's own key.
- the documentation check asserted `"cache:" in text`, which is satisfied by the prose explaining why caching is off. **Deleting the snippet passed it.** Now matches the copy-pasteable directive.

That's the fourth and fifth blind assertion of mine mutation testing has caught in this session.

**Full suite: 4594 passed, 16 skipped, ruff clean.**

## Still open on #347

The two findings that need design calls: `$defs` duplication across 6 schemas (deduping means the templates stop being standalone single-file stamps) and the slug-case grammar mismatch. Plus the naming inversions, which #433 established cost three validation records — one of them non-replayable.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*