### PR TITLE
fix(formal-models): an unschema'd artifact type is UNSUPPORTED, not malformed (#289)

### DIFF
--- a/scripts/formal_models.py
+++ b/scripts/formal_models.py
@@ -84,6 +84,12 @@ def _load_schema(name: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# Marks a recognised artifact type that has no schema to validate against.
+# `validate` reports these as UNSUPPORTED and exits 3 — never 0, because
+# "nothing was checked" is not a pass.
+UNSCHEMAD_PREFIX = "unschema'd:"
+
+
 def detect_schema_type(data: dict) -> str:
     """Heuristic detection of which schema a JSON document conforms to."""
     if "nodes" in data and "edges" in data:
@@ -102,6 +108,12 @@ def detect_schema_type(data: dict) -> str:
     # XState format has 'id' and 'states' but no 'transitions' array
     if "id" in data and "states" in data:
         return "xstate"
+    # Known artifact types that have NO schema. Naming them is what separates
+    # "no schema exists for this" from "this document is broken" — without the
+    # list, both exit the same way and read the same (chief-wiggum#289's
+    # four-state discipline, applied to schema detection).
+    if "paths" in data and "summary" in data:
+        return UNSCHEMAD_PREFIX + "test-paths"
     raise ValueError("Cannot detect schema type from document structure")
 
 
@@ -765,6 +777,16 @@ def cmd_validate(args: argparse.Namespace) -> int:
     raw_text = Path(args.model).read_text()
     data = json.loads(raw_text)
     schema_type = args.type or detect_schema_type(data)
+
+    if schema_type.startswith(UNSCHEMAD_PREFIX):
+        kind = schema_type[len(UNSCHEMAD_PREFIX):]
+        print(
+            f"UNSUPPORTED ({kind}): no schema exists for this artifact type, so "
+            f"nothing was validated. This is NOT a pass — it means the checker "
+            f"had nothing to check (chief-wiggum#289)."
+        )
+        return 3
+
     errors = validate(data, schema_type)
     # chief-wiggum#293: report-only by default (docs/gate-rollout.md) — a
     # malformed id never hard-fails `validate` unless --strict-ids is passed,

--- a/tests/test_formal_models_unschemad.py
+++ b/tests/test_formal_models_unschemad.py
@@ -1,0 +1,115 @@
+"""An artifact type with no schema is UNSUPPORTED, not malformed (#289).
+
+`formal_models.py validate` on `models/test-paths.json` used to die with
+
+    ValueError: Cannot detect schema type from document structure
+
+and exit 1 — indistinguishable from a genuinely broken document. `test-paths.json`
+is a legitimate artifact `render_models.py` writes; it simply has no schema under
+`templates/formal-models/`.
+
+Two different claims shared one output, which is exactly the conflation #289
+separated everywhere else:
+
+    this document is malformed        -> a real problem
+    this type has no schema           -> expected, and NOT a pass either
+
+The second is now its own state with its own exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "formal_models.py"
+sys.path.insert(0, str(REPO / "scripts"))
+
+from formal_models import UNSCHEMAD_PREFIX, detect_schema_type  # noqa: E402
+
+UNSUPPORTED_EXIT = 3
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(SCRIPT), "validate", str(path)],
+                          capture_output=True, text=True)
+
+
+def test_test_paths_is_recognised_rather_than_unknown():
+    kind = detect_schema_type({"paths": [], "summary": {}})
+    assert kind.startswith(UNSCHEMAD_PREFIX)
+    assert kind.endswith("test-paths")
+
+
+def test_a_genuinely_unrecognisable_document_still_raises():
+    """The real failure must stay a failure. Widening detection to swallow
+    everything would trade one conflation for a worse one."""
+    with pytest.raises(ValueError):
+        detect_schema_type({"nothing": "familiar"})
+
+
+def test_unsupported_exits_three_not_zero(tmp_path):
+    """Never 0. `nothing was checked` is not a pass — the whole point."""
+    artifact = tmp_path / "test-paths.json"
+    artifact.write_text(json.dumps({"paths": [], "summary": {}}))
+    result = _run(artifact)
+    assert result.returncode == UNSUPPORTED_EXIT
+    assert "UNSUPPORTED" in result.stdout
+    assert "NOT a pass" in result.stdout
+
+
+def test_unsupported_exits_three_not_one(tmp_path):
+    """Never 1 either. Exit 1 is `this document is invalid`, which is a claim
+    about the artifact rather than about the checker's coverage."""
+    artifact = tmp_path / "test-paths.json"
+    artifact.write_text(json.dumps({"paths": [], "summary": {}}))
+    assert _run(artifact).returncode != 1
+
+
+def test_the_message_names_the_type(tmp_path):
+    artifact = tmp_path / "test-paths.json"
+    artifact.write_text(json.dumps({"paths": [], "summary": {}}))
+    assert "test-paths" in _run(artifact).stdout
+
+
+def test_a_malformed_document_is_still_reported_as_invalid(tmp_path):
+    """A schema'd type with real errors must not be swept into UNSUPPORTED."""
+    artifact = tmp_path / "contracts.json"
+    artifact.write_text(json.dumps({"entities": [{"no_name": True}]}))
+    result = _run(artifact)
+    assert result.returncode == 1
+    assert "INVALID" in result.stdout
+
+
+def test_a_valid_document_still_passes(tmp_path):
+    artifact = tmp_path / "contracts.json"
+    artifact.write_text(json.dumps({
+        "entities": [{"name": "Order", "fields": [
+            {"name": "id", "type": "string"}]}]}))
+    result = _run(artifact)
+    assert result.returncode == 0
+    assert "VALID" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    sorted((REPO / "docs" / "epics").glob("*/models/*.json")),
+    ids=lambda p: f"{p.parent.parent.name}/{p.name}",
+)
+def test_every_committed_model_reports_a_meaningful_state(artifact):
+    """No model may answer with a traceback. Before this, both epics'
+    test-paths.json did exactly that."""
+    result = _run(artifact)
+    assert result.returncode in (0, 1, UNSUPPORTED_EXIT), result.stderr[:200]
+    assert "Traceback" not in result.stderr, (
+        f"{artifact.name} answers with a traceback rather than a stated outcome")
+
+
+def test_there_are_committed_models_to_check():
+    models = list((REPO / "docs" / "epics").glob("*/models/*.json"))
+    assert len(models) >= 8, f"expected committed models, found {len(models)}"


