### PR TITLE
docs: name the visual-only scope of Step 9 and the two ID grammars (#355, #347)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -782,6 +782,10 @@ git diff "$DEFAULT_BRANCH"...HEAD --name-only > "$TICKET_TMP/changed.txt"
 
 (Real example: a shipped production SaaS had 131 passing tests and 40 green E2E specs while its client-facing playlist was numbered "0., 1., ..." and the component library was completely unthemed. One screenshot caught both.)
 
+**This step is VISUAL only, and for a product with a non-visual surface that is a gap, not a pass (chief-wiggum#355).** It captures and compares screenshots. A realtime/audio/interaction surface has no equivalent in the loop, and the failures there are invisible to every frame: a 24kHz→48kHz resample that garbles playback, a 2s jitter buffer that drops bursty long-response chunks into choppiness, an over-sensitive VAD that cuts the user off. All three shipped past a green loop, and all three would have screenshotted perfectly.
+
+So do not let "Step 9 passed" stand as *the loop looked at the result* on such a product. Say in the PR which surfaces were actually observed and which were not — the same distinction `check_external_smoke.py` draws between `verified` and `unverified`. What a mechanical audio/interaction observation should BE (a recorded capture reviewed by a model, a spectral assertion, a human checkpoint that refuses to be skipped) is an open design question on #355; naming the gap is not.
+
 #### Phase 1: Capture screenshots
 
 Determine what tooling is available, in priority order:

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -270,6 +270,26 @@ journals written before this canonicalization are read compatibly (keys are
 canonicalized on load — hash *values* cover block content only and are
 unaffected).
 
+**The two written grammars differ on purpose (chief-wiggum#347).** The stable-ID
+`pattern`s in `templates/formal-models/*.json` allow a mixed-case slug
+(`^ARC-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$`), while `tim-registry`'s `id_pattern`
+is lowercase-only (`^(BR|CTR|INV|...)-[a-z0-9][a-z0-9-]*-[0-9]{3}$`). That reads
+like a disagreement and is not one: they describe **different stages**.
+
+- The schema patterns describe what an author may WRITE. Accepting
+  `CTR-BIL-001` means a human who capitalises an abbreviation is not rejected
+  by a validator over letter case.
+- `id_pattern` describes the CANONICAL form everything joins on after
+  `canonical_id()` has run — uppercase kind, lowercase slug.
+
+So `CTR-BIL-001`, `ctr-bil-001` and `CTR-Bil-001` are all valid to author and
+all join as `CTR-bil-001`.
+
+Reconciling them by editing either side would be a regression, not a tidy-up:
+tightening the schemas to lowercase rejects IDs that are valid today, and
+loosening `id_pattern` lets non-canonical IDs into the registry that the join
+would then have to guess about.
+
 On every run, if a sidecar exists at the resolved location, each recorded link
 is compared against the ID's CURRENT definition hash. A mismatch is **SUSPECT**
 — reported in `suspect_links`/`suspect_contracts`, distinct from both dangling


### PR DESCRIPTION
Two findings I'd classified as open design questions. Each had a decision-free half: writing down what is already true.

## Step 9 is visual only (#355)

`/implement` Step 9 calls itself *"the only step in the loop that actually looks at the result"* — and it captures and compares **screenshots**.

A realtime/audio/interaction surface has no equivalent anywhere in the loop, and the failures there are invisible to every frame:

- a 24kHz→48kHz resample that garbles playback
- a 2s jitter buffer that drops bursty long-response chunks into choppiness
- an over-sensitive VAD that cuts the user off

All three shipped past a green loop. All three would have screenshotted perfectly.

So "Step 9 passed" must not stand as *the loop looked at the result* on such a product. The PR now says which surfaces were actually observed and which were not — the same distinction `check_external_smoke.py` draws between `verified` and `unverified`.

**What a mechanical audio/interaction observation should BE** — a recorded capture reviewed by a model, a spectral assertion, a human checkpoint that refuses to be skipped — stays open on #355. Naming the gap doesn't need that answer.

## The two ID grammars differ on purpose (#347)

#347 filed this as a mismatch: the stable-ID `pattern`s in `templates/formal-models/*.json` allow a mixed-case slug, while `tim-registry`'s `id_pattern` is lowercase-only — *"reconciled at ingestion by canonical_id() but the two written grammars disagree on face"*.

Checked against the code: they describe **different stages**, not two opinions about one thing.

| | describes |
| --- | --- |
| schema `pattern` | what an author may **write** — `CTR-BIL-001` isn't rejected over letter case |
| `id_pattern` | the **canonical** form everything joins on, after `canonical_id()` |

Verified: `CTR-BIL-001`, `ctr-bil-001` and `CTR-Bil-001` all canonicalise to `CTR-bil-001`.

Recorded because **"reconciling" them would be a regression, not a tidy-up.** Tightening the schemas to lowercase rejects IDs that are valid today; loosening `id_pattern` lets non-canonical IDs into the registry that the join would then have to guess about. That's exactly the fix a future reader makes from the face of the two patterns alone — the same failure mode as #413's `.lua`, where the missing context was the whole problem.

**Full suite: 4594 passed, 16 skipped, ruff clean.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*