### PR TITLE
fix(schemas): re-sync duplicated $defs and restore a lost constraint (#347)

### DIFF
--- a/templates/formal-models/architecture-schema.json
+++ b/templates/formal-models/architecture-schema.json
@@ -158,13 +158,19 @@
       "properties": {
         "id": {
           "type": "string",
-          "pattern": "^ASM-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$"
+          "pattern": "^ASM-[A-Za-z0-9][A-Za-z0-9-]*-[0-9]{3}$",
+          "description": "Stable ID, e.g. ASM-elevenlabs-ttfb-001"
         },
         "evidence": {
           "type": "string",
-          "enum": ["sla-doc", "live-probe", "justified"]
+          "enum": ["sla-doc", "live-probe", "justified"],
+          "description": "How this assumption is backed. 'sla-doc'/'live-probe' render as covered; 'justified' renders as a DOCUMENTED WAIVER (a distinct status, not silently equal to covered). Missing/invalid evidence is a finding."
         },
-        "ref": { "type": "string", "minLength": 1 }
+        "ref": {
+          "type": "string",
+          "description": "Pointer to the evidence (doc URL, probe script/run, or waiver rationale)",
+          "minLength": 1
+        }
       }
     },
     "provenance": {
@@ -174,10 +180,17 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"],
+          "description": "What kind of source this traces back to"
         },
-        "ref": { "type": "string" },
-        "description": { "type": "string" }
+        "ref": {
+          "type": "string",
+          "description": "Reference identifier (e.g., '#42', 'AC-3', 'INV-order-002', 'FACT-17')"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable summary of what was derived"
+        }
       }
     }
   }

--- a/templates/formal-models/contracts-schema.json
+++ b/templates/formal-models/contracts-schema.json
@@ -215,13 +215,16 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"],
+          "description": "What kind of source this traces back to"
         },
         "ref": {
-          "type": "string"
+          "type": "string",
+          "description": "Reference identifier (e.g., '#42', 'AC-3', 'INV-order-002', 'FACT-17')"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Human-readable summary of what was derived"
         }
       }
     }

--- a/templates/formal-models/gap-classification.json
+++ b/templates/formal-models/gap-classification.json
@@ -141,10 +141,17 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"],
+          "description": "What kind of source this traces back to"
         },
-        "ref": { "type": "string" },
-        "description": { "type": "string" }
+        "ref": {
+          "type": "string",
+          "description": "Reference identifier (e.g., '#42', 'AC-3', 'INV-order-002', 'FACT-17')"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable summary of what was derived"
+        }
       }
     }
   }

--- a/templates/formal-models/system-contracts-schema.json
+++ b/templates/formal-models/system-contracts-schema.json
@@ -110,7 +110,8 @@
         },
         "ref": {
           "type": "string",
-          "description": "Pointer to the evidence (doc URL, probe script/run, or waiver rationale)"
+          "description": "Pointer to the evidence (doc URL, probe script/run, or waiver rationale)",
+          "minLength": 1
         }
       }
     },
@@ -145,10 +146,17 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"]
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "api_doc", "user_input"],
+          "description": "What kind of source this traces back to"
         },
-        "ref": { "type": "string" },
-        "description": { "type": "string" }
+        "ref": {
+          "type": "string",
+          "description": "Reference identifier (e.g., '#42', 'AC-3', 'INV-order-002', 'FACT-17')"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable summary of what was derived"
+        }
       }
     }
   }

--- a/templates/formal-models/ui-spec-schema.json
+++ b/templates/formal-models/ui-spec-schema.json
@@ -646,28 +646,21 @@
     },
     "provenance": {
       "type": "object",
-      "required": [
-        "type",
-        "ref"
-      ],
+      "required": ["type", "ref"],
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "ticket",
-            "acceptance_criterion",
-            "epic_invariant",
-            "observed_fact",
-            "screenshot",
-            "user_input"
-          ]
+          "enum": ["ticket", "acceptance_criterion", "epic_invariant", "observed_fact", "screenshot", "user_input"],
+          "description": "What kind of source this traces back to"
         },
         "ref": {
-          "type": "string"
+          "type": "string",
+          "description": "Reference identifier (e.g., '#42', 'AC-3', 'INV-order-002', 'FACT-17')"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Human-readable summary of what was derived"
         }
       }
     }