### PR DESCRIPTION
The smaller finding I flagged in #453 and deliberately didn't bundle in.

## The failure

`formal_models.py validate` on `models/test-paths.json` died with a raw traceback:

```
ValueError: Cannot detect schema type from document structure
```

exit 1 — indistinguishable from a genuinely broken document. It happens in **both** of CW's epics, because `test-paths.json` is a legitimate artifact `render_models.py` writes and there is simply no schema for it under `templates/formal-models/`.

## Two claims sharing one output

Exactly the conflation #289 spent a whole epic separating everywhere else:

| claim | should be |
| --- | --- |
| this document is malformed | a real problem — exit 1 |
| this type has no schema | expected, and **not a pass either** |

The second is now its own state: `UNSUPPORTED (<type>)` with **exit 3**, matching the convention the newer gates use for *present and could not be checked*.

**Deliberately not exit 0.** "Nothing was checked" is not a pass, and a validator returning success for an artifact it cannot validate is the same fail-open this repo keeps paying for.

## Detection narrowed, not widened

Only the recognised `paths` + `summary` shape returns the sentinel. A document matching nothing **still raises** — swallowing every unknown structure would trade one conflation for a worse one, where malformed input reads as merely unsupported. There's a test for that.

## Result

All 10 committed epic models now answer with a stated outcome:

```
8 VALID   2 UNSUPPORTED   0 tracebacks
```

**5/5 mutants caught:** unsupported exiting 0, unsupported exiting 1, detection swallowing everything, the unsupported branch never firing, and the message dropping its "NOT a pass" clause.

One fixture of mine was wrong on first write — a contracts entity requires `fields`, so my "valid document" case was actually invalid and the test failed for the right reason. Fixed the fixture rather than loosening the assertion.

**Full suite: 4639 passed, 16 skipped, ruff clean.**

---

*Generated by chief-wiggum, an AI system, per its Article 50 disclosure posture — see [docs/ai-act-posture.md](https://github.com/plwp/chief-wiggum/blob/main/docs/ai-act-posture.md).*
