### PR TITLE
fix(triggers): count humans, not email addresses, for the contributor trigger (#171)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,19 @@
+# Canonical author identities (chief-wiggum#171's human_contributors_gte).
+#
+# Several deferred-rigor triggers key off "a second human contributor". That
+# check counted distinct author EMAILS, and one human commonly commits under
+# several — so it read CANDIDATE on this repo's whole history purely because
+# the same person has a work address, a personal address, a plus-addressed
+# alias and a GitHub noreply. A trigger that is permanently CANDIDATE on noise
+# cannot signal the thing it exists to signal: a genuine second contributor
+# would look exactly the same.
+#
+# Git's own mechanism fixes it. `--use-mailmap` collapses these to one identity,
+# so the count means humans rather than addresses.
+#
+# The canonical address is deliberately NOT the GitHub noreply one: that string
+# matches BOT_EMAIL_MARKERS and would filter the author out entirely, taking
+# the count to zero.
+Pat Prendergast <plwprendergast@gmail.com> <47509024+plwp@users.noreply.github.com>
+Pat Prendergast <plwprendergast@gmail.com> <plwprendergast+github@gmail.com>
+Pat Prendergast <plwprendergast@gmail.com> <pat.prendergast@rollerdigital.com>

--- a/scripts/check_deferred_triggers.py
+++ b/scripts/check_deferred_triggers.py
@@ -28,7 +28,7 @@ Check kinds:
 - ``file_count_gt``: git-tracked file count in ``--repo`` exceeds ``value``.
 - ``module_count_gt``: heuristic — directories (depth <= 2, excluding
   tests/vendor/node_modules/hidden) containing source files in ``--repo``.
-- ``human_contributors_gte``: distinct non-bot author emails on ``--repo``'s
+- ``human_contributors_gte``: distinct non-bot MAILMAP-CANONICAL authors on ``--repo``'s
   history (heuristic: excludes emails containing bot/noreply markers).
 - ``validated_gates_gt``: gate-validation records in
   ``<cw>/docs/quality/validation/*.json``.
@@ -87,17 +87,30 @@ def check_module_count_gt(repo: Path | None, value: int) -> tuple[str, str]:
 
 
 def check_human_contributors_gte(repo: Path | None, value: int) -> tuple[str, str]:
-    """Heuristic (one human commonly commits under several emails) — CANDIDATE
-    at most, never FIRED: email identity must be confirmed by a human."""
+    """Heuristic — CANDIDATE at most, never FIRED: identity is a human's call.
+
+    Counts MAILMAP-CANONICAL authors (`--use-mailmap`, `%aE`), not raw emails.
+    Counting raw addresses made this permanently CANDIDATE on chief-wiggum's
+    own history — one person with a work address, a personal one, a
+    plus-addressed alias and a GitHub noreply reads as four contributors. A
+    trigger that is always CANDIDATE cannot signal what it exists to signal,
+    because a genuine second contributor looks identical to the noise
+    (chief-wiggum#171).
+
+    A repo with no .mailmap is unaffected: git falls back to the raw address,
+    so this is strictly an improvement where the map exists and a no-op where
+    it does not.
+    """
     if repo is None:
         return "UNEVALUATED", "needs --repo"
-    out = subprocess.run(["git", "-C", str(repo), "log", "--format=%ae"],
+    out = subprocess.run(["git", "-C", str(repo), "log", "--use-mailmap", "--format=%aE"],
                          capture_output=True, text=True, check=True)
     humans = sorted({e.strip().lower() for e in out.stdout.splitlines() if e.strip()
                      and not any(m in e.lower() for m in BOT_EMAIL_MARKERS)})
     n = len(humans)
     return ("CANDIDATE" if n >= value else "QUIET"), \
-        f"{n} distinct non-bot author email(s) {humans} (threshold {value}) — may be one human under several emails"
+        f"{n} distinct non-bot author identit(ies) {humans} (threshold {value}, " \
+        f"mailmap-canonical) — one human may still commit under several unmapped emails"
 
 
 def check_validated_gates_gt(value: int) -> tuple[str, str]:

--- a/tests/test_deferred_trigger_contributors.py
+++ b/tests/test_deferred_trigger_contributors.py
@@ -1,0 +1,134 @@
+"""`human_contributors_gte` counts humans, not email addresses (chief-wiggum#171).
+
+Several deferred-rigor triggers key off "a second human contributor". The check
+counted distinct author EMAILS, and chief-wiggum's own history has one person
+committing under four: a work address, a personal address, a plus-addressed
+alias, and a GitHub noreply.
+
+So the trigger read CANDIDATE on this repo permanently — and a trigger that is
+always CANDIDATE cannot signal the thing it exists for, because a genuine
+second contributor looks exactly like the noise.
+
+Git already solves this. `--use-mailmap` collapses mapped addresses to one
+identity, and a repo with no `.mailmap` is unaffected: git falls back to the
+raw address, so the change is an improvement where the map exists and a no-op
+where it does not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+from check_deferred_triggers import check_human_contributors_gte  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, check=True).stdout
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "r"
+    root.mkdir()
+    # --initial-branch pinned: Apple git defaults to main, Linux CI to master,
+    # and a fixture that relies on the default passes locally and fails in CI.
+    subprocess.run(["git", "init", "--initial-branch", "main", str(root)],
+                   capture_output=True, check=True)
+    return root
+
+
+def _commit(repo: Path, name: str, email: str, text: str) -> None:
+    (repo / "f.txt").write_text(text)
+    _git(repo, "add", "f.txt")
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", f"user.name={name}", "-c", f"user.email={email}",
+         "commit", "-m", text],
+        capture_output=True, check=True)
+
+
+def test_one_human_under_several_emails_counts_once(tmp_path):
+    """The defect: four addresses, one person, reported as four contributors."""
+    repo = _repo(tmp_path)
+    _commit(repo, "Pat", "pat@work.example", "a")
+    _commit(repo, "pat", "pat+github@personal.example", "b")
+    _commit(repo, "Patrick", "pat@personal.example", "c")
+    (repo / ".mailmap").write_text(
+        "Pat <pat@personal.example> <pat@work.example>\n"
+        "Pat <pat@personal.example> <pat+github@personal.example>\n")
+    _commit(repo, "Pat", "pat@personal.example", "d")
+
+    status, detail = check_human_contributors_gte(repo, 2)
+    assert status == "QUIET", detail
+    assert "1 distinct" in detail
+
+
+def test_a_genuine_second_contributor_still_registers(tmp_path):
+    """The mailmap must not suppress the signal it exists to clarify."""
+    repo = _repo(tmp_path)
+    _commit(repo, "Pat", "pat@work.example", "a")
+    (repo / ".mailmap").write_text("Pat <pat@personal.example> <pat@work.example>\n")
+    _commit(repo, "Pat", "pat@personal.example", "b")
+    _commit(repo, "Someone Else", "someone@else.example", "c")
+
+    status, detail = check_human_contributors_gte(repo, 2)
+    assert status == "CANDIDATE", detail
+    assert "2 distinct" in detail
+
+
+def test_a_repo_with_no_mailmap_is_unaffected(tmp_path):
+    """Strictly an improvement where the map exists, a no-op where it does not."""
+    repo = _repo(tmp_path)
+    _commit(repo, "A", "a@example.com", "a")
+    _commit(repo, "B", "b@example.com", "b")
+    status, detail = check_human_contributors_gte(repo, 2)
+    assert status == "CANDIDATE", detail
+    assert "2 distinct" in detail
+
+
+def test_bots_are_still_excluded(tmp_path):
+    repo = _repo(tmp_path)
+    _commit(repo, "Pat", "pat@example.com", "a")
+    _commit(repo, "bot", "actions@github.com", "b")
+    _commit(repo, "nr", "12345+x@users.noreply.github.com", "c")
+    status, detail = check_human_contributors_gte(repo, 2)
+    assert status == "QUIET", detail
+    assert "1 distinct" in detail
+
+
+def test_no_repo_is_unevaluated_not_quiet():
+    """UNEVALUATED and QUIET are different claims: 'nobody looked' must never
+    read as 'checked, and nothing fired'."""
+    status, detail = check_human_contributors_gte(None, 2)
+    assert status == "UNEVALUATED"
+
+
+# --- this repo's own map ------------------------------------------------------
+
+def test_chief_wiggum_has_a_mailmap_covering_its_alias_history():
+    """Without it, every trigger keyed on a second contributor sits at
+    CANDIDATE forever and tells nobody anything."""
+    mailmap = REPO / ".mailmap"
+    assert mailmap.is_file(), "no .mailmap — the contributor triggers cannot mean anything"
+    text = mailmap.read_text()
+    assert "noreply" in text, "the GitHub noreply alias is unmapped"
+
+
+def test_this_repo_now_reports_a_single_human():
+    status, detail = check_human_contributors_gte(REPO, 2)
+    assert status == "QUIET", (
+        f"chief-wiggum reports multiple contributors: {detail}. If that is a real "
+        f"second human, this test should be updated — if it is another unmapped "
+        f"alias, add it to .mailmap")
+
+
+def test_the_canonical_address_is_not_itself_filtered_as_a_bot():
+    """A mailmap that canonicalises onto the GitHub noreply address would take
+    the count to ZERO, since 'noreply' matches BOT_EMAIL_MARKERS — a silent
+    inversion of the whole check."""
+    _, detail = check_human_contributors_gte(REPO, 2)
+    assert "0 distinct" not in detail, detail


### PR DESCRIPTION
Fixes a measurement defect in #171's deferred-rigor triggers, found by running the check rather than reading it.

## Two triggers were permanently CANDIDATE on noise

`reflexion-conformance-c4` and `process-json` both key off *"a second human contributor"*. Running `check_deferred_triggers.py --repo .` reports both as CANDIDATE, on the strength of three author emails:

```
Pat Prendergast     <47509024+plwp@users.noreply.github.com>   228 commits
Pat Prendergast     <plwprendergast@gmail.com>                  42
plwp                <plwprendergast+github@gmail.com>           12
Patrick Prendergast <pat.prendergast@rollerdigital.com>          1
```

One person, four identities, counted as multiple contributors.

The check's own detail line admitted it — *"may be one human under several emails"* — which is honest and doesn't help. A row that sits at CANDIDATE forever cannot signal what it exists to signal, because **a genuine second contributor looks exactly like the noise**.

That's the same failure shape as the rest of this session's work, one layer out: a signal that can't distinguish the thing it's watching for from its own background.

## The fix is git's own mechanism

A `.mailmap` collapses the aliases, and the check now reads `git log --use-mailmap --format=%aE`. Both rows are now QUIET and can actually fire.

**A repo with no `.mailmap` is unaffected** — git falls back to the raw address — so this is strictly an improvement where the map exists and a no-op where it doesn't. Every target repo keeps today's behaviour.

## One trap worth naming

The canonical address is deliberately **not** the GitHub noreply one. `"noreply"` matches `BOT_EMAIL_MARKERS`, so canonicalising onto it would filter every author out and take the count to **zero** — a silent inversion of the whole check. There's a test for exactly that.

## Evidence

**8 tests, 6/6 mutants caught:** mailmap ignored again, bot filtering dropped, no `--repo` reporting QUIET instead of UNEVALUATED, the threshold comparison inverting, the mailmap emptied, and every alias canonicalised onto the noreply address.

That last one took two attempts to test honestly. Reversing a **single** mailmap line looked like it should reproduce the count-to-zero failure and didn't — mailmap resolution isn't transitive, so the other aliases still resolved to a non-bot address. **The mutation was wrong, not the test.** Reproducing it properly needs every alias pointed at the noreply address, and then the guard fires.

Git fixtures pin `--initial-branch main`, since Apple git and Linux CI disagree on the default and a fixture that relies on it passes locally and fails in CI.

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