--- a/tests/test_formal_model_shared_defs.py
+++ b/tests/test_formal_model_shared_defs.py
@@ -1,0 +1,127 @@
+"""Duplicated `$defs` may not drift apart silently (chief-wiggum#347).
+
+`provenance` is copy-pasted into six schemas and `asm_ref` into two. #347
+proposed deduping them behind a shared file and `$ref`, and noted the cost:
+the templates would stop being standalone single-file stamps. That call is
+still open.
+
+This guards the part that needs no call — the copies must agree, and the one
+deliberate variant must stay deliberate.
+
+Measuring the drift first turned up something the ticket did not predict.
+`asm_ref.ref` carried `"minLength": 1` in `architecture-schema.json` and had
+LOST it in `system-contracts-schema.json`, so an empty `ref` was rejected by
+one schema and accepted by the other. That is a silent constraint divergence,
+not a documentation difference, and it is exactly what a copy-paste `$def`
+does when nothing watches it.
+
+Not guarded, deliberately: `entity`, `node` and `summary` also appear in two
+schemas each, but they are unrelated concepts that happen to share a name — a
+contracts `entity` (fields, operations) and a transition-map `entity`
+(model_file, transitions) have nothing to reconcile. Requiring those to match
+would be a bug, not a guard.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+FM = REPO / "templates" / "formal-models"
+
+PROVENANCE_FILES = [
+    "architecture-schema.json",
+    "contracts-schema.json",
+    "gap-classification.json",
+    "state-machine-schema.json",
+    "system-contracts-schema.json",
+    "ui-spec-schema.json",
+]
+ASM_REF_FILES = ["architecture-schema.json", "system-contracts-schema.json"]
+
+# The ONE sanctioned divergence, with its reason. A UI fact is evidenced by a
+# screenshot; a vendor API doc is not a thing a ui-spec cites. Anything else
+# differing is drift.
+UI_SPEC_VARIANT = {
+    "file": "ui-spec-schema.json",
+    "swaps": ("api_doc", "screenshot"),
+    "why": "a UI fact is evidenced by a screenshot, not by a vendor API doc",
+}
+
+
+def defs(name: str) -> dict:
+    return json.loads((FM / name).read_text())["$defs"]
+
+
+def test_the_files_and_defs_exist():
+    """A denominator: if these move or get renamed, this file must fail rather
+    than pass by checking nothing."""
+    assert len(PROVENANCE_FILES) >= 6
+    for name in PROVENANCE_FILES:
+        assert "provenance" in defs(name), f"{name} has no $defs.provenance"
+    for name in ASM_REF_FILES:
+        assert "asm_ref" in defs(name), f"{name} has no $defs.asm_ref"
+
+
+def test_provenance_is_identical_except_for_the_sanctioned_variant():
+    canonical_files = [f for f in PROVENANCE_FILES if f != UI_SPEC_VARIANT["file"]]
+    bodies = {f: defs(f)["provenance"] for f in canonical_files}
+    first = bodies[canonical_files[0]]
+    drifted = [f for f, body in bodies.items() if body != first]
+    assert drifted == [], (
+        f"$defs.provenance has drifted in {drifted}; the copies must agree until "
+        f"#347's dedupe call is made")
+
+
+def test_the_ui_spec_variant_differs_only_in_the_documented_swap():
+    """A sanctioned variant is not a licence to differ in other ways."""
+    canonical = defs("contracts-schema.json")["provenance"]
+    variant = defs(UI_SPEC_VARIANT["file"])["provenance"]
+    old, new = UI_SPEC_VARIANT["swaps"]
+
+    normalised = json.loads(json.dumps(variant))
+    enum = normalised["properties"]["type"]["enum"]
+    assert new in enum, f"{UI_SPEC_VARIANT['file']} lost its {new!r} provenance type"
+    assert old not in enum, (
+        f"{UI_SPEC_VARIANT['file']} now accepts {old!r} too — the variant exists "
+        f"because {UI_SPEC_VARIANT['why']}")
+    normalised["properties"]["type"]["enum"] = [
+        old if e == new else e for e in enum]
+    assert normalised == canonical, (
+        "the ui-spec provenance differs from the canonical copy in more than the "
+        "documented api_doc->screenshot swap")
+
+
+def test_asm_ref_is_identical_across_its_copies():
+    bodies = {f: defs(f)["asm_ref"] for f in ASM_REF_FILES}
+    first = bodies[ASM_REF_FILES[0]]
+    drifted = [f for f, body in bodies.items() if body != first]
+    assert drifted == [], f"$defs.asm_ref has drifted in {drifted}"
+
+
+@pytest.mark.parametrize("name", ASM_REF_FILES)
+def test_asm_ref_keeps_the_constraint_one_copy_had_lost(name):
+    """The specific regression #347's inspection uncovered: an empty `ref` was
+    rejected by architecture-schema and accepted by system-contracts."""
+    ref = defs(name)["asm_ref"]["properties"]["ref"]
+    assert ref.get("minLength") == 1, (
+        f"{name} dropped minLength on asm_ref.ref — an empty evidence pointer "
+        f"would validate, which is the divergence this guard exists for")
+
+
+def test_unrelated_defs_that_share_a_name_are_not_forced_to_match():
+    """`entity` means different things in contracts and transition-map. This
+    asserts the guard above is scoped, not that it forgot them."""
+    contracts_entity = defs("contracts-schema.json")["entity"]
+    transition_entity = defs("transition-map-schema.json")["entity"]
+    assert contracts_entity != transition_entity
+    assert "operations" in contracts_entity["properties"]
+    assert "transitions" in transition_entity["properties"]
+
+
+def test_every_schema_still_parses():
+    for path in sorted(FM.glob("*.json")):
+        json.loads(path.read_text())


### PR DESCRIPTION
Partial for #347 — the `$defs` duplication finding, minus the dedupe decision.

## The decision is still yours

#347 proposed deduping `provenance` (6 copies) and `asm_ref` (2) behind a shared file + `$ref`, and named the cost: **the templates would stop being standalone single-file stamps**. That call is untouched here.

This does the part that needs no call — make the copies agree, and keep the one deliberate variant deliberate.

## Measuring first found something the ticket didn't predict

**A lost constraint, not a documentation difference.** `asm_ref.ref` carries `"minLength": 1` in `architecture-schema.json` and had **lost it** in `system-contracts-schema.json`. An empty evidence pointer was rejected by one schema and accepted by the other. Restored in both.

That's precisely what a copy-pasted `$def` does when nothing watches it, and it's the strongest argument in the ticket's own favour.

**The descriptions never propagated.** `state-machine-schema`'s `provenance` carried three `description` fields the other five lacked; `system-contracts`' `asm_ref` carried three the architecture copy lacked. Richest copy wins.

**The ui-spec variant stays deliberate** — `screenshot` in place of `api_doc`, because a UI fact is evidenced by a screenshot, not a vendor API doc. It is now the *only* difference that exists, and the guard checks it differs in that way and no other.

## Not guarded, on purpose

`entity`, `node` and `summary` also appear in two schemas each — but they're **unrelated concepts sharing a name**. A contracts `entity` (fields, operations) and a transition-map `entity` (model_file, transitions) have nothing to reconcile. Forcing those to match would be a bug, not a guard. There's a test asserting they're allowed to differ.

## Two mistakes of mine, both caught before landing

- **A whole-file `json.dumps` round-trip** reformatted every compact object in these schemas — **451 insertions** for a two-definition change, burying the real edit. Replaced with surgical block replacement plus compact-array rendering matching house style. The diff is now 62 lines, all semantic.
- **The first block locator was unscoped**, and `gap-classification.json` *also* has a `"provenance"` key inside `$defs.gap.properties` — which is **not a copy** but `{"type": "array", "items": {"$ref": "#/$defs/provenance"}}`, the correct usage. It matched that one first and **would have replaced an array-of-refs with an object, breaking the schema**. The drift test caught it. The locator now scopes to direct children of `$defs`.

**6/6 mutants caught:** a copy losing a description, `asm_ref` losing `minLength` again, a copy gaining a provenance type the others lack, the variant re-admitting `api_doc`, the variant losing `screenshot`, and the variant drifting in an unsanctioned way.

**Full suite: 4602 passed, 16 skipped, ruff clean.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*